### PR TITLE
[FlyDSL] [MoE] Address expert weights past 4 GB in the MoE GEMMs

### DIFF
--- a/aiter/ops/flydsl/kernels/buffer_ops.py
+++ b/aiter/ops/flydsl/kernels/buffer_ops.py
@@ -266,6 +266,53 @@ def get_element_ptr(
     ).result
 
 
+@dsl_loc_tracing
+def global_load_dwords(
+    base_ptr,
+    byte_offset,
+    *,
+    vec_width: int,
+    cache_modifier: int = 0,
+    address_space: int = 1,
+):
+    """Load ``vec_width`` i32 dwords from a global pointer via GEP + ``llvm.load``.
+
+    Counterpart to :func:`buffer_load` for offsets past 4 GB: the GEP forms the
+    address in full 64-bit, where a buffer resource's voffset is 32-bit. Lowers to
+    ``global_load_dwordxN``. There is **no hardware bounds check** -- a buffer
+    clamps to ``num_records``, a raw pointer does not -- so the caller owns keeping
+    ``byte_offset`` inside the allocation.
+
+    Args:
+        base_ptr: Allocation base; an ``!llvm.ptr``, or an address converted to one
+            in ``address_space``.
+        byte_offset: Byte offset from ``base_ptr``. Pass as index/i64 so it is not
+            truncated before reaching the GEP.
+        vec_width: Number of i32 dwords (1, 2 or 4).
+        cache_modifier: As :func:`buffer_load`. Bit 1 (value 2) is the non-temporal
+            hint; other bits have no ``llvm.load`` equivalent and are ignored.
+
+    Requires ``base_ptr + byte_offset`` aligned to ``vec_width * 4``, which the
+    emitted ``alignment`` asserts. Understating alignment to LLVM is undefined
+    behaviour, so this is a precondition rather than a hint.
+    """
+    if vec_width not in (1, 2, 4):
+        raise ValueError(f"vec_width must be 1, 2 or 4, got {vec_width}")
+
+    base_ptr = _unwrap_value(base_ptr)
+    if not str(base_ptr.type).startswith("!llvm.ptr"):
+        base_ptr = create_llvm_ptr(base_ptr, address_space=address_space)
+
+    ptr = get_element_ptr(base_ptr, byte_offset, elem_type=T.i8())
+    load_bytes = int(vec_width) * 4
+    return llvm.LoadOp(
+        ir.VectorType.get([int(vec_width)], ir.IntegerType.get_signless(32)),
+        ptr,
+        alignment=load_bytes,
+        nontemporal=bool(int(cache_modifier) & 2),
+    ).result
+
+
 class BufferResourceDescriptor:
     """AMD Buffer Resource Descriptor
 

--- a/aiter/ops/flydsl/kernels/mfma_preshuffle_pipeline.py
+++ b/aiter/ops/flydsl/kernels/mfma_preshuffle_pipeline.py
@@ -93,6 +93,37 @@ def _buffer_load_vec(
     return vector.bitcast(T.vec(int(vec_elems), elem_type), i32_vec)
 
 
+def _global_load_vec(
+    buffer_ops,
+    vector,
+    base_ptr,
+    idx,
+    *,
+    elem_type,
+    vec_elems,
+    elem_bytes,
+    offset_in_bytes,
+    cache_modifier=0,
+):
+    """Raw-pointer counterpart of :func:`_buffer_load_vec`.
+
+    Same ``idx`` convention, but the address is formed in full 64-bit by a GEP rather
+    than capped by ``buffer_load``'s 32-bit voffset. No hardware bounds check; see
+    ``buffer_ops.global_load_dwords``.
+    """
+    from flydsl.expr import arith as _ld_arith
+
+    elem_size = int(elem_bytes)
+    load_bytes = int(vec_elems) * elem_size
+    vec_width = load_bytes // 4
+
+    byte_idx = idx if offset_in_bytes else idx * _ld_arith.index(elem_size)
+    i32_vec = buffer_ops.global_load_dwords(
+        base_ptr, byte_idx, vec_width=vec_width, cache_modifier=cache_modifier
+    )
+    return vector.bitcast(T.vec(int(vec_elems), elem_type), i32_vec)
+
+
 @dataclass(frozen=True)
 class PreshuffleScaleLayout:
     """Container returned by `make_preshuffle_scale_layout`.

