### PR TITLE
[CI] ci: re-enable moe 2stage test

### DIFF
--- a/.github/scripts/aiter_test.sh
+++ b/.github/scripts/aiter_test.sh
@@ -35,7 +35,6 @@ else
 fi
 
 skip_tests=(
-    "op_tests/test_moe_2stage.py"
     "op_tests/multigpu_tests/test_dispatch_combine.py"
     "op_tests/multigpu_tests/test_communication.py"
     "op_tests/multigpu_tests/test_mori_all2all.py"


### PR DESCRIPTION
## Summary
- Re-enable op_tests/test_moe_2stage.py in Aiter Test
- The OOM issue has been addressed on main by #4844

## Testing
- bash -n .github/scripts/aiter_test.sh
- git diff --check