### PR TITLE
[Docs] : fix MI300A gfx target in attention docs (gfx942, not gfx950)

### DIFF
--- a/docs/api/attention.rst
+++ b/docs/api/attention.rst
@@ -129,7 +129,7 @@ AITER attention kernels are optimized for:
 
 * **AMD Instinct MI300X** (gfx942) - Best performance
 * **AMD Instinct MI250X** (gfx90a) - Fully supported
-* **AMD Instinct MI300A** (gfx950) - Experimental
+* **AMD Instinct MI300A** (gfx942) - Experimental
 
 Performance Characteristics
 ----------------------------

--- a/docs/api/attention.rst
+++ b/docs/api/attention.rst
@@ -129,7 +129,7 @@ AITER attention kernels are optimized for:
 
 * **AMD Instinct MI300X** (gfx942) - Best performance
 * **AMD Instinct MI250X** (gfx90a) - Fully supported
-* **AMD Instinct MI300A** (gfx942) - Experimental
+* **AMD Instinct MI355X** (gfx950) - Experimental
 
 Performance Characteristics
 ----------------------------


### PR DESCRIPTION
MI300A is CDNA3 / gfx942, the same ISA target as MI300X, not gfx950 (which is CDNA4, MI350X/MI355X). This matches docs/index.rst, which lists MI300A and MI300X under gfx942.