--- a/aiter/ops/flydsl/kernels/mixed_moe_gemm_2stage_common.py
+++ b/aiter/ops/flydsl/kernels/mixed_moe_gemm_2stage_common.py
@@ -55,6 +55,7 @@ from .layout_utils import get as layout_get
 from .mfma_epilogues import c_shuffle_epilog, default_epilog
 from .mfma_preshuffle_pipeline import (
     _buffer_load_vec,
+    _global_load_vec,
     buffer_copy_gmem16_dwordx4,
     lds_store_4b_xor16,
     lds_store_8b_xor16,
@@ -3560,6 +3561,11 @@ def compile_mixed_moe_gemm2_common(
     w_elem_bytes = 1
     w_elem_pack = 2 if is_f4_b else 1
     w_nbytes = (experts * model_dim * inter_dim * w_elem_bytes) // w_elem_pack
+    # w spans every expert and buffer_load's voffset is 32-bit, so past 2**32 an expert
+    # silently reads another's weights. Use a 64-bit GEP above 2 GB (not 4: the signed
+    # index math breaks first); the name tag separates the two JIT cache entries.
+    _use_wptr64 = w_nbytes >= (1 << 31)
+    _wptr64_tag = "_wptr64" if _use_wptr64 else ""
     shared_w_nbytes = model_dim * inter_dim
     # #3476: host e8m0_shuffle pads scale group-N up to a multiple of 8, i.e.
     # 128- but not 256-aligned (e.g. 384) read OOB scales -> garbage e8m0 -> NaN.
@@ -3640,7 +3646,7 @@ def compile_mixed_moe_gemm2_common(
         )
     module_name = (
         f"mfma_moe2_a{a_dtype}_w{b_dtype}_{out_s}_{epilog_tag}"
-        f"_t{tile_m}x{tile_n}x{tile_k}{variant_tags}"
+        f"_t{tile_m}x{tile_n}x{tile_k}{variant_tags}{_wptr64_tag}"
     ).replace("-", "_")
     lds_x_bytes = 2 * int(tile_m) * int(lds_stride) * int(a_elem_bytes)
     lds_out_bytes = 2 * int(tile_m) * int(tile_n) if _use_cshuffle_epilog else 0
@@ -3824,7 +3830,8 @@ def compile_mixed_moe_gemm2_common(
             x_nbytes_i32 = arith.index_cast(T.i32, x_nbytes_idx)
             x_rsrc = ptr_buffer_resource(arg_x, x_nbytes_i32)
 
-            w_rsrc = ptr_buffer_resource(arg_w, w_nbytes)
+            # Bound to one resource only when it fits; see _use_wptr64.
+            w_rsrc = None if _use_wptr64 else ptr_buffer_resource(arg_w, w_nbytes)
             shared_w_rsrc = ptr_buffer_resource(arg_shared_w, shared_w_nbytes)
 
             out_elem_bytes = 1 if need_fp8_out else (4 if out_is_f32 else 2)
@@ -3987,6 +3994,16 @@ def compile_mixed_moe_gemm2_common(
                 delta_expert_idx = arith.index_cast(ir.IndexType.get(), delta_expert)
                 delta_b = delta_expert_idx * arith.constant(expert_b_stride, index=True)
                 expert_b_base = prev_expert_b_base + delta_b
+
+            # load_cell folds expert_b_base into the load offset, so past 2 GB that
+            # offset has to be formed off a raw 64-bit pointer instead of a voffset.
+            w_base_ptr = (
+                buffer_ops.create_llvm_ptr(
+                    arith.index_cast(T.i64, fx.ptrtoint(arg_w)), address_space=1
+                )
+                if _use_wptr64
+                else None
+            )
 
             first_tok = buffer_ops.buffer_load(
                 sorted_rsrc, bx_m, vec_width=1, dtype=T.i32
@@ -4245,7 +4262,9 @@ def compile_mixed_moe_gemm2_common(
                     k1 = lane_div_16
                     vec_elems = kpack_bytes // int(b_elem_bytes)
 
-                    def load_cell(rsrc, expert_base, stride_n0, elem_type, k0):
+                    def load_cell(
+                        rsrc, expert_base, stride_n0, elem_type, k0, via_ptr=False
+                    ):
                         idx_pack = (
                             expert_base
                             + blk[ni] * arith.constant(stride_n0, index=True)
@@ -4253,7 +4272,10 @@ def compile_mixed_moe_gemm2_common(
                             + k1 * arith.constant(b_stride_klane, index=True)
                             + intra[ni] * arith.constant(b_stride_nlane, index=True)
                         )
-                        b16 = _buffer_load_vec(
+                        # Routed weights take the raw-pointer path; the shared expert is
+                        # one expert wide, so it stays on a bounds-checked buffer.
+                        _load = _global_load_vec if via_ptr else _buffer_load_vec
+                        b16 = _load(
                             buffer_ops,
                             vector,
                             rsrc,
@@ -4293,19 +4315,21 @@ def compile_mixed_moe_gemm2_common(
                         return s0, s1, s2, s3
 
                     b0, b1 = load_cell(
-                        w_rsrc,
+                        w_base_ptr if _use_wptr64 else w_rsrc,
                         expert_b_base,
                         b_stride_n0,
                         w_elem_type(),
                         routed_k0_base,
+                        via_ptr=_use_wptr64,
                     )
                     if const_expr(is_f8_b):
                         b2, b3 = load_cell(
-                            w_rsrc,
+                            w_base_ptr if _use_wptr64 else w_rsrc,
                             expert_b_base,
                             b_stride_n0,
                             w_elem_type(),
                             routed_k0_base + arith.index(1),
+                            via_ptr=_use_wptr64,
                         )
                         return b0, b1, b2, b3
                     return b0, b1

--- a/aiter/ops/flydsl/kernels/moe_2stage_a16wmix/utils.py
+++ b/aiter/ops/flydsl/kernels/moe_2stage_a16wmix/utils.py
@@ -498,18 +498,15 @@ def make_b_loader(
     _g_half = (K // A16WI4_GROUP_SIZE) // 2
 
     # ---- buffer resources -----------------------------------------------------
-    # bf16 W [E, N_OUT, K] whole-tensor extent overflows the 32-bit num_records/i32
-    # byte-offset at large E (E896: 6.6GB): fold the per-expert base into the i64
-    # resource addr and index within the expert. mxfp4/int4 keep the whole-tensor path.
-    if const_expr(_is_bf16):
-        _w_per_expert_bytes = N_OUT * (K * 2)
-        w_base_i64 = fx.Int64(arg_bq) + fx.Int64(e) * fx.Int64(_w_per_expert_bytes)
-        w_tiles = _global_i32_buffer_tiles(
-            w_base_i64, min(_w_per_expert_bytes, 0xFFFFFFFF), 4
-        )
-    else:
-        _w_bytes = NE * N_OUT * K_HALF
-        w_tiles = _global_i32_buffer_tiles(arg_bq, min(_w_bytes, 0xFFFFFFFF), 4)
+    # W's whole-tensor extent overflows the 32-bit num_records and the i32 N index at
+    # large E for every weight dtype (E896: bf16 6.6 GB, mxfp4/int4 9.9 GB at N_OUT=6144),
+    # so fold the per-expert base into the i64 resource address and index within the
+    # expert. num_records then bounds one expert instead of being clamped to 4 GB.
+    _w_per_expert_bytes = N_OUT * (K * 2) if _is_bf16 else N_OUT * K_HALF
+    w_base_i64 = fx.Int64(arg_bq) + fx.Int64(e) * fx.Int64(_w_per_expert_bytes)
+    w_tiles = _global_i32_buffer_tiles(
+        w_base_i64, min(_w_per_expert_bytes, 0xFFFFFFFF), 4
+    )
     # W dwordx4 load via BufferCopy128b atom (cache modifier in the aux field).
     w_copy_atom = fx.make_copy_atom(fx.rocdl.BufferCopy128b(b_cache_mod), fx.Int32)
     w_reg_lay = fx.make_layout(4, 1)
@@ -518,7 +515,9 @@ def make_b_loader(
         # port MFMA-K32 block is two such slots 128 B apart (see load_b_raw_int4).
         w_copy_atom64 = fx.make_copy_atom(fx.rocdl.BufferCopy64b(b_cache_mod), fx.Int32)
         w_reg_lay2 = fx.make_layout(2, 1)
-        w_tiles8 = _global_i32_buffer_tiles(arg_bq, min(_w_bytes, 0xFFFFFFFF), 2)
+        w_tiles8 = _global_i32_buffer_tiles(
+            w_base_i64, min(_w_per_expert_bytes, 0xFFFFFFFF), 2
+        )
     if _is_int4:
         # int4 groupwise scale buffer (E, G//2, N_OUT, 2) bf16 -> G//2 dwords per N.
         _sw_bytes = NE * N_OUT * _g_half * 4
@@ -572,9 +571,9 @@ def make_b_loader(
     def col(*n_terms):
         """Address one 16-wide N block; this lane owns row ``sum(n_terms) + lane``."""
         col_g = _sum(n_terms[0], n_terms[1:]) + lane_mod_16
-        # bf16 W folds the expert into the resource base (above); mxfp4/int4 index it.
-        _row_expert_off = fx.Int32(0) if const_expr(_is_bf16) else expert_off
-        row = _row_expert_off + col_g
+        # W's resource is re-based per expert, so the row is expert-relative. `ng` keeps
+        # the expert term: the scale tensors are indexed whole and cannot overflow i32.
+        row = col_g
         n_blk = row // fx.Int32(16)
         n_intra = row % fx.Int32(16)
         ng = _sum(expert_off, n_terms)
@@ -583,8 +582,7 @@ def make_b_loader(
     def col_pair(*n_terms, shift):
         """Address a gate|up pair: one block, and the one ``shift`` further along N."""
         col_g = _sum(n_terms[0], n_terms[1:]) + lane_mod_16
-        _row_expert_off = fx.Int32(0) if const_expr(_is_bf16) else expert_off
-        row_g = _row_expert_off + col_g
+        row_g = col_g
         row_u = row_g + shift
         blk_g, intra_g = row_g // fx.Int32(16), row_g % fx.Int32(16)
         blk_u, intra_u = row_u // fx.Int32(16), row_u % fx.Int32(16)

--- a/aiter/ops/flydsl/kernels/mxfp4_gemm1.py
+++ b/aiter/ops/flydsl/kernels/mxfp4_gemm1.py
@@ -212,7 +212,17 @@ def _gemm1_body(
             _global_i32_buffer_view(addr_i64, num_bytes), fx.make_layout(tile_elems, 1)
         )
 
-    bq_tiles = _global_i32_buffer_tiles(arg_bq, BQ_BYTES, 4)
+    # The soffset below used to carry `e * N_OUT * K_HALF`, which overflows i32 before
+    # the buffer's own voffset would (9.85e9 at NE=896, N_OUT=6144, K_HALF=1792). Fold
+    # the expert into the descriptor's 64-bit base and keep the soffset expert-relative.
+    BQ_PER_EXPERT = BQ_BYTES // NE
+    assert BQ_PER_EXPERT == N_OUT * K_HALF, (
+        f"mxfp4 gemm1 per-expert B bytes {BQ_PER_EXPERT} != N_OUT*K_HALF "
+        f"({N_OUT * K_HALF}); the expert-relative soffset below assumes they match"
+    )
+    bq_tiles = _global_i32_buffer_tiles(
+        arg_bq + fx.Int64(e) * fx.Int64(BQ_PER_EXPERT), BQ_PER_EXPERT, 4
+    )
     bq_copy_atom = fx.make_copy_atom(fx.rocdl.BufferCopy128b(b_aux), fx.Int32)
     bq_reg_lay = fx.make_layout(4, 1)
 
@@ -264,7 +274,8 @@ def _gemm1_body(
             g = tile_il & fx.Int32(1)
             n0 = tile_il >> fx.Int32(1)
             col = (g * fx.Int32(N0_HALF) + n0) * fx.Int32(16)
-        v = (e * fx.Int32(N_OUT) + col) * fx.Int32(K_HALF)
+        # expert-relative: bq_tiles is already re-based to this expert
+        v = col * fx.Int32(K_HALF)
         b_load_s_base.append(rocdl.readfirstlane(T.i32, v))
 
     # -- b_scale_s_base / _hi (HIP 418-429) -----------------------------------

--- a/aiter/ops/flydsl/kernels/mxfp4_gemm2.py
+++ b/aiter/ops/flydsl/kernels/mxfp4_gemm2.py
@@ -365,6 +365,9 @@ def _gemm2_body(
     _asc_chunk_div = 16 if const_expr(BM == 16) else 32
     _asc_per_mb = (BM // _asc_chunk_div) * _kAS_per_chunk_dw * 4
     _bq_bytes = bq_bytes_for(NE, N_OUT, _K)
+    # Raw-pointer B loads once B outgrows a buffer resource. No name tag needed: this is
+    # a function of NE/N_OUT/K, all three of which the kernel name already carries.
+    _use_bqptr64 = _bq_bytes >= (1 << 31)
     _bscale_bytes = bscale_bytes_for(NE, N_OUT, _K)
     _kbs_per_expert_dw = kbs_per_expert_dw_for(N_OUT, _K)
     _num_n_blocks = num_n_blocks_for(N_OUT, BN)
@@ -379,7 +382,24 @@ def _gemm2_body(
 
     _asc_num = arith.index_cast(T.index, _raw(i32_max_m_blocks)) * fx.Index(_asc_per_mb)
     ascale_rsrc = _buffer_rsrc(arg_ascale, _asc_num)
-    bq_rsrc = _buffer_rsrc(arg_bq, fx.Index(_bq_bytes))
+    # The soffset below used to carry `e * N_OUT * _K_HALF`, which overflows i32 at a
+    # large expert count (4.9e9 at NE=896, N_OUT=3584, _K_HALF=1536). Fold the expert
+    # into the descriptor's 64-bit base and keep the soffset expert-relative.
+    _bq_per_expert = _bq_bytes // NE
+    assert _bq_per_expert == N_OUT * _K_HALF, (
+        f"mxfp4 gemm2 per-expert B bytes {_bq_per_expert} != N_OUT*K_HALF "
+        f"({N_OUT * _K_HALF}); the expert-relative soffset below assumes they match"
+    )
+    # Stay on buffer_load while B fits, for its hardware bounds check; 2 GB rather than
+    # 4 because the signed index math breaks first. Either way the expert base is added
+    # in 64-bit, which is what removes the wrap.
+    _bq_expert_base = arg_bq + fx.Int64(e) * fx.Int64(_bq_per_expert)
+    if const_expr(_use_bqptr64):
+        bq_rsrc = None
+        bq_base_ptr = buffer_ops.create_llvm_ptr(_bq_expert_base, address_space=1)
+    else:
+        bq_rsrc = _buffer_rsrc(_bq_expert_base, fx.Index(_bq_per_expert))
+        bq_base_ptr = None
     bscale_rsrc = _buffer_rsrc(arg_bscale, fx.Index(_bscale_bytes))
 
     # Sequential LDS layout: saq bytes at offset 0, f32 accumulator after them.
@@ -391,11 +411,9 @@ def _gemm2_body(
 
     b_load_s_base = []
     for j in range_constexpr(4):
+        # expert-relative: bq_rsrc is already re-based to this expert
         v = (
-            e * fx.Int32(N_OUT)
-            + n_block_idx * fx.Int32(BN)
-            + wave * fx.Int32(BN // 4)
-            + fx.Int32(j * 16)
+            n_block_idx * fx.Int32(BN) + wave * fx.Int32(BN // 4) + fx.Int32(j * 16)
         ) * fx.Int32(_K_HALF)
         b_load_s_base.append(rocdl.readfirstlane(T.i32, v))
 
@@ -455,14 +473,25 @@ def _gemm2_body(
             for half in range_constexpr(2):
                 if const_expr(kt * 2 + half >= _n_real_half):
                     continue
-                frag = buffer_ops.buffer_load(
-                    bq_rsrc,
-                    (v_voff_b + fx.Int32(half * 1024)) // fx.Int32(4),
-                    vec_width=4,
-                    dtype=T.i32,
-                    cache_modifier=b_aux,
-                    soffset_bytes=b_load_s_base[j],
-                )
+                if const_expr(_use_bqptr64):
+                    frag = buffer_ops.global_load_dwords(
+                        bq_base_ptr,
+                        arith.index_cast(
+                            T.index,
+                            v_voff_b + fx.Int32(half * 1024) + b_load_s_base[j],
+                        ),
+                        vec_width=4,
+                        cache_modifier=b_aux,
+                    )
+                else:
+                    frag = buffer_ops.buffer_load(
+                        bq_rsrc,
+                        (v_voff_b + fx.Int32(half * 1024)) // fx.Int32(4),
+                        vec_width=4,
+                        dtype=T.i32,
+                        cache_modifier=b_aux,
+                        soffset_bytes=b_load_s_base[j],
+                    )
                 out[j][half] = Vec(frag)
         return out
 

--- a/op_tests/flydsl_tests/test_flydsl_moe_4gib_addressing.py
+++ b/op_tests/flydsl_tests/test_flydsl_moe_4gib_addressing.py
@@ -1,0 +1,284 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+"""Do the MoE GEMMs still address the right expert once the weights pass 4 GB?
+
+``buffer_load``'s voffset is 32-bit, so a kernel spanning a whole weight tensor with
+one buffer resource and folding the expert offset into that offset wraps as soon as
+an expert's byte offset passes 2**32, silently reading a different expert's weights.
+E=896 with model_dim=3584 and inter_dim=3072 makes w1 9.2 GB and w2 4.6 GB.
+
+A torch reference cannot exist at these shapes: it dequantizes fp4 to f32, and
+``w1 = 2 * w2`` always holds here, so ``w2 > 4 GB`` forces a >68 GB reference. That
+is also why the bug survived -- the existing harnesses cannot reach these shapes.
+
+So calibrate a twin instead: give one weight code to a LOW expert (whose offset
+never wraps) and the same code to a HIGH expert (whose offset does), background code
+elsewhere, and route every token to one expert at a time. Correct addressing makes
+``out(high) == out(low)`` exactly; a wrap collapses ``out(high)`` to the background
+level. Outputs are only ever compared against outputs that should be identical, so
+stage1's activation nonlinearity never has to be inverted.
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from aiter import dtypes
+from aiter.fused_moe import moe_sorting
+from aiter.jit.utils.chip_info import get_gfx
+from aiter.ops.flydsl.moe_kernels import flydsl_moe_stage1, flydsl_moe_stage2
+from aiter.ops.flydsl.utils import is_flydsl_available
+from aiter.ops.shuffle import shuffle_scale_a16w4, shuffle_weight_a16w4
+
+# One rank holding every expert, which is what makes the weight tensors big
+# enough to trip the 32-bit offset.
+E, MODEL_DIM, INTER_DIM = 896, 3584, 3072
+TOKEN, TOPK, BLOCK_M = 32, 1, 32
+DTYPE = dtypes.bf16
+
+# e2m1 codes, sign bit clear: 1 -> 0.5, 7 -> 6.0. Both nibbles of a byte carry the
+# same code, so every element of an expert decodes to one value and the output
+# becomes a fingerprint of *which* expert was actually read.
+BG_CODE = 1
+HI_CODE = 7
+
+# w1 needs 9.2 GB, and shuffle_weight_a16w4 makes a second copy while it runs.
+_NEED_GIB = 26.0
+
+
+def _free_gib() -> float:
+    if not torch.cuda.is_available():
+        return 0.0
+    free, _total = torch.cuda.mem_get_info()
+    return free / 2**30
+
+
+_SKIP = pytest.mark.skipif(
+    get_gfx() not in ("gfx950",) or not is_flydsl_available(),
+    reason="gfx950 FlyDSL required",
+)
+_SKIP_MEM = pytest.mark.skipif(
+    _free_gib() < _NEED_GIB,
+    reason=f"needs ~{_NEED_GIB:.0f} GiB free VRAM, have {_free_gib():.1f} GiB",
+)
+
+
+def _byte(code: int) -> int:
+    return (code << 4) | code
+
+
+def _wraps(per_expert_bytes: int, expert: int) -> bool:
+    return expert * per_expert_bytes > 2**32
+
+
+def _run_one_expert(launch, target: int) -> float:
+    """Route every token to ``target`` and reduce the output to one number."""
+    topk_ids = torch.full((TOKEN, TOPK), target, dtype=torch.int32, device="cuda")
+    topk_w = torch.ones((TOKEN, TOPK), dtype=torch.float32, device="cuda")
+    sorted_ids, sorted_w, sorted_eids, num_valid, _ = moe_sorting(
+        topk_ids, topk_w, E, MODEL_DIM, DTYPE, BLOCK_M
+    )
+    out = launch(sorted_ids, sorted_eids, num_valid, sorted_w)
+    torch.cuda.synchronize()
+    return out.float().abs().mean().item()
+
+
+def _assert_addressing(outs: dict[int, float], bg_e: int, low_e: int, high_e: int):
+    bg, low, high = outs[bg_e], outs[low_e], outs[high_e]
+
+    # Guard against a degenerate pass: if the background and the calibration expert
+    # produced the same output, the fingerprint carries no information and an
+    # "out(high) == out(low)" match would prove nothing.
+    assert abs(low - bg) > 0.1 * max(bg, 1e-9), (
+        f"probe is degenerate: background expert {bg_e} ({bg:.4f}) and calibration "
+        f"expert {low_e} ({low:.4f}) are indistinguishable, so the test cannot tell "
+        f"a correct read from a wrapped one"
+    )
+
+    wrapped = abs(high - bg) <= 0.1 * max(bg, 1e-9)
+    assert abs(high - low) <= 1e-6 * max(low, 1e-9), (
+        f"expert {high_e} read the wrong weights: got {high:.4f}, expected "
+        f"{low:.4f} (same weight code as expert {low_e})"
+        + (
+            f" -- it matches the background level {bg:.4f}, i.e. the byte offset "
+            f"wrapped past 2**32"
+            if wrapped
+            else ""
+        )
+    )
+
+
+@_SKIP
+@_SKIP_MEM
+def test_a16w4_stage1_past_4gib():
+    """w1 = [E, 2*inter, model] = 9.2 GB; wraps from expert 390 on."""
+    per_expert = (2 * INTER_DIM) * MODEL_DIM // 2
+    bg_e, low_e, high_e = 50, 100, 400
+    assert not _wraps(per_expert, low_e), "calibration expert must not wrap"
+    assert _wraps(per_expert, high_e), "test expert must wrap"
+
+    w1 = torch.empty(
+        (E, 2 * INTER_DIM, MODEL_DIM // 2), dtype=torch.uint8, device="cuda"
+    )
+    w1.fill_(_byte(BG_CODE))
+    for e in (low_e, high_e):
+        w1[e].fill_(_byte(HI_CODE))
+    w1_shuf = shuffle_weight_a16w4(w1, 16, False)
+    # The whole premise is "expert e decodes to one value", so the shuffle must not
+    # move data across experts.
+    for e in (bg_e, low_e, high_e):
+        assert torch.unique(w1_shuf[e]).numel() == 1, f"shuffle mixed expert {e}"
+    del w1
+    torch.cuda.empty_cache()
+
+    scale = torch.full(
+        (E * 2 * INTER_DIM, MODEL_DIM // 32), 127, dtype=torch.uint8, device="cuda"
+    )
+    scale_shuf = shuffle_scale_a16w4(scale, E, False)
+    del scale
+    torch.cuda.empty_cache()
+
+    inp = torch.full((TOKEN, MODEL_DIM), 1.0, dtype=DTYPE, device="cuda")
+
+    def launch(sids, seids, nvalid, sw):
+        return flydsl_moe_stage1(
+            a=inp,
+            w1=w1_shuf,
+            sorted_token_ids=sids,
+            sorted_expert_ids=seids,
+            num_valid_ids=nvalid,
+            topk=TOPK,
+            tile_m=BLOCK_M,
+            tile_n=256,
+            tile_k=256,
+            a_dtype="bf16",
+            b_dtype="fp4",
+            out_dtype="bf16",
+            w1_scale=scale_shuf,
+            a1_scale=None,
+            sorted_weights=sw,
+        )
+
+    try:
+        outs = {e: _run_one_expert(launch, e) for e in (bg_e, low_e, high_e)}
+        _assert_addressing(outs, bg_e, low_e, high_e)
+    finally:
+        # Rebound rather than deleted: `launch` closes over both, so a del would leave
+        # the closure referring to an unbound name.
+        w1_shuf = scale_shuf = None
+        torch.cuda.empty_cache()
+
+
+def _inter_pad(inter_dim: int) -> int:
+    return ((inter_dim + 255) // 256 * 256) - inter_dim
+
+
+@_SKIP
+@_SKIP_MEM
+@pytest.mark.parametrize("a_dtype", ["bf16", "fp4"], ids=["a16w4", "a4w4"])
+@pytest.mark.parametrize(
+    "inter_dim",
+    # 3072: the real TP1 shape, K a multiple of the tile, no padding.
+    # 1408: padded (1408 % 256 == 128) *and* still over the size threshold, so the
+    #       raw-pointer path runs with the k-tail clamping active. Worth covering
+    #       separately: the buffer path bounds-checks in hardware and the raw
+    #       pointer does not, so anything that leant on out-of-range-reads-zero
+    #       for the padded tail would only break here.
+    [3072, 1408],
+    ids=["i3072", "i1408_padded"],
+)
+def test_stage2_past_4gib(a_dtype, inter_dim):
+    """w2 = [E, model, inter]; 4.6 GB at inter=3072, wrapping from expert 780 on.
+
+    Both activation dtypes are covered because they reach different builders:
+    bf16 -> compile_mixed_moe_gemm2_a16w4, fp4 -> compile_mixed_moe_gemm2_common.
+    """
+    per_expert = MODEL_DIM * inter_dim // 2
+    bg_e, low_e, high_e = 50, 100, 800
+    assert not _wraps(per_expert, low_e), "calibration expert must not wrap"
+    # Only the big shape actually wraps. The padded one is here for a different
+    # reason: its total size still puts the kernel on the raw-pointer path, so it
+    # checks that path stays correct while the padded-k tail clamping is active.
+    # Both cases share the same assertion, which is the point -- two experts with
+    # identical weights must give identical output either way.
+
+    w2 = torch.empty((E, MODEL_DIM, inter_dim // 2), dtype=torch.uint8, device="cuda")
+    w2.fill_(_byte(BG_CODE))
+    for e in (low_e, high_e):
+        w2[e].fill_(_byte(HI_CODE))
+    w2_shuf = shuffle_weight_a16w4(w2, 16, False)
+    for e in (bg_e, low_e, high_e):
+        assert torch.unique(w2_shuf[e]).numel() == 1, f"shuffle mixed expert {e}"
+    del w2
+    torch.cuda.empty_cache()
+
+    scale = torch.full(
+        (E * MODEL_DIM, inter_dim // 32), 127, dtype=torch.uint8, device="cuda"
+    )
+    scale_shuf = shuffle_scale_a16w4(scale, E, False)
+    del scale
+    torch.cuda.empty_cache()
+
+    if a_dtype == "bf16":
+        # a16w4 stage2 takes the intermediate buffer already in sorted-row layout and
+        # atomic-scatters into a caller-provided, zeroed output, so both are built per
+        # launch from the sorted ids rather than up front as (TOKEN, TOPK, K).
+        a2 = None
+        a2_scale = None
+    else:
+        # 0x22 = both nibbles e2m1 code 2 (=1.0), so the activation is constant too.
+        a2 = torch.full(
+            (TOKEN, TOPK, inter_dim // 2), 0x22, dtype=torch.uint8, device="cuda"
+        )
+        a2_scale = torch.full(
+            (TOKEN * TOPK, inter_dim // 32), 127, dtype=torch.uint8, device="cuda"
+        )
+
+    def launch(sids, seids, nvalid, sw):
+        a2s = a2_scale
+        if a2s is not None:
+            from aiter.utility.fp4_utils import moe_mxfp4_sort
+
+            a2s = moe_mxfp4_sort(
+                a2_scale.view(TOKEN, TOPK, -1),
+                sorted_ids=sids,
+                num_valid_ids=nvalid,
+                token_num=TOKEN,
+                block_size=BLOCK_M,
+            )
+        if a_dtype == "bf16":
+            states = torch.full(
+                (sids.numel(), inter_dim), 1.0, dtype=DTYPE, device="cuda"
+            )
+            out = torch.zeros((TOKEN, MODEL_DIM), dtype=DTYPE, device="cuda")
+        else:
+            states, out = a2, None
+        return flydsl_moe_stage2(
+            inter_states=states,
+            out=out,
+            w2=w2_shuf,
+            sorted_token_ids=sids,
+            sorted_expert_ids=seids,
+            num_valid_ids=nvalid,
+            topk=TOPK,
+            tile_m=BLOCK_M,
+            tile_n=128 if a_dtype == "bf16" else 256,
+            tile_k=256,
+            a_dtype=a_dtype,
+            b_dtype="fp4",
+            out_dtype="bf16",
+            mode="atomic",
+            w2_scale=scale_shuf,
+            a2_scale=a2s,
+            sorted_weights=sw,
+            inter_dim_pad=_inter_pad(inter_dim),
+        )
+
+    try:
+        outs = {e: _run_one_expert(launch, e) for e in (bg_e, low_e, high_e)}
+        _assert_addressing(outs, bg_e, low_e, high_e)
+    finally:
+        w2_shuf = scale_shuf = None
+        torch.cuda.empty_cache()


### PR DESCRIPTION
## Problem

`buffer_load`'s voffset is 32-bit. A kernel that spans a whole weight tensor with
one buffer resource and folds the expert offset into that offset wraps as soon as an
expert's byte offset passes `2**32` — it silently reads a *different* expert's
weights, with no fault and no error. E=896 with `model_dim=3584` and
`inter_dim=3072`, held in full on one rank, makes w1 9.2 GB and w2 4.6 GB, so both
stages cross the line.

`d19f3325` fixed this for the a4w4 stage1 builder. Three paths were left with it:

| Path | Failure mode |
| --- | --- |
| `compile_mixed_moe_gemm2_common` | whole-tensor resource, expert offset in the 32-bit voffset |
| `moe_2stage_a16wmix` (mxfp4/int4 W) | whole-tensor path with a clamped extent, and `e * N_OUT` in i32 |
| mxfp4 port gemm1/gemm2 | `e * N_OUT * K_HALF` overflows i32 before any address is formed |

## Fix

Each path is converted to whichever form fits its operand staging.

`compile_mixed_moe_gemm2_common` routes the routed-weight loads through a new
`buffer_ops.global_load_dwords`, a GEP + `llvm.load` counterpart to `buffer_load`
that forms the address in full 64-bit. Which path runs is a **compile-time**
decision keyed on the static weight size: under 2 GB the loads stay on
`buffer_load`, which is bounds-checked in hardware and encodes the address more
cheaply. Kernel names carry a `_wptr64` tag so the two variants cannot collide in
the JIT cache. The shared-expert loads stay on a buffer, being one expert wide.

`moe_2stage_a16wmix` already folded the per-expert base into an i64 resource address
for bf16 W; mxfp4/int4 kept the whole-tensor path, where `min(_w_bytes, 0xFFFFFFFF)`
hides the truncation rather than preventing the wrap. Re-basing for all three dtypes
makes the row expert-relative and lets `num_records` bound one expert instead of
being clamped. The scale index keeps the expert term — those tensors are small
enough that the i32 product cannot overflow.

The mxfp4 port re-bases its B descriptor per expert in 64-bit and keeps the soffset
expert-relative. `gemm1` stays on a buffer tensor because its B operand is staged
through a `BufferCopy128b` copy atom, which is defined over a buffer resource;
`gemm2` additionally takes the raw-pointer path above 2 GB.

## Test

`op_tests/flydsl_tests/test_flydsl_moe_4gib_addressing.py`, 5 cases, no reference
needed. A torch reference cannot exist at these shapes: it dequantises fp4 to f32,
and `w1 = 2 * w2` always holds in this parametrisation, so `w2 > 4 GB` forces a
>68 GB reference. That is also why the bug survived — the existing harnesses
structurally cannot reach these shapes.

Instead the test gives one weight code to a LOW expert (whose byte offset never
wraps) and the SAME code to a HIGH expert (whose offset does), background code
elsewhere, then routes every token to one expert at a time. The output becomes a
fingerprint of which expert was actually read, so the assertion is exact rather than
a tolerance. It asserts up front that background and calibration experts are
distinguishable, so a degenerate case cannot pass vacuously.

Measured on gfx950:

| Case | Wraps? | Before | After |
| --- | :-: | --- | --- |
| a16w4 stage1, w1 9.2 GB | yes | **FAIL** | PASS |
| stage2 i3072 a16w4, w2 4.6 GB | yes | **FAIL** | PASS |
| stage2 i3072 a4w4, w2 4.6 GB | yes | **FAIL** | PASS |
| stage2 i1408 padded, a16w4 / a4w4 | no | pass | PASS |

The failures report the wrap directly, e.g. `expert 800 read the wrong weights: got
1536.0001, expected 18432.0000 ... it matches the background level, i.e. the byte
offset wrapped past 2**32`. The two padded cases do not wrap; they are there to
check the raw-pointer path stays correct while the padded-k tail clamping is active,
since that path has no hardware bounds check and the buffer path does.