### PR TITLE
[HIP] [MLA PS] workload-aware KV-split count for auto mode

### DIFF
--- a/csrc/kernels/mla/metadata/v1_2_device.cuh
+++ b/csrc/kernels/mla/metadata/v1_2_device.cuh
@@ -24,6 +24,31 @@ struct MlaMetadataV12Traits
 
 static constexpr int32_t MLA_V12_FILL_WARPS = 8;
 
+// Scales the sqrt(workload) split-K law; absorbs the arch reduction/compute
+// cost ratio. 1.2 tuned on gfx950; retune per arch if needed.
+static constexpr float MLA_V12_SPLIT_COEF = 1.2f;
+
+// Workload-adaptive KV-split count for "auto" mode (max_split_per_batch < 0).
+// The old policy pinned splits to num_clusters regardless of workload, which
+// over-splits short/medium ctx (reduction dominates, ~2x slower) while the
+// legacy cap of 16 under-splits long ctx. Split-K optimum for a unit of weight w
+// is ~coef*sqrt(w) (compute ~w/e, reduction ~e). The grid is shared across all
+// units, so the budget is the SUM of per-unit sqrt(w) -- passed in as
+// sum_sqrt_blocks -- not sqrt(sum(w)), which under-splits with >1 unit. eff is
+// clamped to [1, num_splits]; eff <= num_splits keeps the reduce-buffer
+// worst-case reservation valid (CUDA-graph safe). coef is MLA_V12_SPLIT_COEF.
+// Explicit (>= 0) requests keep the exact count asked for.
+__device__ __forceinline__ int32_t
+mla_v12_effective_splits(const MlaMetadataV1KernelParameter& params, const float sum_sqrt_blocks)
+{
+    if(!params.auto_split)
+    {
+        return params.num_splits;
+    }
+    int32_t eff = static_cast<int32_t>(lrintf(MLA_V12_SPLIT_COEF * sum_sqrt_blocks));
+    return max(1, min(eff, params.num_splits));
+}
+
 template <typename Traits>
 __device__ __forceinline__ int32_t mla_v12_num_qo_tiles(const MlaMetadataV1KernelParameter& params,
                                                         QoState<Traits>& qo_state,
@@ -54,9 +79,11 @@ mla_v12_compute_sum_blocks(const MlaMetadataV1KernelParameter& params,
                            int32_t* p_lds_seqlens_kv,
                            const int32_t ori_seqlen_qo,
                            const int32_t num_batches,
-                           const int32_t lane_idx)
+                           const int32_t lane_idx,
+                           float& sum_sqrt_blocks_out)
 {
-    int32_t sum_blocks = 0;
+    int32_t sum_blocks      = 0;
+    float   sum_sqrt_blocks = 0.0f;
     for(int32_t bid = lane_idx; bid < num_batches; bid += opus::get_warp_size())
     {
         const int32_t bid_ori = Traits::kIsSparse ? (bid / ori_seqlen_qo / params.qk_batch_ratio)
@@ -74,7 +101,11 @@ mla_v12_compute_sum_blocks(const MlaMetadataV1KernelParameter& params,
         const int32_t num_blocks = integer_divide_ceil_power2(
             seqlen_kv, params.kv_granularity, params.kv_granularity_log2);
         const int32_t num_qo_tiles = mla_v12_num_qo_tiles<Traits>(params, qo_state, bid);
-        sum_blocks += (num_blocks + params.fixed_over_head_num_blocks) * num_qo_tiles;
+        const int32_t unit_blocks  = num_blocks + params.fixed_over_head_num_blocks;
+        sum_blocks += unit_blocks * num_qo_tiles;
+        // per (batch, qo_tile) work unit: num_qo_tiles terms of sqrt(unit_blocks)
+        sum_sqrt_blocks += static_cast<float>(num_qo_tiles) *
+                           sqrtf(static_cast<float>(max(1, unit_blocks)));
 
         if constexpr(QoState<Traits>::is_unique() == false)
         {
@@ -83,6 +114,8 @@ mla_v12_compute_sum_blocks(const MlaMetadataV1KernelParameter& params,
         }
     }
 
+    sum_sqrt_blocks_out =
+        aiter::warpReduce<aiter::AddFunctor, float, opus::get_warp_size()>(sum_sqrt_blocks);
     return aiter::warpReduce<aiter::AddFunctor, decltype(sum_blocks), opus::get_warp_size()>(
         sum_blocks);
 }
@@ -128,15 +161,18 @@ __launch_bounds__(opus::get_warp_size() * MLA_V12_FILL_WARPS, 1) __global__
     // Phase 1 (warp 0): closed-form scan, no stores
     if(warp_id == 0)
     {
-        const int32_t sum_blocks = mla_v12_compute_sum_blocks<Traits>(params,
+        float         sum_sqrt_blocks = 0.0f;
+        const int32_t sum_blocks      = mla_v12_compute_sum_blocks<Traits>(params,
                                                                       qo_state,
                                                                       p_lds_seqlens_qo,
                                                                       p_lds_seqlens_kv,
                                                                       ori_seqlen_qo,
                                                                       num_batches,
-                                                                      lane_idx);
+                                                                      lane_idx,
+                                                                      sum_sqrt_blocks);
 
-        const int32_t payload       = integer_divide_ceil(sum_blocks, params.num_splits) + overhead;
+        const int32_t eff_splits    = mla_v12_effective_splits(params, sum_sqrt_blocks);
+        const int32_t payload       = integer_divide_ceil(sum_blocks, eff_splits) + overhead;
         const int32_t blocks_per_cu = payload - overhead;
 
         if(lane_idx == 0)
@@ -395,8 +431,15 @@ __launch_bounds__(opus::get_warp_size(), 1) __global__
 
     MlaWorkInfo* p_work_info_set = reinterpret_cast<MlaWorkInfo*>(params.p_work_info_set_raw);
 
-    const int32_t sum_blocks = mla_v12_compute_sum_blocks<Traits>(
-        params, qo_state, p_lds_seqlens_qo, p_lds_seqlens_kv, ori_seqlen_qo, num_batches, lane_idx);
+    float         sum_sqrt_blocks = 0.0f;
+    const int32_t sum_blocks      = mla_v12_compute_sum_blocks<Traits>(params,
+                                                                  qo_state,
+                                                                  p_lds_seqlens_qo,
+                                                                  p_lds_seqlens_kv,
+                                                                  ori_seqlen_qo,
+                                                                  num_batches,
+                                                                  lane_idx,
+                                                                  sum_sqrt_blocks);
 
     if(lane_idx == 0)
     {
@@ -408,9 +451,10 @@ __launch_bounds__(opus::get_warp_size(), 1) __global__
             static_cast<uint64_t>(reinterpret_cast<uintptr_t>(p_work_info_set));
     }
 
-    // expected payload handled by each cu part.
+    // same eff_splits as the phase-1 count so fill and count agree
+    const int32_t eff_splits = mla_v12_effective_splits(params, sum_sqrt_blocks);
     const int32_t payload =
-        integer_divide_ceil(sum_blocks, params.num_splits) + params.fixed_over_head_num_blocks;
+        integer_divide_ceil(sum_blocks, eff_splits) + params.fixed_over_head_num_blocks;
     const int32_t page_size   = params.page_size;
     int32_t curr_batch        = 0; // batch ID of the batch which is under review
     int32_t curr_kv_block     = 0; // #blocks handled by previous cu part(s)
@@ -891,6 +935,9 @@ void get_mla_metadata_v1_2_device(const aiter_tensor_t& seqlens_qo_indptr, // [b
                              ? num_clusters
                              : min(num_clusters, max_split_per_batch * num_batches);
 
+    // auto mode: device derives the split count; num_splits above only caps it
+    const bool auto_split = (max_split_per_batch < 0);
+
     MlaMetadataV1KernelParameter params = {};
     params.p_work_metadata_ptrs         = static_cast<uint64_t*>(work_metadata_ptrs.data_ptr());
     params.p_work_indptr                = static_cast<int32_t*>(work_indptr.data_ptr());
@@ -905,6 +952,7 @@ void get_mla_metadata_v1_2_device(const aiter_tensor_t& seqlens_qo_indptr, // [b
     params.num_heads                    = num_heads;
     params.num_cu                       = num_clusters;
     params.num_splits                   = num_splits;
+    params.auto_split                   = auto_split;
     params.reduce_indptr_size           = reduce_indptr.size(0);
     params.page_size                    = page_size;
     params.kv_granularity               = kv_granularity;

--- a/csrc/kernels/mla/metadata/v1_comm.cuh
+++ b/csrc/kernels/mla/metadata/v1_comm.cuh
@@ -87,6 +87,10 @@ struct MlaMetadataV1KernelParameter
     int32_t topk;
     int32_t qk_batch_ratio;
     int32_t num_splits;
+    // auto_split (caller passed max_split_per_batch < 0): device derives the
+    // split count from workload; num_splits is only the upper bound.
+    // See mla_v12_effective_splits.
+    bool auto_split;
     bool is_causal;
     // round-robin context-parallel: when true, skip the per-qo-tile local-causal
     // KV trim (batch_tail) so each work spans the full local kv; the kernel masks


### PR DESCRIPTION
# MLA decode: workload-adaptive KV-split count for `-1` (auto) mode

## Summary

When a caller passes `max_split_per_batch = -1` ("auto") to the persistent MLA decode metadata planner, aiter previously set the KV-split count to `num_clusters` unconditionally (a flat, workload-independent choice). This over-splits short and medium contexts — the cross-split reduction dominates and wastes CUs — while the historical fixed cap of 16 under-splits long contexts. Neither is context-length aware.

This PR makes the auto path derive the split count **on-device** from the actual per-launch block workload, following split-K theory. The `-1` API contract is unchanged; only aiter's *implementation* of auto improves. Explicit (`>= 0`) split requests are untouched.

Measured on MI355X (gfx950), fp8/fp8, across **nhead {16,32,48,64,96,128} × qlen {1,2,3,4,5,6,7,8} × ctx {512..1048576}** (624 shapes), both builds passing `-1`: **geomean 1.13×, median 1.06×, max 1.93×**, worst-case 0.94× (within measurement noise).

## Root cause

Split-K attention trades compute parallelism against reduction cost. For a launch whose total work is `S` blocks split into `eff` partial results:

- compute time ∝ `S / eff` (more splits → more CUs busy in parallel)
- reduction time ∝ `eff` (more splits → more partials to combine)

The wall-clock optimum is therefore `eff ≈ coef·√S`, **not** `eff = num_clusters`. Pinning `eff` to the cluster count is only near-optimal when `S` is large enough that `√S ≈ num_clusters`; for short/medium contexts it massively over-splits, so the reduction term dominates and the kernel is 1.3–2× slower than it needs to be.

## The change

Compute an effective split count from the workload and clamp it to the old bound:

```
eff = clamp( round( coef · Σ_units √(blocks_unit) ),  1,  num_splits )
```

- A launch has **one work unit per (batch, qo_tile)** (`num_qo_tiles = seqlen_qo` when `nhead*2 > packed_qo_len_per_wg`, else `ceil(nhead*qlen / packed_qo_len_per_wg)`).
- `blocks_unit = num_blocks(kv) + overhead` is that unit's payload weight.
- `coef` defaults to **1.2**, tunable per-arch via env `AITER_MLA_SPLIT_COEF`.
- `num_splits` (= `num_clusters` in auto mode) remains the **upper bound**, so the number of partial results never exceeds the worst-case buffer reservation made by `get_mla_metadata_info_v1`. Buffer sizes are unchanged and decode-phase CUDA-graph capture stays valid.
- The phase-1 count kernel and the fill kernel share the same helper, so counts and fills always agree.

### Why per-unit √, not √ of the sum

A first version used `eff = coef·√(ΣS)` (sqrt of the *summed* workload). With more than one work unit per launch that under-splits: per-tile splits collapse to `coef·√kv / √(num_tiles)`. This is invisible for kimi-k3 (`nhead=16`, a single qo tile) but hurts high `nhead×qlen` at medium ctx. The split-K optimum is **per unit**, so the correct budget is the **sum of per-unit √weight**, which keeps per-tile splits at `≈ coef·√kv` independent of tile count. For the single-tile case the sum collapses to one term, so the kimi-k3 tuning is preserved exactly.

## Safety / compatibility

- `eff ≤ num_splits` always ⇒ partial-result / reduce-entry counts never exceed the `-1` worst-case reservation ⇒ no OOB, no buffer-size change, no CUDA-graph recapture.
- Metadata is built outside graph capture; only the derived split count changes.
- Explicit `max_split_per_batch >= 0` bypasses the adaptation entirely (bit-for-bit unchanged behavior).

## Test methodology

A **true A/B**: two separate builds of `module_mla_metadata` from the *same* tree — one with the change reverted (`UNPATCHED`), one with it applied (`PATCHED`) — were each run passing `max_split_per_batch = -1`. The `UNPATCHED` build was verified to contain **zero** adaptive markers. For every shape we record the split count each build chose for `-1` and the `mla_decode_fwd` latency (`run_perftest` median). `speedup = UNPATCHED_us / PATCHED_us` (>1 means this PR is faster).

**Scenarios covered**

- **nhead** `{16,32,48,64,96,128}` — kimi-k3 uses 16 per GPU (128 heads / TP8); larger values cover other MLA models / TP degrees so the kernel is validated beyond k3.
- **qlen** `{1,2,3,4,5,6,7,8}` — 1 = plain decode; 2–4 = common speculative/MTP depths; 5–8 = deeper draft (e.g. DSpark can propose up to ~7 tokens, so target verification runs qlen up to 8).
- **ctx** `{512,1024,2048,4096,8192,16384,32768,65536,131072,196608,262144,524288,1048576}` — from very short to ultra-long (1M) to exercise both the over-split (short/medium) and saturated (long) regimes.
- decode phase, `causal=1` (target), fp8 q / fp8 kv, page_size=1, batch=1.

## Results

### Aggregate (all shapes, speedup = old `-1` / new `-1`)

| metric | value |
|---|---|
| configs | 624 |
| geomean speedup | 1.13× |
| median speedup | 1.06× |
| max speedup | 1.93× |
| min speedup | 0.94× |
| fraction ≥ 1.00× | 88% |

### Speedup range per (nhead, qlen)

| nhead | qlen | min | median | max |
|---:|---:|:--:|:--:|:--:|
| 16 | 1 | 1.00× | 1.35× | 1.92× |
| 16 | 2 | 1.00× | 1.28× | 1.85× |
| 16 | 3 | 1.00× | 1.37× | 1.92× |
| 16 | 4 | 1.00× | 1.40× | 1.89× |
| 16 | 5 | 0.96× | 1.13× | 1.56× |
| 16 | 6 | 0.98× | 1.16× | 1.61× |
| 16 | 7 | 0.99× | 1.16× | 1.56× |
| 16 | 8 | 0.99× | 1.17× | 1.58× |
| 32 | 1 | 1.00× | 1.35× | 1.92× |
| 32 | 2 | 0.99× | 1.40× | 1.87× |
| 32 | 3 | 0.99× | 1.19× | 1.65× |
| 32 | 4 | 0.97× | 1.17× | 1.56× |
| 32 | 5 | 0.97× | 1.06× | 1.37× |
| 32 | 6 | 0.99× | 1.08× | 1.35× |
| 32 | 7 | 0.99× | 1.10× | 1.39× |
| 32 | 8 | 0.99× | 1.13× | 1.39× |
| 48 | 1 | 1.00× | 1.12× | 1.70× |
| 48 | 2 | 0.99× | 1.03× | 1.33× |
| 48 | 3 | 0.98× | 1.06× | 1.39× |
| 48 | 4 | 0.99× | 1.07× | 1.35× |
| 48 | 5 | 0.98× | 1.03× | 1.26× |
| 48 | 6 | 0.98× | 1.04× | 1.26× |
| 48 | 7 | 0.96× | 1.04× | 1.26× |
| 48 | 8 | 0.99× | 1.05× | 1.33× |
| 64 | 1 | 1.01× | 1.37× | 1.93× |
| 64 | 2 | 0.98× | 1.18× | 1.58× |
| 64 | 3 | 0.97× | 1.12× | 1.38× |
| 64 | 4 | 0.99× | 1.16× | 1.41× |
| 64 | 5 | 0.98× | 1.04× | 1.41× |
| 64 | 6 | 0.99× | 1.05× | 1.53× |
| 64 | 7 | 0.96× | 1.04× | 1.20× |
| 64 | 8 | 0.97× | 1.03× | 1.20× |
| 96 | 1 | 1.00× | 1.01× | 1.24× |
| 96 | 2 | 0.99× | 1.02× | 1.18× |
| 96 | 3 | 0.98× | 1.02× | 1.17× |
| 96 | 4 | 1.00× | 1.01× | 1.14× |
| 96 | 5 | 0.94× | 1.00× | 1.07× |
| 96 | 6 | 0.98× | 1.00× | 1.09× |
| 96 | 7 | 0.97× | 1.01× | 1.13× |
| 96 | 8 | 0.98× | 1.02× | 1.13× |
| 128 | 1 | 0.99× | 1.18× | 1.56× |
| 128 | 2 | 0.99× | 1.16× | 1.39× |
| 128 | 3 | 0.98× | 1.06× | 1.53× |
| 128 | 4 | 0.98× | 1.07× | 1.23× |
| 128 | 5 | 0.99× | 1.04× | 1.29× |
| 128 | 6 | 0.97× | 1.01× | 1.21× |
| 128 | 7 | 0.99× | 1.01× | 1.18× |
| 128 | 8 | 0.96× | 1.01× | 1.14× |

### Full raw data

Columns: `OFF` = aiter unchanged (`-1`), `ON` = this PR (`-1`); `sp` = split count the build chose, `us` = latency; `speedup = OFF_us / ON_us`.

<details><summary><b>nhead = 16</b></summary>

| qlen | ctx | OFF sp | OFF us | ON sp | ON us | speedup | faster% |
|---:|---:|---:|---:|---:|---:|:--:|:--:|
| 1 | 512 | 32 | 15.88 | 6 | 12.86 | 1.23× | +19.0% |
| 1 | 1024 | 64 | 19.29 | 8 | 14.34 | 1.35× | +25.7% |
| 1 | 2048 | 128 | 30.79 | 12 | 16.07 | 1.92× | +47.8% |
| 1 | 4096 | 128 | 30.84 | 19 | 17.70 | 1.74× | +42.6% |
| 1 | 8192 | 171 | 38.36 | 27 | 21.79 | 1.76× | +43.2% |
| 1 | 16384 | 205 | 44.82 | 38 | 26.99 | 1.66× | +39.8% |
| 1 | 32768 | 228 | 48.27 | 54 | 28.74 | 1.68× | +40.5% |
| 1 | 65536 | 241 | 53.84 | 76 | 35.81 | 1.50× | +33.5% |
| 1 | 131072 | 249 | 60.68 | 108 | 49.70 | 1.22× | +18.1% |
| 1 | 196608 | 251 | 67.25 | 133 | 59.79 | 1.12× | +11.1% |
| 1 | 262144 | 253 | 73.06 | 154 | 65.18 | 1.12× | +10.8% |
| 1 | 524288 | 255 | 109.73 | 216 | 95.43 | 1.15× | +13.0% |
| 1 | 1048576 | 256 | 154.11 | 256 | 153.88 | 1.00× | +0.1% |
| 2 | 512 | 32 | 17.90 | 6 | 15.58 | 1.15× | +12.9% |
| 2 | 1024 | 64 | 22.87 | 8 | 15.68 | 1.46× | +31.4% |
| 2 | 2048 | 128 | 33.48 | 12 | 18.07 | 1.85× | +46.0% |
| 2 | 4096 | 128 | 33.45 | 19 | 20.99 | 1.59× | +37.3% |
| 2 | 8192 | 171 | 40.44 | 27 | 24.61 | 1.64× | +39.2% |
| 2 | 16384 | 205 | 46.26 | 38 | 28.68 | 1.61× | +38.0% |
| 2 | 32768 | 228 | 52.14 | 54 | 34.85 | 1.50× | +33.2% |
| 2 | 65536 | 241 | 56.75 | 76 | 44.50 | 1.28× | +21.6% |
| 2 | 131072 | 249 | 64.10 | 108 | 55.30 | 1.16× | +13.7% |
| 2 | 196608 | 251 | 71.45 | 133 | 67.76 | 1.05× | +5.2% |
| 2 | 262144 | 253 | 76.16 | 154 | 75.69 | 1.01× | +0.6% |
| 2 | 524288 | 255 | 117.04 | 216 | 103.73 | 1.13× | +11.4% |
| 2 | 1048576 | 256 | 159.17 | 256 | 159.23 | 1.00× | -0.0% |
| 3 | 512 | 32 | 18.50 | 6 | 16.22 | 1.14× | +12.3% |
| 3 | 1024 | 64 | 23.21 | 8 | 16.89 | 1.37× | +27.2% |
| 3 | 2048 | 128 | 35.62 | 12 | 18.53 | 1.92× | +48.0% |
| 3 | 4096 | 128 | 35.87 | 19 | 20.97 | 1.71× | +41.5% |
| 3 | 8192 | 171 | 40.94 | 27 | 25.69 | 1.59× | +37.3% |
| 3 | 16384 | 205 | 47.90 | 38 | 29.16 | 1.64× | +39.1% |
| 3 | 32768 | 228 | 53.20 | 54 | 34.41 | 1.55× | +35.3% |
| 3 | 65536 | 241 | 58.78 | 76 | 42.63 | 1.38× | +27.5% |
| 3 | 131072 | 249 | 65.96 | 108 | 54.91 | 1.20× | +16.8% |
| 3 | 196608 | 251 | 73.47 | 133 | 66.98 | 1.10× | +8.8% |
| 3 | 262144 | 253 | 80.47 | 154 | 75.84 | 1.06× | +5.8% |
| 3 | 524288 | 255 | 117.64 | 216 | 106.62 | 1.10× | +9.4% |
| 3 | 1048576 | 256 | 164.39 | 256 | 164.04 | 1.00× | +0.2% |
| 4 | 512 | 32 | 19.07 | 6 | 16.45 | 1.16× | +13.8% |
| 4 | 1024 | 64 | 25.10 | 8 | 17.02 | 1.47× | +32.2% |
| 4 | 2048 | 128 | 35.61 | 12 | 18.81 | 1.89× | +47.2% |
| 4 | 4096 | 128 | 35.26 | 19 | 21.06 | 1.67× | +40.3% |
| 4 | 8192 | 171 | 40.79 | 27 | 24.87 | 1.64× | +39.0% |
| 4 | 16384 | 205 | 48.25 | 38 | 29.85 | 1.62× | +38.1% |
| 4 | 32768 | 228 | 54.47 | 54 | 34.67 | 1.57× | +36.3% |
| 4 | 65536 | 241 | 60.61 | 76 | 43.26 | 1.40× | +28.6% |
| 4 | 131072 | 249 | 67.71 | 108 | 55.68 | 1.22× | +17.8% |
| 4 | 196608 | 251 | 74.66 | 133 | 67.42 | 1.11× | +9.7% |
| 4 | 262144 | 253 | 80.81 | 154 | 78.32 | 1.03× | +3.1% |
| 4 | 524288 | 255 | 122.88 | 216 | 108.59 | 1.13× | +11.6% |
| 4 | 1048576 | 256 | 169.05 | 256 | 168.57 | 1.00× | +0.3% |
| 5 | 512 | 32 | 23.21 | 6 | 21.65 | 1.07× | +6.7% |
| 5 | 1024 | 64 | 29.23 | 8 | 21.85 | 1.34× | +25.3% |
| 5 | 2048 | 128 | 38.85 | 12 | 24.95 | 1.56× | +35.8% |
| 5 | 4096 | 128 | 38.83 | 19 | 28.26 | 1.37× | +27.2% |
| 5 | 8192 | 171 | 45.28 | 27 | 32.30 | 1.40× | +28.7% |
| 5 | 16384 | 205 | 53.33 | 38 | 39.50 | 1.35× | +25.9% |
| 5 | 32768 | 228 | 60.60 | 54 | 47.13 | 1.29× | +22.2% |
| 5 | 65536 | 241 | 67.18 | 76 | 59.54 | 1.13× | +11.4% |
| 5 | 131072 | 249 | 78.67 | 108 | 76.56 | 1.03× | +2.7% |
| 5 | 196608 | 251 | 89.65 | 133 | 93.16 | 0.96× | -3.9% |
| 5 | 262144 | 253 | 99.85 | 154 | 103.24 | 0.97× | -3.4% |
| 5 | 524288 | 255 | 146.16 | 216 | 141.17 | 1.04× | +3.4% |
| 5 | 1048576 | 256 | 222.62 | 256 | 227.89 | 0.98× | -2.4% |
| 6 | 512 | 32 | 25.00 | 6 | 21.63 | 1.16× | +13.5% |
| 6 | 1024 | 64 | 30.30 | 8 | 22.07 | 1.37× | +27.2% |
| 6 | 2048 | 128 | 38.94 | 12 | 24.15 | 1.61× | +38.0% |
| 6 | 4096 | 128 | 38.83 | 19 | 28.42 | 1.37× | +26.8% |
| 6 | 8192 | 171 | 45.79 | 27 | 33.33 | 1.37× | +27.2% |
| 6 | 16384 | 205 | 53.89 | 38 | 39.87 | 1.35× | +26.0% |
| 6 | 32768 | 228 | 61.86 | 54 | 46.97 | 1.32× | +24.1% |
| 6 | 65536 | 241 | 68.72 | 76 | 59.80 | 1.15× | +13.0% |
| 6 | 131072 | 249 | 80.05 | 108 | 76.00 | 1.05× | +5.1% |
| 6 | 196608 | 251 | 91.19 | 133 | 92.54 | 0.99× | -1.5% |
| 6 | 262144 | 253 | 101.29 | 154 | 103.53 | 0.98× | -2.2% |
| 6 | 524288 | 255 | 144.20 | 216 | 144.72 | 1.00× | -0.4% |
| 6 | 1048576 | 256 | 225.26 | 256 | 229.26 | 0.98× | -1.8% |
| 7 | 512 | 32 | 25.08 | 6 | 21.84 | 1.15× | +12.9% |
| 7 | 1024 | 64 | 32.71 | 8 | 22.06 | 1.48× | +32.6% |
| 7 | 2048 | 128 | 38.97 | 12 | 24.95 | 1.56× | +36.0% |
| 7 | 4096 | 128 | 39.12 | 19 | 28.82 | 1.36× | +26.3% |
| 7 | 8192 | 171 | 46.30 | 27 | 34.41 | 1.35× | +25.7% |
| 7 | 16384 | 205 | 54.96 | 38 | 39.76 | 1.38× | +27.7% |
| 7 | 32768 | 228 | 62.46 | 54 | 48.36 | 1.29× | +22.6% |
| 7 | 65536 | 241 | 70.23 | 76 | 60.41 | 1.16× | +14.0% |
| 7 | 131072 | 249 | 81.46 | 108 | 77.07 | 1.06× | +5.4% |
| 7 | 196608 | 251 | 93.23 | 133 | 93.95 | 0.99× | -0.8% |
| 7 | 262144 | 253 | 104.90 | 154 | 106.02 | 0.99× | -1.1% |
| 7 | 524288 | 255 | 150.96 | 216 | 147.39 | 1.02× | +2.4% |
| 7 | 1048576 | 256 | 231.44 | 256 | 234.88 | 0.99× | -1.5% |
| 8 | 512 | 32 | 25.09 | 6 | 21.49 | 1.17× | +14.3% |
| 8 | 1024 | 64 | 32.64 | 8 | 21.26 | 1.53× | +34.8% |
| 8 | 2048 | 128 | 39.59 | 12 | 25.01 | 1.58× | +36.8% |
| 8 | 4096 | 128 | 39.73 | 19 | 28.76 | 1.38× | +27.6% |
| 8 | 8192 | 171 | 47.42 | 27 | 33.14 | 1.43× | +30.1% |
| 8 | 16384 | 205 | 56.50 | 38 | 39.84 | 1.42× | +29.5% |
| 8 | 32768 | 228 | 63.95 | 54 | 48.55 | 1.32× | +24.1% |
| 8 | 65536 | 241 | 71.52 | 76 | 61.02 | 1.17× | +14.7% |
| 8 | 131072 | 249 | 82.44 | 108 | 77.40 | 1.07× | +6.1% |
| 8 | 196608 | 251 | 93.61 | 133 | 94.05 | 1.00× | -0.5% |
| 8 | 262144 | 253 | 105.66 | 154 | 106.70 | 0.99× | -1.0% |
| 8 | 524288 | 255 | 157.68 | 216 | 154.21 | 1.02× | +2.2% |
| 8 | 1048576 | 256 | 239.06 | 256 | 240.30 | 0.99× | -0.5% |

</details>

<details><summary><b>nhead = 32</b></summary>

| qlen | ctx | OFF sp | OFF us | ON sp | ON us | speedup | faster% |
|---:|---:|---:|---:|---:|---:|:--:|:--:|
| 1 | 512 | 32 | 19.57 | 6 | 14.96 | 1.31× | +23.6% |
| 1 | 1024 | 64 | 23.37 | 8 | 15.94 | 1.47× | +31.8% |
| 1 | 2048 | 128 | 33.98 | 12 | 17.72 | 1.92× | +47.9% |
| 1 | 4096 | 128 | 34.22 | 19 | 19.80 | 1.73× | +42.1% |
| 1 | 8192 | 171 | 40.85 | 27 | 25.00 | 1.63× | +38.8% |
| 1 | 16384 | 205 | 45.03 | 38 | 29.76 | 1.51× | +33.9% |
| 1 | 32768 | 228 | 51.98 | 54 | 33.15 | 1.57× | +36.2% |
| 1 | 65536 | 241 | 57.24 | 76 | 42.37 | 1.35× | +26.0% |
| 1 | 131072 | 249 | 65.58 | 108 | 55.06 | 1.19× | +16.0% |
| 1 | 196608 | 251 | 72.53 | 133 | 66.26 | 1.09× | +8.6% |
| 1 | 262144 | 253 | 78.65 | 154 | 75.87 | 1.04× | +3.5% |
| 1 | 524288 | 255 | 114.88 | 216 | 105.31 | 1.09× | +8.3% |
| 1 | 1048576 | 256 | 157.90 | 256 | 158.12 | 1.00× | -0.1% |
| 2 | 512 | 32 | 19.08 | 6 | 16.21 | 1.18× | +15.0% |
| 2 | 1024 | 64 | 25.04 | 8 | 16.76 | 1.49× | +33.1% |
| 2 | 2048 | 128 | 33.80 | 12 | 18.07 | 1.87× | +46.6% |
| 2 | 4096 | 128 | 35.05 | 19 | 20.49 | 1.71× | +41.5% |
| 2 | 8192 | 171 | 41.22 | 27 | 25.24 | 1.63× | +38.8% |
| 2 | 16384 | 205 | 48.36 | 38 | 29.84 | 1.62× | +38.3% |
| 2 | 32768 | 228 | 54.28 | 54 | 35.13 | 1.55× | +35.3% |
| 2 | 65536 | 241 | 60.55 | 76 | 43.37 | 1.40× | +28.4% |
| 2 | 131072 | 249 | 67.72 | 108 | 54.88 | 1.23× | +19.0% |
| 2 | 196608 | 251 | 74.78 | 133 | 67.77 | 1.10× | +9.4% |
| 2 | 262144 | 253 | 80.70 | 154 | 76.18 | 1.06× | +5.6% |
| 2 | 524288 | 255 | 120.59 | 216 | 107.64 | 1.12× | +10.7% |
| 2 | 1048576 | 256 | 168.18 | 256 | 169.95 | 0.99× | -1.1% |
| 3 | 512 | 32 | 19.86 | 6 | 16.46 | 1.21× | +17.1% |
| 3 | 1024 | 64 | 27.87 | 8 | 16.90 | 1.65× | +39.4% |
| 3 | 2048 | 64 | 26.58 | 13 | 19.08 | 1.39× | +28.2% |
| 3 | 4096 | 86 | 28.11 | 19 | 21.33 | 1.32× | +24.1% |
| 3 | 8192 | 103 | 32.57 | 26 | 25.24 | 1.29× | +22.5% |
| 3 | 16384 | 114 | 36.82 | 37 | 28.57 | 1.29× | +22.4% |
| 3 | 32768 | 121 | 41.59 | 54 | 35.08 | 1.19× | +15.7% |
| 3 | 65536 | 125 | 47.27 | 76 | 43.36 | 1.09× | +8.3% |
| 3 | 131072 | 127 | 58.45 | 108 | 57.05 | 1.02× | +2.4% |
| 3 | 196608 | 127 | 70.79 | 127 | 70.89 | 1.00× | -0.1% |
| 3 | 262144 | 128 | 85.34 | 128 | 86.06 | 0.99× | -0.8% |
| 3 | 524288 | 128 | 146.41 | 128 | 147.07 | 1.00× | -0.5% |
| 3 | 1048576 | 128 | 243.54 | 128 | 244.09 | 1.00× | -0.2% |
| 4 | 512 | 32 | 25.30 | 6 | 21.63 | 1.17× | +14.5% |
| 4 | 1024 | 64 | 32.72 | 8 | 21.36 | 1.53× | +34.7% |
| 4 | 2048 | 128 | 39.52 | 12 | 25.37 | 1.56× | +35.8% |
| 4 | 4096 | 128 | 39.58 | 19 | 28.65 | 1.38× | +27.6% |
| 4 | 8192 | 171 | 46.73 | 27 | 34.79 | 1.34× | +25.6% |
| 4 | 16384 | 205 | 56.51 | 38 | 39.78 | 1.42× | +29.6% |
| 4 | 32768 | 228 | 63.38 | 54 | 48.05 | 1.32× | +24.2% |
| 4 | 65536 | 241 | 70.75 | 76 | 60.96 | 1.16× | +13.8% |
| 4 | 131072 | 249 | 81.85 | 108 | 77.04 | 1.06× | +5.9% |
| 4 | 196608 | 251 | 94.27 | 133 | 95.01 | 0.99× | -0.8% |
| 4 | 262144 | 253 | 103.82 | 154 | 105.69 | 0.98× | -1.8% |
| 4 | 524288 | 255 | 147.93 | 216 | 152.88 | 0.97× | -3.3% |
| 4 | 1048576 | 256 | 242.73 | 256 | 233.25 | 1.04× | +3.9% |
| 5 | 512 | 32 | 26.39 | 6 | 21.70 | 1.22× | +17.7% |
| 5 | 1024 | 64 | 30.30 | 8 | 22.17 | 1.37× | +26.8% |
| 5 | 2048 | 64 | 30.03 | 13 | 26.17 | 1.15× | +12.8% |
| 5 | 4096 | 86 | 34.05 | 19 | 29.82 | 1.14× | +12.4% |
| 5 | 8192 | 103 | 40.94 | 26 | 32.84 | 1.25× | +19.8% |
| 5 | 16384 | 114 | 46.81 | 37 | 38.97 | 1.20× | +16.7% |
| 5 | 32768 | 121 | 52.64 | 54 | 49.77 | 1.06× | +5.4% |
| 5 | 65536 | 125 | 63.82 | 76 | 63.32 | 1.01× | +0.8% |
| 5 | 131072 | 127 | 85.08 | 108 | 82.01 | 1.04× | +3.6% |
| 5 | 196608 | 127 | 105.22 | 127 | 108.62 | 0.97× | -3.2% |
| 5 | 262144 | 128 | 127.70 | 128 | 131.86 | 0.97× | -3.3% |
| 5 | 524288 | 128 | 218.78 | 128 | 218.95 | 1.00× | -0.1% |
| 5 | 1048576 | 128 | 383.72 | 128 | 379.17 | 1.01× | +1.2% |
| 6 | 512 | 32 | 27.03 | 6 | 22.12 | 1.22× | +18.1% |
| 6 | 1024 | 64 | 30.49 | 8 | 22.57 | 1.35× | +26.0% |
| 6 | 2048 | 64 | 30.47 | 13 | 26.04 | 1.17× | +14.5% |
| 6 | 4096 | 86 | 34.55 | 19 | 30.12 | 1.15× | +12.8% |
| 6 | 8192 | 103 | 41.61 | 26 | 32.82 | 1.27× | +21.1% |
| 6 | 16384 | 114 | 48.06 | 37 | 39.19 | 1.23× | +18.5% |
| 6 | 32768 | 121 | 54.32 | 54 | 50.08 | 1.08× | +7.8% |
| 6 | 65536 | 125 | 65.32 | 76 | 64.53 | 1.01× | +1.2% |
| 6 | 131072 | 127 | 85.56 | 108 | 82.89 | 1.03× | +3.1% |
| 6 | 196608 | 127 | 107.53 | 127 | 108.29 | 0.99× | -0.7% |
| 6 | 262144 | 128 | 131.99 | 128 | 131.77 | 1.00× | +0.2% |
| 6 | 524288 | 128 | 221.48 | 128 | 224.27 | 0.99× | -1.3% |
| 6 | 1048576 | 128 | 390.09 | 128 | 392.97 | 0.99× | -0.7% |
| 7 | 512 | 32 | 28.61 | 6 | 22.02 | 1.30× | +23.0% |
| 7 | 1024 | 64 | 31.21 | 8 | 22.52 | 1.39× | +27.9% |
| 7 | 2048 | 64 | 31.19 | 13 | 25.92 | 1.20× | +16.9% |
| 7 | 4096 | 86 | 35.86 | 19 | 31.17 | 1.15× | +13.1% |
| 7 | 8192 | 103 | 43.10 | 26 | 33.45 | 1.29× | +22.4% |
| 7 | 16384 | 114 | 48.16 | 37 | 40.12 | 1.20× | +16.7% |
| 7 | 32768 | 121 | 55.62 | 54 | 50.56 | 1.10× | +9.1% |
| 7 | 65536 | 125 | 67.20 | 76 | 64.08 | 1.05× | +4.6% |
| 7 | 131072 | 127 | 88.57 | 108 | 87.34 | 1.01× | +1.4% |
| 7 | 196608 | 127 | 114.27 | 127 | 112.38 | 1.02× | +1.6% |
| 7 | 262144 | 128 | 137.52 | 128 | 137.84 | 1.00× | -0.2% |
| 7 | 524288 | 128 | 228.39 | 128 | 228.27 | 1.00× | +0.0% |
| 7 | 1048576 | 128 | 397.13 | 128 | 401.04 | 0.99× | -1.0% |
| 8 | 512 | 32 | 28.46 | 6 | 22.08 | 1.29× | +22.4% |
| 8 | 1024 | 64 | 31.59 | 8 | 22.79 | 1.39× | +27.8% |
| 8 | 2048 | 64 | 31.54 | 13 | 26.37 | 1.20× | +16.4% |
| 8 | 4096 | 86 | 36.89 | 19 | 31.53 | 1.17× | +14.5% |
| 8 | 8192 | 103 | 44.19 | 26 | 33.83 | 1.31× | +23.4% |
| 8 | 16384 | 114 | 50.48 | 37 | 40.76 | 1.24× | +19.3% |
| 8 | 32768 | 121 | 58.00 | 54 | 51.26 | 1.13× | +11.6% |
| 8 | 65536 | 125 | 68.80 | 76 | 65.74 | 1.05× | +4.5% |
| 8 | 131072 | 127 | 92.69 | 108 | 91.75 | 1.01× | +1.0% |
| 8 | 196608 | 127 | 115.78 | 127 | 117.51 | 0.99× | -1.5% |
| 8 | 262144 | 128 | 142.08 | 128 | 141.40 | 1.00× | +0.5% |
| 8 | 524288 | 128 | 236.64 | 128 | 233.95 | 1.01× | +1.1% |
| 8 | 1048576 | 128 | 408.31 | 128 | 408.68 | 1.00× | -0.1% |

</details>

<details><summary><b>nhead = 48</b></summary>

| qlen | ctx | OFF sp | OFF us | ON sp | ON us | speedup | faster% |
|---:|---:|---:|---:|---:|---:|:--:|:--:|
| 1 | 512 | 32 | 18.18 | 6 | 13.48 | 1.35× | +25.8% |
| 1 | 1024 | 64 | 25.12 | 8 | 14.80 | 1.70× | +41.1% |
| 1 | 2048 | 64 | 23.29 | 12 | 16.30 | 1.43× | +30.0% |
| 1 | 4096 | 64 | 24.29 | 19 | 18.03 | 1.35× | +25.8% |
| 1 | 8192 | 74 | 26.12 | 26 | 22.18 | 1.18× | +15.1% |
| 1 | 16384 | 79 | 29.67 | 38 | 26.39 | 1.12× | +11.1% |
| 1 | 32768 | 82 | 35.93 | 54 | 31.57 | 1.14× | +12.1% |
| 1 | 65536 | 84 | 40.95 | 76 | 39.10 | 1.05× | +4.5% |
| 1 | 131072 | 85 | 57.65 | 85 | 57.77 | 1.00× | -0.2% |
| 1 | 196608 | 85 | 72.90 | 85 | 72.85 | 1.00× | +0.1% |
| 1 | 262144 | 85 | 85.83 | 85 | 85.60 | 1.00× | +0.3% |
| 1 | 524288 | 86 | 154.03 | 86 | 153.84 | 1.00× | +0.1% |
| 1 | 1048576 | 86 | 322.23 | 86 | 322.39 | 1.00× | -0.1% |
| 2 | 512 | 32 | 30.59 | 6 | 26.54 | 1.15× | +13.3% |
| 2 | 1024 | 64 | 35.45 | 8 | 26.67 | 1.33× | +24.8% |
| 2 | 2048 | 64 | 36.69 | 12 | 28.85 | 1.27× | +21.4% |
| 2 | 4096 | 64 | 37.25 | 19 | 31.80 | 1.17× | +14.6% |
| 2 | 8192 | 74 | 38.21 | 26 | 35.12 | 1.09× | +8.1% |
| 2 | 16384 | 79 | 42.27 | 38 | 39.64 | 1.07× | +6.2% |
| 2 | 32768 | 82 | 47.41 | 54 | 45.93 | 1.03× | +3.1% |
| 2 | 65536 | 84 | 56.86 | 76 | 56.52 | 1.01× | +0.6% |
| 2 | 131072 | 85 | 75.89 | 85 | 75.45 | 1.01× | +0.6% |
| 2 | 196608 | 85 | 92.60 | 85 | 93.61 | 0.99× | -1.1% |
| 2 | 262144 | 85 | 111.91 | 85 | 111.24 | 1.01× | +0.6% |
| 2 | 524288 | 86 | 203.21 | 86 | 197.73 | 1.03× | +2.7% |
| 2 | 1048576 | 86 | 370.05 | 86 | 368.34 | 1.00× | +0.5% |
| 3 | 512 | 32 | 32.21 | 6 | 26.52 | 1.21× | +17.7% |
| 3 | 1024 | 64 | 37.60 | 8 | 27.13 | 1.39× | +27.8% |
| 3 | 2048 | 64 | 37.75 | 12 | 29.83 | 1.27× | +21.0% |
| 3 | 4096 | 64 | 37.51 | 19 | 32.74 | 1.15× | +12.7% |
| 3 | 8192 | 74 | 39.78 | 26 | 35.15 | 1.13× | +11.6% |
| 3 | 16384 | 79 | 43.91 | 38 | 40.11 | 1.09× | +8.7% |
| 3 | 32768 | 82 | 49.34 | 54 | 46.74 | 1.06× | +5.3% |
| 3 | 65536 | 84 | 56.78 | 76 | 55.02 | 1.03× | +3.1% |
| 3 | 131072 | 85 | 73.73 | 85 | 73.91 | 1.00× | -0.2% |
| 3 | 196608 | 85 | 91.55 | 85 | 90.80 | 1.01× | +0.8% |
| 3 | 262144 | 85 | 107.51 | 85 | 109.94 | 0.98× | -2.3% |
| 3 | 524288 | 86 | 191.08 | 86 | 191.47 | 1.00× | -0.2% |
| 3 | 1048576 | 86 | 372.90 | 86 | 373.51 | 1.00× | -0.2% |
| 4 | 512 | 32 | 32.04 | 6 | 26.67 | 1.20× | +16.8% |
| 4 | 1024 | 64 | 37.26 | 8 | 27.55 | 1.35× | +26.1% |
| 4 | 2048 | 64 | 37.61 | 12 | 30.28 | 1.24× | +19.5% |
| 4 | 4096 | 64 | 38.27 | 19 | 33.93 | 1.13× | +11.4% |
| 4 | 8192 | 74 | 41.04 | 26 | 35.36 | 1.16× | +13.9% |
| 4 | 16384 | 79 | 44.81 | 38 | 40.32 | 1.11× | +10.0% |
| 4 | 32768 | 82 | 50.46 | 54 | 47.10 | 1.07× | +6.7% |
| 4 | 65536 | 84 | 56.58 | 76 | 56.18 | 1.01× | +0.7% |
| 4 | 131072 | 85 | 73.54 | 85 | 73.59 | 1.00× | -0.1% |
| 4 | 196608 | 85 | 91.26 | 85 | 90.77 | 1.01× | +0.5% |
| 4 | 262144 | 85 | 106.92 | 85 | 107.45 | 1.00× | -0.5% |
| 4 | 524288 | 86 | 192.33 | 86 | 191.00 | 1.01× | +0.7% |
| 4 | 1048576 | 86 | 373.88 | 86 | 376.55 | 0.99× | -0.7% |
| 5 | 512 | 32 | 38.92 | 6 | 32.61 | 1.19× | +16.2% |
| 5 | 1024 | 64 | 41.68 | 8 | 33.12 | 1.26× | +20.5% |
| 5 | 2048 | 64 | 41.59 | 12 | 36.94 | 1.13× | +11.2% |
| 5 | 4096 | 64 | 42.26 | 19 | 42.10 | 1.00× | +0.4% |
| 5 | 8192 | 74 | 47.91 | 26 | 44.30 | 1.08× | +7.5% |
| 5 | 16384 | 79 | 54.73 | 38 | 53.09 | 1.03× | +3.0% |
| 5 | 32768 | 82 | 64.11 | 54 | 62.25 | 1.03× | +2.9% |
| 5 | 65536 | 84 | 78.34 | 76 | 76.35 | 1.03× | +2.5% |
| 5 | 131072 | 85 | 109.02 | 85 | 109.50 | 1.00× | -0.4% |
| 5 | 196608 | 85 | 145.90 | 85 | 146.79 | 0.99× | -0.6% |
| 5 | 262144 | 85 | 178.30 | 85 | 174.73 | 1.02× | +2.0% |
| 5 | 524288 | 86 | 304.30 | 86 | 302.14 | 1.01× | +0.7% |
| 5 | 1048576 | 86 | 583.31 | 86 | 592.96 | 0.98× | -1.7% |
| 6 | 512 | 32 | 35.97 | 6 | 33.17 | 1.08× | +7.8% |
| 6 | 1024 | 64 | 42.10 | 8 | 33.39 | 1.26× | +20.7% |
| 6 | 2048 | 64 | 42.41 | 12 | 37.32 | 1.14× | +12.0% |
| 6 | 4096 | 64 | 42.57 | 19 | 41.09 | 1.04× | +3.5% |
| 6 | 8192 | 74 | 48.11 | 26 | 44.67 | 1.08× | +7.2% |
| 6 | 16384 | 79 | 56.04 | 38 | 52.63 | 1.06× | +6.1% |
| 6 | 32768 | 82 | 64.74 | 54 | 62.24 | 1.04× | +3.9% |
| 6 | 65536 | 84 | 78.67 | 76 | 76.50 | 1.03× | +2.8% |
| 6 | 131072 | 85 | 112.33 | 85 | 109.81 | 1.02× | +2.2% |
| 6 | 196608 | 85 | 146.87 | 85 | 145.06 | 1.01× | +1.2% |
| 6 | 262144 | 85 | 176.33 | 85 | 180.35 | 0.98× | -2.3% |
| 6 | 524288 | 86 | 307.84 | 86 | 304.39 | 1.01× | +1.1% |
| 6 | 1048576 | 86 | 590.37 | 86 | 584.45 | 1.01× | +1.0% |
| 7 | 512 | 32 | 36.83 | 6 | 33.18 | 1.11× | +9.9% |
| 7 | 1024 | 64 | 42.82 | 8 | 33.88 | 1.26× | +20.9% |
| 7 | 2048 | 64 | 42.87 | 12 | 38.48 | 1.11× | +10.2% |
| 7 | 4096 | 64 | 43.26 | 19 | 41.79 | 1.04× | +3.4% |
| 7 | 8192 | 74 | 49.60 | 26 | 45.12 | 1.10× | +9.0% |
| 7 | 16384 | 79 | 57.67 | 38 | 52.84 | 1.09× | +8.4% |
| 7 | 32768 | 82 | 65.61 | 54 | 62.84 | 1.04× | +4.2% |
| 7 | 65536 | 84 | 80.24 | 76 | 78.80 | 1.02× | +1.8% |
| 7 | 131072 | 85 | 113.66 | 85 | 116.28 | 0.98× | -2.3% |
| 7 | 196608 | 85 | 147.05 | 85 | 153.01 | 0.96× | -4.1% |
| 7 | 262144 | 85 | 187.37 | 85 | 183.89 | 1.02× | +1.9% |
| 7 | 524288 | 86 | 311.90 | 86 | 310.23 | 1.01× | +0.5% |
| 7 | 1048576 | 86 | 600.89 | 86 | 602.30 | 1.00× | -0.2% |
| 8 | 512 | 32 | 37.39 | 6 | 33.42 | 1.12× | +10.6% |
| 8 | 1024 | 64 | 44.50 | 8 | 33.52 | 1.33× | +24.7% |
| 8 | 2048 | 64 | 44.40 | 12 | 39.15 | 1.13× | +11.8% |
| 8 | 4096 | 64 | 44.75 | 19 | 42.25 | 1.06× | +5.6% |
| 8 | 8192 | 74 | 50.55 | 26 | 45.65 | 1.11× | +9.7% |
| 8 | 16384 | 79 | 58.80 | 38 | 54.07 | 1.09× | +8.0% |
| 8 | 32768 | 82 | 66.74 | 54 | 63.80 | 1.05× | +4.4% |
| 8 | 65536 | 84 | 82.26 | 76 | 79.61 | 1.03× | +3.2% |
| 8 | 131072 | 85 | 118.02 | 85 | 115.26 | 1.02× | +2.3% |
| 8 | 196608 | 85 | 157.11 | 85 | 155.42 | 1.01× | +1.1% |
| 8 | 262144 | 85 | 188.24 | 85 | 188.10 | 1.00× | +0.1% |
| 8 | 524288 | 86 | 310.62 | 86 | 312.87 | 0.99× | -0.7% |
| 8 | 1048576 | 86 | 610.34 | 86 | 607.94 | 1.00× | +0.4% |

</details>

<details><summary><b>nhead = 64</b></summary>

| qlen | ctx | OFF sp | OFF us | ON sp | ON us | speedup | faster% |
|---:|---:|---:|---:|---:|---:|:--:|:--:|
| 1 | 512 | 32 | 19.08 | 6 | 16.04 | 1.19× | +16.0% |
| 1 | 1024 | 64 | 25.14 | 8 | 16.48 | 1.53× | +34.5% |
| 1 | 2048 | 128 | 35.40 | 12 | 18.38 | 1.93× | +48.1% |
| 1 | 4096 | 128 | 35.04 | 19 | 20.58 | 1.70× | +41.3% |
| 1 | 8192 | 171 | 41.25 | 27 | 25.55 | 1.61× | +38.1% |
| 1 | 16384 | 205 | 48.57 | 38 | 29.89 | 1.62× | +38.4% |
| 1 | 32768 | 228 | 54.39 | 54 | 35.29 | 1.54× | +35.1% |
| 1 | 65536 | 241 | 60.38 | 76 | 44.23 | 1.37× | +26.7% |
| 1 | 131072 | 249 | 67.00 | 108 | 55.83 | 1.20× | +16.7% |
| 1 | 196608 | 251 | 74.57 | 133 | 68.97 | 1.08× | +7.5% |
| 1 | 262144 | 253 | 81.69 | 154 | 78.43 | 1.04× | +4.0% |
| 1 | 524288 | 255 | 123.75 | 216 | 110.02 | 1.12× | +11.1% |
| 1 | 1048576 | 256 | 169.68 | 256 | 167.81 | 1.01× | +1.1% |
| 2 | 512 | 32 | 25.06 | 6 | 21.91 | 1.14× | +12.6% |
| 2 | 1024 | 64 | 32.38 | 8 | 22.18 | 1.46× | +31.5% |
| 2 | 2048 | 128 | 39.38 | 12 | 24.92 | 1.58× | +36.7% |
| 2 | 4096 | 128 | 39.40 | 19 | 28.75 | 1.37× | +27.0% |
| 2 | 8192 | 171 | 47.06 | 27 | 33.96 | 1.39× | +27.8% |
| 2 | 16384 | 205 | 56.28 | 38 | 39.54 | 1.42× | +29.7% |
| 2 | 32768 | 228 | 63.85 | 54 | 47.75 | 1.34× | +25.2% |
| 2 | 65536 | 241 | 71.69 | 76 | 60.52 | 1.18× | +15.6% |
| 2 | 131072 | 249 | 82.77 | 108 | 77.52 | 1.07× | +6.3% |
| 2 | 196608 | 251 | 92.93 | 133 | 94.54 | 0.98× | -1.7% |
| 2 | 262144 | 253 | 105.18 | 154 | 107.13 | 0.98× | -1.9% |
| 2 | 524288 | 255 | 152.86 | 216 | 147.48 | 1.04× | +3.5% |
| 2 | 1048576 | 256 | 243.86 | 256 | 243.09 | 1.00× | +0.3% |
| 3 | 512 | 32 | 26.73 | 6 | 21.65 | 1.23× | +19.0% |
| 3 | 1024 | 64 | 30.80 | 8 | 22.30 | 1.38× | +27.6% |
| 3 | 2048 | 64 | 30.42 | 13 | 25.84 | 1.18× | +15.1% |
| 3 | 4096 | 86 | 35.33 | 19 | 30.65 | 1.15× | +13.3% |
| 3 | 8192 | 103 | 41.56 | 26 | 33.12 | 1.25× | +20.3% |
| 3 | 16384 | 114 | 46.32 | 37 | 40.11 | 1.15× | +13.4% |
| 3 | 32768 | 121 | 55.15 | 54 | 49.45 | 1.12× | +10.3% |
| 3 | 65536 | 125 | 63.92 | 76 | 64.06 | 1.00× | -0.2% |
| 3 | 131072 | 127 | 86.60 | 108 | 86.30 | 1.00× | +0.3% |
| 3 | 196608 | 127 | 108.13 | 127 | 111.12 | 0.97× | -2.8% |
| 3 | 262144 | 128 | 134.75 | 128 | 133.28 | 1.01× | +1.1% |
| 3 | 524288 | 128 | 221.99 | 128 | 218.85 | 1.01× | +1.4% |
| 3 | 1048576 | 128 | 391.75 | 128 | 390.29 | 1.00× | +0.4% |
| 4 | 512 | 32 | 28.20 | 6 | 21.96 | 1.28× | +22.1% |
| 4 | 1024 | 64 | 31.66 | 8 | 22.52 | 1.41× | +28.9% |
| 4 | 2048 | 64 | 31.35 | 13 | 26.46 | 1.18× | +15.6% |
| 4 | 4096 | 86 | 36.65 | 19 | 31.68 | 1.16× | +13.6% |
| 4 | 8192 | 103 | 44.06 | 26 | 33.81 | 1.30× | +23.3% |
| 4 | 16384 | 114 | 48.89 | 37 | 40.54 | 1.21× | +17.1% |
| 4 | 32768 | 121 | 58.85 | 54 | 50.30 | 1.17× | +14.5% |
| 4 | 65536 | 125 | 67.74 | 76 | 65.39 | 1.04× | +3.5% |
| 4 | 131072 | 127 | 92.40 | 108 | 90.64 | 1.02× | +1.9% |
| 4 | 196608 | 127 | 116.82 | 127 | 117.80 | 0.99× | -0.8% |
| 4 | 262144 | 128 | 140.24 | 128 | 140.37 | 1.00× | -0.1% |
| 4 | 524288 | 128 | 232.93 | 128 | 230.54 | 1.01× | +1.0% |
| 4 | 1048576 | 128 | 409.69 | 128 | 409.18 | 1.00× | +0.1% |
| 5 | 512 | 32 | 26.96 | 6 | 22.64 | 1.19× | +16.0% |
| 5 | 1024 | 64 | 32.87 | 8 | 23.39 | 1.41× | +28.9% |
| 5 | 2048 | 64 | 32.80 | 12 | 27.54 | 1.19× | +16.0% |
| 5 | 4096 | 64 | 32.42 | 19 | 30.35 | 1.07× | +6.4% |
| 5 | 8192 | 74 | 39.29 | 26 | 34.28 | 1.15× | +12.7% |
| 5 | 16384 | 79 | 45.94 | 38 | 42.36 | 1.08× | +7.8% |
| 5 | 32768 | 82 | 53.91 | 54 | 51.99 | 1.04× | +3.6% |
| 5 | 65536 | 84 | 69.72 | 76 | 68.99 | 1.01× | +1.1% |
| 5 | 131072 | 85 | 107.97 | 85 | 110.28 | 0.98× | -2.1% |
| 5 | 196608 | 85 | 143.38 | 85 | 141.47 | 1.01× | +1.3% |
| 5 | 262144 | 85 | 175.67 | 85 | 173.29 | 1.01× | +1.4% |
| 5 | 524288 | 86 | 295.77 | 86 | 297.77 | 0.99× | -0.7% |
| 5 | 1048576 | 86 | 578.63 | 86 | 576.15 | 1.00× | +0.4% |
| 6 | 512 | 32 | 27.53 | 6 | 22.74 | 1.21× | +17.4% |
| 6 | 1024 | 64 | 34.98 | 8 | 22.85 | 1.53× | +34.7% |
| 6 | 2048 | 64 | 34.85 | 12 | 27.88 | 1.25× | +20.0% |
| 6 | 4096 | 64 | 34.68 | 19 | 30.90 | 1.12× | +10.9% |
| 6 | 8192 | 74 | 41.02 | 26 | 34.87 | 1.18× | +15.0% |
| 6 | 16384 | 79 | 49.01 | 38 | 43.34 | 1.13× | +11.6% |
| 6 | 32768 | 82 | 56.29 | 54 | 53.55 | 1.05× | +4.9% |
| 6 | 65536 | 84 | 72.10 | 76 | 71.64 | 1.01× | +0.6% |
| 6 | 131072 | 85 | 111.06 | 85 | 111.43 | 1.00× | -0.3% |
| 6 | 196608 | 85 | 146.96 | 85 | 146.08 | 1.01× | +0.6% |
| 6 | 262144 | 85 | 178.54 | 85 | 178.30 | 1.00× | +0.1% |
| 6 | 524288 | 86 | 305.36 | 86 | 306.46 | 1.00× | -0.4% |
| 6 | 1048576 | 86 | 591.28 | 86 | 594.50 | 0.99× | -0.5% |
| 7 | 512 | 32 | 27.83 | 6 | 23.24 | 1.20× | +16.5% |
| 7 | 1024 | 32 | 27.75 | 8 | 23.77 | 1.17× | +14.3% |
| 7 | 2048 | 43 | 29.28 | 13 | 27.89 | 1.05× | +4.8% |
| 7 | 4096 | 52 | 34.59 | 19 | 31.39 | 1.10× | +9.3% |
| 7 | 8192 | 57 | 39.91 | 26 | 34.89 | 1.14× | +12.6% |
| 7 | 16384 | 61 | 46.15 | 38 | 43.74 | 1.06× | +5.2% |
| 7 | 32768 | 63 | 56.46 | 54 | 56.16 | 1.01× | +0.5% |
| 7 | 65536 | 64 | 81.56 | 64 | 78.73 | 1.04× | +3.5% |
| 7 | 131072 | 64 | 129.85 | 64 | 127.64 | 1.02× | +1.7% |
| 7 | 196608 | 64 | 167.75 | 64 | 174.97 | 0.96× | -4.3% |
| 7 | 262144 | 64 | 215.25 | 64 | 213.60 | 1.01× | +0.8% |
| 7 | 524288 | 64 | 375.37 | 64 | 372.06 | 1.01× | +0.9% |
| 7 | 1048576 | 64 | 698.45 | 64 | 708.37 | 0.99× | -1.4% |
| 8 | 512 | 32 | 28.49 | 6 | 23.83 | 1.20× | +16.4% |
| 8 | 1024 | 32 | 28.70 | 8 | 24.73 | 1.16× | +13.8% |
| 8 | 2048 | 43 | 30.40 | 13 | 27.76 | 1.10× | +8.7% |
| 8 | 4096 | 52 | 35.98 | 19 | 31.84 | 1.13× | +11.5% |
| 8 | 8192 | 57 | 41.47 | 26 | 35.24 | 1.18× | +15.0% |
| 8 | 16384 | 61 | 48.27 | 38 | 44.47 | 1.09× | +7.9% |
| 8 | 32768 | 63 | 59.07 | 54 | 57.51 | 1.03× | +2.6% |
| 8 | 65536 | 64 | 83.42 | 64 | 82.56 | 1.01× | +1.0% |
| 8 | 131072 | 64 | 130.59 | 64 | 135.04 | 0.97× | -3.4% |
| 8 | 196608 | 64 | 177.39 | 64 | 175.50 | 1.01× | +1.1% |
| 8 | 262144 | 64 | 218.66 | 64 | 217.53 | 1.01× | +0.5% |
| 8 | 524288 | 64 | 391.17 | 64 | 383.59 | 1.02× | +1.9% |
| 8 | 1048576 | 64 | 712.00 | 64 | 724.58 | 0.98× | -1.8% |

</details>

<details><summary><b>nhead = 96</b></summary>

| qlen | ctx | OFF sp | OFF us | ON sp | ON us | speedup | faster% |
|---:|---:|---:|---:|---:|---:|:--:|:--:|
| 1 | 512 | 16 | 15.24 | 6 | 13.57 | 1.12× | +11.0% |
| 1 | 1024 | 32 | 18.68 | 8 | 15.09 | 1.24× | +19.2% |
| 1 | 2048 | 32 | 18.66 | 12 | 16.76 | 1.11× | +10.2% |
| 1 | 4096 | 37 | 20.43 | 19 | 18.34 | 1.11× | +10.3% |
| 1 | 8192 | 40 | 24.79 | 26 | 22.26 | 1.11× | +10.2% |
| 1 | 16384 | 41 | 30.08 | 38 | 27.18 | 1.11× | +9.6% |
| 1 | 32768 | 42 | 34.49 | 42 | 34.09 | 1.01× | +1.1% |
| 1 | 65536 | 43 | 51.20 | 43 | 50.87 | 1.01× | +0.7% |
| 1 | 131072 | 43 | 79.90 | 43 | 79.81 | 1.00× | +0.1% |
| 1 | 196608 | 43 | 112.27 | 43 | 112.24 | 1.00× | +0.0% |
| 1 | 262144 | 43 | 140.87 | 43 | 140.62 | 1.00× | +0.2% |
| 1 | 524288 | 43 | 272.92 | 43 | 272.00 | 1.00× | +0.3% |
| 1 | 1048576 | 43 | 483.60 | 43 | 484.39 | 1.00× | -0.2% |
| 2 | 512 | 16 | 28.63 | 6 | 26.55 | 1.08× | +7.3% |
| 2 | 1024 | 32 | 31.84 | 8 | 27.04 | 1.18× | +15.1% |
| 2 | 2048 | 32 | 31.27 | 12 | 29.88 | 1.05× | +4.5% |
| 2 | 4096 | 37 | 33.77 | 19 | 32.75 | 1.03× | +3.0% |
| 2 | 8192 | 40 | 37.77 | 26 | 35.90 | 1.05× | +5.0% |
| 2 | 16384 | 41 | 42.03 | 38 | 40.66 | 1.03× | +3.2% |
| 2 | 32768 | 42 | 51.00 | 42 | 49.84 | 1.02× | +2.3% |
| 2 | 65536 | 43 | 69.89 | 43 | 69.56 | 1.00× | +0.5% |
| 2 | 131072 | 43 | 107.56 | 43 | 105.63 | 1.02× | +1.8% |
| 2 | 196608 | 43 | 153.60 | 43 | 152.29 | 1.01× | +0.8% |
| 2 | 262144 | 43 | 188.39 | 43 | 189.14 | 1.00× | -0.4% |
| 2 | 524288 | 43 | 341.48 | 43 | 344.49 | 0.99× | -0.9% |
| 2 | 1048576 | 43 | 661.05 | 43 | 659.90 | 1.00× | +0.2% |
| 3 | 512 | 16 | 30.05 | 6 | 27.42 | 1.10× | +8.8% |
| 3 | 1024 | 32 | 33.01 | 8 | 28.33 | 1.17× | +14.2% |
| 3 | 2048 | 32 | 33.56 | 12 | 31.50 | 1.07× | +6.1% |
| 3 | 4096 | 37 | 35.57 | 19 | 33.79 | 1.05× | +5.0% |
| 3 | 8192 | 40 | 39.67 | 26 | 36.59 | 1.08× | +7.8% |
| 3 | 16384 | 41 | 44.41 | 38 | 42.20 | 1.05× | +5.0% |
| 3 | 32768 | 42 | 50.56 | 42 | 49.74 | 1.02× | +1.6% |
| 3 | 65536 | 43 | 67.97 | 43 | 67.84 | 1.00× | +0.2% |
| 3 | 131072 | 43 | 100.24 | 43 | 102.71 | 0.98× | -2.5% |
| 3 | 196608 | 43 | 142.99 | 43 | 141.71 | 1.01× | +0.9% |
| 3 | 262144 | 43 | 177.50 | 43 | 176.58 | 1.01× | +0.5% |
| 3 | 524288 | 43 | 328.77 | 43 | 330.24 | 1.00× | -0.4% |
| 3 | 1048576 | 43 | 616.00 | 43 | 613.13 | 1.00× | +0.5% |
| 4 | 512 | 16 | 29.97 | 6 | 27.94 | 1.07× | +6.8% |
| 4 | 1024 | 32 | 33.23 | 8 | 29.18 | 1.14× | +12.2% |
| 4 | 2048 | 32 | 33.79 | 12 | 32.22 | 1.05× | +4.7% |
| 4 | 4096 | 37 | 36.55 | 19 | 33.84 | 1.08× | +7.4% |
| 4 | 8192 | 40 | 40.06 | 26 | 36.15 | 1.11× | +9.8% |
| 4 | 16384 | 41 | 46.13 | 38 | 43.61 | 1.06× | +5.5% |
| 4 | 32768 | 42 | 52.00 | 42 | 51.27 | 1.01× | +1.4% |
| 4 | 65536 | 43 | 69.54 | 43 | 69.22 | 1.00× | +0.5% |
| 4 | 131072 | 43 | 101.78 | 43 | 101.48 | 1.00× | +0.3% |
| 4 | 196608 | 43 | 146.72 | 43 | 145.07 | 1.01× | +1.1% |
| 4 | 262144 | 43 | 178.23 | 43 | 177.81 | 1.00× | +0.2% |
| 4 | 524288 | 43 | 327.03 | 43 | 328.04 | 1.00× | -0.3% |
| 4 | 1048576 | 43 | 614.28 | 43 | 612.02 | 1.00× | +0.4% |
| 5 | 512 | 16 | 36.24 | 6 | 34.72 | 1.04× | +4.2% |
| 5 | 1024 | 32 | 37.58 | 8 | 35.27 | 1.07× | +6.2% |
| 5 | 2048 | 32 | 37.95 | 12 | 40.19 | 0.94× | -5.9% |
| 5 | 4096 | 37 | 42.11 | 19 | 43.34 | 0.97× | -2.9% |
| 5 | 8192 | 40 | 49.34 | 26 | 46.92 | 1.05× | +4.9% |
| 5 | 16384 | 41 | 59.11 | 38 | 55.67 | 1.06× | +5.8% |
| 5 | 32768 | 42 | 71.96 | 42 | 71.10 | 1.01× | +1.2% |
| 5 | 65536 | 43 | 103.52 | 43 | 104.30 | 0.99× | -0.8% |
| 5 | 131072 | 43 | 170.49 | 43 | 170.60 | 1.00× | -0.1% |
| 5 | 196608 | 43 | 233.05 | 43 | 240.65 | 0.97× | -3.3% |
| 5 | 262144 | 43 | 298.87 | 43 | 292.44 | 1.02× | +2.2% |
| 5 | 524288 | 43 | 551.01 | 43 | 549.58 | 1.00× | +0.3% |
| 5 | 1048576 | 43 | 1074.13 | 43 | 1071.47 | 1.00× | +0.2% |
| 6 | 512 | 16 | 35.00 | 6 | 34.88 | 1.00× | +0.4% |
| 6 | 1024 | 32 | 37.86 | 8 | 36.37 | 1.04× | +3.9% |
| 6 | 2048 | 32 | 38.41 | 12 | 39.25 | 0.98× | -2.2% |
| 6 | 4096 | 37 | 43.75 | 19 | 44.12 | 0.99× | -0.8% |
| 6 | 8192 | 40 | 51.59 | 26 | 47.15 | 1.09× | +8.6% |
| 6 | 16384 | 41 | 60.93 | 38 | 57.70 | 1.06× | +5.3% |
| 6 | 32768 | 42 | 73.35 | 42 | 73.13 | 1.00× | +0.3% |
| 6 | 65536 | 43 | 106.25 | 43 | 105.37 | 1.01× | +0.8% |
| 6 | 131072 | 43 | 170.61 | 43 | 170.71 | 1.00× | -0.1% |
| 6 | 196608 | 43 | 237.07 | 43 | 235.32 | 1.01× | +0.7% |
| 6 | 262144 | 43 | 289.77 | 43 | 292.99 | 0.99× | -1.1% |
| 6 | 524288 | 43 | 555.56 | 43 | 549.78 | 1.01× | +1.0% |
| 6 | 1048576 | 43 | 1093.73 | 43 | 1096.40 | 1.00× | -0.2% |
| 7 | 512 | 16 | 37.68 | 6 | 37.45 | 1.01× | +0.6% |
| 7 | 1024 | 32 | 43.55 | 8 | 38.50 | 1.13× | +11.6% |
| 7 | 2048 | 32 | 44.34 | 12 | 42.10 | 1.05× | +5.0% |
| 7 | 4096 | 37 | 50.13 | 19 | 46.86 | 1.07× | +6.5% |
| 7 | 8192 | 40 | 58.41 | 26 | 52.50 | 1.11× | +10.1% |
| 7 | 16384 | 41 | 66.68 | 38 | 64.43 | 1.03× | +3.4% |
| 7 | 32768 | 42 | 80.06 | 42 | 80.01 | 1.00× | +0.1% |
| 7 | 65536 | 43 | 113.32 | 43 | 116.27 | 0.97× | -2.6% |
| 7 | 131072 | 43 | 180.54 | 43 | 185.38 | 0.97× | -2.7% |
| 7 | 196608 | 43 | 250.99 | 43 | 250.55 | 1.00× | +0.2% |
| 7 | 262144 | 43 | 307.05 | 43 | 302.43 | 1.02× | +1.5% |
| 7 | 524288 | 43 | 579.10 | 43 | 579.61 | 1.00× | -0.1% |
| 7 | 1048576 | 43 | 1143.04 | 43 | 1137.82 | 1.00× | +0.5% |
| 8 | 512 | 16 | 38.54 | 6 | 37.99 | 1.01× | +1.4% |
| 8 | 1024 | 32 | 44.76 | 8 | 39.52 | 1.13× | +11.7% |
| 8 | 2048 | 32 | 45.77 | 12 | 41.84 | 1.09× | +8.6% |
| 8 | 4096 | 37 | 51.06 | 19 | 46.90 | 1.09× | +8.2% |
| 8 | 8192 | 40 | 59.20 | 26 | 52.74 | 1.12× | +10.9% |
| 8 | 16384 | 41 | 67.54 | 38 | 65.40 | 1.03× | +3.2% |
| 8 | 32768 | 42 | 81.78 | 42 | 81.29 | 1.01× | +0.6% |
| 8 | 65536 | 43 | 115.21 | 43 | 117.14 | 0.98× | -1.7% |
| 8 | 131072 | 43 | 187.32 | 43 | 184.55 | 1.01× | +1.5% |
| 8 | 196608 | 43 | 252.28 | 43 | 248.15 | 1.02× | +1.6% |
| 8 | 262144 | 43 | 309.15 | 43 | 302.26 | 1.02× | +2.2% |
| 8 | 524288 | 43 | 579.53 | 43 | 577.11 | 1.00× | +0.4% |
| 8 | 1048576 | 43 | 1131.94 | 43 | 1132.17 | 1.00× | -0.0% |

</details>

<details><summary><b>nhead = 128</b></summary>

| qlen | ctx | OFF sp | OFF us | ON sp | ON us | speedup | faster% |
|---:|---:|---:|---:|---:|---:|:--:|:--:|
| 1 | 512 | 32 | 25.11 | 6 | 21.29 | 1.18× | +15.2% |
| 1 | 1024 | 64 | 32.33 | 8 | 21.18 | 1.53× | +34.5% |
| 1 | 2048 | 128 | 39.38 | 12 | 25.18 | 1.56× | +36.1% |
| 1 | 4096 | 128 | 39.49 | 19 | 28.72 | 1.38× | +27.3% |
| 1 | 8192 | 171 | 47.31 | 27 | 33.28 | 1.42× | +29.7% |
| 1 | 16384 | 205 | 56.40 | 38 | 39.67 | 1.42× | +29.7% |
| 1 | 32768 | 228 | 63.55 | 54 | 48.03 | 1.32× | +24.4% |
| 1 | 65536 | 241 | 71.73 | 76 | 60.93 | 1.18× | +15.1% |
| 1 | 131072 | 249 | 82.36 | 108 | 77.37 | 1.06× | +6.0% |
| 1 | 196608 | 251 | 94.33 | 133 | 94.44 | 1.00× | -0.1% |
| 1 | 262144 | 253 | 105.15 | 154 | 106.33 | 0.99× | -1.1% |
| 1 | 524288 | 255 | 147.36 | 216 | 148.10 | 0.99× | -0.5% |
| 1 | 1048576 | 256 | 238.23 | 256 | 241.01 | 0.99× | -1.2% |
| 2 | 512 | 32 | 28.36 | 6 | 22.05 | 1.29× | +22.3% |
| 2 | 1024 | 64 | 31.59 | 8 | 22.68 | 1.39× | +28.2% |
| 2 | 2048 | 64 | 31.43 | 13 | 26.56 | 1.18× | +15.5% |
| 2 | 4096 | 86 | 36.75 | 19 | 31.61 | 1.16× | +14.0% |
| 2 | 8192 | 103 | 44.15 | 26 | 33.98 | 1.30× | +23.0% |
| 2 | 16384 | 114 | 49.94 | 37 | 40.71 | 1.23× | +18.5% |
| 2 | 32768 | 121 | 58.40 | 54 | 50.55 | 1.16× | +13.4% |
| 2 | 65536 | 125 | 68.80 | 76 | 65.63 | 1.05× | +4.6% |
| 2 | 131072 | 127 | 91.90 | 108 | 89.48 | 1.03× | +2.6% |
| 2 | 196608 | 127 | 117.25 | 127 | 117.40 | 1.00× | -0.1% |
| 2 | 262144 | 128 | 140.36 | 128 | 138.54 | 1.01× | +1.3% |
| 2 | 524288 | 128 | 232.73 | 128 | 231.43 | 1.01× | +0.6% |
| 2 | 1048576 | 128 | 403.95 | 128 | 407.58 | 0.99× | -0.9% |
| 3 | 512 | 32 | 27.35 | 6 | 22.89 | 1.19× | +16.3% |
| 3 | 1024 | 64 | 34.81 | 8 | 22.80 | 1.53× | +34.5% |
| 3 | 2048 | 64 | 34.64 | 12 | 28.58 | 1.21× | +17.5% |
| 3 | 4096 | 64 | 34.70 | 19 | 31.28 | 1.11× | +9.9% |
| 3 | 8192 | 74 | 40.84 | 26 | 34.61 | 1.18× | +15.2% |
| 3 | 16384 | 79 | 48.69 | 38 | 44.08 | 1.10× | +9.5% |
| 3 | 32768 | 82 | 57.22 | 54 | 54.22 | 1.06× | +5.2% |
| 3 | 65536 | 84 | 72.67 | 76 | 71.60 | 1.01× | +1.5% |
| 3 | 131072 | 85 | 112.39 | 85 | 108.54 | 1.04× | +3.4% |
| 3 | 196608 | 85 | 146.21 | 85 | 145.90 | 1.00× | +0.2% |
| 3 | 262144 | 85 | 178.86 | 85 | 181.99 | 0.98× | -1.8% |
| 3 | 524288 | 86 | 303.33 | 86 | 305.02 | 0.99× | -0.6% |
| 3 | 1048576 | 86 | 592.25 | 86 | 589.77 | 1.00× | +0.4% |
| 4 | 512 | 32 | 28.33 | 6 | 22.94 | 1.23× | +19.0% |
| 4 | 1024 | 32 | 28.59 | 8 | 24.67 | 1.16× | +13.7% |
| 4 | 2048 | 43 | 30.11 | 13 | 27.67 | 1.09× | +8.1% |
| 4 | 4096 | 52 | 36.04 | 19 | 32.62 | 1.10× | +9.5% |
| 4 | 8192 | 57 | 42.14 | 26 | 35.33 | 1.19× | +16.1% |
| 4 | 16384 | 61 | 48.08 | 38 | 44.62 | 1.08× | +7.2% |
| 4 | 32768 | 63 | 61.83 | 54 | 57.76 | 1.07× | +6.6% |
| 4 | 65536 | 64 | 83.53 | 64 | 83.35 | 1.00× | +0.2% |
| 4 | 131072 | 64 | 132.85 | 64 | 132.01 | 1.01× | +0.6% |
| 4 | 196608 | 64 | 178.27 | 64 | 177.35 | 1.01× | +0.5% |
| 4 | 262144 | 64 | 216.83 | 64 | 216.99 | 1.00× | -0.1% |
| 4 | 524288 | 64 | 386.15 | 64 | 386.89 | 1.00× | -0.2% |
| 4 | 1048576 | 64 | 710.23 | 64 | 725.47 | 0.98× | -2.1% |
| 5 | 512 | 32 | 34.33 | 6 | 26.59 | 1.29× | +22.5% |
| 5 | 1024 | 32 | 34.45 | 8 | 27.21 | 1.27× | +21.0% |
| 5 | 2048 | 43 | 39.51 | 13 | 31.17 | 1.27× | +21.1% |
| 5 | 4096 | 43 | 42.67 | 19 | 37.39 | 1.14× | +12.4% |
| 5 | 8192 | 47 | 47.98 | 26 | 41.27 | 1.16× | +14.0% |
| 5 | 16384 | 49 | 57.51 | 38 | 52.94 | 1.09× | +7.9% |
| 5 | 32768 | 50 | 69.95 | 50 | 70.61 | 0.99× | -0.9% |
| 5 | 65536 | 51 | 101.16 | 51 | 97.03 | 1.04× | +4.1% |
| 5 | 131072 | 51 | 157.25 | 51 | 157.73 | 1.00× | -0.3% |
| 5 | 196608 | 51 | 207.51 | 51 | 208.58 | 0.99× | -0.5% |
| 5 | 262144 | 52 | 264.04 | 52 | 258.71 | 1.02× | +2.0% |
| 5 | 524288 | 52 | 473.97 | 52 | 476.37 | 0.99× | -0.5% |
| 5 | 1048576 | 52 | 955.97 | 52 | 959.45 | 1.00× | -0.4% |
| 6 | 512 | 16 | 26.16 | 6 | 24.98 | 1.05× | +4.5% |
| 6 | 1024 | 32 | 32.64 | 8 | 26.98 | 1.21× | +17.3% |
| 6 | 2048 | 32 | 33.20 | 12 | 28.46 | 1.17× | +14.3% |
| 6 | 4096 | 37 | 35.99 | 19 | 33.86 | 1.06× | +5.9% |
| 6 | 8192 | 40 | 42.90 | 26 | 37.25 | 1.15× | +13.2% |
| 6 | 16384 | 41 | 51.67 | 38 | 49.33 | 1.05× | +4.5% |
| 6 | 32768 | 42 | 66.34 | 42 | 67.17 | 0.99× | -1.2% |
| 6 | 65536 | 43 | 104.91 | 43 | 103.84 | 1.01× | +1.0% |
| 6 | 131072 | 43 | 168.58 | 43 | 174.06 | 0.97× | -3.2% |
| 6 | 196608 | 43 | 237.25 | 43 | 236.85 | 1.00× | +0.2% |
| 6 | 262144 | 43 | 295.74 | 43 | 298.31 | 0.99× | -0.9% |
| 6 | 524288 | 43 | 559.75 | 43 | 564.30 | 0.99× | -0.8% |
| 6 | 1048576 | 43 | 1093.48 | 43 | 1098.39 | 1.00× | -0.4% |
| 7 | 512 | 16 | 27.46 | 6 | 26.89 | 1.02× | +2.1% |
| 7 | 1024 | 22 | 27.69 | 8 | 26.62 | 1.04× | +3.9% |
| 7 | 2048 | 32 | 34.69 | 13 | 29.42 | 1.18× | +15.2% |
| 7 | 4096 | 32 | 37.53 | 19 | 34.97 | 1.07× | +6.8% |
| 7 | 8192 | 35 | 43.90 | 26 | 38.98 | 1.13× | +11.2% |
| 7 | 16384 | 36 | 53.78 | 36 | 54.06 | 0.99× | -0.5% |
| 7 | 32768 | 36 | 71.07 | 36 | 70.51 | 1.01× | +0.8% |
| 7 | 65536 | 37 | 116.05 | 37 | 116.40 | 1.00× | -0.3% |
| 7 | 131072 | 37 | 193.46 | 37 | 195.21 | 0.99× | -0.9% |
| 7 | 196608 | 37 | 265.89 | 37 | 267.64 | 0.99× | -0.7% |
| 7 | 262144 | 37 | 339.78 | 37 | 336.28 | 1.01× | +1.0% |
| 7 | 524288 | 37 | 649.70 | 37 | 646.14 | 1.01× | +0.5% |
| 7 | 1048576 | 37 | 1315.68 | 37 | 1329.22 | 0.99× | -1.0% |
| 8 | 512 | 16 | 27.56 | 6 | 26.82 | 1.03× | +2.7% |
| 8 | 1024 | 22 | 28.94 | 8 | 26.07 | 1.11× | +9.9% |
| 8 | 2048 | 26 | 33.82 | 12 | 29.75 | 1.14× | +12.0% |
| 8 | 4096 | 29 | 39.59 | 19 | 35.90 | 1.10× | +9.3% |
| 8 | 8192 | 31 | 45.89 | 26 | 40.86 | 1.12× | +11.0% |
| 8 | 16384 | 32 | 58.61 | 32 | 58.43 | 1.00× | +0.3% |
| 8 | 32768 | 32 | 80.19 | 32 | 79.73 | 1.01× | +0.6% |
| 8 | 65536 | 32 | 128.57 | 32 | 127.77 | 1.01× | +0.6% |
| 8 | 131072 | 32 | 212.83 | 32 | 215.07 | 0.99× | -1.1% |
| 8 | 196608 | 32 | 293.49 | 32 | 299.44 | 0.98× | -2.0% |
| 8 | 262144 | 32 | 368.47 | 32 | 371.94 | 0.99× | -0.9% |
| 8 | 524288 | 32 | 679.77 | 32 | 688.83 | 0.99× | -1.3% |
| 8 | 1048576 | 32 | 1320.44 | 32 | 1369.71 | 0.96× | -3.7% |

</details>

## Reproduce

```
# two builds from one tree, both passing -1, on gfx950 fp8/fp8
bash run_ab_both.sh -n 16 32 48 64 96 128 -q 1 2 3 4 5 6 7 8 \
     -c 512 1024 2048 4096 8192 16384 32768 65536 131072 196608 262144 524288 1048576
# run_ab_both.sh: reverts the two kernel files -> rebuild -> bench (UNPATCHED),
#                 then overlays the patched files -> rebuild -> bench (PATCHED).
```
