### PR TITLE
[HIP] fix(topk_per_row): support ROCm 10 by dropping hipcub::Traits dependency

### DIFF
--- a/csrc/include/hip_reduce.h
+++ b/csrc/include/hip_reduce.h
@@ -139,6 +139,25 @@ struct ArgMin
     }
 };
 
+// The unsigned type a radix pass reinterprets T as, i.e. what
+// hipcub::Traits<T>::UnsignedBits used to give us. ROCm 10 hipcub (CCCL 3.0)
+// dropped the public Traits<> class, so carry the one mapping the radix top-k
+// paths actually need. hipcub resolved float through
+// NumericTraits<float> -> BaseTraits<FLOATING_POINT, ..., unsigned int, float>,
+// so UnsignedBits was uint32_t; this is that type, not an approximation of it.
+//
+// Left undefined for every other T on purpose: the radix paths are fp32-only,
+// and a missing specialization should fail to compile rather than silently
+// pick a width. Add one here if a caller ever needs another dtype.
+template <typename T>
+struct radix_traits;
+
+template <>
+struct radix_traits<float>
+{
+    using UnsignedBits = uint32_t;
+};
+
 } // namespace aiter
 
 template <typename T, typename F>

--- a/csrc/kernels/topk_per_row_kernels.cu
+++ b/csrc/kernels/topk_per_row_kernels.cu
@@ -4,6 +4,7 @@
 #include "aiter_hip_common.h"
 #include "aiter_tensor.h"
 #include "aiter_stream.h"
+#include "hip_reduce.h"
 #include <hipcub/hipcub.hpp>
 #include <hipcub/util_type.hpp>
 
@@ -103,36 +104,16 @@ __device__ constexpr unsigned calc_mask(int pass)
  * whose sign bit is 1 but compares equal to +0.0f under IEEE 754.
  */
 template <typename T>
-__device__ typename hipcub::Traits<T>::UnsignedBits twiddle_in(T key, bool select_min)
+__device__ typename aiter::radix_traits<T>::UnsignedBits twiddle_in(T key, bool select_min)
 {
-    auto bits = reinterpret_cast<typename hipcub::Traits<T>::UnsignedBits&>(key);
-    if constexpr(std::is_same_v<T, float>)
-    {
-        uint32_t mask = (bits >> 31) ? 0 : 0x7fffffff;
-        return bits ^ mask;
-    }
-    else
-    {
-        bits = hipcub::Traits<T>::TwiddleIn(bits);
-        if(!select_min)
-        {
-            bits = ~bits;
-        }
-        return bits;
-    }
+    static_assert(std::is_same_v<T, float>, "radix top-k only supports fp32");
+    // select_min never mattered for float: the mask below is symmetric, so the
+    // ordering flip is handled by the comparison direction at the call sites.
+    (void)select_min;
+    auto bits     = reinterpret_cast<typename aiter::radix_traits<T>::UnsignedBits&>(key);
+    uint32_t mask = (bits >> 31) ? 0 : 0x7fffffff;
+    return bits ^ mask;
 }
-
-// // twiddle_out: convert sorted bits back to the original value type.
-// template <typename T>
-// __device__ T twiddle_out(typename hipcub::Traits<T>::UnsignedBits bits, bool select_min)
-// {
-//     if(!select_min)
-//     {
-//         bits = ~bits;
-//     }
-//     bits = hipcub::Traits<T>::TwiddleOut(bits);
-//     return reinterpret_cast<T&>(bits);
-// }
 
 // Compute bucket index using v_bfe_u32 (single-instruction bit field extract).
 // `mask` is unused: __builtin_amdgcn_ubfe extracts a fixed BitsPerPass-wide
@@ -277,7 +258,7 @@ struct alignas(128) Counter
     IdxT k;
     IdxT len;
     IdxT previous_len;
-    typename hipcub::Traits<T>::UnsignedBits kth_value_bits;
+    typename aiter::radix_traits<T>::UnsignedBits kth_value_bits;
     alignas(128) IdxT filter_cnt;
     alignas(128) unsigned int finished_block_cnt;
     alignas(128) IdxT out_cnt;
