### PR TITLE
[Config] perf(kimi-k3): tune K2 c8 BF16 projections on gfx950

### DIFF
--- a/aiter/configs/model_configs/kimik3_bf16_tuned_gemm.csv
+++ b/aiter/configs/model_configs/kimik3_bf16_tuned_gemm.csv
@@ -450,3 +450,5 @@ gfx1250,256,2048,12440,7168,False,torch.bfloat16,torch.bfloat16,False,False,trit
 gfx1250,256,4096,12440,7168,False,torch.bfloat16,torch.bfloat16,False,False,triton,0,0,1124.254,auto,0.0,649.75,301.51
 gfx1250,256,8192,12440,7168,False,torch.bfloat16,torch.bfloat16,False,False,triton,0,0,2237.2325,auto,0.0,653.02,223.31
 gfx1250,256,16384,12440,7168,False,torch.bfloat16,torch.bfloat16,False,False,triton,0,0,4958.5079,auto,0.0,589.27,165.54
+gfx950,256,24,3584,7168,False,torch.bfloat16,torch.bfloat16,False,False,hipblaslt,441426,0,13.726,native,0.0,89.84,0.0
+gfx950,256,24,6288,7168,False,torch.bfloat16,torch.bfloat16,False,False,hipblaslt,440174,0,16.671,native,0.0,129.77,0.0


### PR DESCRIPTION
## Purpose

Kimi-K3 K2 verification at concurrency 8 produces `M=24`. The bf16 tuned-GEMM table
has no exact `gfx950` entry at that M for either the routed down projection
(`N=3584, K=7168`) or the fused QKVGFA projection (`N=6288, K=7168`), so both fall
back to torch solution 0 on every layer.

This adds the two measured hipblaslt solutions. `tuned_gemm` already dispatches
`libtype == "hipblaslt"` and honours an explicit `solidx`; these are the first
hipblaslt rows in this particular table, which is why the shapes were missing rather
than mistuned.

Only the exact `gfx950` M24 dispatch changes. Every other batch size, arch and shape
takes the same path as before.

## Test Plan

Measured through the production wrapper under HIP graph replay on MI355X, comparing
the fallback against the selected solution at the exact shapes.

## Test Result

| shape | before | after | |
|---|---|---|---|
| `M24 N3584 K7168` (routed down) | 20.27 us | 18.43 us | **1.100x** |
| `M24 N6288 K7168` (fused QKVGFA) | 24.67 us | 21.21 us | **1.163x** |

Solutions `441426` and `440174` respectively.

Note that hipblaslt solution indices are tied to the ROCm build they were tuned on;
these were selected on ROCm 7.2.
