### PR TITLE
test(activation): skip fp4 silu_and_mul_quant on non-gfx950 archs

### DIFF
--- a/op_tests/test_activation.py
+++ b/op_tests/test_activation.py
@@ -492,22 +492,32 @@ if df:
     aiter.logger.info("silu_and_mul_quant (fp8) summary (markdown):\n%s", df_md)
 
 # silu_and_mul_quant with fp4 (group_size=32)
-df = []
-for dtype in args.dtype:
-    for m in args.m:
-        for n in args.n:
-            d = n // 2
-            gs = 32
-            if d >= gs and d % gs == 0:
-                ret = test_silu_and_mul_quant(
-                    m, n, dtype, group_size=gs, output_dtype=dtypes.fp4x2
-                )
-                df.append(ret)
-if df:
-    df = pd.DataFrame(df)
-    df = df[quant_cols]
-    df_md = df.to_markdown(index=False)
-    aiter.logger.info("silu_and_mul_quant (fp4) summary (markdown):\n%s", df_md)
+# FP4 (e2m1) output uses CDNA4-only MFMA and is compiled in only for
+# gfx950/gfx1250. On other archs (e.g. gfx942/MI300A) the kernel is not
+# built, so skip instead of aborting inside the C++ dispatch.
+_fp4_gfx = aiter.get_gfx()
+if _fp4_gfx not in ("gfx950", "gfx1250"):
+    aiter.logger.info(
+        "skip silu_and_mul_quant (fp4): fp4 output requires gfx950/gfx1250, got %s",
+        _fp4_gfx,
+    )
+else:
+    df = []
+    for dtype in args.dtype:
+        for m in args.m:
+            for n in args.n:
+                d = n // 2
+                gs = 32
+                if d >= gs and d % gs == 0:
+                    ret = test_silu_and_mul_quant(
+                        m, n, dtype, group_size=gs, output_dtype=dtypes.fp4x2
+                    )
+                    df.append(ret)
+    if df:
+        df = pd.DataFrame(df)
+        df = df[quant_cols]
+        df_md = df.to_markdown(index=False)
+        aiter.logger.info("silu_and_mul_quant (fp4) summary (markdown):\n%s", df_md)
 
 # silu_and_mul_quant with fp8 + limit=10
 df = []


### PR DESCRIPTION
FP4 (e2m1) output relies on CDNA4-only MFMA and is compiled in only for gfx950/gfx1250 (guarded by #if defined(__Float4_e2m1fn_x2) in csrc/kernels/activation_kernels.cu). On gfx942 (MI300A/MI300X) the fp4 branch is compiled out, so the dispatch hits AITER_CHECK(false) and aborts the whole test process. Gate the fp4 case on the runtime gfx (matching the mxfp4 skip idiom in test_moe_ep.py) so it is skipped cleanly, letting the remaining activation tests run.