@@ -402,7 +383,7 @@ __global__ void radix_kernel_persistent(T const* in,
     const size_t total_threads = static_cast<size_t>(blockDim.x) * gridDim.x;
 
     __shared__ IdxT histogram_smem[num_buckets];
-    __shared__ typename hipcub::Traits<T>::UnsignedBits local_kth_value_bits;
+    __shared__ typename aiter::radix_traits<T>::UnsignedBits local_kth_value_bits;
     __shared__ IdxT local_k;
     __shared__ IdxT local_len;
 
@@ -558,7 +539,7 @@ __global__ void radix_kernel_persistent(T const* in,
                 {
                     local_k = current_k - prev;
                     local_len = cur - prev;
-                    typename hipcub::Traits<T>::UnsignedBits bucket = i;
+                    typename aiter::radix_traits<T>::UnsignedBits bucket = i;
                     local_kth_value_bits |= bucket << start_bit;
                 }
             }
@@ -969,23 +950,15 @@ __device__ constexpr unsigned calc_mask(int pass)
 
 // Map value to order-preserving unsigned bits; uses (bits >> 31) for correct -0.0f handling.
 template <typename T>
-__device__ typename hipcub::Traits<T>::UnsignedBits twiddle_in(T key, bool select_min)
+__device__ typename aiter::radix_traits<T>::UnsignedBits twiddle_in(T key, bool select_min)
 {
-    auto bits = reinterpret_cast<typename hipcub::Traits<T>::UnsignedBits&>(key);
-    if constexpr(std::is_same_v<T, float>)
-    {
-        uint32_t mask = (bits >> 31) ? 0 : 0x7fffffff;
-        return bits ^ mask;
-    }
-    else
-    {
-        bits = hipcub::Traits<T>::TwiddleIn(bits);
-        if(!select_min)
-        {
-            bits = ~bits;
-        }
-        return bits;
-    }
+    static_assert(std::is_same_v<T, float>, "radix top-k only supports fp32");
+    // select_min never mattered for float: the mask below is symmetric, so the
+    // ordering flip is handled by the comparison direction at the call sites.
+    (void)select_min;
+    auto bits     = reinterpret_cast<typename aiter::radix_traits<T>::UnsignedBits&>(key);
+    uint32_t mask = (bits >> 31) ? 0 : 0x7fffffff;
+    return bits ^ mask;
 }
 
 // Compute bucket index using v_bfe_u32.
@@ -1131,7 +1104,7 @@ struct alignas(128) Counter
     IdxT k;
     IdxT len;
     IdxT previous_len;
-    typename hipcub::Traits<T>::UnsignedBits kth_value_bits;
+    typename aiter::radix_traits<T>::UnsignedBits kth_value_bits;
     alignas(128) IdxT filter_cnt;
     alignas(128) unsigned int finished_block_cnt;
     alignas(128) IdxT out_cnt;
@@ -1320,8 +1293,8 @@ choose_bucket(Counter<T, IdxT>* counter, IdxT const* histogram, const IdxT k, in
         {
             counter->k   = k - prev;
             counter->len = cur - prev;
-            typename hipcub::Traits<T>::UnsignedBits bucket = i;
-            int start_bit                                   = calc_start_bit<T, BitsPerPass>(pass);
+            typename aiter::radix_traits<T>::UnsignedBits bucket = i;
+            int start_bit = calc_start_bit<T, BitsPerPass>(pass);
             counter->kth_value_bits |= bucket << start_bit;
         }
     }

--- a/csrc/kernels/topk_per_row_kernels.cu
+++ b/csrc/kernels/topk_per_row_kernels.cu
@@ -9,6 +9,7 @@
 
 #include <algorithm>
 #include <limits>
+#include <optional>
 #include <type_traits>
 #include <vector>
 


### PR DESCRIPTION
## Summary

Re-enable `topk_per_row` on ROCm 10 by removing its `hipcub::Traits` dependency,
and put the replacement where aiter already keeps its hipcub stand-ins
(`csrc/include/hip_reduce.h`).

This is the same breakage #4843 is fixing in `csrc/cpp_itfs/sampling/sampling.cuh`,
in the other file that has it. The two are not merely similar — they are copies of
the same code (see below). #4843 fixes one copy; this fixes the other two.

## Root cause

ROCm 10 ships hipcub built on CCCL 3.0, which removed the public
`hipcub::Traits<>` class. `csrc/kernels/topk_per_row_kernels.cu` uses it in 13
places (11 live, 2 inside a commented-out `twiddle_out`), so both modules that
compile this TU — `module_top_k_per_row` and `module_topk_plain` — fail to build
on ROCm 10 with the same error #4843 reports:

```
error: no type named 'Traits' in namespace 'hipcub'
```

### Why there are three copies

`git blame` on the radix top-k `twiddle_in`:

| where | first written | by |
|---|---|---|
| `topk_per_row_kernels.cu` L105 (`aiter::mb`) | #1394, 2025-11-17 | Lingpeng Jin |
| `topk_per_row_kernels.cu` L971 (`aiter::ob`) | #3087, 2026-05-10 | chuanbowang2026 |
| `sampling.cuh` L87 | #3217, 2026-05-24 | chuanbowang2026 |

Same function body, character for character. #4843 covers the third row only.

## Fix

**`csrc/include/hip_reduce.h`** — add `aiter::radix_traits`, next to the
`Max/Min/Sum/ArgMax/ArgMin` functors #4594 moved there. `radix_traits<float>::UnsignedBits`
is `uint32_t`, which is exactly what hipcub resolved:
`NumericTraits<float>` → `BaseTraits<FLOATING_POINT, true, false, unsigned int, float>`.
Deliberately left undefined for every other `T`.

#4594's message noted it skipped `sampling.cuh` because `Traits` "had no local
equivalent". This adds that equivalent, so #4843's file-local `radix_traits` can
collapse onto it afterwards. That is a follow-up, not this PR: sampling builds
through `cpp_itfs`, whose include set is an explicit file whitelist, so it needs
three one-line changes in `csrc/cpp_itfs/sampling/*.py`.

**`csrc/kernels/topk_per_row_kernels.cu`** — route all 11 live uses through
`aiter::radix_traits`. Both `twiddle_in` copies lose their non-float `else` branch
in favour of a `static_assert`; every instantiation of this file's radix paths is
`<float, ...>` (`mb::standalone_stable_radix_topk` and `ob::dispatch_topk_oneblock`,
14 call sites), so a new dtype should fail to compile rather than silently pick a
width. `select_min` was already dead in the float branch — the mask is symmetric and
the ordering flip lives at the call sites. The float bit math is transcribed
unchanged. The commented-out `twiddle_out` is deleted; it referenced
`hipcub::Traits<T>::TwiddleOut`.

The first commit is separate and unrelated to `Traits`: this TU declares its own
entry points taking `std::optional<aiter_tensor_t>` but never includes `<optional>`
(it does not include its own header, which does). On ROCm 7.0.0 nothing supplies it
transitively and pristine upstream does not compile. Probably fallout from #4702
de-torching this TU. Split out so it can be taken or dropped on its own.

## Validation

gfx942 + gfx950, ROCm 7.0.0 / hipcc 7.0.51831 / torch 2.9.1+rocm7.0.

**ISA is byte-identical on both arches.** `.text`, `.rodata`, and the full
disassembly of every code object in `.hip_fatbin` all match the pre-change build:

| arch | `.text` | disassembly | kernels |
|---|---|---|---|
| gfx942 | `d115e671f0ea2eeb` unchanged | 138991 lines identical | 19 |
| gfx950 | `051fa067e0199306` unchanged | 138548 lines identical | 19 |

Note for anyone reproducing this: the raw code-object ELF bytes are *not* a usable
check — `.dynsym` / `.dynstr` / `.strtab` / `.hash` differ between two builds of the
*same* source. The harness was self-checked first by building the baseline twice and
confirming `.text` and the disassembly are stable across runs.

**No new warnings.** The 3 `-Wc++23-extensions` warnings this TU now emits come from
`block_reduce` in `hip_reduce.h` and are pre-existing: the unmodified header on its
own emits the same 3, as does `topk_softmax_kernels.cu` and every other consumer.

**Build and tests.** `module_top_k_per_row` builds in 19.6s.
`op_tests/test_topk_per_row.py` 737/737 rows pass plus `mb_workspace_reuse` PASS;
`op_tests/test_topk_per_row_stable.py` reports `RESULT: ALL PASS`;
`op_tests/test_topk_row_prefill.py` standard and fast kernels both pass.

## Known gaps

Listing these so the PR is not read as "topk_per_row is ROCm 10 clean now".

- **Not verified on ROCm 10** — no such toolchain available here. The claim rests on
  this being the same edit #4843 validated in a `rocm10.0.0rc3` container, removing
  the one symbol that errored there. Someone with that image should confirm.
- **This TU is not hipcub-free.** It still uses `BlockScan` / `BlockLoad` /
  `BlockStore`, which #4843 shows survive CCCL 3.0, and `BlockRadixSort`, whose
  ROCm 10 status neither PR covers. Fixing `Traits` is what unblocks the build; it
  is not the whole hipcub surface.
- **`module_topk_plain` still does not build here**, for an unrelated pre-existing
  reason: `topk_plain_kernels.cu` fails with `ComputeTypeTraits<unsigned short>` not
  specialized (12 errors on pristine upstream as well). That file does not include
  `hip_reduce.h` and is untouched here.
- **No ROCm 10 CI.** `.github/` pins ROCm 7.2 throughout and mentions 10 nowhere, so
  neither this nor #4843 is guarded against regression. Worth a separate issue.

## Relationship to #4843

Independent — different file, different modules, different tests. Either can merge
first. Once both are in, #4843's local `radix_traits` and this one should become a
single definition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
