### PR TITLE
[Bugfix] Fix ASM split-K semaphore deadlock under CUDA graph capture

### DIFF
--- a/aiter/ops/gemm_op_a16w16.py
+++ b/aiter/ops/gemm_op_a16w16.py
@@ -38,6 +38,51 @@ def _get_semaphore_workspace_keyed(device: torch.device, stream_id: int) -> Tens
     return torch.zeros(_SEMA_SHAPE, dtype=torch.uint32, device=device)
 
 
+# A graph records launches, not the allocation that zeroed the counter. Give
+# each recorded launch its own slot and record the zero-fill inside the graph.
+# Public: a host that records more than this raises it before its first launch.
+CAPTURE_SEMAPHORE_POOL_SLOTS = 4096
+_capture_rings: dict[torch.device, Tensor] = {}
+_capture_ring_next: dict[torch.device, int] = {}
+
+
+def _prime_capture_pool(device: torch.device) -> Tensor:
+    """Allocate the capture pool. Never called from inside a capture."""
+    ring = _capture_rings.get(device)
+    if ring is None:
+        ring = torch.zeros(
+            (CAPTURE_SEMAPHORE_POOL_SLOTS, *_SEMA_SHAPE),
+            dtype=torch.uint32,
+            device=device,
+        )
+        _capture_rings[device] = ring
+    return ring
+
+
+def _get_captured_semaphore_workspace(device: torch.device) -> Tensor:
+    ring = _capture_rings.get(device)
+    if ring is None:
+        raise RuntimeError(
+            f"no split-K a16w16 semaphore pool on {device}: the pool is "
+            "allocated by an eager call that takes the splitK path (splitK "
+            "None or > 1); make one on this device before capturing a graph."
+        )
+    idx = _capture_ring_next.get(device, 0)
+    # Bound against the pool as allocated, not the constant: raising the
+    # constant after allocation must not let idx past the end of the tensor.
+    if idx >= ring.shape[0]:
+        raise RuntimeError(
+            f"split-K a16w16 capture semaphore pool exhausted on {device}: "
+            f"{ring.shape[0]} slots recorded. Raise "
+            "aiter.ops.gemm_op_a16w16.CAPTURE_SEMAPHORE_POOL_SLOTS before the "
+            "first split-K launch; the pool is sized when it is allocated."
+        )
+    _capture_ring_next[device] = idx + 1
+    sema = ring[idx]
+    sema.zero_()  # a graph node, so every replay starts from zero
+    return sema
+
+
 def get_semaphore_workspace(device: torch.device) -> Tensor:
     """Return a per-(device, stream) zero-initialized semaphore workspace.
 
@@ -53,7 +98,30 @@ def get_semaphore_workspace(device: torch.device) -> Tensor:
     Workspace size is small (~4 KB) and stream count per process is typically
     < 8, so the LRU cap of 64 leaves plenty of headroom before any in-flight
     workspace risks being evicted.
+
+    Under capture this returns a slot from a per-device pool instead, with the
+    zero-fill recorded as a graph node so replay restores counter == 0. That
+    pool has to exist before capture starts, so the first eager splitK call on
+    a device allocates it: a fixed CAPTURE_SEMAPHORE_POOL_SLOTS * 4 KiB, paid
+    once per device even by a process that never captures a graph.
     """
+    # torch.device("cuda") means "the current device", which is not a stable
+    # key: resolve it now so the pool is keyed and allocated per GPU.
+    if device.index is None:
+        device = torch.device(device.type, torch.cuda.current_device())
+
+    # is_current_stream_capturing() answers about the current device; only pay
+    # the device switch (~1us, and this is a per-GEMM path) when it differs.
+    if device.index == torch.cuda.current_device():
+        capturing = torch.cuda.is_current_stream_capturing()
+    else:
+        with torch.cuda.device(device):
+            capturing = torch.cuda.is_current_stream_capturing()
+    if capturing:
+        return _get_captured_semaphore_workspace(device)
+
+    # Allocate here, never under capture: graph-pool memory cannot be freed.
+    _prime_capture_pool(device)
     stream = torch.cuda.current_stream(device)
     return _get_semaphore_workspace_keyed(device, stream.cuda_stream)
 

--- a/op_tests/test_gemm_a16w16.py
+++ b/op_tests/test_gemm_a16w16.py
@@ -12,6 +12,7 @@ import torch.nn.functional as F
 import aiter
 from aiter import dtypes, hipb_create_extension, hipb_mm
 from aiter.jit.utils.chip_info import get_gfx_runtime as get_gfx
