### PR TITLE
[HIP] fix(mla): fold fp8 qlen 2 onto the qseqlen-4 kernel on gfx950

### DIFF
--- a/csrc/py_itfs_cu/asm_mla.cu
+++ b/csrc/py_itfs_cu/asm_mla.cu
@@ -988,7 +988,7 @@ void mla_decode_stage1_asm_fwd(
         config_gqa_ratio = 32;
         args.s_MQA = gqa_ratio;
     } else if (arch_id == "gfx950" && q_type == "fp8" && kv_type == "fp8" && persistent
-        && ((gqa_ratio == 16 && (max_seqlen_q == 3 || max_seqlen_q == 4))
+        && ((gqa_ratio == 16 && (max_seqlen_q >= 2 && max_seqlen_q <= 4))
             || (gqa_ratio == 32 && (max_seqlen_q == 2 || max_seqlen_q == 3))
             || (gqa_ratio == 64 && max_seqlen_q == 1))){
         config_max_seqlen_q = 4;


### PR DESCRIPTION
## Motivation

On gfx950, an fp8 MLA decode with `gqa_ratio == 16` and a 2-token query block has
no non-causal kernel:

```
get_heuristic_kernel_mla: cannot get heuristic kernel!
  q_type:fp8 kv_type:fp8 gqa:16 ps:1 prefill:0 causal:0 qseqlen:2 lse:0 cprr:0
```

A missing kernel aborts the process rather than raising, so this takes the server
down. Every other block length works: the dispatch folds `(gqa 16, qlen 3 or 4)`
onto the qseqlen-4 kernel, but the list skips 2, so the lookup falls through to
the exact-match table where `Gqa=16 qSeqLen=2` exists only as `causal=1`.

vLLM hits this with a Kimi-K3 DSpark draft at `num_speculative_tokens=1`.

## Technical Details

Widen the gqa-16 fold from `{3, 4}` to `{2, 3, 4}`.

The neighbouring `gqa_ratio == 32` branch already folds that length, and
`gqa * qlen` stays inside the 64-lane tile (16x2 pads to 16x4, as 16x3 does).
Padding is selection-only: `q_seq_lens_kernel` is computed from the real
`max_seqlen_q`, not from `config_max_seqlen_q`, so no extra query rows are
processed.

Both masks fold, which retires `mla_a8w8_qh16_qseqlen2_gqaratio16*` for this
shape. #3013 proposed the same widening in May, to work around a precision issue
reported in that kernel. Those binaries were replaced in 13040146d (2026-06-29)
and I do not see the issue on the current ones, so this is not a bug fix for the
causal path -- it is one fold rule instead of two, at equal cost.

## Test Plan

gfx950 (MI355X). `mla_decode_fwd` driven directly with the persistent schedule
from `get_mla_metadata_v1`; B=2, 16 heads, kv_lora 512, rope 64, page_size 1.
Reference is fp32 over the same dequantized fp8 values, so it isolates the kernel
from input quantization. Each output is compared against both a causal and a
non-causal reference, at ctx `[16, 24]` so the two actually differ.

## Test Result

fp8, gqa 16, qlen 2:

| | before | after |
|---|---|---|
| `causal=True` error | 1.46e-02 | **1.46e-02** |
| `causal=False` error | **no kernel** | **1.39e-02** |
| kernel selected | `qseqlen2_gqaratio16_ps` (causal only) | `qseqlen4_gqaratio16[_msk0]_v3_ps` |

Against the opposite reference both land at 1.41e-01, so each runs the mask it
was asked for. The causal error is unchanged to three digits despite moving to a
different kernel.

Timing, causal qlen 2, direct qseqlen-2 kernel against the folded path:

| B / ctx | 512 | 4096 |
|---|---|---|
| 1 | 72.4 -> 75.1 us | 72.8 -> 74.2 us |
| 8 | 72.5 -> 85.0 us | 72.1 -> 73.2 us |
| 32 | 72.8 -> 73.3 us | 72.5 -> 73.3 us |
| 128 | 72.5 -> 73.6 us | 80.1 -> 78.2 us |

Flat either way; the 85.0 is a single outlier in an otherwise 72-75 us band.

Block lengths 1, 3, 4 and 8 are unaffected, and bf16 takes a different fold
branch entirely.
