### PR TITLE
[Triton] NUM_KSPLIT=1 for M<=32 preshuffled fp4 GEMM (N=8192, K=8192) (fixes #4867)

### DIFF
--- a/aiter/ops/triton/configs/gemm/gfx950-GEMM-AFP4WFP4_PRESHUFFLED-N=8192-K=8192.json
+++ b/aiter/ops/triton/configs/gemm/gfx950-GEMM-AFP4WFP4_PRESHUFFLED-N=8192-K=8192.json
@@ -33,7 +33,7 @@
         "waves_per_eu": 2,
         "matrix_instr_nonkdim": 16,
         "cache_modifier": ".cg",
-        "NUM_KSPLIT": 4
+        "NUM_KSPLIT": 1
     },
     "M_LEQ_64": {
         "BLOCK_SIZE_M": 64,


### PR DESCRIPTION
Fixes #4867.

The `M_LEQ_32` tuned entry for the `N=8192, K=8192` preshuffled fp4 GEMM selected `NUM_KSPLIT=4`. The preshuffled-scales kernel's split-K weight-scale load is not K-masked (and `get_splitk` overshoots), so `NUM_KSPLIT > 1` reads past the scale buffer and faults for small M. #4630 started selecting this config, turning the latent OOB into a GPU memory access fault.

Pin this shape to `NUM_KSPLIT=1` until the kernel's split-K scale handling is fixed. Other preshuffled configs still carry `NUM_KSPLIT>1`; this patches only the shape confirmed to crash.

**Repro** (gfx950): `M=32, N=8192, K=8192` preshuffled fp4 GEMM → GPU memory access fault before, clean after. Unblocks vLLM `test_rocm_mxfp4.py::test_aiter_fp4_gemm_preshuffled_tuned_shapes[shape1]`.

AI assistance was used; reviewed by the submitter.