+from aiter.ops.gemm_op_a16w16 import get_semaphore_workspace
 from aiter.ops.shuffle import shuffle_weight
 from aiter.test_common import benchmark, checkAllclose, perftest
 from aiter.tuned_gemm import tgemm, triton_gemm
@@ -428,6 +429,77 @@ def test_skinny_gemm():
     return df
 
 
+def check_graph(dtype, m, n, k, otype):
+    """Capture the asm split-K GEMM in a HIP graph, replay it, compare against eager.
+
+    Not part of the perf table: this is a pass/fail check that the split-K
+    semaphore survives capture/replay. The kernel needs its counter to be zero
+    when a launch starts; a graph records launches, not the memset that zeroed
+    the counter, so a replay can start dirty and the kernel spins forever.
+    """
+    if dtype != dtypes.bf16 or otype not in (dtypes.bf16, dtypes.fp32):
+        return  # the asm a16w16 path only takes bf16 in, bf16/fp32 out
+    if k % 64 or n % 64:
+        return
+
+    x = torch.randn(m, k, dtype=dtype, device="cuda")
+    weight = torch.randn(n, k, dtype=dtype, device="cuda")
+    wshuffle = shuffle_weight(weight, layout=(16, 16))
+    out = torch.empty(m, n, dtype=otype, device="cuda")
+
+    # Warm up outside capture: the first call loads the module and allocates the
+    # semaphore workspace, neither of which may happen inside a capture region.
+    aiter.gemm_a16w16_asm(x, wshuffle, out, bpreshuffle=wshuffle.is_shuffled)
+    torch.cuda.synchronize()
+    eager = out.clone()
+
+    # Leave the counter dirty on the stream the graph captures on -- the state
+    # production reaches, and the one an unfixed build cannot recover from.
+    stream = torch.cuda.Stream()
+    stream.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(stream):
+        get_semaphore_workspace(x.device).fill_(2)
+    stream.synchronize()
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph, stream=stream):
+        aiter.gemm_a16w16_asm(x, wshuffle, out, bpreshuffle=wshuffle.is_shuffled)
+    torch.cuda.current_stream().wait_stream(stream)
+
+    out.zero_()
+    graph.replay()
+    torch.cuda.synchronize()
+
+    # splitK reduces in whatever order the blocks finish, so the same inputs are
+    # not bit-identical run to run; compare with the file's usual tolerance.
+    err = checkAllclose(
+        eager,
+        out,
+        msg=f"graph dim: {(m, n, k)!s:<20} dtype: {dtype} otype: {otype}, replay vs eager: ",
+        catastrophic_check=True,
+    )
+    assert err == 0, f"graph replay diverged from eager at {(m, n, k)} {dtype} {otype}"
+
+    # The workspace a capture hands out must have its zero-fill recorded as a
+    # graph node, or replay N starts from whatever replay N-1 left. Checked on
+    # its own graph, with no kernel, so a regression asserts here in
+    # milliseconds instead of spinning in the GEMM above.
+    sink = torch.zeros(1, device=x.device)
+    probe = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(probe, stream=stream):
+        sema = get_semaphore_workspace(x.device)
+        sink.add_(1)  # a graph needs at least one node
+    torch.cuda.current_stream().wait_stream(stream)
+    torch.cuda.synchronize()
+    sema.view(torch.int32).fill_(2)
+    torch.cuda.synchronize()
+    probe.replay()
+    torch.cuda.synchronize()
+    assert (
+        int(sema.view(torch.int32).max().item()) == 0
+    ), f"capture recorded no zero-fill for the splitK counter at {(m, n, k)}"
+
+
 parser = argparse.ArgumentParser(
     formatter_class=argparse.RawTextHelpFormatter,
     description="config input of a16w16_gemm_test",
@@ -495,6 +567,13 @@ parser.add_argument(
     help="""Scale B.
     e.g.: -sb 0.5""",
 )
+parser.add_argument(
+    "--graph",
+    action="store_true",
+    help="""Also run the HIP-graph capture/replay check for the asm splitK path
+    over the same sweep. Use shapes that select splitK (small m, large k).
+    e.g.: --graph -mnk 64,256,5120 32,512,8192 -d bf16 -o fp32""",
+)
 args = parser.parse_args()
 
 df = []
@@ -503,6 +582,8 @@ for test in args.test:
         for dtype in args.dtype:
             for otype in args.otype:
                 for m, n, k in args.mnk:
+                    if args.graph:
+                        check_graph(dtype, m, n, k, otype)
                     ret = test_gemm(
                         dtype,
                         m,
@@ -521,3 +602,5 @@ for test in args.test:
 df = pd.DataFrame(df)
 df_md = df.to_markdown(index=False)
 aiter.logger.info("gemm_a16w16 summary (markdown):\n%s", df_md)
+if args.graph:
+    aiter.logger.info("all graph capture/replay checks passed")


### PR DESCRIPTION
## Summary

A split-K a16w16 GEMM recorded into a CUDA graph hangs forever on replay — the GPU wedges, no wrong number, no recovery. Each recorded launch now gets its own counter, and the zero-fill is recorded inside the graph.

Supersedes #4494, reverted by #4709 for unbounded VRAM growth.

## Motivation

The kernel needs its split-K counter to be 0 when a launch starts. aiter zeroes it once, where it allocates it. A graph records launches, not that allocation, so replay never re-zeroes it — and a counter that is not 0 means the reduction never fires and the waves spin.

`rocgdb` on a hung endpoint: 132 waves of `bf16gemm_fp32bf16_tn_64x64_splitk_clean` waiting on a counter holding `2`.

## Technical Details

#4494 allocated the workspace while the graph was capturing. That memory belongs to the graph's private pool, and aiter never learns when a graph dies, so it could not free it — every workspace went into a list that grew with each capture. That list is what #4709 objected to.

This allocates the pool once, on the eager path, from the normal allocator. Nothing to keep alive, so no list.

| | #4494 | this PR |
|---|---|---|
| allocated | during capture | before capture |
| can be freed? | no | nothing to free |
| footprint | 4 KiB per launch, **grows** | **fixed 16 MiB per device** |

Running out of slots raises instead of reusing one, since two graphs sharing a counter deadlock when replayed together. So does capturing on a device that never ran eagerly, where the only alternative is to allocate from the graph's pool. Both are loud at startup rather than wedged in production later — the same choice `_check_split_k_semaphore_capacity` makes in the FlyDSL split-K path.

Removing the counter from the kernel would make all of this unnecessary. That is #4920.

## Test Plan

`check_graph()` and a `--graph` flag in `op_tests/test_gemm_a16w16.py`, following `test_inverse_rope_group_quant.py`. Two assertions per shape:

1. capture the GEMM, replay, compare against eager — with the counter left dirty first, the way production reaches it.
2. capture `get_semaphore_workspace()` alone, write a sentinel into what it returns, replay, require it back at 0. No kernel, so a build that stops recording the zero-fill fails in milliseconds instead of spinning.

`--graph` is off by default, so CI (`python3 <file>`) runs neither.

```bash
python3 op_tests/test_gemm_a16w16.py --graph -mnk 64,256,5120 32,512,8192 -d bf16 -o fp32
```

## Test Result

MI355X (gfx950):

```console
graph dim: (64, 256, 5120)   replay vs eager: [checkAllclose atol=0.01 rtol=0.01 passed~]
graph dim: (32, 512, 8192)   replay vs eager: [checkAllclose atol=0.01 rtol=0.01 passed~]
all graph capture/replay checks passed
```

| build | `--graph` | no flag |
|---|---|---|
| with the fix | passes | table as before |
| **fix minus `sema.zero_()`** | **`AssertionError: capture recorded no zero-fill`** | table as before |
| without the fix | **hangs** | table as before |

The middle row is the one for #4709: delete the single line this PR turns on and the check goes red, so the property is guarded, not just claimed.

End to end, Kimi-K3 TP8 with a graphed speculative draft on 8x MI355X. Without the fix the draft capture wedges 3.6 minutes in and the server never starts — 25 minutes later, 8 GPUs still pinned at 100% with no worker progress. With it, capture completes on all 8 ranks, the endpoint is up in 330 s, and GSM8K-100 scores 1.000 with 0 invalid at 120.18 output tok/s. #4494 measured 120.1 tok/s on the same stack, so throughput is unchanged and the unbounded memory is gone.

## Submission Checklist

- [x] No kernel and no numerics change; eager launches return the same workspace as before, plus a one-time pool allocation per device
- [x] Verified on MI355X (gfx950), including in the current upstream ROCm nightly
- [x] Looked over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests

## Tool assistance

Claude Opus 5 (1M context) assisted with the fix, the tests and this description.
