### PR TITLE
[HIP] [GFX950]OPUS MHA Support LSE

### DIFF
--- a/aiter/ops/mha.py
+++ b/aiter/ops/mha.py
@@ -334,6 +334,7 @@ def gen_fmha_fwd_bf16_opus_fwd_fake(
     out: Tensor,
     causal: bool,
     softmax_scale: float,
+    lse: Tensor | None = None,
     seqstart_q: Tensor | None = None,
     seqstart_k: Tensor | None = None,
     seqstart_q_pad: Tensor | None = None,
@@ -347,7 +348,7 @@ def gen_fmha_fwd_bf16_opus_fwd_fake(
 # OPUS gfx950 bf16 forward (shared entry point): low-level @compile_ops stub bound to
 # the pybind symbol via fc_name. Dispatches by head dim in C++ to the symmetric D=128
 # kernel (batch only) or the asymmetric D_QK=192/D_V=128 kernel (batch + group/varlen).
-# Writes `out` in place, returns None.
+# Writes `out` (and `lse`, when given) in place, returns None.
 @compile_ops(
     "module_fmha_fwd_bf16_opus",
     fc_name="fmha_fwd_bf16_opus_fwd",
@@ -360,6 +361,7 @@ def _fmha_fwd_bf16_opus_fwd(
     out: Tensor,
     causal: bool,
     softmax_scale: float,
+    lse: Tensor | None = None,
     seqstart_q: Tensor | None = None,
     seqstart_k: Tensor | None = None,
     seqstart_q_pad: Tensor | None = None,
@@ -376,26 +378,38 @@ def fmha_fwd_bf16_opus_fwd(
     softmax_scale: float,
     causal: bool,
     out: Tensor | None = None,
-) -> Tensor:
+    return_lse: bool = False,
+    lse: Tensor | None = None,
+) -> Tensor | tuple[Tensor, Tensor]:
     """Public wrapper for the OPUS gfx950 bf16 dense (batch) forward (D=128 and
     D_QK=192/D_V=128). q/k/v are dense bshd [B, S, H, D]; allocates `out`
     ([B, S, H_q, D_v]) if needed and forwards. The kernel applies `softmax_scale`
-    to Q·K^T internally, handles GQA fan-out, and produces no LSE.
+    to Q·K^T internally and handles GQA fan-out.
+
+    `lse` is an output buffer for the log-sum-exp of the scaled scores ([B, H_q, S]
+    float32, natural log; rows that see no keys get -inf), filled when supplied and
+    allocated here when `return_lse` is set. Like `out` it does not change the return
+    type on its own: only `return_lse` does, and then the return is `(out, lse)`.
 
     Varlen / packed inputs go through `fmha_fwd_bf16_opus_varlen_fwd` instead.
     """
     v_head_dim = v.size(-1)
+    batch, q_seq_len, q_head_num = q.size(0), q.size(1), q.size(2)
 
     if out is None:
-        batch, q_seq_len, q_head_num = q.size(0), q.size(1), q.size(2)
         out = torch.empty(
             (batch, q_seq_len, q_head_num, v_head_dim),
             dtype=q.dtype,
             device=q.device,
         )
 
-    _fmha_fwd_bf16_opus_fwd(q, k, v, out, bool(causal), float(softmax_scale))
-    return out
+    if return_lse and lse is None:
+        lse = torch.empty(
+            (batch, q_head_num, q_seq_len), dtype=torch.float32, device=q.device
+        )
+
+    _fmha_fwd_bf16_opus_fwd(q, k, v, out, bool(causal), float(softmax_scale), lse=lse)
+    return (out, lse) if return_lse else out
 
 
 def fmha_fwd_bf16_opus_varlen_fwd(
@@ -411,11 +425,19 @@ def fmha_fwd_bf16_opus_varlen_fwd(
     out: Tensor | None = None,
     seqstart_q_pad: Tensor | None = None,
     seqstart_k_pad: Tensor | None = None,
-) -> Tensor:
+    return_lse: bool = False,
+    lse: Tensor | None = None,
+) -> Tensor | tuple[Tensor, Tensor]:
     """Public wrapper for the OPUS gfx950 bf16 group/varlen forward (D_QK=192/D_V=128
     only). q/k/v are packed [total, H, D]; allocates `out` ([total_q, H_q, D_v]) if
-    needed and forwards. The kernel applies `softmax_scale` to Q·K^T internally,
-    handles GQA fan-out, and produces no LSE.
+    needed and forwards. The kernel applies `softmax_scale` to Q·K^T internally and
+    handles GQA fan-out.
+
+    `lse` is an output buffer for the log-sum-exp of the scaled scores ([H_q, total_q]
+    float32, natural log), filled when supplied and allocated here when `return_lse` is
+    set. Like `out` it does not change the return type on its own: only `return_lse`
+    does, and then the return is `(out, lse)`. Rows that see no keys get -inf; rows in
+    the padding gaps of a KV-padded layout are left untouched.
 
     seqstart_q / seqstart_k          : cumulative REAL sequence lengths (int32, len
                                        num_groups+1; drive masks / tile counts).
@@ -424,12 +446,15 @@ def fmha_fwd_bf16_opus_varlen_fwd(
     max_seqlen_q / max_seqlen_k      : upper bounds driving the grid.
     """
     v_head_dim = v.size(-1)
+    total_q, q_head_num = q.size(0), q.size(1)
 
     if out is None:
-        total_q, q_head_num = q.size(0), q.size(1)
         out = torch.empty(
             (total_q, q_head_num, v_head_dim), dtype=q.dtype, device=q.device
         )
+
+    if return_lse and lse is None:
+        lse = torch.empty((q_head_num, total_q), dtype=torch.float32, device=q.device)
 
     seqstart_q = seqstart_q.to(torch.int32).contiguous()
     seqstart_k = seqstart_k.to(torch.int32).contiguous()
@@ -445,6 +470,7 @@ def fmha_fwd_bf16_opus_varlen_fwd(
         out,
         bool(causal),
         float(softmax_scale),
+        lse,
         seqstart_q,
         seqstart_k,
         seqstart_q_pad if seqstart_q_pad is not None else seqstart_q,
@@ -452,7 +478,7 @@ def fmha_fwd_bf16_opus_varlen_fwd(
         int(max_seqlen_q),
         int(max_seqlen_k),
     )
-    return out
+    return (out, lse) if return_lse else out
 
 
 # ---------------------------------------------------------------------------
@@ -1958,10 +1984,11 @@ def _flash_attn_forward(
         return hdim_q == 192 and hdim_v == 128
 
     def can_impl_fmha_fwd_bf16_opus():
-        # Shared eligibility for the OPUS gfx950 bf16 forward kernels (inference-only:
-        # no LSE/dropout mask, so it must never capture return_lse / the autograd path).
-        # Cheapest / most-selective gates first so the per-head-dim helpers (which read
-        # env vars) are only evaluated once the common conditions already hold.
+        # Shared eligibility for the OPUS gfx950 bf16 forward kernels. LSE is supported
+        # ([B, H_q, S] fp32, natural log), so return_lse no longer disqualifies the path;
+        # the dropout mask (return_softmax) still does. Cheapest / most-selective gates
+        # first so the per-head-dim helpers (which read env vars) are only evaluated once
+        # the common conditions already hold.
         ret = get_gfx() == "gfx950"
         ret = ret and (q.dtype == dtypes.bf16)
         ret = ret and (nhead_q % nhead_k == 0)
@@ -1971,7 +1998,7 @@ def _flash_attn_forward(
         ret = ret and (window_size_left == -1 and window_size_right == -1)
         ret = ret and (sink_size == 0 and sink_ptr is None)
         ret = ret and (q_descale is None and k_descale is None and v_descale is None)
-        ret = ret and (not return_lse) and (not return_softmax)
+        ret = ret and (not return_softmax)
         ret = ret and (
             _can_impl_fmha_fwd_hd128_bf16_opus()
             or _can_impl_fmha_fwd_hd192_v128_bf16_opus()
@@ -2059,8 +2086,13 @@ def _flash_attn_forward(
         rng_state = torch.empty((2,), dtype=torch.int64, device=q.device)
     elif can_impl_fmha_fwd_bf16_opus():
         # OPUS gfx950 dense forward (shared entry point; dispatches D=128 vs
-        # D_QK=192/D_V=128 in C++ by head dim). Inference-only: the lse/S_dmask/rng
-        # slots are unused placeholders (gate guarantees not return_lse/return_softmax).
+        # D_QK=192/D_V=128 in C++ by head dim). The S_dmask/rng slots stay unused
+        # placeholders (the gate guarantees no dropout mask).
+        softmax_lse = torch.empty(
+            (batch_size, nhead_q, seqlen_q) if return_lse else (0,),
+            dtype=torch.float32,
+            device=q.device,
+        )
         out_ = fmha_fwd_bf16_opus_fwd(
             q,
             k,
@@ -2068,8 +2100,8 @@ def _flash_attn_forward(
             softmax_scale=float(softmax_scale),
             causal=bool(causal),
             out=out,
+            lse=softmax_lse if return_lse else None,
         )
-        softmax_lse = torch.empty((0,), dtype=torch.float32, device=q.device)
         S_dmask = torch.empty((0,), dtype=torch.float32, device=q.device)
         rng_state = torch.empty((2,), dtype=torch.int64, device=q.device)
     elif can_impl_fmha_v3_fwd() and seqlen_q > 128:  # Prefer CK for decode cases
@@ -2893,9 +2925,9 @@ def _flash_attn_varlen_forward(
 
     def can_impl_fmha_fwd_hd192_v128_bf16_opus_varlen():
         # OPUS gfx950 group/varlen D_QK=192 / D_V=128 bf16 forward. Enabled by DEFAULT
-        # (no env). Packed THD q/k/v; supports KV padding (cu_seqlens_*_padded) and
-        # cross-attention (causal bottom-right aligned). Inference-only: no LSE / dropout
-        # / bias / alibi / swa / sink / quant / paged.
+        # (no env). Packed THD q/k/v; supports KV padding (cu_seqlens_*_padded),
+        # cross-attention (causal bottom-right aligned) and LSE ([H_q, total_q] fp32,
+        # natural log). No dropout / bias / alibi / swa / sink / quant / paged.
         # AITER_DISABLE_FMHA_OPUS=1 force-disables it (fall back to v3/CK; for A/B).
         if int(os.environ.get("AITER_DISABLE_FMHA_OPUS", "0")) != 0:
             return False
@@ -2910,7 +2942,7 @@ def _flash_attn_varlen_forward(
         ret = ret and (sink_size == 0 and sink_ptr is None)
         ret = ret and (q_descale is None and k_descale is None and v_descale is None)
         ret = ret and (block_table is None)
-        ret = ret and (not return_lse) and (not return_softmax)
+        ret = ret and (not return_softmax)
         return ret
 
     q, k, v = [maybe_contiguous(x) for x in (q, k, v)]
@@ -2919,6 +2951,11 @@ def _flash_attn_varlen_forward(
         # OPUS gfx950 group/varlen D=192 path. cu_seqlens_* are the REAL cumulative
         # lengths (masks / tile counts); cu_seqlens_*_padded are the PHYSICAL row
         # offsets (KV padding). When no padded arrays are given, physical == real.
+        softmax_lse = torch.empty(
+            (nhead_q, q.size(0)) if return_lse else (0,),
+            dtype=torch.float32,
+            device=q.device,
+        )
         out = fmha_fwd_bf16_opus_varlen_fwd(
             q,
             k,
@@ -2932,8 +2969,8 @@ def _flash_attn_varlen_forward(
             seqstart_k_pad=cu_seqlens_k_padded,
             max_seqlen_q=int(max_seqlen_q),
             max_seqlen_k=int(max_seqlen_k),
+            lse=softmax_lse if return_lse else None,
         )
-        softmax_lse = torch.empty((0,), dtype=torch.float32, device=q.device)
         S_dmask = torch.empty((0,), dtype=torch.float32, device=q.device)
         rng_state = torch.empty((2,), dtype=torch.int64, device=q.device)
     elif can_impl_fmha_fwd_with_sink_varlen_asm():

--- a/aiter/ops/mha.py
+++ b/aiter/ops/mha.py
@@ -1973,7 +1973,8 @@ def _flash_attn_forward(
             return False
         # KV byte extent >= 2^32 wraps the kernel's 32-bit async-load soffset; fall back to
         # v3/CK. Actual seqlen stride (layout-aware, matches the C++ guard).
-        return not seqlen_k * k.stride(1) * k.element_size() >= 1 << 32
+        kv_stride = max(k.stride(1), v.stride(1))
+        return not seqlen_k * kv_stride * k.element_size() >= 1 << 32
 
     def _can_impl_fmha_fwd_hd192_v128_bf16_opus():
         # OPUS gfx950 dense D_QK=192 / D_V=128 bf16 forward. Enabled by DEFAULT (no env)
@@ -2943,6 +2944,7 @@ def _flash_attn_varlen_forward(
         ret = ret and (q_descale is None and k_descale is None and v_descale is None)
         ret = ret and (block_table is None)
         ret = ret and (not return_softmax)
+        ret = ret and (max_seqlen_q > 0 and max_seqlen_k > 0)
         return ret
 
     q, k, v = [maybe_contiguous(x) for x in (q, k, v)]

--- a/aiter/test_mha_common.py
+++ b/aiter/test_mha_common.py
@@ -678,3 +678,40 @@ def attention_ref_with_tol(q, k, v, do, is_fp8=False, **kwargs):
     bwd_tols = [_tol(dq, dq_pt), _tol(dk, dk_pt), _tol(dv, dv_pt)]
 
     return out, (dq, dk, dv), fwd_tol, bwd_tols
+
+
+def opus_ref_lse(q, k, causal):
+    """fp32 logsumexp of the scaled scores (bottom-right causal aligned), GQA-aware.
+
+    attention_ref casts its lse back down to the input dtype, which at |lse| ~ 8 is
+    coarser than the OPUS kernels' own error, so their LSE is checked against this.
+    """
+    seqlen_q, nheads = q.shape[1], q.shape[2]
+    seqlen_k, nheads_k = k.shape[1], k.shape[2]
+    k_rep = k.repeat_interleave(nheads // nheads_k, dim=2)
+    scores = torch.einsum("bthd,bshd->bhts", q.float(), k_rep.float()) * (
+        q.shape[-1] ** -0.5
+    )
+    if causal:
+        off = seqlen_k - seqlen_q
+        row = torch.arange(seqlen_q, device=q.device)[:, None]
+        col = torch.arange(seqlen_k, device=q.device)[None, :]
+        scores = scores.masked_fill(col > row + off, float("-inf"))
+    return torch.logsumexp(scores, dim=-1)
+
+
+def opus_check_lse(tag, lse, lse_ref):
+    """Compare fp32 LSE against opus_ref_lse. 0.01 is the same floor the out checks use:
+    the D=128 kernel folds softmax_scale into Q and rounds back to bf16, so its scores
+    (and hence its LSE) sit ~4e-3 off an fp32 post-scale reference, while D=192 lands at
+    ~1e-6. Any real defect (stale softmax base, wrong layout, missing rescale) is off by
+    >= O(1).
+    """
+    assert lse.dtype == torch.float32, f"{tag}: lse dtype {lse.dtype}, expected float32"
+    assert torch.equal(
+        torch.isneginf(lse), torch.isneginf(lse_ref)
+    ), f"{tag}: -inf (fully-masked row) pattern differs from the reference"
+    finite = ~torch.isneginf(lse_ref)
+    diff = (lse[finite] - lse_ref[finite]).abs().max().item() if finite.any() else 0.0
+    print(f"[{tag}] lse max diff: {diff}")
+    assert diff <= 0.01, f"{tag}: lse diff {diff} > 0.01"

--- a/aiter/test_mha_common.py
+++ b/aiter/test_mha_common.py
@@ -680,32 +680,41 @@ def attention_ref_with_tol(q, k, v, do, is_fp8=False, **kwargs):
     return out, (dq, dk, dv), fwd_tol, bwd_tols
 
 
-def opus_ref_lse(q, k, causal):
-    """fp32 logsumexp of the scaled scores (bottom-right causal aligned), GQA-aware.
+def opus_ref_lse(q, k, causal, budget=1 << 23):
+    """fp32 logsumexp of the scaled scores, bottom-right causal, GQA-aware.
 
-    attention_ref casts its lse back down to the input dtype, which at |lse| ~ 8 is
-    coarser than the OPUS kernels' own error, so their LSE is checked against this.
+    attention_ref downcasts its lse to the input dtype, too coarse to check against.
+    Chunked over query rows (`budget` score elements) to bound peak memory.
     """
-    seqlen_q, nheads = q.shape[1], q.shape[2]
+    batch, seqlen_q, nheads, d = q.shape
     seqlen_k, nheads_k = k.shape[1], k.shape[2]
-    k_rep = k.repeat_interleave(nheads // nheads_k, dim=2)
-    scores = torch.einsum("bthd,bshd->bhts", q.float(), k_rep.float()) * (
-        q.shape[-1] ** -0.5
-    )
-    if causal:
-        off = seqlen_k - seqlen_q
-        row = torch.arange(seqlen_q, device=q.device)[:, None]
-        col = torch.arange(seqlen_k, device=q.device)[None, :]
-        scores = scores.masked_fill(col > row + off, float("-inf"))
-    return torch.logsumexp(scores, dim=-1)
+    group = nheads // nheads_k
+    scale = d**-0.5
+
+    k_f = k.float()
+    lse = torch.empty((batch, nheads, seqlen_q), dtype=torch.float32, device=q.device)
+    col = torch.arange(seqlen_k, device=q.device)
+    off = seqlen_k - seqlen_q
+    rows = max(1, budget // max(1, batch * nheads * seqlen_k))
+
+    for lo in range(0, seqlen_q, rows):
+        hi = min(lo + rows, seqlen_q)
+        q_c = q[:, lo:hi].float().reshape(batch, hi - lo, nheads_k, group, d)
+        scores = torch.einsum("bthgd,bshd->bhgts", q_c, k_f) * scale
+        if causal:
+            row = torch.arange(lo, hi, device=q.device)[:, None]
+            scores = scores.masked_fill(col > row + off, float("-inf"))
+        lse[:, :, lo:hi] = torch.logsumexp(scores, dim=-1).reshape(
+            batch, nheads, hi - lo
+        )
+    return lse
 
 
 def opus_check_lse(tag, lse, lse_ref):
-    """Compare fp32 LSE against opus_ref_lse. 0.01 is the same floor the out checks use:
-    the D=128 kernel folds softmax_scale into Q and rounds back to bf16, so its scores
-    (and hence its LSE) sit ~4e-3 off an fp32 post-scale reference, while D=192 lands at
-    ~1e-6. Any real defect (stale softmax base, wrong layout, missing rescale) is off by
-    >= O(1).
+    """Compare fp32 LSE against opus_ref_lse.
+
+    0.01 accommodates D=128 folding softmax_scale into bf16 Q (~4e-3 off an fp32
+    post-scale reference); D=192 lands at ~1e-6.
     """
     assert lse.dtype == torch.float32, f"{tag}: lse dtype {lse.dtype}, expected float32"
     assert torch.equal(

--- a/csrc/include/fmha_fwd_hd128_bf16_opus_defs.h
+++ b/csrc/include/fmha_fwd_hd128_bf16_opus_defs.h
@@ -22,6 +22,11 @@ struct opus_gqa_kargs {
     int stride_kv_n;
     int stride_kv_h;
     float softmax_scale;  // QK^T scale (host passes 1/sqrt(D) by default)
+    // Optional fp32 log-sum-exp (natural log) output, [B, H, N] with unit stride along
+    // the query dim. nullptr => not produced (the kernel skips the store).
+    void* __restrict__ ptr_lse;
+    int stride_lse_b;
+    int stride_lse_h;
 };
 
 // Configuration traits for the GQA kernel (tile sizes, data types, vector lengths,

--- a/csrc/include/fmha_fwd_hd128_bf16_opus_defs.h
+++ b/csrc/include/fmha_fwd_hd128_bf16_opus_defs.h
@@ -18,9 +18,15 @@ struct opus_gqa_kargs {
     int stride_q_b;
     int stride_q_n;
     int stride_q_h;
-    int stride_kv_b;
-    int stride_kv_n;
-    int stride_kv_h;
+    int stride_o_b;
+    int stride_o_n;
+    int stride_o_h;
+    int stride_k_b;
+    int stride_k_n;
+    int stride_k_h;
+    int stride_v_b;
+    int stride_v_n;
+    int stride_v_h;
     float softmax_scale;  // QK^T scale (host passes 1/sqrt(D) by default)
     // Optional fp32 log-sum-exp (natural log) output, [B, H, N] with unit stride along
     // the query dim. nullptr => not produced (the kernel skips the store).

--- a/csrc/include/fmha_fwd_hd128_bf16_opus_kernel.hpp
+++ b/csrc/include/fmha_fwd_hd128_bf16_opus_kernel.hpp
@@ -546,8 +546,10 @@ __device__ __attribute__((always_inline)) void gqa_d128_impl(opus_gqa_kargs karg
     const int q_block_size = T::NUM_WARPS * T::Q_TILE_SIZE;
     const int q_block_start = q_block_idx * q_block_size;
     // int64 offsets: B*N*H*D can exceed INT_MAX at large shapes.
-    const int64_t qo_gmem_offset = (int64_t)b * kargs.stride_q_b + (int64_t)q_block_start * kargs.stride_q_n + (int64_t)h * kargs.stride_q_h;
-    const int64_t kv_gmem_offset = (int64_t)b * kargs.stride_kv_b + (int64_t)h_kv * kargs.stride_kv_h;
+    const int64_t q_gmem_offset = (int64_t)b * kargs.stride_q_b + (int64_t)q_block_start * kargs.stride_q_n + (int64_t)h * kargs.stride_q_h;
+    const int64_t o_gmem_offset = (int64_t)b * kargs.stride_o_b + (int64_t)q_block_start * kargs.stride_o_n + (int64_t)h * kargs.stride_o_h;
+    const int64_t k_gmem_offset = (int64_t)b * kargs.stride_k_b + (int64_t)h_kv * kargs.stride_k_h;
+    const int64_t v_gmem_offset = (int64_t)b * kargs.stride_v_b + (int64_t)h_kv * kargs.stride_v_h;
 
     // num_records (bytes) bounds each descriptor to its valid rows so an out-of-bounds
     // read (partial last KV tile / partial last Q block, arbitrary seqlen) returns 0 with
@@ -557,17 +559,19 @@ __device__ __attribute__((always_inline)) void gqa_d128_impl(opus_gqa_kargs karg
         const int64_t bytes = elems * (int64_t)sizeof(D_ATTN);
         return bytes >= (int64_t)0xffffffffu ? 0xffffffffu : (unsigned int)bytes;
     };
-    const unsigned int kv_num_records = rec_bytes((int64_t)kargs.N_KV * kargs.stride_kv_n);
-    const unsigned int qo_num_records = rec_bytes((int64_t)(kargs.N - q_block_start) * kargs.stride_q_n);
+    const unsigned int k_num_records = rec_bytes((int64_t)kargs.N_KV * kargs.stride_k_n);
+    const unsigned int v_num_records = rec_bytes((int64_t)kargs.N_KV * kargs.stride_v_n);
+    const unsigned int q_num_records = rec_bytes((int64_t)(kargs.N - q_block_start) * kargs.stride_q_n);
+    const unsigned int o_num_records = rec_bytes((int64_t)(kargs.N - q_block_start) * kargs.stride_o_n);
     // Same bound for the fp32 LSE buffer (different element size than D_ATTN).
     const unsigned int lse_num_records =
         (unsigned int)((int64_t)(kargs.N - q_block_start) * (int64_t)sizeof(D_ACC));
 
     // Global memory tensors
-    auto g_q = make_gmem(reinterpret_cast<const D_ATTN*>(kargs.ptr_q) + qo_gmem_offset, qo_num_records);
-    auto g_k = make_gmem(reinterpret_cast<const D_ATTN*>(kargs.ptr_k) + kv_gmem_offset, kv_num_records);
-    auto g_v = make_gmem(reinterpret_cast<const D_ATTN*>(kargs.ptr_v) + kv_gmem_offset, kv_num_records);
-    auto g_o = make_gmem(reinterpret_cast<D_ATTN*>(kargs.ptr_o) + qo_gmem_offset, qo_num_records);
+    auto g_q = make_gmem(reinterpret_cast<const D_ATTN*>(kargs.ptr_q) + q_gmem_offset, q_num_records);
+    auto g_k = make_gmem(reinterpret_cast<const D_ATTN*>(kargs.ptr_k) + k_gmem_offset, k_num_records);
+    auto g_v = make_gmem(reinterpret_cast<const D_ATTN*>(kargs.ptr_v) + v_gmem_offset, v_num_records);
+    auto g_o = make_gmem(reinterpret_cast<D_ATTN*>(kargs.ptr_o) + o_gmem_offset, o_num_records);
 
     // Shared memory: K double-buffered contiguously (2*K), then a shared region that the
     // prologue uses for Q and the main loop reuses for the double-buffered V (s_q aliases
@@ -622,7 +626,7 @@ __device__ __attribute__((always_inline)) void gqa_d128_impl(opus_gqa_kargs karg
     auto u_gq = make_layout_gq<T, T::Q_TOTAL_TILE_SIZE>(warp_id, lane_id, kargs.stride_q_n);
     auto u_sq = make_layout_sq<T, T::smem_d_rpt, T::smem_padding_16B>(warp_id);
     auto u_rq = make_layout_rq<T>(warp_id, lane_id);
-    auto u_gk = make_layout_gk_gv<T>(warp_id, lane_id, kargs.stride_kv_n);
+    auto u_gk = make_layout_gk_gv<T>(warp_id, lane_id, kargs.stride_k_n);
     auto u_sk = make_layout_sk_sv<T, T::smem_padding_16B>(warp_id);
     auto u_rk = make_layout_rk<T>(lane_id);
     // Separate rk layout for the pong phase, built from an OPAQUE copy of lane_id so the
@@ -632,7 +636,7 @@ __device__ __attribute__((always_inline)) void gqa_d128_impl(opus_gqa_kargs karg
     int lane_id_pong = lane_id;
     asm volatile("" : "+v"(lane_id_pong));
     auto u_rk2 = make_layout_rk<T>(lane_id_pong);
-    auto u_gv = make_layout_gk_gv<T>(warp_id, lane_id, kargs.stride_kv_n);
+    auto u_gv = make_layout_gk_gv<T>(warp_id, lane_id, kargs.stride_v_n);
     auto u_sv = make_layout_sk_sv<T, T::smem_padding_64B>(warp_id);
     auto u_rv = make_layout_rv<T>(lane_id);
 
@@ -653,7 +657,8 @@ __device__ __attribute__((always_inline)) void gqa_d128_impl(opus_gqa_kargs karg
 
     // Tile traversal helpers. KV traversal is driven by seqlen_kv (N_KV), which may
     // differ from seqlen_q (N) for cross-attention.
-    const int kv_tile_stride = T::KV_TILE_SIZE * kargs.stride_kv_n;
+    const int k_tile_stride = T::KV_TILE_SIZE * kargs.stride_k_n;
+    const int v_tile_stride = T::KV_TILE_SIZE * kargs.stride_v_n;
     const int num_kv_tiles = ceil_div(kargs.N_KV, T::KV_TILE_SIZE);
     // causal bottom-right alignment: query at global pos q_pos attends to keys with
     // k_pos <= q_pos + causal_offset. offset==0 for self-attention (N_KV==N).
@@ -668,7 +673,8 @@ __device__ __attribute__((always_inline)) void gqa_d128_impl(opus_gqa_kargs karg
         // also keeps every tile index non-negative (no OOB kv_tile offset).
         if (max_num_tiles < 1) max_num_tiles = 1;
     }
-    auto kv_tile = [&](int tile_idx) { return tile_idx * kv_tile_stride; };
+    auto k_tile = [&](int tile_idx) { return tile_idx * k_tile_stride; };
+    auto v_tile = [&](int tile_idx) { return tile_idx * v_tile_stride; };
     // Clamp a (possibly out-of-range) prefetch tile index to the last valid tile so K is
     // always prefetched (constant in-flight vmem → uniform rolling vmcnt, no tail branch;
     // the extra re-read of the last tile is harmless — it is never consumed).
@@ -679,6 +685,60 @@ __device__ __attribute__((always_inline)) void gqa_d128_impl(opus_gqa_kargs karg
     [[maybe_unused]] const int q_start_pos = q_block_start + warp_id * T::Q_TILE_SIZE;
     [[maybe_unused]] const int q_start_pos_c = q_start_pos + causal_offset;
     [[maybe_unused]] const opus::u32_t neg_inf_v = std::bit_cast<opus::u32_t>(-opus::numeric_limits<D_ACC>::infinity());
+
+    // Result store, in its own lambda so the no-keys exit below can jump straight here,
+    // mirroring the production asm's `s_cmp_le_u32 s_KV_seq_len, 0 / s_cbranch_scc1
+    // label_write_out`. The stagger balancing barrier stays outside it: the no-keys path
+    // runs no prologue, so neither wave group owes the other one.
+    auto store_result = [&]() {
+        if (kargs.ptr_lse != nullptr && lane_id < T::W_M) {
+            constexpr D_ACC LN2 = D_ACC(0.69314718055994531f);   // 1 / log2(e)
+            const D_ACC lse = (l_row > D_ACC(0.0f))
+                                  ? ((m_row + __builtin_amdgcn_logf(l_row)) * LN2)
+                                  : -opus::numeric_limits<D_ACC>::infinity();
+            auto g_lse = make_gmem(reinterpret_cast<D_ACC*>(kargs.ptr_lse) +
+                                       (int64_t)b * kargs.stride_lse_b +
+                                       (int64_t)h * kargs.stride_lse_h + q_block_start,
+                                   lse_num_records);
+            g_lse.store(lse, warp_id * T::Q_TILE_SIZE + lane_id);
+        }
+
+        D_ACC l_inv = (l_row > D_ACC(0.0f)) ? (D_ACC(1.0f) / l_row) : D_ACC(0.0f);
+        static_for<o_len>([&](auto i) { v_o[i.value] *= l_inv; });
+
+        // Widened store: each dwordx4 (VEC_O_X4) group is packed and stored one group at a
+        // time so store(g) overlaps the cvt/permlane of group g+1 (a monolithic pack would
+        // serialize that). group g owns v_o elements [g*VEC_O_X4, (g+1)*VEC_O_X4).
+        constexpr index_t VEC_X4    = T::VEC_O_X4;                                  // bf16 / dwordx4
+        constexpr index_t NUM_GROUP = o_len / VEC_X4;                               // store groups / lane
+        constexpr index_t GRP_U32   = VEC_X4 * sizeof(D_ATTN) / sizeof(u32_t);      // u32 regs / group
+        constexpr index_t GRP_HALF  = GRP_U32 / 2;                                  // permlane swap pairs
+        auto u_o   = make_layout_o_x4<T>(warp_id, lane_id, kargs.stride_o_n);
+        auto offs  = opus::layout_to_offsets<VEC_X4>(u_o);
+        opus::static_for<NUM_GROUP>([&](auto g) {
+            auto grp_f  = slice(v_o, number<g.value * VEC_X4>{}, number<g.value * VEC_X4 + VEC_X4>{});
+            auto grp_bf = opus::cast<D_ATTN>(grp_f);
+            auto gu = __builtin_bit_cast(opus::vector_t<u32_t, GRP_U32>, grp_bf);
+            // Swap this lane's high head_dim half [GRP_HALF, GRP_U32) with the lane±32
+            // partner's low half so each half ends up holding VEC_O contiguous head_dim →
+            // together VEC_O_X4 contiguous per lane.
+            opus::static_for<GRP_HALF>([&](auto i) {
+                opus::vector_t<u32_t, 2> s =
+                    __builtin_amdgcn_permlane32_swap(gu[i.value], gu[i.value + GRP_HALF], false, true);
+                gu[i.value] = s.x; gu[i.value + GRP_HALF] = s.y;
+            });
+            auto out = __builtin_bit_cast(opus::vector_t<D_ATTN, VEC_X4>, gu);
+            store<VEC_X4>(g_o, out, offs[g.value]);
+        });
+    };
+
+    // No keys at all: nothing to accumulate, and v_o is already cleared with l_row == 0,
+    // so the store emits lse = -inf and O = 0. N_KV is workgroup-uniform, so both wave
+    // groups exit together.
+    if (num_kv_tiles == 0) {
+        store_result();
+        return;
+    }
 
     auto stage_end = [&]() {
         __builtin_amdgcn_sched_barrier(0);
@@ -698,7 +758,7 @@ __device__ __attribute__((always_inline)) void gqa_d128_impl(opus_gqa_kargs karg
             opus::static_for<K_SPLIT_NOP>([&](auto) { asm volatile("s_nop 15"); });
         }
         v_kv.k = load<T::VEC_KV>(s_k[cur], u_rk_p);
-        async_load<T::VEC_KV>(g_v, s_v[cur].ptr, u_gv, u_sv, kv_tile(t));
+        async_load<T::VEC_KV>(g_v, s_v[cur].ptr, u_gv, u_sv, v_tile(t));
         s_waitcnt_lgkmcnt(0_I);
         s_waitcnt_vmcnt(number<T::KEEP_VMCNT>{});
         stage_end();
@@ -731,7 +791,7 @@ __device__ __attribute__((always_inline)) void gqa_d128_impl(opus_gqa_kargs karg
             asm volatile("s_nop 5");
         }
         v_kv.v = tr_load<T::VEC_TR_V>(s_v[prev], u_rv);
-        async_load<T::VEC_KV>(g_k, s_k[cur].ptr, u_gk, u_sk, kv_tile(clamp_tile(t + 2)));
+        async_load<T::VEC_KV>(g_k, s_k[cur].ptr, u_gk, u_sk, k_tile(clamp_tile(t + 2)));
         if constexpr (T::CAUSAL) {
             const int kv_end_pos = (t + 1) * T::KV_TILE_SIZE;
             if (q_start_pos_c < kv_end_pos) {
@@ -808,12 +868,12 @@ __device__ __attribute__((always_inline)) void gqa_d128_impl(opus_gqa_kargs karg
     // barrier is needed before each warp reads its 32 contiguous rows back; and s_q must
     // be fully read before V0 (which aliases s_q) overwrites it.
     async_load<T::VEC_Q>(g_q, s_q.ptr, u_gq, u_sq, 0);
-    async_load<T::VEC_KV>(g_k, s_k[0].ptr, u_gk, u_sk, kv_tile(0));
+    async_load<T::VEC_KV>(g_k, s_k[0].ptr, u_gk, u_sk, k_tile(0));
     s_waitcnt_vmcnt(number<T::k_buffer_load_insts>{}); // wait vmem-Q
     stage_end();
 
     v_q = load<T::VEC_Q>(s_q, u_rq);
-    async_load<T::VEC_KV>(g_k, s_k[1].ptr, u_gk, u_sk, kv_tile(clamp_tile(1)));
+    async_load<T::VEC_KV>(g_k, s_k[1].ptr, u_gk, u_sk, k_tile(clamp_tile(1)));
     s_waitcnt_lgkmcnt(0_I);                      // Q read from LDS done → s_q free
     s_waitcnt_vmcnt(number<T::k_buffer_load_insts>{}); // wait vmem-K.blk[0]
     stage_end();
@@ -823,7 +883,7 @@ __device__ __attribute__((always_inline)) void gqa_d128_impl(opus_gqa_kargs karg
     if (stagger) { stage_end(); }
 
     v_kv.k = load<T::VEC_KV>(s_k[0], u_rk);
-    async_load<T::VEC_KV>(g_v, s_v[0].ptr, u_gv, u_sv, kv_tile(0));   // V0 aliases s_q (now safe)
+    async_load<T::VEC_KV>(g_v, s_v[0].ptr, u_gv, u_sv, v_tile(0));   // V0 aliases s_q (now safe)
     auto v_q_f32 = opus::cast<float>(v_q);
     static_for<q_len>([&](auto i) { v_q_f32[i.value] *= temperature_scale; });
     v_q = opus::cast<D_ATTN>(v_q_f32);
@@ -856,7 +916,7 @@ __device__ __attribute__((always_inline)) void gqa_d128_impl(opus_gqa_kargs karg
 
     stage_end();
 
-    async_load<T::VEC_KV>(g_k, s_k[0].ptr, u_gk, u_sk, kv_tile(clamp_tile(2)));
+    async_load<T::VEC_KV>(g_k, s_k[0].ptr, u_gk, u_sk, k_tile(clamp_tile(2)));
     if constexpr(!STAGGER) {
         __builtin_amdgcn_s_setprio(1);
     }
@@ -891,51 +951,12 @@ __device__ __attribute__((always_inline)) void gqa_d128_impl(opus_gqa_kargs karg
     else                          do_epilogue(v_s0, 0);
     __builtin_amdgcn_sched_barrier(0);
 
-    // ──── Optional LSE (fp32, natural log) ────
-    if (kargs.ptr_lse != nullptr && lane_id < T::W_M) {
-        constexpr D_ACC LN2 = D_ACC(0.69314718055994531f);   // 1 / log2(e)
-        const D_ACC lse = (l_row > D_ACC(0.0f))
-                              ? ((m_row + __builtin_amdgcn_logf(l_row)) * LN2)
-                              : -opus::numeric_limits<D_ACC>::infinity();
-        auto g_lse = make_gmem(reinterpret_cast<D_ACC*>(kargs.ptr_lse) +
-                                   (int64_t)b * kargs.stride_lse_b +
-                                   (int64_t)h * kargs.stride_lse_h + q_block_start,
-                               lse_num_records);
-        g_lse.store(lse, warp_id * T::Q_TILE_SIZE + lane_id);
-    }
-
-    // ──── Normalize O and store to gmem ────
-    D_ACC l_inv = (l_row > D_ACC(0.0f)) ? (D_ACC(1.0f) / l_row) : D_ACC(0.0f);
-    static_for<o_len>([&](auto i) { v_o[i.value] *= l_inv; });
-
+    // Stagger: the group that skipped the prologue barrier does its extra one here.
     if (!stagger) {
         __builtin_amdgcn_s_barrier();
     }
 
-    // Widened store: each dwordx4 (VEC_O_X4) group is packed and stored one group at a
-    // time so store(g) overlaps the cvt/permlane of group g+1 (a monolithic pack would
-    // serialize that). group g owns v_o elements [g*VEC_O_X4, (g+1)*VEC_O_X4).
-    constexpr index_t VEC_X4    = T::VEC_O_X4;                                  // bf16 / dwordx4
-    constexpr index_t NUM_GROUP = o_len / VEC_X4;                               // store groups / lane
-    constexpr index_t GRP_U32   = VEC_X4 * sizeof(D_ATTN) / sizeof(u32_t);      // u32 regs / group
-    constexpr index_t GRP_HALF  = GRP_U32 / 2;                                  // permlane swap pairs
-    auto u_o   = make_layout_o_x4<T>(warp_id, lane_id, kargs.stride_q_n);
-    auto offs  = opus::layout_to_offsets<VEC_X4>(u_o);
-    opus::static_for<NUM_GROUP>([&](auto g) {
-        auto grp_f  = slice(v_o, number<g.value * VEC_X4>{}, number<g.value * VEC_X4 + VEC_X4>{});
-        auto grp_bf = opus::cast<D_ATTN>(grp_f);
-        auto gu = __builtin_bit_cast(opus::vector_t<u32_t, GRP_U32>, grp_bf);
-        // Swap this lane's high head_dim half [GRP_HALF, GRP_U32) with the lane±32
-        // partner's low half so each half ends up holding VEC_O contiguous head_dim →
-        // together VEC_O_X4 contiguous per lane.
-        opus::static_for<GRP_HALF>([&](auto i) {
-            opus::vector_t<u32_t, 2> s =
-                __builtin_amdgcn_permlane32_swap(gu[i.value], gu[i.value + GRP_HALF], false, true);
-            gu[i.value] = s.x; gu[i.value + GRP_HALF] = s.y;
-        });
-        auto out = __builtin_bit_cast(opus::vector_t<D_ATTN, VEC_X4>, gu);
-        store<VEC_X4>(g_o, out, offs[g.value]);
-    });
+    store_result();
 }
 
 // Outer dispatcher: pick the stagger / non-stagger specialization per wave group.

--- a/csrc/include/fmha_fwd_hd128_bf16_opus_kernel.hpp
+++ b/csrc/include/fmha_fwd_hd128_bf16_opus_kernel.hpp
@@ -559,6 +559,9 @@ __device__ __attribute__((always_inline)) void gqa_d128_impl(opus_gqa_kargs karg
     };
     const unsigned int kv_num_records = rec_bytes((int64_t)kargs.N_KV * kargs.stride_kv_n);
     const unsigned int qo_num_records = rec_bytes((int64_t)(kargs.N - q_block_start) * kargs.stride_q_n);
+    // Same bound for the fp32 LSE buffer (different element size than D_ATTN).
+    const unsigned int lse_num_records =
+        (unsigned int)((int64_t)(kargs.N - q_block_start) * (int64_t)sizeof(D_ACC));
 
     // Global memory tensors
     auto g_q = make_gmem(reinterpret_cast<const D_ATTN*>(kargs.ptr_q) + qo_gmem_offset, qo_num_records);
@@ -888,6 +891,23 @@ __device__ __attribute__((always_inline)) void gqa_d128_impl(opus_gqa_kargs karg
     else                          do_epilogue(v_s0, 0);
     __builtin_amdgcn_sched_barrier(0);
 
+    // ──── Optional LSE (fp32, natural log) ────
+    // temperature_scale is folded into v_q in the prologue, so m_row is already in the
+    // log2 domain and lse = ln2 * (m_row + log2(l_row)). The selective max update leaves
+    // m_row below the true row max, but l_row is kept consistent with it and log-sum-exp
+    // is invariant to the base, so this is exact. W_M == 32 with a single permlane32
+    // reduction means lanes L and L+32 carry the same row, so only the low half stores.
+    if (kargs.ptr_lse != nullptr && lane_id < T::W_M) {
+        constexpr D_ACC LN2 = D_ACC(0.69314718055994531f);   // 1 / log2(e)
+        const D_ACC lse = (l_row > D_ACC(0.0f))
+                              ? ((m_row + __builtin_amdgcn_logf(l_row)) * LN2)
+                              : -opus::numeric_limits<D_ACC>::infinity();
+        auto g_lse = make_gmem(reinterpret_cast<D_ACC*>(kargs.ptr_lse) +
+                                   (int64_t)b * kargs.stride_lse_b +
+                                   (int64_t)h * kargs.stride_lse_h + q_block_start,
+                               lse_num_records);
+        g_lse.store(lse, warp_id * T::Q_TILE_SIZE + lane_id);
+    }
 
     // ──── Normalize O and store to gmem ────
     D_ACC l_inv = (l_row > D_ACC(0.0f)) ? (D_ACC(1.0f) / l_row) : D_ACC(0.0f);

--- a/csrc/include/fmha_fwd_hd128_bf16_opus_kernel.hpp
+++ b/csrc/include/fmha_fwd_hd128_bf16_opus_kernel.hpp
@@ -892,11 +892,6 @@ __device__ __attribute__((always_inline)) void gqa_d128_impl(opus_gqa_kargs karg
     __builtin_amdgcn_sched_barrier(0);
 
     // ──── Optional LSE (fp32, natural log) ────
-    // temperature_scale is folded into v_q in the prologue, so m_row is already in the
-    // log2 domain and lse = ln2 * (m_row + log2(l_row)). The selective max update leaves
-    // m_row below the true row max, but l_row is kept consistent with it and log-sum-exp
-    // is invariant to the base, so this is exact. W_M == 32 with a single permlane32
-    // reduction means lanes L and L+32 carry the same row, so only the low half stores.
     if (kargs.ptr_lse != nullptr && lane_id < T::W_M) {
         constexpr D_ACC LN2 = D_ACC(0.69314718055994531f);   // 1 / log2(e)
         const D_ACC lse = (l_row > D_ACC(0.0f))

--- a/csrc/include/fmha_fwd_hd192_v128_bf16_opus_defs.h
+++ b/csrc/include/fmha_fwd_hd192_v128_bf16_opus_defs.h
@@ -54,6 +54,15 @@ struct opus_gqa_d192_kargs {
     // Runtime option bits (see OPT_* below). Decided once by the host and read by the
     // kernel, so the head/tail-merge decision is NOT recomputed on both sides.
     int opt;
+    // ── optional log-sum-exp output (fp32, natural log) ──
+    // nullptr => not produced (the kernel skips the store entirely; scalar branch).
+    // One value per (head, query row), unit stride along the query dim:
+    //   batch mode: [B, H, N]        (stride_lse_b, stride_lse_h)
+    //   group mode: [H, total_q]     (stride_lse_h; the group's row offset comes from
+    //                                seqstart_q_pad, same as Q/O)
+    void* __restrict__ ptr_lse;
+    int stride_lse_b;
+    int stride_lse_h;
 };
 
 // opus_gqa_d192_kargs::opt bit flags.

--- a/csrc/include/fmha_fwd_hd192_v128_bf16_opus_kernel.hpp
+++ b/csrc/include/fmha_fwd_hd192_v128_bf16_opus_kernel.hpp
@@ -769,6 +769,60 @@ __device__ __attribute__((always_inline)) void gqa_d192_v128_impl(opus_gqa_d192_
         auto u_rk = make_layout_rk_su<T>(lane_id);
         auto u_rv = make_layout_rv_su<T>(lane_id);
 
+        // Result store, in its own lambda so the no-keys exit below can jump straight
+        // here, mirroring the production asm's `s_cmp_le_u32 s_KV_seq_len, 0 /
+        // s_cbranch_scc1 label_write_out`.
+        auto store_result = [&]() {
+            if (kargs.ptr_lse != nullptr && lane_id < T::W_M) {
+                constexpr D_ACC LN2 = D_ACC(0.69314718055994531f);   // 1 / log2(e)
+                const D_ACC lse = (l_row > D_ACC(0.0f))
+                                      ? ((m_row + __builtin_amdgcn_logf(l_row)) * LN2)
+                                      : -opus::numeric_limits<D_ACC>::infinity();
+                auto g_lse = make_gmem(reinterpret_cast<D_ACC*>(kargs.ptr_lse) + lse_batch_base +
+                                           (int64_t)h * kargs.stride_lse_h + q_block_start,
+                                       rec_bytes_lse(seqlen_q - q_block_start));
+                g_lse.store(lse, warp_id * T::Q_TILE_SIZE + lane_id);
+            }
+
+            D_ACC l_inv = (l_row > D_ACC(0.0f)) ? (D_ACC(1.0f) / l_row) : D_ACC(0.0f);
+            static_for<o_len>([&](auto i) { v_o[i.value] *= l_inv; });
+
+            // Widened store: each dwordx4 (VEC_O_X4) group is packed and stored one group
+            // at a time so store(g) overlaps the cvt/permlane of group g+1 (a monolithic
+            // pack would serialize that). group g owns v_o [g*VEC_O_X4, (g+1)*VEC_O_X4).
+            constexpr index_t VEC_X4    = T::VEC_O_X4;                                  // bf16 / dwordx4
+            constexpr index_t NUM_GROUP = o_len / VEC_X4;                               // store groups / lane
+            constexpr index_t GRP_U32   = VEC_X4 * sizeof(D_ATTN) / sizeof(opus::u32_t); // u32 regs / group
+            constexpr index_t GRP_HALF  = GRP_U32 / 2;                                  // permlane swap pairs
+            auto u_o  = make_layout_o_x4<T>(warp_id, lane_id, kargs.stride_o_n);
+            auto offs = opus::layout_to_offsets<VEC_X4>(u_o);
+            auto g_o  = make_gmem(reinterpret_cast<D_ATTN*>(kargs.ptr_o) + o_gmem_offset, o_num_records);
+            opus::static_for<NUM_GROUP>([&](auto g) {
+                auto grp_f  = slice(v_o, number<g.value * VEC_X4>{}, number<g.value * VEC_X4 + VEC_X4>{});
+                auto grp_bf = opus::cast<D_ATTN>(grp_f);
+                auto gu = __builtin_bit_cast(opus::vector_t<opus::u32_t, GRP_U32>, grp_bf);
+                // Swap this lane's high head_dim half [GRP_HALF, GRP_U32) with the lane±32
+                // partner's low half so each half ends up holding VEC_O contiguous head_dim
+                // → together VEC_O_X4 contiguous per lane.
+                opus::static_for<GRP_HALF>([&](auto i) {
+                    opus::vector_t<opus::u32_t, 2> s =
+                        __builtin_amdgcn_permlane32_swap(gu[i.value], gu[i.value + GRP_HALF], false, true);
+                    gu[i.value] = s.x; gu[i.value + GRP_HALF] = s.y;
+                });
+                auto out = __builtin_bit_cast(opus::vector_t<D_ATTN, VEC_X4>, gu);
+                store<VEC_X4>(g_o, out, offs[g.value]);
+            });
+        };
+
+        // No keys at all: nothing to accumulate, and l_row == 0 already makes the store
+        // emit lse = -inf and O = 0. seqlen_kv is workgroup-uniform, so both wave groups
+        // exit together — neither reaches the stagger balancing barrier below.
+        if (num_kv_tiles == 0) {
+            clear(v_o);
+            store_result();
+            return;
+        }
+
         // ─── One pipelined phase (8 stages): gemm0+softmax-head of tile t into vs_cur
         //     while finishing softmax-tail + gemm1 of t-1 from vs_prev. cur/prev = smem
         //     buffer parity for t / t-1. ───
@@ -1034,47 +1088,7 @@ __device__ __attribute__((always_inline)) void gqa_d192_v128_impl(opus_gqa_d192_
     // Stagger: the group that skipped the prologue barrier does its extra one here.
     if (!stagger) { __builtin_amdgcn_s_barrier(); }
 
-    // ─── Optional LSE (fp32, natural log) ───
-    if (kargs.ptr_lse != nullptr && lane_id < T::W_M) {
-        constexpr D_ACC LN2 = D_ACC(0.69314718055994531f);   // 1 / log2(e)
-        const D_ACC lse = (l_row > D_ACC(0.0f))
-                              ? ((m_row + __builtin_amdgcn_logf(l_row)) * LN2)
-                              : -opus::numeric_limits<D_ACC>::infinity();
-        auto g_lse = make_gmem(reinterpret_cast<D_ACC*>(kargs.ptr_lse) + lse_batch_base +
-                                   (int64_t)h * kargs.stride_lse_h + q_block_start,
-                               rec_bytes_lse(seqlen_q - q_block_start));
-        g_lse.store(lse, warp_id * T::Q_TILE_SIZE + lane_id);
-    }
-
-    // ─── Normalize O and store to gmem ───
-    D_ACC l_inv = (l_row > D_ACC(0.0f)) ? (D_ACC(1.0f) / l_row) : D_ACC(0.0f);
-    static_for<o_len>([&](auto i) { v_o[i.value] *= l_inv; });
-
-    // Widened store: each dwordx4 (VEC_O_X4) group is packed and stored one group at a
-    // time so store(g) overlaps the cvt/permlane of group g+1 (a monolithic pack would
-    // serialize that). group g owns v_o elements [g*VEC_O_X4, (g+1)*VEC_O_X4).
-    constexpr index_t VEC_X4    = T::VEC_O_X4;                                  // bf16 / dwordx4
-    constexpr index_t NUM_GROUP = o_len / VEC_X4;                               // store groups / lane
-    constexpr index_t GRP_U32   = VEC_X4 * sizeof(D_ATTN) / sizeof(opus::u32_t); // u32 regs / group
-    constexpr index_t GRP_HALF  = GRP_U32 / 2;                                  // permlane swap pairs
-    auto u_o  = make_layout_o_x4<T>(warp_id, lane_id, kargs.stride_o_n);
-    auto offs = opus::layout_to_offsets<VEC_X4>(u_o);
-    auto g_o  = make_gmem(reinterpret_cast<D_ATTN*>(kargs.ptr_o) + o_gmem_offset, o_num_records);
-    opus::static_for<NUM_GROUP>([&](auto g) {
-        auto grp_f  = slice(v_o, number<g.value * VEC_X4>{}, number<g.value * VEC_X4 + VEC_X4>{});
-        auto grp_bf = opus::cast<D_ATTN>(grp_f);
-        auto gu = __builtin_bit_cast(opus::vector_t<opus::u32_t, GRP_U32>, grp_bf);
-        // Swap this lane's high head_dim half [GRP_HALF, GRP_U32) with the lane±32
-        // partner's low half so each half ends up holding VEC_O contiguous head_dim →
-        // together VEC_O_X4 contiguous per lane.
-        opus::static_for<GRP_HALF>([&](auto i) {
-            opus::vector_t<opus::u32_t, 2> s =
-                __builtin_amdgcn_permlane32_swap(gu[i.value], gu[i.value + GRP_HALF], false, true);
-            gu[i.value] = s.x; gu[i.value + GRP_HALF] = s.y;
-        });
-        auto out = __builtin_bit_cast(opus::vector_t<D_ATTN, VEC_X4>, gu);
-        store<VEC_X4>(g_o, out, offs[g.value]);
-    });
+    store_result();
     };   // end run_pass lambda
 
     reverse = false;

--- a/csrc/include/fmha_fwd_hd192_v128_bf16_opus_kernel.hpp
+++ b/csrc/include/fmha_fwd_hd192_v128_bf16_opus_kernel.hpp
@@ -479,6 +479,7 @@ __device__ __attribute__((always_inline)) void gqa_d192_v128_impl(opus_gqa_d192_
     int seqlen_q, seqlen_kv;                 // effective Q / KV lengths for this WG
     int64_t q_batch_base, o_batch_base;      // Q/O base offset (excludes q_block_start & head)
     int64_t k_batch_base, v_batch_base;      // K/V base offset (excludes head)
+    int64_t lse_batch_base;                  // LSE base offset (excludes q_block_start & head)
     int q_block_idx, h;
     if constexpr (T::GROUP_MODE) {
         // Rotated axis order (matches production asm GROUP_MODE): head=x, group=y,
@@ -498,6 +499,7 @@ __device__ __attribute__((always_inline)) void gqa_d192_v128_impl(opus_gqa_d192_
         o_batch_base = qpad * kargs.stride_o_n;
         k_batch_base = kpad * kargs.stride_k_n;
         v_batch_base = kpad * kargs.stride_v_n;
+        lse_batch_base = qpad;                    // [H, total_q]: unit stride along the packed row
         h           = block_id_x();          // head    ← hw x
         q_block_idx = block_id_z();          // Q-block ← hw z (empty tail blocks on slowest axis)
         // short-circuit: drop workgroups past this group's real Q-block count (the
@@ -513,6 +515,7 @@ __device__ __attribute__((always_inline)) void gqa_d192_v128_impl(opus_gqa_d192_
         o_batch_base = (int64_t)b * kargs.stride_o_b;
         k_batch_base = (int64_t)b * kargs.stride_k_b;
         v_batch_base = (int64_t)b * kargs.stride_v_b;
+        lse_batch_base = (int64_t)b * kargs.stride_lse_b;
         q_block_idx = block_id_x();          // config A: q-block=x, head=y, batch=z
         h = block_id_y();
     }
@@ -530,6 +533,11 @@ __device__ __attribute__((always_inline)) void gqa_d192_v128_impl(opus_gqa_d192_
     // fixed up to -inf by the border mask after QK. Capped to the 32-bit descriptor.
     auto rec_bytes = [](int64_t elems) -> unsigned int {
         const int64_t bytes = elems * (int64_t)sizeof(D_ATTN);
+        return bytes >= (int64_t)0xffffffffu ? 0xffffffffu : (unsigned int)bytes;
+    };
+    // Same bound for the fp32 LSE buffer (different element size than D_ATTN).
+    auto rec_bytes_lse = [](int64_t elems) -> unsigned int {
+        const int64_t bytes = elems * (int64_t)sizeof(D_ACC);
         return bytes >= (int64_t)0xffffffffu ? 0xffffffffu : (unsigned int)bytes;
     };
 
@@ -642,12 +650,6 @@ __device__ __attribute__((always_inline)) void gqa_d192_v128_impl(opus_gqa_d192_
 
     // Two full S tiles (ping/pong) so gemm0 of tile t overlaps the softmax of
     // tile t-1, and one full O accumulator (2 super units along D).
-    // P shares storage with the S tile it is cast from (-4 VGPR at the stage2/stage3
-    // peak): stage3 casts vs_prev to P, after which that S tile is dead until the
-    // *next* phase's gemm0 rewrites it at stage1, and gemm1 consumes P at stage5/
-    // stage7 — strictly inside that window. bf16 P is 16 dwords, the low half of the
-    // 32-dword fp32 S tile. Invariant to preserve: never read vs_prev.s once its .p
-    // has been written.
     union s_frag_t {
         vector_t<D_ACC, T::GEMM0_E_N * (T::W_M * T::W_N / T::WARP_SIZE)> s;
         typename decltype(mma1)::vtype_a p;           // full P (spans KV_TILE)
@@ -1031,6 +1033,18 @@ __device__ __attribute__((always_inline)) void gqa_d192_v128_impl(opus_gqa_d192_
 
     // Stagger: the group that skipped the prologue barrier does its extra one here.
     if (!stagger) { __builtin_amdgcn_s_barrier(); }
+
+    // ─── Optional LSE (fp32, natural log) ───
+    if (kargs.ptr_lse != nullptr && lane_id < T::W_M) {
+        constexpr D_ACC LN2 = D_ACC(0.69314718055994531f);   // 1 / log2(e)
+        const D_ACC lse = (l_row > D_ACC(0.0f))
+                              ? ((m_row + __builtin_amdgcn_logf(l_row)) * LN2)
+                              : -opus::numeric_limits<D_ACC>::infinity();
+        auto g_lse = make_gmem(reinterpret_cast<D_ACC*>(kargs.ptr_lse) + lse_batch_base +
+                                   (int64_t)h * kargs.stride_lse_h + q_block_start,
+                               rec_bytes_lse(seqlen_q - q_block_start));
+        g_lse.store(lse, warp_id * T::Q_TILE_SIZE + lane_id);
+    }
 
     // ─── Normalize O and store to gmem ───
     D_ACC l_inv = (l_row > D_ACC(0.0f)) ? (D_ACC(1.0f) / l_row) : D_ACC(0.0f);

--- a/csrc/include/fmha_fwd_hd192_v128_bf16_opus_kernel.hpp
+++ b/csrc/include/fmha_fwd_hd192_v128_bf16_opus_kernel.hpp
@@ -638,12 +638,21 @@ __device__ __attribute__((always_inline)) void gqa_d192_v128_impl(opus_gqa_d192_
     // Register fragments
     typename decltype(mma0)::vtype_a v_q;             // full Q (spans D_QK)
     typename decltype(mma0)::vtype_b v_k;             // one K super unit
-    typename decltype(mma1)::vtype_a v_p;             // full P (spans KV_TILE)
     typename decltype(mma1)::vtype_b v_v;             // one V super unit
 
     // Two full S tiles (ping/pong) so gemm0 of tile t overlaps the softmax of
     // tile t-1, and one full O accumulator (2 super units along D).
-    vector_t<D_ACC, T::GEMM0_E_N * (T::W_M * T::W_N / T::WARP_SIZE)> v_s0, v_s1;
+    // P shares storage with the S tile it is cast from (-4 VGPR at the stage2/stage3
+    // peak): stage3 casts vs_prev to P, after which that S tile is dead until the
+    // *next* phase's gemm0 rewrites it at stage1, and gemm1 consumes P at stage5/
+    // stage7 — strictly inside that window. bf16 P is 16 dwords, the low half of the
+    // 32-dword fp32 S tile. Invariant to preserve: never read vs_prev.s once its .p
+    // has been written.
+    union s_frag_t {
+        vector_t<D_ACC, T::GEMM0_E_N * (T::W_M * T::W_N / T::WARP_SIZE)> s;
+        typename decltype(mma1)::vtype_a p;           // full P (spans KV_TILE)
+        __device__ s_frag_t() {}
+    } v_s0, v_s1;
     vector_t<D_ACC, T::GEMM1_E_N * (T::W_M * T::W_N / T::WARP_SIZE)> v_o;
     constexpr index_t s_len      = T::GEMM0_E_N * (T::W_M * T::W_N / T::WARP_SIZE); // 32
     constexpr index_t s_half_len = s_len / 2;                                       // 16
@@ -690,12 +699,12 @@ __device__ __attribute__((always_inline)) void gqa_d192_v128_impl(opus_gqa_d192_
         __builtin_amdgcn_sched_barrier(0);
     };
     // GEMM1 super-unit accumulation into the matching half of the O tile.
-    auto gemm1_su0 = [&]() {
+    auto gemm1_su0 = [&](const auto& v_p) {
         auto o = slice(v_o, number<0>{}, number<O_SU_LEN>{});
         o = mma1(v_p, v_v, o);
         set_slice(v_o, o, number<0>{}, number<O_SU_LEN>{});
     };
-    auto gemm1_su1 = [&]() {
+    auto gemm1_su1 = [&](const auto& v_p) {
         auto o = slice(v_o, number<O_SU_LEN>{}, number<2 * O_SU_LEN>{});
         o = mma1(v_p, v_v, o);
         set_slice(v_o, o, number<O_SU_LEN>{}, number<2 * O_SU_LEN>{});
@@ -772,11 +781,11 @@ __device__ __attribute__((always_inline)) void gqa_d192_v128_impl(opus_gqa_d192_
             stage_end();
 
             // stage1 [compute]: gemm0 su0(t) [12 MFMA]; softmax-tail(t-1) exp slice [8 EXP].
-            set_slice(vs_cur, mma0(v_q, v_k), number<0>{}, number<S_SU_LEN>{});
+            set_slice(vs_cur.s, mma0(v_q, v_k), number<0>{}, number<S_SU_LEN>{});
             // tail(t-1) exp: [0,24) — the head-exp [0,16) was moved here from stage7 so the
             // gemm1-heavy stage5/stage7 are relieved; stage1 has spare MFMA shadows (12 MFMA).
-            attn_exp2_slice<T, 0, s_half_len + s_quarter>(vs_prev);
-            asm volatile("" : "+v"(vs_prev) ::);
+            attn_exp2_slice<T, 0, s_half_len + s_quarter>(vs_prev.s);
+            asm volatile("" : "+v"(vs_prev.s) ::);
             if constexpr(STAGGER) {
                 sched_mfma_exp<1, 3, 1>();
                 sched_mfma_tail<3, 1>();       // 4 MFMA dense
@@ -799,13 +808,13 @@ __device__ __attribute__((always_inline)) void gqa_d192_v128_impl(opus_gqa_d192_
             s_waitcnt_vmcnt(number<T::KEEP_VMCNT>{});   // uniform: K is always prefetched (clamped) → constant in-flight count
             stage_end();
 
-            // stage3 [compute]: gemm0 su1(t) → full S(t); finish softmax-tail(t-1) → v_p
-            set_slice(vs_cur, mma0(v_q, v_k), number<S_SU_LEN>{}, number<2 * S_SU_LEN>{});
-            attn_exp2_slice<T, s_half_len + s_quarter, s_quarter>(vs_prev);
-            l_row += attn_sum<T>(vs_prev);
-            v_p = opus::cast<D_ATTN>(vs_prev);
+            // stage3 [compute]: gemm0 su1(t) → full S(t); finish softmax-tail(t-1) → P
+            set_slice(vs_cur.s, mma0(v_q, v_k), number<S_SU_LEN>{}, number<2 * S_SU_LEN>{});
+            attn_exp2_slice<T, s_half_len + s_quarter, s_quarter>(vs_prev.s);
+            l_row += attn_sum<T>(vs_prev.s);
+            vs_prev.p = opus::cast<D_ATTN>(vs_prev.s);
             asm volatile("" : "+v"(l_row) ::);
-            asm volatile("" : "+v"(v_p) ::);
+            asm volatile("" : "+v"(vs_prev.p) ::);
             // stage3 co-exec: 12 MFMA; 8 EXP (tail second half) then ~48 VALU (sum + cast).
             sched_mfma_exp<2, 3, 2>();     // 3 MFMA × 3 EXP  (covers 8 EXP)
             sched_mfma_exp_valu<1, 2, 2, 2>(); 
@@ -839,30 +848,30 @@ __device__ __attribute__((always_inline)) void gqa_d192_v128_impl(opus_gqa_d192_
                 const int dt = tile_idx(t);
                 const int kv_end_pos = (dt + 1) * T::KV_TILE_SIZE;
                 if (q_start_pos + causal_offset < kv_end_pos) {
-                    attn_mask_causal_tile<T>(vs_cur, q_start_pos + causal_offset, dt, neg_inf_v, lane_id);
+                    attn_mask_causal_tile<T>(vs_cur.s, q_start_pos + causal_offset, dt, neg_inf_v, lane_id);
                 }
             } else {
                 // Non-causal: mask padded columns (global KV idx >= seqlen_k) of the last
                 // KV tile to -inf when seqlen_k is not a multiple of KV_TILE.
                 if ((seqlen_kv % T::KV_TILE_SIZE) != 0 && t == max_num_tiles - 1) {
                     __builtin_amdgcn_sched_barrier(0);
-                    attn_mask_border_tile<T>(vs_cur, seqlen_kv, t, neg_inf_v, lane_id);
+                    attn_mask_border_tile<T>(vs_cur.s, seqlen_kv, t, neg_inf_v, lane_id);
                 }
             }
             s_waitcnt_lgkmcnt(0_I);
             stage_end();
 
             // stage5 [compute]: gemm1 su0(t-1); softmax-head(t) row-max + rescale decision.
-            gemm1_su0();
-            D_ACC row_max = temperature_scale * attn_row_max<T>(vs_cur);
+            gemm1_su0(vs_prev.p);
+            D_ACC row_max = temperature_scale * attn_row_max<T>(vs_cur.s);
             bool below_thresh = ((row_max - m_row) <= RESCALE_THRESHOLD);
             bool all_below = (__builtin_amdgcn_ballot_w64(below_thresh) == __builtin_amdgcn_read_exec());
             row_max = all_below ? m_row : max(m_row, row_max);
             asm volatile("" : "+v"(row_max) ::);
             // scale-sub a leading slice (STAGE5_SUB_CNT) of the S tile here (moved forward
             // from stage7); the rest stays in stage7. Pin vs_cur so it stays in this stage.
-            attn_scale_sub_row_slice<T, 0, STAGE5_SUB_CNT>(vs_cur, temperature_scale, row_max);
-            asm volatile("" : "+v"(vs_cur) ::);
+            attn_scale_sub_row_slice<T, 0, STAGE5_SUB_CNT>(vs_cur.s, temperature_scale, row_max);
+            asm volatile("" : "+v"(vs_cur.s) ::);
             sched_mfma_valu<2, 5, 3>();    // 6 MFMA × 6 VALU
             sched_mfma_valu<1, 6, 3>();
             sched_mfma_valu<1, 4, 3>();
@@ -880,9 +889,9 @@ __device__ __attribute__((always_inline)) void gqa_d192_v128_impl(opus_gqa_d192_
             stage_end();
 
             // stage7 [compute]: gemm1 su1(t-1) → full O update; softmax-head(t) sub+exp+rescale
-            gemm1_su1();
-            attn_scale_sub_row_slice<T, STAGE5_SUB_CNT, s_len - STAGE5_SUB_CNT>(vs_cur, temperature_scale, row_max);
-            asm volatile("" : "+v"(vs_cur) ::);
+            gemm1_su1(vs_prev.p);
+            attn_scale_sub_row_slice<T, STAGE5_SUB_CNT, s_len - STAGE5_SUB_CNT>(vs_cur.s, temperature_scale, row_max);
+            asm volatile("" : "+v"(vs_cur.s) ::);
             // stage7 co-exec: 8 MFMA; ~32 VALU (sub) + rescale mul. Pin vs_cur so the compiler
             // cannot sink the sub past the `if(!all_below)` branch below (d128 trick).
             if constexpr(STAGGER) {
@@ -934,7 +943,7 @@ __device__ __attribute__((always_inline)) void gqa_d192_v128_impl(opus_gqa_d192_
     s_waitcnt_lgkmcnt(0_I); //wait LDS-K.blk[0].su0
     stage_end();
 
-    set_slice(v_s0, mma0(v_q, v_k), number<0>{}, number<S_SU_LEN>{});
+    set_slice(v_s0.s, mma0(v_q, v_k), number<0>{}, number<S_SU_LEN>{});
     clear(v_o);
     sched_mfma_valu<12, 3, 5>();
     pin_output_tile(v_o); 
@@ -944,21 +953,21 @@ __device__ __attribute__((always_inline)) void gqa_d192_v128_impl(opus_gqa_d192_
     s_waitcnt_lgkmcnt(0_I); //wait LDS-K.blk[0].su1
     stage_end();
 
-    set_slice(v_s0, mma0(v_q, v_k), number<S_SU_LEN>{}, number<2 * S_SU_LEN>{});
+    set_slice(v_s0.s, mma0(v_q, v_k), number<S_SU_LEN>{}, number<2 * S_SU_LEN>{});
     if constexpr (T::CAUSAL) {
         const int dt0 = tile_idx(0);
         if (q_start_pos + causal_offset < (dt0 + 1) * T::KV_TILE_SIZE) {
-            attn_mask_causal_tile<T>(v_s0, q_start_pos + causal_offset, dt0, neg_inf_v, lane_id);
+            attn_mask_causal_tile<T>(v_s0.s, q_start_pos + causal_offset, dt0, neg_inf_v, lane_id);
         }
     } else {
         // Non-causal: border-mask tile 0 only when it is also the last tile
         // (tiny seqlen, num_kv_tiles==1) and seqlen_k is not KV_TILE-aligned.
         if ((seqlen_kv % T::KV_TILE_SIZE) != 0 && max_num_tiles == 1) {
-            attn_mask_border_tile<T>(v_s0, seqlen_kv, 0, neg_inf_v, lane_id);
+            attn_mask_border_tile<T>(v_s0.s, seqlen_kv, 0, neg_inf_v, lane_id);
         }
     }
-    m_row = temperature_scale * attn_row_max<T>(v_s0);
-    attn_scale_sub_row<T>(v_s0, temperature_scale, m_row);
+    m_row = temperature_scale * attn_row_max<T>(v_s0.s);
+    attn_scale_sub_row<T>(v_s0.s, temperature_scale, m_row);
     // head-exp of tile 0 moved to the first main-loop phase's tail (stage1/stage3, on v_s0).
     s_waitcnt_vmcnt(number<T::v_buffer_load_insts>{}); // wait vmem-K.blk[1]
     stage_end();
@@ -998,23 +1007,23 @@ __device__ __attribute__((always_inline)) void gqa_d192_v128_impl(opus_gqa_d192_
     auto do_epilogue = [&](auto& vs_last, int v_buf) {
         // stage0 [compute]: finish softmax-tail of the last tile (full exp: head-exp was
         // moved out of the last phase's stage7 into the tail, so epilogue does the whole tile).
-        attn_exp2_slice<T, 0, s_len>(vs_last);
-        l_row += attn_sum<T>(vs_last);
-        v_p = opus::cast<D_ATTN>(vs_last);
+        attn_exp2_slice<T, 0, s_len>(vs_last.s);
+        l_row += attn_sum<T>(vs_last.s);
+        vs_last.p = opus::cast<D_ATTN>(vs_last.s);
         stage_end();
         // stage1 [mem]: read V(T-1) su0
         v_v = tr_load<T::VEC_TR_V>(s_v[v_buf], u_rv);
         s_waitcnt_lgkmcnt(0_I);
         stage_end();
         // stage2 [compute]: gemm1 su0
-        gemm1_su0();
+        gemm1_su0(vs_last.p);
         stage_end();
         // stage3 [mem]: read V(T-1) su1
         v_v = tr_load<T::VEC_TR_V>(s_v[v_buf], u_rv + V_SU1_OFF);
         s_waitcnt_lgkmcnt(0_I);
         stage_end();
         // stage4 [compute]: gemm1 su1
-        gemm1_su1();
+        gemm1_su1(vs_last.p);
     };
     if ((max_num_tiles & 1) == 0) do_epilogue(v_s1, 1);
     else                          do_epilogue(v_s0, 0);

--- a/csrc/include/rocm_ops.hpp
+++ b/csrc/include/rocm_ops.hpp
@@ -1509,6 +1509,7 @@ namespace py = pybind11;
           py::arg("out"),                           \
           py::arg("causal"),                        \
           py::arg("softmax_scale"),                 \
+          py::arg("lse")            = std::nullopt, \
           py::arg("seqstart_q")     = std::nullopt, \
           py::arg("seqstart_k")     = std::nullopt, \
           py::arg("seqstart_q_pad") = std::nullopt, \

--- a/csrc/include/torch/fmha_fwd_bf16_opus.h
+++ b/csrc/include/torch/fmha_fwd_bf16_opus.h
@@ -25,6 +25,12 @@
 // `causal` selects the causal mask (bottom-right aligned when seqlen_q != seqlen_kv).
 // `softmax_scale` is applied to Q·K^T internally (pass <= 0 for the default 1/sqrt(D_QK)).
 //
+// `lse` (optional) receives the log-sum-exp of the scaled scores in natural log,
+// float32, contiguous along the query dim:
+//   batch mode: [B, H, N]        group mode: [H, total_q]
+// Rows that see no keys (causal with seqlen_q > seqlen_kv) get -inf, matching
+// torch.logsumexp. Pass std::nullopt to skip it (the kernel then stores nothing).
+//
 // Group / varlen (all four seqstart tensors are int32, length num_groups+1; pass
 // std::nullopt for batch mode):
 //   seqstart_q / seqstart_k          : cumulative REAL sequence lengths (mask / tile count)
@@ -37,6 +43,7 @@ void fmha_fwd_bf16_opus_fwd(at::Tensor& q,
                             at::Tensor& out,
                             bool causal,
                             float softmax_scale,
+                            std::optional<at::Tensor> lse            = std::nullopt,
                             std::optional<at::Tensor> seqstart_q     = std::nullopt,
                             std::optional<at::Tensor> seqstart_k     = std::nullopt,
                             std::optional<at::Tensor> seqstart_q_pad = std::nullopt,

--- a/csrc/py_itfs_cu/fmha_fwd_bf16_opus_kernels.cu
+++ b/csrc/py_itfs_cu/fmha_fwd_bf16_opus_kernels.cu
@@ -59,7 +59,8 @@ void launch_d128(at::Tensor& q,
 
     // 32-bit KV buffer-offset guard: extent >= 2^32 wraps the async-load soffset (silent
     // wrong output), reject instead.
-    const long long kv_slice_bytes = (long long)N_KV * (long long)k.stride(1) * 2LL;  // bf16
+    const long long kv_slice_bytes =
+        (long long)N_KV * std::max(k.stride(1), v.stride(1)) * 2LL;  // bf16
     TORCH_CHECK(kv_slice_bytes < (1LL << 32),
                 "OPUS D=128: KV byte extent ", kv_slice_bytes,
                 " reaches the 32-bit buffer-offset limit (2^32); reduce seqlen_kv or use another backend");
@@ -80,9 +81,15 @@ void launch_d128(at::Tensor& q,
     kargs.stride_q_b  = static_cast<int>(q.stride(0));
     kargs.stride_q_n  = static_cast<int>(q.stride(1));
     kargs.stride_q_h  = static_cast<int>(q.stride(2));
-    kargs.stride_kv_b = static_cast<int>(k.stride(0));
-    kargs.stride_kv_n = static_cast<int>(k.stride(1));
-    kargs.stride_kv_h = static_cast<int>(k.stride(2));
+    kargs.stride_o_b  = static_cast<int>(out.stride(0));
+    kargs.stride_o_n  = static_cast<int>(out.stride(1));
+    kargs.stride_o_h  = static_cast<int>(out.stride(2));
+    kargs.stride_k_b  = static_cast<int>(k.stride(0));
+    kargs.stride_k_n  = static_cast<int>(k.stride(1));
+    kargs.stride_k_h  = static_cast<int>(k.stride(2));
+    kargs.stride_v_b  = static_cast<int>(v.stride(0));
+    kargs.stride_v_n  = static_cast<int>(v.stride(1));
+    kargs.stride_v_h  = static_cast<int>(v.stride(2));
 
     if (softmax_scale <= 0.0f) {
         softmax_scale = 1.0f / std::sqrt(static_cast<float>(D));
@@ -254,7 +261,7 @@ void launch_d192_v128(at::Tensor& q,
     TORCH_CHECK(H_KV > 0 && (H % H_KV) == 0, "H must be divisible by H_KV (GQA group)");
     TORCH_CHECK(q.stride(-1) == 1 && k.stride(-1) == 1 && v.stride(-1) == 1 && out.stride(-1) == 1,
                 "q/k/v/out must be contiguous along the head dim");
-    if (B == 0 || H == 0) return;
+    if (B == 0 || H == 0 || num_q_blocks == 0) return;
 
     kargs.B = B; kargs.N = N; kargs.N_KV = N_KV; kargs.H = H; kargs.H_KV = H_KV;
 

--- a/csrc/py_itfs_cu/fmha_fwd_bf16_opus_kernels.cu
+++ b/csrc/py_itfs_cu/fmha_fwd_bf16_opus_kernels.cu
@@ -30,7 +30,8 @@ void launch_d128(at::Tensor& q,
                  at::Tensor& v,
                  at::Tensor& out,
                  bool causal,
-                 float softmax_scale)
+                 float softmax_scale,
+                 std::optional<at::Tensor>& lse)
 {
     TORCH_CHECK(q.dim() == 4, "q must be 4-D [B, N, H, D], got ndim=", q.dim());
     TORCH_CHECK(k.dim() == 4, "k must be 4-D [B, N, H_KV, D], got ndim=", k.dim());
@@ -88,6 +89,21 @@ void launch_d128(at::Tensor& q,
     }
     kargs.softmax_scale = softmax_scale;  // kernel applies scale * log2(e) to Q
 
+    // Optional LSE (fp32, natural log; one value per (head, query row)). Left as nullptr
+    // when absent, which the kernel reads as "skip the store".
+    if (lse.has_value()) {
+        const at::Tensor& l = *lse;
+        TORCH_CHECK(l.device() == q.device(), "lse must be on the same device as q");
+        TORCH_CHECK(l.scalar_type() == at::kFloat, "lse must be float32");
+        TORCH_CHECK(l.stride(-1) == 1, "lse must be contiguous along the query dim");
+        TORCH_CHECK(l.dim() == 3 && static_cast<int>(l.size(0)) == B &&
+                        static_cast<int>(l.size(1)) == H && static_cast<int>(l.size(2)) == N,
+                    "lse must be [B, H, N]");
+        kargs.ptr_lse      = l.data_ptr();
+        kargs.stride_lse_b = static_cast<int>(l.stride(0));
+        kargs.stride_lse_h = static_cast<int>(l.stride(1));
+    }
+
     HipDeviceGuard guard(q.device().index());
     const hipStream_t stream = at::hip::getCurrentHIPStream();
 
@@ -118,6 +134,7 @@ void launch_d192_v128(at::Tensor& q,
                       at::Tensor& out,
                       bool causal,
                       float softmax_scale,
+                      std::optional<at::Tensor>& lse,
                       std::optional<at::Tensor>& seqstart_q,
                       std::optional<at::Tensor>& seqstart_k,
                       std::optional<at::Tensor>& seqstart_q_pad,
@@ -241,6 +258,29 @@ void launch_d192_v128(at::Tensor& q,
 
     kargs.B = B; kargs.N = N; kargs.N_KV = N_KV; kargs.H = H; kargs.H_KV = H_KV;
 
+    // Optional LSE (fp32, natural log; one value per (head, query row)). Left as
+    // nullptr when absent, which the kernel reads as "skip the store".
+    if (lse.has_value()) {
+        const at::Tensor& l = *lse;
+        TORCH_CHECK(l.device() == q.device(), "lse must be on the same device as q");
+        TORCH_CHECK(l.scalar_type() == at::kFloat, "lse must be float32");
+        TORCH_CHECK(l.stride(-1) == 1, "lse must be contiguous along the query dim");
+        if (is_group) {
+            TORCH_CHECK(l.dim() == 2 && static_cast<int>(l.size(0)) == H &&
+                            l.size(1) == q.size(0),
+                        "group mode lse must be [H, total_q]");
+            kargs.stride_lse_b = 0;
+            kargs.stride_lse_h = static_cast<int>(l.stride(0));
+        } else {
+            TORCH_CHECK(l.dim() == 3 && static_cast<int>(l.size(0)) == B &&
+                            static_cast<int>(l.size(1)) == H && static_cast<int>(l.size(2)) == N,
+                        "batch mode lse must be [B, H, N]");
+            kargs.stride_lse_b = static_cast<int>(l.stride(0));
+            kargs.stride_lse_h = static_cast<int>(l.stride(1));
+        }
+        kargs.ptr_lse = l.data_ptr();
+    }
+
     // Head/tail merge (causal load balance): host is the single source of truth; the
     // kernel reads the OPT_MERGE_HEADTAIL bit and never recomputes it.
     const bool small_shape = (long long)num_q_blocks * H * B < (long long)HEADTAIL_MIN_WG;
@@ -301,6 +341,7 @@ void fmha_fwd_bf16_opus_fwd(at::Tensor& q,
                             at::Tensor& out,
                             bool causal,
                             float softmax_scale,
+                            std::optional<at::Tensor> lse,
                             std::optional<at::Tensor> seqstart_q,
                             std::optional<at::Tensor> seqstart_k,
                             std::optional<at::Tensor> seqstart_q_pad,
@@ -323,9 +364,9 @@ void fmha_fwd_bf16_opus_fwd(at::Tensor& q,
 
     if (D_QK == 128 && D_V == 128) {
         TORCH_CHECK(!is_group, "OPUS D=128 kernel supports batch mode only (no varlen)");
-        launch_d128(q, k, v, out, causal, softmax_scale);
+        launch_d128(q, k, v, out, causal, softmax_scale, lse);
     } else if (D_QK == 192 && D_V == 128) {
-        launch_d192_v128(q, k, v, out, causal, softmax_scale,
+        launch_d192_v128(q, k, v, out, causal, softmax_scale, lse,
                          seqstart_q, seqstart_k, seqstart_q_pad, seqstart_k_pad,
                          max_seqlen_q, max_seqlen_k);
     } else {

--- a/op_tests/test_mha.py
+++ b/op_tests/test_mha.py
@@ -1104,11 +1104,7 @@ def test_mha_bwd_sink_null_gives_same_as_no_sink(dtype):
 
 
 # OPUS gfx950 dense (batch) cases, shared by the D=128 and D_QK=192/D_V=128 tests.
-# seqlen_q == seqlen_kv entries cover the self-attention tile/Q-block geometry; the rest
-# are cross-attention. Causal is bottom-right aligned, so seqlen_q > seqlen_kv leaves the
-# leading (seqlen_q - seqlen_kv) rows seeing no keys: the kernel writes O=0 (l_inv guard)
-# and LSE=-inf there, and attention_ref agrees (it zeroes all-masked rows, and its
-# logsumexp is -inf).
+# Causal is bottom-right aligned, so seqlen_q > seqlen_kv gives O=0 / LSE=-inf rows.
 #   (batch, seqlen_q, seqlen_kv, nheads, nheads_k)
 _OPUS_BATCH_CASES = [
     (2, 64, 64, 8, 2),  # 1 KV tile, GQA
@@ -1121,17 +1117,11 @@ _OPUS_BATCH_CASES = [
     (1, 4096, 4096, 8, 2),  # large, GQA
     (4, 256, 256, 8, 8),  # larger batch, MHA
     (2, 128, 512, 8, 2),  # cross sq < sk, GQA
-    (2, 512, 128, 8, 2),  # cross sq > sk -> fully-masked leading rows when causal
-    (1, 300, 700, 4, 4),  # cross, partial tiles on both sides, MHA
+    (2, 512, 128, 8, 2),  # cross sq > sk, GQA
+    (1, 300, 700, 4, 4),  # cross, partial both sides, MHA
     (2, 256, 65, 16, 4),  # cross, sk under one KV tile, GQA
-    (2, 1, 1024, 8, 8),  # single query row (partial Q block), MHA
-    (
-        2,
-        1024,
-        640,
-        64,
-        8,
-    ),  # sq > sk large: ceil(1024/256)*64*2 = 512 -> head/tail merge
+    (2, 1, 1024, 8, 8),  # single query row, MHA
+    (2, 1024, 640, 64, 8),  # 4*64*2 = 512 -> causal head/tail merge
 ]
 
 _OPUS_BATCH_IDS = [
@@ -1142,8 +1132,7 @@ _OPUS_BATCH_IDS = [
 def _run_opus_batch_case(
     batch_size, seqlen_q, seqlen_kv, nheads, nheads_k, d_qk, d_v, causal
 ):
-    """Body shared by the two OPUS dense tests: run through flash_attn_func with LSE,
-    assert it actually routed to OPUS, then check out / LSE / fully-masked rows."""
+    """Shared body: flash_attn_func with LSE, assert it routed to OPUS, check results."""
     torch.manual_seed(0)
     q = torch.randn(
         batch_size, seqlen_q, nheads, d_qk, device="cuda", dtype=dtypes.bf16
@@ -1167,9 +1156,8 @@ def _run_opus_batch_case(
             return_lse=True,
             return_attn_probs=False,
         )
-        # Bitwise match against the direct wrapper: the dispatch chain tries several
-        # backends before OPUS, so without this the checks below could be validating
-        # some other kernel entirely.
+        # The dispatch chain tries several backends before OPUS; without this the
+        # checks below could be validating a different kernel.
         out_opus = fmha_fwd_bf16_opus_fwd(
             q, k, v, softmax_scale=d_qk**-0.5, causal=causal
         )
@@ -1189,8 +1177,7 @@ def _run_opus_batch_case(
     assert tuple(lse.shape) == (batch_size, nheads, seqlen_q), f"lse {tuple(lse.shape)}"
     opus_check_lse(tag, lse, lse_ref)
 
-    # Rows that see no keys must produce exactly 0 (not NaN) for O.
-    dead = torch.isneginf(lse_ref)  # [B, H, Sq]
+    dead = torch.isneginf(lse_ref)  # rows that see no keys -> O must be exactly 0
     if dead.any():
         dead_o = dead.permute(0, 2, 1).unsqueeze(-1).expand_as(out)
         assert (out[dead_o] == 0).all(), f"{tag}: fully-masked rows must produce O=0"
@@ -1208,9 +1195,8 @@ def test_flash_attn_func_opus(
 ):
     """OPUS gfx950 dense D=128 forward through flash_attn_func, with LSE.
 
-    This kernel is env-gated (AITER_ENABLE_FMHA_OPUS=1) on top of the shared gate
-    (gfx950, bf16, dense, no dropout/bias/swa/sink/quant). The env is monkeypatched
-    scoped to this test so every other case keeps exercising the default v3/CK dispatch.
+    Env-gated (AITER_ENABLE_FMHA_OPUS=1); monkeypatched scoped to this test so the
+    other cases keep exercising the default v3/CK dispatch.
     """
     if get_gfx() != "gfx950":
         pytest.skip("opus D=128 kernel requires gfx950")
@@ -1231,8 +1217,7 @@ def test_flash_attn_func_opus_d192_v128(
 ):
     """OPUS gfx950 dense D_QK=192/D_V=128 forward through flash_attn_func, with LSE.
 
-    Enabled by DEFAULT (no env), so flash_attn_func should route here for (192,128) bf16
-    on gfx950 without any monkeypatch.
+    Enabled by default (no env), so no monkeypatch.
     """
     if get_gfx() != "gfx950":
         pytest.skip("opus D=192 kernel requires gfx950")

--- a/op_tests/test_mha.py
+++ b/op_tests/test_mha.py
@@ -11,7 +11,7 @@ import torch
 import aiter
 from aiter import dtypes
 from aiter.jit.utils.chip_info import get_gfx
-from aiter.ops.mha import fmha_fwd_bf16_opus_fwd, fmha_fwd_bf16_opus_varlen_fwd
+from aiter.ops.mha import fmha_fwd_bf16_opus_fwd
 from aiter.test_common import benchmark, run_perftest
 from aiter.test_mha_common import (
     attention_ref,
@@ -19,6 +19,8 @@ from aiter.test_mha_common import (
     ck_randval_to_dropout_mask,
     convert_flash_attn_S_to_softmax,
     generate_qkv,
+    opus_check_lse,
+    opus_ref_lse,
 )
 
 
@@ -1101,112 +1103,60 @@ def test_mha_bwd_sink_null_gives_same_as_no_sink(dtype):
     )
 
 
-# OPUS gfx950 dense D=128 via flash_attn_func. Cases span the gate (sq==sk):
-# le2 (<=128), pipelined odd/even, partial last tile (n%64), large n; MHA/GQA/MQA.
-_OPUS_CASES = [
-    (2, 64, 8, 2),  # le2 1-tile, GQA
-    (2, 128, 16, 1),  # le2 2-tile, MQA
-    (2, 100, 8, 2),  # partial last tile, GQA
-    (2, 127, 8, 8),  # partial last tile, MHA
-    (2, 129, 32, 8),  # pipelined odd (3 tiles), GQA
-    (1, 200, 16, 16),  # pipelined, MHA
-    (2, 256, 8, 1),  # pipelined even, MQA
-    (2, 512, 8, 2),  # pipelined even, GQA
-    (1, 1000, 8, 8),  # partial large, MHA
-    (2, 1023, 16, 4),  # partial odd, GQA
-    (1, 4096, 8, 2),  # large, GQA
-    (4, 256, 8, 8),  # larger batch, MHA
+# OPUS gfx950 dense (batch) cases, shared by the D=128 and D_QK=192/D_V=128 tests.
+# seqlen_q == seqlen_kv entries cover the self-attention tile/Q-block geometry; the rest
+# are cross-attention. Causal is bottom-right aligned, so seqlen_q > seqlen_kv leaves the
+# leading (seqlen_q - seqlen_kv) rows seeing no keys: the kernel writes O=0 (l_inv guard)
+# and LSE=-inf there, and attention_ref agrees (it zeroes all-masked rows, and its
+# logsumexp is -inf).
+#   (batch, seqlen_q, seqlen_kv, nheads, nheads_k)
+_OPUS_BATCH_CASES = [
+    (2, 64, 64, 8, 2),  # 1 KV tile, GQA
+    (2, 128, 128, 16, 1),  # 2 KV tiles, MQA
+    (2, 100, 100, 8, 2),  # partial last KV tile, GQA
+    (2, 129, 129, 32, 8),  # pipelined odd tile count, GQA
+    (1, 256, 256, 16, 16),  # exactly one Q block, MHA
+    (2, 512, 512, 8, 1),  # multiple Q blocks, MQA
+    (2, 1023, 1023, 16, 4),  # partial odd, GQA
+    (1, 4096, 4096, 8, 2),  # large, GQA
+    (4, 256, 256, 8, 8),  # larger batch, MHA
+    (2, 128, 512, 8, 2),  # cross sq < sk, GQA
+    (2, 512, 128, 8, 2),  # cross sq > sk -> fully-masked leading rows when causal
+    (1, 300, 700, 4, 4),  # cross, partial tiles on both sides, MHA
+    (2, 256, 65, 16, 4),  # cross, sk under one KV tile, GQA
+    (2, 1, 1024, 8, 8),  # single query row (partial Q block), MHA
+    (
+        2,
+        1024,
+        640,
+        64,
+        8,
+    ),  # sq > sk large: ceil(1024/256)*64*2 = 512 -> head/tail merge
+]
+
+_OPUS_BATCH_IDS = [
+    f"b{b}_sq{sq}_sk{sk}_h{h}_hkv{hk}" for (b, sq, sk, h, hk) in _OPUS_BATCH_CASES
 ]
 
 
-@pytest.mark.parametrize("causal", [False, True])
-@pytest.mark.parametrize(
-    "batch_size,seqlen,nheads,nheads_k",
-    _OPUS_CASES,
-    ids=[f"b{b}_s{s}_h{h}_hkv{hk}" for (b, s, h, hk) in _OPUS_CASES],
-)
-def test_flash_attn_func_opus(
-    batch_size, seqlen, nheads, nheads_k, causal, monkeypatch
+def _run_opus_batch_case(
+    batch_size, seqlen_q, seqlen_kv, nheads, nheads_k, d_qk, d_v, causal
 ):
-    """Validate the OPUS D=128 kernel THROUGH flash_attn_func.
-
-    Opus engages only with AITER_ENABLE_FMHA_OPUS=1 + the gate (gfx950, bf16,
-    D=128, dense, sq==sk, inference/no-LSE). The env is monkeypatched scoped to
-    this test so the other cases keep exercising the default v3/CK dispatch.
-    """
-    if get_gfx() != "gfx950":
-        pytest.skip("opus D=128 kernel requires gfx950")
-    monkeypatch.setenv("AITER_ENABLE_FMHA_OPUS", "1")
-
+    """Body shared by the two OPUS dense tests: run through flash_attn_func with LSE,
+    assert it actually routed to OPUS, then check out / LSE / fully-masked rows."""
     torch.manual_seed(0)
-    d = 128
-    q = torch.randn(batch_size, seqlen, nheads, d, device="cuda", dtype=dtypes.bf16)
-    k = torch.randn(batch_size, seqlen, nheads_k, d, device="cuda", dtype=dtypes.bf16)
-    v = torch.randn(batch_size, seqlen, nheads_k, d, device="cuda", dtype=dtypes.bf16)
-
-    with torch.no_grad():
-        out = aiter.flash_attn_func(
-            q,
-            k,
-            v,
-            dropout_p=0.0,
-            softmax_scale=None,  # -> default 1/sqrt(d), matches attention_ref
-            causal=causal,
-            window_size=(-1, -1),
-            return_lse=False,
-            return_attn_probs=False,
-        )
-
-    out_ref, _ = run_torch(q, k, v, causal=causal)
-    out_pt, _ = run_torch(q, k, v, causal=causal, upcast=False, reorder_ops=True)
-    out_tol = max(2 * (out_pt - out_ref).abs().max().item(), 0.01)
-    print(f"[opus] out max diff: {(out - out_ref).abs().max().item()} tol={out_tol}")
-    assert (out - out_ref).abs().max().item() <= out_tol
-
-    with torch.no_grad():
-        out_opus = fmha_fwd_bf16_opus_fwd(q, k, v, softmax_scale=d**-0.5, causal=causal)
-    assert torch.equal(
-        out, out_opus
-    ), "flash_attn_func did not route to the opus kernel (env/gate not engaged)"
-
-
-# OPUS gfx950 asymmetric D_QK=192 / D_V=128. Batch cases span partial/odd/large seqlen
-# and MHA/GQA/MQA. This kernel is enabled by DEFAULT (no env), so flash_attn_func should
-# route here for (192,128) bf16 on gfx950 without any monkeypatch.
-_OPUS_D192_CASES = [
-    (2, 64, 8, 2),  # tiny, GQA
-    (2, 100, 8, 2),  # partial last tile, GQA
-    (2, 127, 8, 8),  # partial last tile, MHA
-    (2, 129, 32, 8),  # pipelined odd, GQA
-    (1, 256, 16, 16),  # MHA
-    (2, 512, 8, 1),  # MQA
-    (1, 1023, 16, 4),  # partial odd, GQA
-    (1, 4096, 8, 2),  # large, GQA
-    (4, 256, 8, 8),  # larger batch, MHA
-]
-
-
-@pytest.mark.parametrize("causal", [False, True])
-@pytest.mark.parametrize(
-    "batch_size,seqlen,nheads,nheads_k",
-    _OPUS_D192_CASES,
-    ids=[f"b{b}_s{s}_h{h}_hkv{hk}" for (b, s, h, hk) in _OPUS_D192_CASES],
-)
-def test_flash_attn_func_opus_d192_v128(batch_size, seqlen, nheads, nheads_k, causal):
-    """Validate the OPUS D_QK=192/D_V=128 kernel THROUGH flash_attn_func (default-on)."""
-    if get_gfx() != "gfx950":
-        pytest.skip("opus D=192 kernel requires gfx950")
-
-    torch.manual_seed(0)
-    d_qk, d_v = 192, 128
-    q = torch.randn(batch_size, seqlen, nheads, d_qk, device="cuda", dtype=dtypes.bf16)
-    k = torch.randn(
-        batch_size, seqlen, nheads_k, d_qk, device="cuda", dtype=dtypes.bf16
+    q = torch.randn(
+        batch_size, seqlen_q, nheads, d_qk, device="cuda", dtype=dtypes.bf16
     )
-    v = torch.randn(batch_size, seqlen, nheads_k, d_v, device="cuda", dtype=dtypes.bf16)
+    k = torch.randn(
+        batch_size, seqlen_kv, nheads_k, d_qk, device="cuda", dtype=dtypes.bf16
+    )
+    v = torch.randn(
+        batch_size, seqlen_kv, nheads_k, d_v, device="cuda", dtype=dtypes.bf16
+    )
 
     with torch.no_grad():
-        out = aiter.flash_attn_func(
+        out, lse = aiter.flash_attn_func(
             q,
             k,
             v,
@@ -1214,98 +1164,78 @@ def test_flash_attn_func_opus_d192_v128(batch_size, seqlen, nheads, nheads_k, ca
             softmax_scale=None,  # -> default 1/sqrt(d_qk), matches attention_ref
             causal=causal,
             window_size=(-1, -1),
-            return_lse=False,
+            return_lse=True,
             return_attn_probs=False,
         )
-
-    out_ref, _, _ = attention_ref(q, k, v, causal=causal)
-    out_pt, _, _ = attention_ref(q, k, v, causal=causal, upcast=False, reorder_ops=True)
-    out_tol = max(2 * (out_pt - out_ref).abs().max().item(), 0.01)
-    print(
-        f"[opus-d192] out max diff: {(out - out_ref).abs().max().item()} tol={out_tol}"
-    )
-    assert (out - out_ref).abs().max().item() <= out_tol
-
-    with torch.no_grad():
+        # Bitwise match against the direct wrapper: the dispatch chain tries several
+        # backends before OPUS, so without this the checks below could be validating
+        # some other kernel entirely.
         out_opus = fmha_fwd_bf16_opus_fwd(
             q, k, v, softmax_scale=d_qk**-0.5, causal=causal
         )
     assert torch.equal(
         out, out_opus
-    ), "flash_attn_func did not route to the opus D=192 kernel"
+    ), f"flash_attn_func did not route to the opus d{d_qk} kernel"
 
+    tag = f"opus-d{d_qk}"
+    out_ref, _, _ = attention_ref(q, k, v, causal=causal)
+    out_pt, _, _ = attention_ref(q, k, v, causal=causal, upcast=False, reorder_ops=True)
+    out_tol = max(2 * (out_pt - out_ref).abs().max().item(), 0.01)
+    out_diff = (out - out_ref).abs().max().item()
+    print(f"[{tag}] out max diff: {out_diff} tol={out_tol}")
+    assert out_diff <= out_tol
 
-# OPUS gfx950 group/varlen D_QK=192 / D_V=128. Validated through the direct wrapper
-# (packed THD; exercises the group-mode host launch + kernel via the shared pybind).
-_OPUS_D192_GROUP_CASES = [
-    (3, [64, 200, 500], 8, 2),  # varlen, GQA
-    (2, [128, 1000], 16, 16),  # varlen, MHA
-    (4, [300, 300, 300, 300], 8, 8),  # uniform, MHA
-    (2, [1023, 65], 16, 4),  # odd/partial, GQA
-]
+    lse_ref = opus_ref_lse(q, k, causal)
+    assert tuple(lse.shape) == (batch_size, nheads, seqlen_q), f"lse {tuple(lse.shape)}"
+    opus_check_lse(tag, lse, lse_ref)
+
+    # Rows that see no keys must produce exactly 0 (not NaN) for O.
+    dead = torch.isneginf(lse_ref)  # [B, H, Sq]
+    if dead.any():
+        dead_o = dead.permute(0, 2, 1).unsqueeze(-1).expand_as(out)
+        assert (out[dead_o] == 0).all(), f"{tag}: fully-masked rows must produce O=0"
+        print(f"[{tag}] fully-masked rows: {int(dead.sum())}")
 
 
 @pytest.mark.parametrize("causal", [False, True])
 @pytest.mark.parametrize(
-    "num_groups,seqlens,nheads,nheads_k",
-    _OPUS_D192_GROUP_CASES,
-    ids=[f"g{g}_h{h}_hkv{hk}" for (g, _sl, h, hk) in _OPUS_D192_GROUP_CASES],
+    "batch_size,seqlen_q,seqlen_kv,nheads,nheads_k",
+    _OPUS_BATCH_CASES,
+    ids=_OPUS_BATCH_IDS,
 )
-def test_fmha_fwd_bf16_opus_d192_v128_group(
-    num_groups, seqlens, nheads, nheads_k, causal
+def test_flash_attn_func_opus(
+    batch_size, seqlen_q, seqlen_kv, nheads, nheads_k, causal, monkeypatch
 ):
-    """Validate the OPUS D=192 group/varlen path via the direct shared wrapper.
+    """OPUS gfx950 dense D=128 forward through flash_attn_func, with LSE.
 
-    Self-attention per group (seqlen_q == seqlen_kv); packed [total, H, D]; no KV
-    padding (physical == real cu_seqlens). Compares each group against attention_ref.
+    This kernel is env-gated (AITER_ENABLE_FMHA_OPUS=1) on top of the shared gate
+    (gfx950, bf16, dense, no dropout/bias/swa/sink/quant). The env is monkeypatched
+    scoped to this test so every other case keeps exercising the default v3/CK dispatch.
+    """
+    if get_gfx() != "gfx950":
+        pytest.skip("opus D=128 kernel requires gfx950")
+    monkeypatch.setenv("AITER_ENABLE_FMHA_OPUS", "1")
+    _run_opus_batch_case(
+        batch_size, seqlen_q, seqlen_kv, nheads, nheads_k, 128, 128, causal
+    )
+
+
+@pytest.mark.parametrize("causal", [False, True])
+@pytest.mark.parametrize(
+    "batch_size,seqlen_q,seqlen_kv,nheads,nheads_k",
+    _OPUS_BATCH_CASES,
+    ids=_OPUS_BATCH_IDS,
+)
+def test_flash_attn_func_opus_d192_v128(
+    batch_size, seqlen_q, seqlen_kv, nheads, nheads_k, causal
+):
+    """OPUS gfx950 dense D_QK=192/D_V=128 forward through flash_attn_func, with LSE.
+
+    Enabled by DEFAULT (no env), so flash_attn_func should route here for (192,128) bf16
+    on gfx950 without any monkeypatch.
     """
     if get_gfx() != "gfx950":
         pytest.skip("opus D=192 kernel requires gfx950")
-    assert len(seqlens) == num_groups
-
-    torch.manual_seed(0)
-    d_qk, d_v = 192, 128
-    total = sum(seqlens)
-    q = torch.randn(total, nheads, d_qk, device="cuda", dtype=dtypes.bf16)
-    k = torch.randn(total, nheads_k, d_qk, device="cuda", dtype=dtypes.bf16)
-    v = torch.randn(total, nheads_k, d_v, device="cuda", dtype=dtypes.bf16)
-
-    cu = torch.tensor(
-        [0] + list(torch.tensor(seqlens).cumsum(0).tolist()),
-        dtype=torch.int32,
-        device="cuda",
+    _run_opus_batch_case(
+        batch_size, seqlen_q, seqlen_kv, nheads, nheads_k, 192, 128, causal
     )
-    max_s = max(seqlens)
-
-    with torch.no_grad():
-        out = fmha_fwd_bf16_opus_varlen_fwd(
-            q,
-            k,
-            v,
-            softmax_scale=d_qk**-0.5,
-            causal=causal,
-            seqstart_q=cu,
-            seqstart_k=cu,
-            max_seqlen_q=max_s,
-            max_seqlen_k=max_s,
-        )
-
-    # Per-group fp32 reference.
-    max_diff = 0.0
-    starts = [0]
-    for s in seqlens:
-        starts.append(starts[-1] + s)
-    for g in range(num_groups):
-        lo, hi = starts[g], starts[g + 1]
-        qg = q[lo:hi].unsqueeze(0)
-        kg = k[lo:hi].unsqueeze(0)
-        vg = v[lo:hi].unsqueeze(0)
-        out_ref, _, _ = attention_ref(qg, kg, vg, causal=causal)
-        out_pt, _, _ = attention_ref(
-            qg, kg, vg, causal=causal, upcast=False, reorder_ops=True
-        )
-        tol = max(2 * (out_pt - out_ref).abs().max().item(), 0.01)
-        diff = (out[lo:hi].unsqueeze(0) - out_ref).abs().max().item()
-        max_diff = max(max_diff, diff)
-        assert diff <= tol, f"group {g} diff {diff} > tol {tol}"
-    print(f"[opus-d192-group] max diff across groups: {max_diff}")

--- a/op_tests/test_mha.py
+++ b/op_tests/test_mha.py
@@ -1122,6 +1122,7 @@ _OPUS_BATCH_CASES = [
     (2, 256, 65, 16, 4),  # cross, sk under one KV tile, GQA
     (2, 1, 1024, 8, 8),  # single query row, MHA
     (2, 1024, 640, 64, 8),  # 4*64*2 = 512 -> causal head/tail merge
+    (2, 300, 0, 8, 2),  # no keys at all -> zero KV tiles, every row fully masked
 ]
 
 _OPUS_BATCH_IDS = [

--- a/op_tests/test_mha_varlen.py
+++ b/op_tests/test_mha_varlen.py
@@ -10,6 +10,8 @@ import torch
 
 import aiter
 from aiter import dtypes
+from aiter.jit.utils.chip_info import get_gfx
+from aiter.ops.mha import fmha_fwd_bf16_opus_varlen_fwd
 from aiter.test_common import benchmark, run_perftest
 from aiter.test_mha_common import (
     attention_ref,
@@ -18,6 +20,8 @@ from aiter.test_mha_common import (
     convert_flash_attn_S_to_softmax,
     generate_qkv,
     generate_random_padding_mask,
+    opus_check_lse,
+    opus_ref_lse,
     pad_rearrange_dropout_mask_hts_to_bhss,
 )
 
@@ -1317,3 +1321,120 @@ def test_mha_varlen_bwd_sink_variable_lengths(dtype):
         atol=0.5,
         msg="varlen variable-length d_sink mismatch",
     )
+
+
+# OPUS gfx950 group/varlen D_QK=192 / D_V=128, validated through the direct shared
+# wrapper (packed THD; exercises the group-mode host launch + kernel via the shared
+# pybind). Q and KV carry independent cu_seqlens, so entries where the two length lists
+# differ are packed cross-attention; causal is bottom-right aligned per group, meaning a
+# group with seqlen_q > seqlen_kv has leading rows that see no keys (O=0, LSE=-inf).
+# kv_pad > 0 selects the KV-padding variant: each group's K/V rows are aligned up to that
+# multiple, so seqstart_k (real lengths, drives masks / tile counts) and seqstart_k_pad
+# (physical row offsets) diverge. The gaps are NaN-filled, so any read past a group's real
+# seqlen_kv -- which the kernel must clamp away via num_records -- shows up as NaN in out.
+#   (q seqlens, kv seqlens, nheads, nheads_k, kv_pad)
+_OPUS_D192_GROUP_CASES = [
+    ([64, 200, 500], [64, 200, 500], 8, 2, 0),  # varlen self-attn, GQA
+    ([128, 1000], [128, 1000], 16, 16, 0),  # varlen self-attn, MHA
+    ([1023, 65], [1023, 65], 16, 4, 0),  # odd / partial, GQA
+    ([777], [777], 8, 2, 0),  # single group, GQA
+    ([64] * 17, [64] * 17, 8, 8, 0),  # many groups, MHA
+    ([128, 512], [512, 128], 8, 2, 0),  # cross, one group each way, GQA
+    ([300, 77, 1024], [700, 200, 300], 4, 4, 0),  # cross, mixed + partial, MHA
+    ([1024, 8], [1, 8], 2, 1, 0),  # 1024 queries vs a single key, MQA
+    ([1, 1, 1], [256, 512, 64], 16, 4, 0),  # decode-shaped groups, GQA
+    # ceil(1024/256)*64*2 = 512 -> causal head/tail merge on, so the mirror Q block scans
+    # KV in reverse; group 0 is also sq > sk so that pass starts on a fully-masked tile.
+    ([1024, 1024], [640, 1024], 64, 8, 0),
+    ([200, 64, 700], [200, 64, 700], 8, 2, 256),  # KV padded to 256, GQA
+    ([1, 300], [1024, 333], 16, 4, 64),  # KV padded + cross, GQA
+]
+
+
+@pytest.mark.parametrize("causal", [False, True])
+@pytest.mark.parametrize(
+    "seqlens_q,seqlens_kv,nheads,nheads_k,kv_pad",
+    _OPUS_D192_GROUP_CASES,
+    ids=[
+        f"g{len(a)}_h{h}_hkv{hk}_pad{p}" for (a, _b, h, hk, p) in _OPUS_D192_GROUP_CASES
+    ],
+)
+def test_fmha_fwd_bf16_opus_d192_v128_group(
+    seqlens_q, seqlens_kv, nheads, nheads_k, kv_pad, causal
+):
+    """OPUS D=192 group/varlen forward with LSE, per group against attention_ref.
+
+    Packed [total, H, D]. kv_pad=0 keeps physical == real cu_seqlens; kv_pad > 0
+    exercises the KV-padding variant (see the case list).
+    """
+    if get_gfx() != "gfx950":
+        pytest.skip("opus D=192 kernel requires gfx950")
+    assert len(seqlens_q) == len(seqlens_kv)
+
+    torch.manual_seed(0)
+    d_qk, d_v = 192, 128
+
+    def _cumsum(lengths):
+        return torch.tensor(
+            [0] + list(torch.tensor(lengths).cumsum(0).tolist()),
+            dtype=torch.int32,
+            device="cuda",
+        )
+
+    # Physical KV rows per group (== real when kv_pad == 0).
+    phys_kv = [
+        ((s + kv_pad - 1) // kv_pad) * kv_pad if kv_pad else s for s in seqlens_kv
+    ]
+    total_q = sum(seqlens_q)
+    cu_q = _cumsum(seqlens_q)
+    cu_k = _cumsum(seqlens_kv)  # real lengths -> masks / tile counts
+    cu_k_pad = _cumsum(phys_kv)  # physical row offsets
+
+    q = torch.randn(total_q, nheads, d_qk, device="cuda", dtype=dtypes.bf16)
+    k = torch.randn(sum(phys_kv), nheads_k, d_qk, device="cuda", dtype=dtypes.bf16)
+    v = torch.randn(sum(phys_kv), nheads_k, d_v, device="cuda", dtype=dtypes.bf16)
+    if kv_pad:
+        for g, (real, phys) in enumerate(zip(seqlens_kv, phys_kv)):
+            gap = slice(int(cu_k_pad[g]) + real, int(cu_k_pad[g]) + phys)
+            k[gap] = float("nan")
+            v[gap] = float("nan")
+
+    with torch.no_grad():
+        out, lse = fmha_fwd_bf16_opus_varlen_fwd(
+            q,
+            k,
+            v,
+            softmax_scale=d_qk**-0.5,
+            causal=causal,
+            seqstart_q=cu_q,
+            seqstart_k=cu_k,
+            seqstart_k_pad=cu_k_pad if kv_pad else None,
+            max_seqlen_q=max(seqlens_q),
+            max_seqlen_k=max(seqlens_kv),
+            return_lse=True,
+        )
+
+    assert tuple(lse.shape) == (nheads, total_q), f"lse shape {tuple(lse.shape)}"
+    assert not torch.isnan(out).any(), "read into the KV padding gap (NaN reached out)"
+    assert not torch.isnan(lse).any(), "read into the KV padding gap (NaN reached lse)"
+
+    max_diff = 0.0
+    for g in range(len(seqlens_q)):
+        ql, qh = int(cu_q[g]), int(cu_q[g + 1])
+        kl = int(cu_k_pad[g])  # physical start, real length
+        kh = kl + seqlens_kv[g]
+        qg = q[ql:qh].unsqueeze(0)
+        kg = k[kl:kh].unsqueeze(0)
+        vg = v[kl:kh].unsqueeze(0)
+        out_ref, _, _ = attention_ref(qg, kg, vg, causal=causal)
+        out_pt, _, _ = attention_ref(
+            qg, kg, vg, causal=causal, upcast=False, reorder_ops=True
+        )
+        tol = max(2 * (out_pt - out_ref).abs().max().item(), 0.01)
+        diff = (out[ql:qh].unsqueeze(0) - out_ref).abs().max().item()
+        max_diff = max(max_diff, diff)
+        assert diff <= tol, f"group {g} diff {diff} > tol {tol}"
+        opus_check_lse(
+            f"opus-d192-group g{g}", lse[:, ql:qh], opus_ref_lse(qg, kg, causal)[0]
+        )
+    print(f"[opus-d192-group] max diff across groups: {max_diff}")

--- a/op_tests/test_mha_varlen.py
+++ b/op_tests/test_mha_varlen.py
@@ -1323,15 +1323,11 @@ def test_mha_varlen_bwd_sink_variable_lengths(dtype):
     )
 
 
-# OPUS gfx950 group/varlen D_QK=192 / D_V=128, validated through the direct shared
-# wrapper (packed THD; exercises the group-mode host launch + kernel via the shared
-# pybind). Q and KV carry independent cu_seqlens, so entries where the two length lists
-# differ are packed cross-attention; causal is bottom-right aligned per group, meaning a
-# group with seqlen_q > seqlen_kv has leading rows that see no keys (O=0, LSE=-inf).
-# kv_pad > 0 selects the KV-padding variant: each group's K/V rows are aligned up to that
-# multiple, so seqstart_k (real lengths, drives masks / tile counts) and seqstart_k_pad
-# (physical row offsets) diverge. The gaps are NaN-filled, so any read past a group's real
-# seqlen_kv -- which the kernel must clamp away via num_records -- shows up as NaN in out.
+# OPUS gfx950 group/varlen D_QK=192 / D_V=128 via the direct wrapper (packed THD).
+# Q and KV take independent cu_seqlens, so entries whose length lists differ are packed
+# cross-attention. kv_pad > 0 aligns each group's K/V rows up to that multiple, making
+# seqstart_k (real lengths) and seqstart_k_pad (physical offsets) diverge; the gaps are
+# NaN-filled so a read past a group's real seqlen_kv surfaces as NaN.
 #   (q seqlens, kv seqlens, nheads, nheads_k, kv_pad)
 _OPUS_D192_GROUP_CASES = [
     ([64, 200, 500], [64, 200, 500], 8, 2, 0),  # varlen self-attn, GQA
@@ -1343,9 +1339,7 @@ _OPUS_D192_GROUP_CASES = [
     ([300, 77, 1024], [700, 200, 300], 4, 4, 0),  # cross, mixed + partial, MHA
     ([1024, 8], [1, 8], 2, 1, 0),  # 1024 queries vs a single key, MQA
     ([1, 1, 1], [256, 512, 64], 16, 4, 0),  # decode-shaped groups, GQA
-    # ceil(1024/256)*64*2 = 512 -> causal head/tail merge on, so the mirror Q block scans
-    # KV in reverse; group 0 is also sq > sk so that pass starts on a fully-masked tile.
-    ([1024, 1024], [640, 1024], 64, 8, 0),
+    ([1024, 1024], [640, 1024], 64, 8, 0),  # 4*64*2 = 512 -> head/tail merge, GQA
     ([200, 64, 700], [200, 64, 700], 8, 2, 256),  # KV padded to 256, GQA
     ([1, 300], [1024, 333], 16, 4, 64),  # KV padded + cross, GQA
 ]
@@ -1362,11 +1356,7 @@ _OPUS_D192_GROUP_CASES = [
 def test_fmha_fwd_bf16_opus_d192_v128_group(
     seqlens_q, seqlens_kv, nheads, nheads_k, kv_pad, causal
 ):
-    """OPUS D=192 group/varlen forward with LSE, per group against attention_ref.
-
-    Packed [total, H, D]. kv_pad=0 keeps physical == real cu_seqlens; kv_pad > 0
-    exercises the KV-padding variant (see the case list).
-    """
+    """OPUS D=192 group/varlen forward with LSE, per group against attention_ref."""
     if get_gfx() != "gfx950":
         pytest.skip("opus D=192 kernel requires gfx950")
     assert len(seqlens_q) == len(seqlens_kv)
@@ -1381,14 +1371,13 @@ def test_fmha_fwd_bf16_opus_d192_v128_group(
             device="cuda",
         )
 
-    # Physical KV rows per group (== real when kv_pad == 0).
     phys_kv = [
         ((s + kv_pad - 1) // kv_pad) * kv_pad if kv_pad else s for s in seqlens_kv
     ]
     total_q = sum(seqlens_q)
     cu_q = _cumsum(seqlens_q)
-    cu_k = _cumsum(seqlens_kv)  # real lengths -> masks / tile counts
-    cu_k_pad = _cumsum(phys_kv)  # physical row offsets
+    cu_k = _cumsum(seqlens_kv)
+    cu_k_pad = _cumsum(phys_kv)
 
     q = torch.randn(total_q, nheads, d_qk, device="cuda", dtype=dtypes.bf16)
     k = torch.randn(sum(phys_kv), nheads_k, d_qk, device="cuda", dtype=dtypes.bf16)
@@ -1415,8 +1404,8 @@ def test_fmha_fwd_bf16_opus_d192_v128_group(
         )
 
     assert tuple(lse.shape) == (nheads, total_q), f"lse shape {tuple(lse.shape)}"
-    assert not torch.isnan(out).any(), "read into the KV padding gap (NaN reached out)"
-    assert not torch.isnan(lse).any(), "read into the KV padding gap (NaN reached lse)"
+    assert not torch.isnan(out).any(), "read into the KV padding gap"
+    assert not torch.isnan(lse).any(), "read into the KV padding gap"
 
     max_diff = 0.0
     for g in range(len(seqlens_q)):

--- a/op_tests/test_mha_varlen.py
+++ b/op_tests/test_mha_varlen.py
@@ -1328,6 +1328,7 @@ def test_mha_varlen_bwd_sink_variable_lengths(dtype):
 # cross-attention. kv_pad > 0 aligns each group's K/V rows up to that multiple, making
 # seqstart_k (real lengths) and seqstart_k_pad (physical offsets) diverge; the gaps are
 # NaN-filled so a read past a group's real seqlen_kv surfaces as NaN.
+# A kv seqlen of 0 is a group with no keys: out == 0 / lse == -inf exactly.
 #   (q seqlens, kv seqlens, nheads, nheads_k, kv_pad)
 _OPUS_D192_GROUP_CASES = [
     ([64, 200, 500], [64, 200, 500], 8, 2, 0),  # varlen self-attn, GQA
@@ -1342,6 +1343,10 @@ _OPUS_D192_GROUP_CASES = [
     ([1024, 1024], [640, 1024], 64, 8, 0),  # 4*64*2 = 512 -> head/tail merge, GQA
     ([200, 64, 700], [200, 64, 700], 8, 2, 256),  # KV padded to 256, GQA
     ([1, 300], [1024, 333], 16, 4, 64),  # KV padded + cross, GQA
+    ([256, 256], [0, 256], 8, 2, 0),  # no keys in the first group, GQA
+    ([128, 96, 300], [256, 0, 128], 8, 8, 0),  # no keys in a middle group, MHA
+    ([600, 100], [0, 33], 4, 1, 0),  # empty group spanning 3 Q blocks, MQA
+    ([100, 100], [0, 300], 8, 2, 64),  # empty group + KV padding, GQA
 ]
 
 
@@ -1350,7 +1355,8 @@ _OPUS_D192_GROUP_CASES = [
     "seqlens_q,seqlens_kv,nheads,nheads_k,kv_pad",
     _OPUS_D192_GROUP_CASES,
     ids=[
-        f"g{len(a)}_h{h}_hkv{hk}_pad{p}" for (a, _b, h, hk, p) in _OPUS_D192_GROUP_CASES
+        f"g{len(a)}_h{h}_hkv{hk}_pad{p}" + ("_emptykv" if 0 in b else "")
+        for (a, b, h, hk, p) in _OPUS_D192_GROUP_CASES
     ],
 )
 def test_fmha_fwd_bf16_opus_d192_v128_group(
@@ -1412,6 +1418,16 @@ def test_fmha_fwd_bf16_opus_d192_v128_group(
         ql, qh = int(cu_q[g]), int(cu_q[g + 1])
         kl = int(cu_k_pad[g])  # physical start, real length
         kh = kl + seqlens_kv[g]
+        if seqlens_kv[g] == 0:
+            # Assert the contract exactly rather than through attention_ref, whose
+            # degenerate-shape behaviour is its own question.
+            assert torch.equal(
+                out[ql:qh], torch.zeros_like(out[ql:qh])
+            ), f"group {g} has no keys, out must be exactly 0"
+            assert torch.isneginf(
+                lse[:, ql:qh]
+            ).all(), f"group {g} has no keys, lse must be -inf"
+            continue
         qg = q[ql:qh].unsqueeze(0)
         kg = k[kl:kh].unsqueeze(0)
         vg = v[kl:kh].unsqueeze(0)


### PR DESCRIPTION
## Motivation

The OPUS gfx950 bf16 forward kernels were inference-only: with no LSE output, `return_lse=True` — and therefore the whole autograd path, which asserts `return_lse` whenever `is_grad` — fell back to `fmha_v3`/CK and lost the OPUS speedup. This adds LSE to both OPUS forward kernels (D=128 and D_QK=192/D_V=128, batch + group/varlen) and opens the dispatch gates so those callers keep it.

## Technical Details

* **LSE is exact under the FAv4 selective max update.** `m_row` is not the true row max (the running max is only refreshed past `RESCALE_THRESHOLD`), but `l_row` stays consistent with whatever base it holds and log-sum-exp is invariant to that base, so `lse = ln2 * (m_row + log2(l_row))`. Fully-masked rows (bottom-right causal, `seqlen_q > seqlen_kv`) get `-inf`, matching `torch.logsumexp`.
* **Gated at runtime on `ptr_lse != nullptr`** rather than a traits flag: a scalar branch, no extra instantiations, and callers that skip LSE skip the allocation and the store. Costs 2 VGPR on D=192 / 1 on D=128, occupancy unchanged.
* **Output** is fp32 natural log — batch `[B, H, N]`, group `[H, total_q]`. In the API `lse` is an out-param like `out`; only `return_lse` changes the return type.
* **Both dispatch gates dropped `not return_lse`** (keeping `not return_softmax`), which also makes the autograd path reachable, i.e. the OPUS forward now feeds the v3/CK backward. Test side: 5 OPUS test functions → 3, with `seqlen_q != seqlen_kv` folded into the shared case lists.

## Test Plan

* `pytest op_tests/{test_mha,test_mha_varlen}.py -k opus`. LSE is compared against an **fp32** logsumexp reference, not `attention_ref`'s — that one is cast back to the input dtype and at `|lse| ~ 8` is coarser than the kernels' own error.
* Coverage: cross-attention both directions incl. fully-masked rows; causal head/tail merge engaged so the mirror Q block scans KV in reverse; KV padding with NaN-filled gaps; single / 17 / decode-shaped groups; autograd grads vs a torch fp32 reference. Every case asserts the output is bitwise-equal to the direct wrapper, so the checks cannot silently validate another backend (negative controls confirm they discriminate).
* Resources via `-Rpass-analysis=kernel-resource-usage` before/after; perf via `run_perftest` on the PR #4205 shapes (`seqlen × batch = 16384`, causal, bf16, nheads ∈ {16, 32}), LSE on vs off plus a rebuilt pre-LSE baseline.

## Test Result

* **Correctness:** 84 passed (60 batch + 24 group). LSE max diff vs fp32 reference: **D=192 ~1e-6**; **D=128 ~4e-3**, which is that kernel's pre-existing bf16 Q pre-scale rather than the LSE — against an arithmetic-matched reference it is also **1.4e-6**. `-inf` row patterns match exactly, no NaN. Grads within bf16 tolerance (causal: out 7.6e-3, dq 1.1e-2, dk 2.1e-2, dv 2.8e-2).
* **Resources:** D=192 248–250 → 250–252 VGPR, D=128 245/246 → 246/247; occupancy 2 waves/SIMD, `VGPRs Spill: 0` throughout.
* **Perf:** LSE on vs off is **0.06%–0.20%** mean across nheads ∈ {16, 32} in both modes (noise-dominated); the no-LSE path is within **±1%** of a rebuilt pre-LSE baseline with no systematic direction.
* **No regressions from opening the gates:** the 320 `test_flash_attn_output[…192-128…]` cases that now reroute to OPUS give an identical 160/160 split with and without `AITER_DISABLE_FMHA_OPUS=1` — those 160 failures are a pre-existing invalid parametrization (`assert nheads % gqa_ratio == 0` → `6 % 8`) that fails in the test's own setup on either backend.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
