### PR TITLE
[Triton/Gluon] Retune unified attention configs for gfx950

### DIFF
--- a/aiter/ops/triton/attention/unified_attention.py
+++ b/aiter/ops/triton/attention/unified_attention.py
@@ -46,6 +46,19 @@ WARP_SIZE = 32 if IS_DEVICE_ARCH_GFX12 else 64
 WAPR_SIZE_LOG2 = int(math.log2(WARP_SIZE))
 
 
+def is_gfx950_small_head(head_size):
+    """
+    True for gfx950 with a head_size the wide-LDS-copy config applies to.
+
+    On gfx950, the direct-to-LDS copy only stays vectorized at TILE_SIZE=64.
+    Below that it degrades to 4 bytes/lane plus a ds_bpermute per copy.
+
+    This covers the arch and head_size half of that condition only,
+    callers add their own path conditions (decode, sw).
+    """
+    return DEVICE_ARCH == "gfx950" and head_size <= 128
+
+
 def is_2d_gluon_available(
     q_dtype, kv_cache_dtype, softcap, use_qq_bias, use_alibi_slopes
 ):
@@ -113,6 +126,12 @@ def select_2d_config(
                 num_stages_2d, num_warps = 1, 4
             else:
                 num_stages_2d, num_warps = 3, 2
+        # gfx950: keep LDS copies wide (TILE_SIZE=64) to avoid the narrow-copy overhead.
+        # Windowed decode only, as wide copy prefers a shallower pipeline.
+        if is_gfx950_small_head(head_size) and sliding_window > 0:
+            TILE_SIZE = 64
+            num_stages_2d, num_warps = 2, 2
+            waves_per_eu = 1
 
     BLOCK_Q = BLOCK_M // num_queries_per_kv
     num_stages_2d = min(max_num_stages_2d, num_stages_2d)
@@ -213,12 +232,20 @@ def select_3d_config(
         if head_size >= 512 and not arch.is_rdna:
             attn_warps, attn_stages = 4, 1
         occ = waves_per_eu * 4 // attn_warps
-        target_num_prgms = target_num_prgms * occ
+        wide_lds_copy = is_gfx950_small_head(head_size)
+        # The occupancy multiplier over-segments the KV split for the wide-copy
+        # path, so we skip it there; every other case applies it.
+        if not wide_lds_copy:
+            target_num_prgms = target_num_prgms * occ
 
         TILE_SIZE = min(64, triton.next_power_of_2(block_size))
+        if wide_lds_copy:
+            # same de-vectorization fix as the 2D path
+            TILE_SIZE = 64
 
         MAX_SEGMENTS = min(128, math.ceil(max_seqlen_k / TILE_SIZE))
-        MIN_SEGMENTS = min(8, MAX_SEGMENTS)
+        # the >= 8 floor would clamp the smaller splits (4 and 2) back up to 8
+        MIN_SEGMENTS = 1 if wide_lds_copy else min(8, MAX_SEGMENTS)
         if head_size >= 512 and not arch.is_rdna:
             MIN_SEGMENTS = min(16, MAX_SEGMENTS)
         if num_segments == 0:
@@ -227,7 +254,9 @@ def select_3d_config(
             num_segments = max(num_segments, MIN_SEGMENTS)
             num_segments = triton.next_power_of_2(num_segments)
 
-        if num_segments == MIN_SEGMENTS:
+        # The wide-copy path can reach 2 segments, so use segment count directly
+        # Keep 1-warp reduce for small segment counts
+        if num_segments <= (2 if wide_lds_copy else MIN_SEGMENTS):
             reduce_num_warps = 1
 
         if shuffled_kv_cache:


### PR DESCRIPTION
## Motivation

On gfx950, Triton 3.8 enables direct-to-LDS async copy by default, and for this kernel that default backfires. The lowering only stays vectorized when `TILE_SIZE` is 64, and below that, it collapses to 4 bytes per lane and hands a `ds_bpermute` address shuffle off every copy. The shipped selector of the old wrapper for `unified_attention` sets `TILE_SIZE` from the kv-cache block size, so any deployment running block 16 or 32 gets the slow form.

That shows up as **51 regressions across 108-shape GPT-OSS decode suite** against the Triton-3.4.0 reference:
- 30 on the sliding-window (2D) path
- 21 on the non-windowed (3D) path

No issues with code-gen, no issues with the kernel or compiler flag `TRITON_HIP_USE_ASYNC_COPY=1`. We tune for the right config selection to get the desired results through the wrapper file for GPT-OSS. 

## Technical Details

All changes are in `select_2d_config` / `select_3d_config`. Four parts, each behind a `is_gfx950_retune()`
guard:

- 2D: pin `TILE_SIZE = 64` instead of `min(64, next_power_of_2(block_size))`. This is what brings back the
  16 B/lane `buffer_load_dwordx4 ... lds` copy. With a wide copy the old pipeline depth and occupancy hint no
  longer fit, so `num_stages` goes 3 → 2 and `waves_per_eu` 2 → 1.
- 3D: drop the `occ` multiplier on `target_num_prgms`, which was inflating the target and over-segmenting the
  KV split. What is left is `target_num_prgms / num_2d_prgms` — for decode just `1024 / (B * KVH)` — giving
  4, 2, 32, 16 across the four (batch, kv-head) groups. Those are the values we measured as optimal, from a
  formula already implicit in the code rather than a lookup table.
- 3D: set `MIN_SEGMENTS = 1` (was `min(8, MAX_SEGMENTS)`). The old floor clamps a split of 4 or 2 back up to 8
  and silently cancels the change above.
- 3D: trigger `reduce_num_warps` on `num_segments <= 2` instead of `== MIN_SEGMENTS`. With the floor at 1 that
  equality never fires, and the `B*KVH >= 512` group would lose the 1-warp reduce it previously got at
  `num_segments == 8`. A small segment count is the real condition, not equality with floor.

The scope is deliberately narrow - `is_gfx950_retune()` requires `DEVICE_ARCH == "gfx950"`. No other architectures are affected.

## Test Plan

Performance: 108-shape GPT-OSS decode suite (bf16 Q + fp8 e4m3 paged KV, `head_dim=64`, `seqlen_q=1`, B in {1,32,64}, block in {16,32,64}, `seqlen_k` in {1k,4k,8k}, sliding window in {none,128}). Wrapper-level A/B between two real checkouts. No per-shape config overrides, so the selector itself produces every config. `TRITON_HIP_USE_ASYNC_COPY=1` on **both** arms. `rocprofv3 --kernel-trace --stats`, 200 launches per run, median of the 3 reps chosen for stable average number.

Correctness: both configs run on identical seeded inputs in one process, compared against an fp8-matched fp32 paged-attention reference; reported as proposed-vs-default error, not only error-vs-reference. Includes a no-op shape per path (config identical on both arms) as a determinism control. Also run `pytest op_tests/triton_tests/attention/test_unified_attention.py -v` to ensure all tests pass

Config justification: each retuned value was bracket-swept on both sides to confirm it is a measured local optimum rather than a fitted value, and the 2D `num_stages`/`waves_per_eu` pairing was validated across all 54 2D shapes before being generalized.

## Test Result

| scope | before (regression / ok / improvement) | after | geomean vs current | geomean vs Triton-3.4 |
|---|---|---|---|---|
| 2D `sw=128` | 11 / 24 / 19 | **0 / 0 / 54** | **1.433x** | **1.447x** |
| 3D `sw=none` | 17 / 2 / 35 | **0 / 1 / 53** | **1.308x** | **1.414x** |
| **All 108** | 28 / 26 / 54 | **0 / 1 / 107** | **1.369x** | **1.430x** |

- All regressions **eliminated (0 after)**, no status degrades, and the selector collapses 108 shapes onto 7 distinct constexpr signatures.
- 3 of 108 are slower than the same-session baseline, all 3D `B=1`: `B1_tp8_QH8_KVH1_D64_BLK16_SWnone_SK1024` **+3.20%** (6.555 -> 6.765 us, still −21.3% vs reference), plus +0.24% and +0.15% on two shapes where the selector emits a byte-identical config on both arms (inside the +/-1.5% null-control noise floor). Only the +3.20% case is a real loss.
- Correctness: 2D is **bitwise identical** to the shipping config on the shapes where only `num_stages`/`waves_per_eu` change, confirming those knobs are scheduling-only. 3D error vs the reference is equal to the default on 15/17 shapes and one bf16 ULP larger on 2/17, never worse; proposed-vs-default agrees to <= 1.0 ULP everywhere.
    - Pytest output: `1088 passed, 1056 skipped, 804 warnings in 247.61s (0:04:07)`

- Caveats: the 3D `B=1` slice measured ~12% faster than the archived baseline (sanity ratio 0.877, outside the window on the fast side), so its vs-reference figures are optimistic by roughly that margin - its same-session delta is unaffected. 3D `B=1` is also where gains are thinnest (median −1.6% overall, −8.9% on the 12 shapes whose config actually changes, no-op at block 64).

### Per-shape results (108 shapes)

`shipped` and `final` tests were measured back-to-back in the same session. 

**You can find the results here in this [excel link](https://amdcloud-my.sharepoint.com/:x:/g/personal/nidanial_amd_com/IQB96vzlMd60TaDdMoM4LV8qAXFgy6h226DOcDHcjyltn78?e=03LEsE)**

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
