### PR TITLE
Fix Iris AllGather correctness and graph capture on gfx950

### DIFF
--- a/aiter/ops/triton/comms/all_gather.py
+++ b/aiter/ops/triton/comms/all_gather.py
@@ -12,7 +12,6 @@ import logging
 from typing import TYPE_CHECKING
 
 import iris
-import torch
 import triton
 import triton.language as tl
 from torch import Tensor
@@ -112,6 +111,67 @@ def _all_gather_impl(
 
 
 @triton.jit
+def _all_gather_pull_impl(
+    pid,
+    shard_ptr,
+    out_ptr,
+    M,
+    M_shard,
+    N,
+    stride_sm,
+    stride_sn,
+    stride_om,
+    stride_on,
+    cur_rank: tl.constexpr,
+    world_size: tl.constexpr,
+    heap_bases: tl.tensor,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    NUM_SMS: tl.constexpr,
+):
+    """Pull each remote shard into the local output."""
+    num_pid_m = tl.cdiv(M_shard, BLOCK_M)
+    num_pid_n = tl.cdiv(N, BLOCK_N)
+    total_tiles = num_pid_m * num_pid_n
+
+    for tile_id in range(pid, total_tiles, NUM_SMS):
+        num_pid_in_group = GROUP_SIZE_M * num_pid_n
+        group_id = tile_id // num_pid_in_group
+        first_pid_m = group_id * GROUP_SIZE_M
+        group_size_m = min(num_pid_m - first_pid_m, GROUP_SIZE_M)
+        pid_m = first_pid_m + ((tile_id % num_pid_in_group) % group_size_m)
+        pid_n = (tile_id % num_pid_in_group) // group_size_m
+
+        rm_local = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+        rn = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+        rm_local = tl.max_contiguous(tl.multiple_of(rm_local, BLOCK_M), BLOCK_M)
+        rn = tl.max_contiguous(tl.multiple_of(rn, BLOCK_N), BLOCK_N)
+        mask = (rm_local[:, None] < M_shard) & (rn[None, :] < N)
+        shard_ptrs = (
+            shard_ptr
+            + rm_local[:, None] * stride_sm
+            + rn[None, :] * stride_sn
+        )
+
+        for src_rank in tl.static_range(world_size):
+            shard_data = iris.load(
+                shard_ptrs,
+                cur_rank,
+                src_rank,
+                heap_bases,
+                mask=mask,
+            )
+            rm_global = src_rank * M_shard + rm_local
+            out_ptrs = (
+                out_ptr
+                + rm_global[:, None] * stride_om
+                + rn[None, :] * stride_on
+            )
+            tl.store(out_ptrs, shard_data, mask=mask & (rm_global[:, None] < M))
+
+
+@triton.jit
 def _all_gather_kernel(
     shard_ptr,  # *[M_shard, N]
     out_ptr,  # *[M, N]
@@ -133,10 +193,10 @@ def _all_gather_kernel(
     """
     All-gather kernel entry point.
 
-    This is a wrapper around _all_gather_impl that gets the program ID.
+    This is a wrapper around _all_gather_pull_impl that gets the program ID.
     """
     pid = tl.program_id(0)
-    _all_gather_impl(
+    _all_gather_pull_impl(
         pid,
         shard_ptr,
         out_ptr,
@@ -164,6 +224,7 @@ def all_gather(
     block_n: int = 64,
     group_size_m: int = 8,
     num_sms: int = 256,
+    output: Tensor | None = None,
 ) -> Tensor:
     """
     Perform all-gather along the M (row) dimension.
@@ -180,6 +241,8 @@ def all_gather(
         block_n (int): Block size for N dimension. Default: 64
         group_size_m (int): Group size for swizzling. Default: 8
         num_sms (int): Number of SMs to use (persistent kernel). Default: 256
+        output (Tensor, optional): Preallocated output. Use this argument during
+            graph capture to keep the output address stable.
 
     Returns:
         Tensor: Full tensor of shape [M, N] where M = M_shard * world_size
@@ -213,21 +276,35 @@ def all_gather(
         f"Rank {cur_rank}/{world_size}: All-gather M_shard={M_shard}, N={N} -> M={M}"
     )
 
-    # Allocate output buffer in IRIS shared memory
-    full_output = iris_ctx.zeros((M, N), dtype=input_shard.dtype)
+    if output is None:
+        output = iris_ctx.empty((M, N), dtype=input_shard.dtype)
+    elif output.shape != (M, N):
+        raise ValueError(f"output must have shape ({M}, {N}), got {output.shape}")
+    elif output.dtype != input_shard.dtype:
+        raise ValueError(
+            f"output dtype must be {input_shard.dtype}, got {output.dtype}"
+        )
+    elif output.device != input_shard.device:
+        raise ValueError(
+            f"output device must be {input_shard.device}, got {output.device}"
+        )
+
+    # Wait until every rank finishes producing its local input shard. The Iris
+    # device barrier uses system-scope atomics and is graph-capturable.
+    iris_ctx.device_barrier()
 
     # Launch kernel
     grid = (num_sms,)
     _all_gather_kernel[grid](
         input_shard,
-        full_output,
+        output,
         M,
         M_shard,
         N,
         input_shard.stride(0),
         input_shard.stride(1),
-        full_output.stride(0),
-        full_output.stride(1),
+        output.stride(0),
+        output.stride(1),
         cur_rank,
         world_size,
         heap_bases,
@@ -240,12 +317,6 @@ def all_gather(
         waves_per_eu=4,
     )
 
-    # Synchronize
-    torch.cuda.synchronize()
-    iris_ctx.barrier()
+    logger.info(f"Rank {cur_rank}: All-gather complete, output shape: {output.shape}")
 
-    logger.info(
-        f"Rank {cur_rank}: All-gather complete, output shape: {full_output.shape}"
-    )
-
-    return full_output
+    return output

--- a/aiter/ops/triton/comms/iris.py
+++ b/aiter/ops/triton/comms/iris.py
@@ -177,6 +177,9 @@ class IrisCommContext:
             self.cur_rank = self.iris_ctx.cur_rank
             self.num_ranks = self.iris_ctx.num_ranks
 
+            # Allocate the persistent device-barrier state before graph capture.
+            self.iris_ctx.device_barrier()
+
             logger.info(
                 f"Iris context initialized: rank {self.cur_rank}/{self.num_ranks}, heap_size={self.heap_size}"
             )

--- a/aiter/ops/triton/comms/reduce_scatter.py
+++ b/aiter/ops/triton/comms/reduce_scatter.py
@@ -169,6 +169,7 @@ def reduce_scatter(
     block_n: int = 64,
     group_size_m: int = 8,
     num_sms: int = 256,
+    output: Tensor | None = None,
 ) -> Tensor:
     """
     Perform reduce-scatter along the M (row) dimension.
@@ -185,6 +186,8 @@ def reduce_scatter(
         block_n (int): Block size for N dimension. Default: 64
         group_size_m (int): Group size for swizzling. Default: 8
         num_sms (int): Number of SMs to use (persistent kernel). Default: 256
+        output (Tensor, optional): Preallocated output. Use this argument during
+            graph capture to keep the output address stable.
 
     Returns:
         Tensor: Output shard of shape [M_shard, N] where M_shard = M // world_size
@@ -223,21 +226,37 @@ def reduce_scatter(
         f"Rank {cur_rank}/{world_size}: Reduce-scatter M={M}, N={N} -> M_shard={M_shard}"
     )
 
-    # Allocate output buffer in IRIS shared memory
-    output_shard = iris_ctx.zeros((M_shard, N), dtype=input_tensor.dtype)
+    if output is None:
+        output = iris_ctx.empty((M_shard, N), dtype=input_tensor.dtype)
+    elif output.shape != (M_shard, N):
+        raise ValueError(
+            f"output must have shape ({M_shard}, {N}), got {output.shape}"
+        )
+    elif output.dtype != input_tensor.dtype:
+        raise ValueError(
+            f"output dtype must be {input_tensor.dtype}, got {output.dtype}"
+        )
+    elif output.device != input_tensor.device:
+        raise ValueError(
+            f"output device must be {input_tensor.device}, got {output.device}"
+        )
+
+    # Wait until every rank finishes producing its local input tensor. The
+    # Iris device barrier uses system-scope atomics and is graph-capturable.
+    iris_ctx.device_barrier()
 
     # Launch kernel
     grid = (num_sms,)
     _reduce_scatter_kernel[grid](
         input_tensor,
-        output_shard,
+        output,
         M,
         M_shard,
         N,
         input_tensor.stride(0),
         input_tensor.stride(1),
-        output_shard.stride(0),
-        output_shard.stride(1),
+        output.stride(0),
+        output.stride(1),
         cur_rank,
         world_size,
         heap_bases,
@@ -250,11 +269,6 @@ def reduce_scatter(
         waves_per_eu=4,
     )
 
-    # Synchronize
-    iris_ctx.barrier()
+    logger.info(f"Rank {cur_rank}: Reduce-scatter complete, output shape: {output.shape}")
 
-    logger.info(
-        f"Rank {cur_rank}: Reduce-scatter complete, output_shard shape: {output_shard.shape}"
-    )
-
-    return output_shard
+    return output

--- a/op_tests/multigpu_tests/triton_test/test_iris_agrs.py
+++ b/op_tests/multigpu_tests/triton_test/test_iris_agrs.py
@@ -1,0 +1,258 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+"""Test Iris AllGather and ReduceScatter on four gfx950 GPUs.
+
+Run with:
+
+    torchrun --standalone --nproc-per-node=4 \
+        op_tests/multigpu_tests/triton_test/test_iris_agrs.py
+"""
+
+import inspect
+import json
+import os
+
+import torch
+import torch.distributed as dist
+from aiter.ops.triton.comms import IrisCommContext, all_gather, reduce_scatter
+
+WORLD_SIZE = 4
+AG_SHAPES = (
+    ("hidden", 4, 4096, torch.bfloat16),
+    ("weights", 4, 6, torch.float32),
+    ("ids", 4, 6, torch.int32),
+)
+RS_SHAPE = (16, 4096, torch.bfloat16)
+HAS_AG_OUTPUT = "output" in inspect.signature(all_gather).parameters
+HAS_RS_OUTPUT = "output" in inspect.signature(reduce_scatter).parameters
+
+
+def make_input(
+    rows: int,
+    columns: int,
+    dtype: torch.dtype,
+    rank: int,
+    replay: int,
+    device: torch.device,
+) -> torch.Tensor:
+    values = torch.arange(rows * columns, dtype=torch.int64, device=device).reshape(
+        rows, columns
+    )
+    if dtype == torch.int32:
+        return ((values % 97) + rank * 101 + replay * 1009).to(dtype)
+    values = ((values % 17) - 8).to(torch.float32) * 0.03125
+    return (values + rank * 0.125 + replay * 2.0).to(dtype)
+
+
+def call_all_gather(
+    input_tensor: torch.Tensor,
+    ctx: IrisCommContext,
+    output: torch.Tensor,
+) -> torch.Tensor:
+    if HAS_AG_OUTPUT:
+        return all_gather(input_tensor, ctx, output=output)
+    return all_gather(input_tensor, ctx)
+
+
+def call_reduce_scatter(
+    input_tensor: torch.Tensor,
+    ctx: IrisCommContext,
+    output: torch.Tensor,
+) -> torch.Tensor:
+    if HAS_RS_OUTPUT:
+        return reduce_scatter(input_tensor, ctx, output=output)
+    return reduce_scatter(input_tensor, ctx)
+
+
+def assert_exact(actual: torch.Tensor, expected: torch.Tensor, name: str) -> None:
+    if actual.dtype == torch.bfloat16:
+        equal = torch.equal(actual.view(torch.int16), expected.view(torch.int16))
+    elif actual.dtype == torch.float32:
+        equal = torch.equal(actual.view(torch.int32), expected.view(torch.int32))
+    else:
+        equal = torch.equal(actual, expected)
+    if not equal:
+        mismatch = actual != expected
+        raise AssertionError(
+            f"{name} has {int(mismatch.sum().item())} wrong values out of "
+            f"{actual.numel()}"
+        )
+
+
+def expected_all_gather(
+    rows: int,
+    columns: int,
+    dtype: torch.dtype,
+    replay: int,
+    device: torch.device,
+) -> torch.Tensor:
+    return torch.cat(
+        [
+            make_input(rows, columns, dtype, rank, replay, device)
+            for rank in range(WORLD_SIZE)
+        ],
+        dim=0,
+    )
+
+
+def expected_reduce_scatter(
+    rank: int,
+    replay: int,
+    device: torch.device,
+) -> torch.Tensor:
+    rows, columns, dtype = RS_SHAPE
+    inputs = [
+        make_input(rows, columns, dtype, source, replay, device)
+        for source in range(WORLD_SIZE)
+    ]
+    reduced = sum(value.float() for value in inputs).to(dtype)
+    return reduced.chunk(WORLD_SIZE, dim=0)[rank]
+
+
+def check_outputs(
+    ag_outputs: list[torch.Tensor],
+    rs_output: torch.Tensor,
+    rank: int,
+    replay: int,
+    device: torch.device,
+) -> None:
+    for output, (name, rows, columns, dtype) in zip(ag_outputs, AG_SHAPES):
+        assert_exact(
+            output,
+            expected_all_gather(rows, columns, dtype, replay, device),
+            f"{name} AllGather replay {replay}",
+        )
+    torch.testing.assert_close(
+        rs_output,
+        expected_reduce_scatter(rank, replay, device),
+        rtol=0.02,
+        atol=0.02,
+    )
+
+
+def main() -> None:
+    rank = int(os.environ["RANK"])
+    local_rank = int(os.environ["LOCAL_RANK"])
+    world_size = int(os.environ["WORLD_SIZE"])
+    if world_size != WORLD_SIZE:
+        raise RuntimeError(f"This test requires {WORLD_SIZE} ranks")
+
+    device = torch.device("cuda", local_rank)
+    torch.cuda.set_device(device)
+    dist.init_process_group("nccl", device_id=device)
+
+    with IrisCommContext(heap_size=128 << 20) as ctx:
+        ag_inputs = [
+            ctx.iris_ctx.empty((rows, columns), dtype=dtype)
+            for _, rows, columns, dtype in AG_SHAPES
+        ]
+        rs_input = ctx.iris_ctx.empty(RS_SHAPE[:2], dtype=RS_SHAPE[2])
+        ag_outputs = [
+            ctx.iris_ctx.empty((rows * WORLD_SIZE, columns), dtype=dtype)
+            for _, rows, columns, dtype in AG_SHAPES
+        ]
+        rs_output = ctx.iris_ctx.empty(
+            (RS_SHAPE[0] // WORLD_SIZE, RS_SHAPE[1]), dtype=RS_SHAPE[2]
+        )
+
+        local_base = int(ctx.get_heap_bases()[rank].item())
+        local_offsets = torch.tensor(
+            [tensor.data_ptr() - local_base for tensor in [*ag_inputs, rs_input]],
+            dtype=torch.int64,
+            device=device,
+        )
+        gathered_offsets = torch.empty(
+            world_size * local_offsets.numel(), dtype=torch.int64, device=device
+        )
+        dist.all_gather_into_tensor(gathered_offsets, local_offsets)
+        offset_rows = gathered_offsets.reshape(world_size, -1)
+        if not torch.all(offset_rows == offset_rows[0]):
+            raise AssertionError(f"Iris heap offsets differ: {offset_rows.cpu().tolist()}")
+
+        for tensor, (_, rows, columns, dtype) in zip(ag_inputs, AG_SHAPES):
+            tensor.copy_(make_input(rows, columns, dtype, rank, 0, device))
+        rs_input.copy_(
+            make_input(*RS_SHAPE, rank=rank, replay=0, device=device)
+        )
+        eager_ag = [
+            call_all_gather(input_tensor, ctx, output)
+            for input_tensor, output in zip(ag_inputs, ag_outputs)
+        ]
+        eager_rs = call_reduce_scatter(rs_input, ctx, rs_output)
+        torch.cuda.synchronize()
+        check_outputs(eager_ag, eager_rs, rank, 0, device)
+
+        legacy_ag = all_gather(ag_inputs[1], ctx)
+        legacy_rs = reduce_scatter(rs_input, ctx)
+        torch.cuda.synchronize()
+        assert_exact(
+            legacy_ag,
+            expected_all_gather(4, 6, torch.float32, 0, device),
+            "legacy AllGather",
+        )
+        torch.testing.assert_close(
+            legacy_rs,
+            expected_reduce_scatter(rank, 0, device),
+            rtol=0.02,
+            atol=0.02,
+        )
+
+        zero_input = ctx.iris_ctx.empty((0, 4096), dtype=torch.bfloat16)
+        zero_output = ctx.iris_ctx.empty((0, 4096), dtype=torch.bfloat16)
+        gathered_zero = call_all_gather(zero_input, ctx, zero_output)
+        if gathered_zero.shape != (0, 4096):
+            raise AssertionError(f"Unexpected zero-token shape: {gathered_zero.shape}")
+
+        capture_stream = torch.cuda.Stream()
+        capture_stream.wait_stream(torch.cuda.current_stream())
+        with torch.cuda.stream(capture_stream):
+            for input_tensor, output in zip(ag_inputs, ag_outputs):
+                call_all_gather(input_tensor, ctx, output)
+            call_reduce_scatter(rs_input, ctx, rs_output)
+        capture_stream.synchronize()
+
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph, stream=capture_stream):
+            graph_ag = [
+                call_all_gather(input_tensor, ctx, output)
+                for input_tensor, output in zip(ag_inputs, ag_outputs)
+            ]
+            graph_rs = call_reduce_scatter(rs_input, ctx, rs_output)
+
+        for replay in range(1, 4):
+            with torch.cuda.stream(capture_stream):
+                for tensor, (_, rows, columns, dtype) in zip(ag_inputs, AG_SHAPES):
+                    tensor.copy_(
+                        make_input(rows, columns, dtype, rank, replay, device)
+                    )
+                rs_input.copy_(
+                    make_input(*RS_SHAPE, rank=rank, replay=replay, device=device)
+                )
+                graph.replay()
+            capture_stream.synchronize()
+            check_outputs(graph_ag, graph_rs, rank, replay, device)
+
+        if rank == 0:
+            print(
+                "IRIS_AGRS_TEST_RESULT="
+                + json.dumps(
+                    {
+                        "all_gather_dtypes": ["bfloat16", "float32", "int32"],
+                        "graph_replays": 3,
+                        "heap_offsets": offset_rows[0].cpu().tolist(),
+                        "reduce_scatter": "bfloat16_sum",
+                        "status": "pass",
+                        "uniform_zero_tokens": True,
+                    },
+                    sort_keys=True,
+                ),
+                flush=True,
+            )
+
+    dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements-triton-comms.txt
+++ b/requirements-triton-comms.txt
@@ -1,5 +1,4 @@
 # Optional dependencies for Triton-based GPU communication
 # Iris library for GPU-initiated communication primitives
-# Pinned to commit 905ec1c (Nov 18, 2024) for reproducibility and API stability
-iris @ git+https://github.com/ROCm/iris.git@905ec1cea8f350211a70c7d0b2bc11a09a6f6429
-
+# Pinned to commit 25285da (Aug 18, 2026) for the graph-capturable device barrier
+iris @ git+https://github.com/ROCm/iris.git@25285da2c52c053de9555b8e78e5120e86412102


### PR DESCRIPTION
## Summary

- Replace standalone Iris AllGather remote stores with remote loads.
- Use the Iris device barrier before remote reads.
- Add optional preallocated outputs for graph capture.
- Pin Iris commit `25285da2c52c053de9555b8e78e5120e86412102`.
- Add a four-rank gfx950 regression test.

This is a draft PR because the fixed path is slower than RCCL for the tested MoE layer.

## Root cause

AITER main used `iris.put` to write each shard to remote output buffers. The remote segments contained zeros or stale values on four MI355X gfx950 GPUs. Current Iris did not fix this push path.

The input heap offsets were equal on all ranks: `[1024, 33792, 34816, 35840]`. A pull kernel with `iris.load` read all remote segments exactly. This result isolates the fault to the push remote-store path or its memory ordering.

The first graph exception occurred in output allocation. `iris_ctx.zeros()` refreshed peer mappings and called `dist.barrier()` during capture. HIP raised `hipErrorStreamCaptureUnsupported`. The preallocated-output path removes allocation from capture. The wrapper also removes its host synchronize and host barrier.

## Correctness

Test stack:

- AITER base: `bb3bca83a32d7aa4f6d579cf596f7009b44132e9`
- Iris: `25285da2c52c053de9555b8e78e5120e86412102`
- Image: `a2labs/deepseek-flash-0731-amd:0.27.1-patched-full`
- ROCm 7.2.3, PyTorch 2.11, Triton 3.6, RCCL 2.27.7
- Four MI355X gfx950 ranks on GPUs 0-3

The new test failed on unmodified AITER. BF16 AllGather had 16,383 or 16,384 wrong values per rank.

The fixed test passed these checks:

- BF16 `[4, 4096]` AllGather is bit-exact.
- FP32 `[4, 6]` AllGather is bit-exact.
- int32 `[4, 6]` AllGather is bit-exact.
- BF16 SUM `[16, 4096]` ReduceScatter passes with `rtol=0.02` and `atol=0.02`.
- The legacy allocation API passes.
- Uniform zero-token AllGather returns `[0, 4096]`.
- The full 3-AllGather plus 1-ReduceScatter graph captures.
- Three graph replays pass with different input values on each replay.

Iris requires equal row counts. A higher layer must use a fallback for uneven rows.

## Device-time benchmark

The workload used 20 warmups and 100 HIP-event samples. Values are milliseconds. Each mean includes the sample standard deviation.

| Operation | RCCL median | RCCL mean ± stdev | RCCL min/max | Fixed Iris median | Fixed Iris mean ± stdev | Fixed Iris min/max |
|---|---:|---:|---:|---:|---:|---:|
| BF16 hidden AG | 0.03852 | 0.03952 ± 0.00425 | 0.03332/0.05312 | 0.03884 | 0.04068 ± 0.00577 | 0.03384/0.06312 |
| FP32 weight AG | 0.03782 | 0.03870 ± 0.00508 | 0.02696/0.05368 | 0.03902 | 0.05241 ± 0.11826 | 0.03344/1.22133 |
| int32 ID AG | 0.03616 | 0.03760 ± 0.00771 | 0.02524/0.09520 | 0.03882 | 0.06758 ± 0.23227 | 0.03220/2.33422 |
| BF16 SUM RS | 0.04066 | 0.04216 ± 0.00513 | 0.02900/0.05680 | 0.04074 | 0.04208 ± 0.00720 | 0.03356/0.08556 |
| 3 AG + 1 RS | 0.06560 | 0.06674 ± 0.00591 | 0.05760/0.10292 | 0.11434 | 0.11615 ± 0.00638 | 0.10740/0.13756 |

The grouped fixed path is 1.74x slower than RCCL. Its median host time with event synchronization is 0.12448 ms. The median host-minus-device value is 0.01019 ms. The wrapper does not use a host synchronize or a host barrier.

A representative rank used eight kernels per layer. Four device-barrier kernels used one workgroup each. Four collective kernels used 256 workgroups each. The layer used 1,028 workgroups in total.

The maximum possible communication saving remains 0.06814 ms per layer, or about 2.93 ms for 43 layers. This implementation gives no saving. A linear estimate adds about 2.10 ms per 43-layer forward against the measured RCCL baseline.

## Test command

```bash
torchrun --standalone --nproc-per-node=4 \
  op_tests/multigpu_tests/triton_test/test_iris_agrs.py
```

`ruff check` also passes for the changed Python files.
