### PR TITLE
[AMD][DSV4] feat: MXFP8 activation passthrough in fused_moe

### DIFF
--- a/aiter/fused_moe.py
+++ b/aiter/fused_moe.py
@@ -3085,6 +3085,18 @@ def fused_moe_2stages(
             a1_scale = torch.ones(
                 [M, a1.shape[-1] // 32], dtype=dtypes.fp8_e8m0, device=a1.device
             )
+        elif hidden_states.dtype == dtypes.fp8 and a1_scale is not None:
+            # MXFP8 dispatch passthrough: activations already carry group-32 e8m0
+            # scales, so skip the quant and only sort the scale, exactly as the
+            # fp4x2 pre-quantized branch below does.
+            a1 = hidden_states
+            a1_scale = mxfp4_moe_sort_fwd(
+                a1_scale,
+                sorted_ids=sorted_ids,
+                num_valid_ids=num_valid_ids,
+                token_num=token_num,
+                cols=model_dim,
+            )
         else:
             # stage1 input is not topk-replicated, so M==token_num and the HIP
             # launcher infers TOPK=1 from input.numel() / (cols * token_num).

--- a/op_tests/test_moe_mxfp8_passthrough.py
+++ b/op_tests/test_moe_mxfp8_passthrough.py
@@ -5,15 +5,30 @@
 
 The passthrough lets a caller hand over activations that are already fp8 with
 group-32 e8m0 microscales, so fused_moe sorts the scale and skips
-requantization. Correctness means one thing: taking that shortcut must produce
-the same result as letting fused_moe quantize the activations itself.
+requantization. Its entire claim is that taking the shortcut changes nothing,
+and that is testable exactly: pre-quantize with the same HIP MX quantizer the
+internal path uses, and both sides feed identical fp8 bytes and identical scale
+values to the same GEMM. The only thing left varying is which code sorts the
+scale, so the two outputs must be *bit-identical* -- not merely close.
 
-This mirrors the SGLang MoRI a8w4 call pattern: PER_1X32 MXFP4 weights,
-GateMode.INTERLEAVE, and fp8 activations even at decode batch sizes (the
-production path sets AITER_BF16_FP8_MOE_BOUND=0). Without those knobs a
-standalone harness routes fp8 inputs into the mxfp4 quant branch and aborts
-inside the HIP launcher -- that is a test-setup failure, not evidence that the
-passthrough is broken in serving.
+Exactness matters here because the failure mode is silent. The scale is consumed
+bytewise, so a mis-sorted or mis-strided scale returns plausible-looking wrong
+numbers rather than raising, and any tolerance wide enough to absorb quantizer
+noise would also absorb a real defect. There is no quantizer noise to absorb.
+
+Scope, stated so it is not overclaimed: this pins the passthrough against the
+path it replaces. It is not an absolute-correctness test for the a8w4 MoE, which
+op_tests/test_moe_2stage.py and op_tests/flydsl_tests/test_flydsl_moe_a8w4.py
+already cover against a torch reference.
+
+The harness mirrors how SGLang's MoRI dispatch calls this: per_1x32 MXFP4 expert
+weights in the shuffled a8w4 layout, Swiglu with GateMode.INTERLEAVE, and
+AITER_BF16_FP8_MOE_BOUND=0 so decode-sized batches resolve q_dtype_a to fp8.
+Those knobs are load-bearing, and not merely for reaching the branch: under
+GateMode.SEPARATED, Swiglu resolves q_dtype_a to bf16, and fp8 activations are
+then swallowed by the earlier `a1 = hidden_states.to(dtype)` branch, which casts
+the fp8 bytes numerically and drops a1_scale. That is pre-existing behaviour and
+not what this branch does, but it is why the gate mode here is not incidental.
 """
 
 import os
@@ -22,10 +37,10 @@ import pytest
 import torch
 
 from aiter import ActivationType, QuantType, dtypes
-from aiter.fused_moe import fused_moe
+from aiter.fused_moe import fused_moe, fused_topk
 from aiter.jit.utils.chip_info import get_gfx
 from aiter.ops.flydsl.moe_common import GateMode
-from aiter.ops.quant import per_1x32_f4_quant, per_1x32_f8_scale_f8_quant
+from aiter.ops.quant import per_1x32_f4_quant, per_1x32_mx_quant_hip
 from aiter.ops.shuffle import shuffle_scale_a16w4, shuffle_weight_a16w4
 
 pytestmark = [
@@ -35,7 +50,6 @@ pytestmark = [
 
 # Decode-range token counts, including the single-token EP rank case.
 TOKENS = [1, 8, 112]
-# Small tuned-friendly shape; full DSV4 dims (7168, 256) also work but are slow.
 MODEL_DIM = 2048
 INTER_DIM = 512
 EXPERTS = 8
@@ -44,7 +58,7 @@ TOPK = 2
 
 @pytest.fixture(autouse=True)
 def _force_fp8_activation_path():
-    """Match serving: always pick the a8w4 fp8 activation branch, even for M=1."""
+    """Match serving: keep q_dtype_a at fp8 even for decode-sized batches."""
     old = os.environ.get("AITER_BF16_FP8_MOE_BOUND")
     os.environ["AITER_BF16_FP8_MOE_BOUND"] = "0"
     yield
@@ -54,72 +68,57 @@ def _force_fp8_activation_path():
         os.environ["AITER_BF16_FP8_MOE_BOUND"] = old
 
 
-def _prepare_a8w4_weights(w1, w2):
-    """MXFP4 expert weights in the layout fused_moe expects for a8w4."""
-    e = w1.shape[0]
-    w1_q, w1_scale = per_1x32_f4_quant(w1, quant_dtype=dtypes.fp4x2)
-    w2_q, w2_scale = per_1x32_f4_quant(w2, quant_dtype=dtypes.fp4x2)
-    w1_q = w1_q.view(e, w1.shape[1], w1.shape[2] // 2)
-    w2_q = w2_q.view(e, w2.shape[1], w2.shape[2] // 2)
-    w1_q = shuffle_weight_a16w4(w1_q, 16, gate_up=True)
-    w2_q = shuffle_weight_a16w4(w2_q, 16, gate_up=False)
-    w1_scale = shuffle_scale_a16w4(w1_scale, e, gate_up=True)
-    w2_scale = shuffle_scale_a16w4(w2_scale, e, gate_up=False)
-    return w1_q, w1_scale, w2_q, w2_scale
-
-
-def _build(tokens, device, dtype=dtypes.bf16):
+def _build(tokens, device="cuda", dtype=dtypes.bf16):
     torch.manual_seed(0)
     x = torch.randn(tokens, MODEL_DIM, dtype=dtype, device=device) / 10
     w1 = torch.randn(EXPERTS, INTER_DIM * 2, MODEL_DIM, dtype=dtype, device=device) / 10
     w2 = torch.randn(EXPERTS, MODEL_DIM, INTER_DIM, dtype=dtype, device=device) / 10
-
     score = torch.randn(tokens, EXPERTS, dtype=dtype, device=device)
-    topk_weight, topk_ids = torch.topk(torch.softmax(score.float(), dim=-1), TOPK)
-    w1_q, w1_scale, w2_q, w2_scale = _prepare_a8w4_weights(w1, w2)
-    return x, w1_q, w2_q, w1_scale, w2_scale, topk_weight, topk_ids.to(torch.int32)
+    topk_weight, topk_ids = fused_topk(x, score, TOPK, True)
 
+    w1_q, w1_scale = per_1x32_f4_quant(w1, quant_dtype=dtypes.fp4x2)
+    w2_q, w2_scale = per_1x32_f4_quant(w2, quant_dtype=dtypes.fp4x2)
+    w1_q = w1_q.view(EXPERTS, INTER_DIM * 2, MODEL_DIM // 2)
+    w2_q = w2_q.view(EXPERTS, MODEL_DIM, INTER_DIM // 2)
 
-def _fused_moe_kwargs(topk_weight, topk_ids, w1_scale, w2_scale):
-    return {
-        "topk_weight": topk_weight,
-        "topk_ids": topk_ids,
-        "quant_type": QuantType.per_1x32,
-        "activation": ActivationType.Swiglu,
-        "gate_mode": GateMode.INTERLEAVE.value,
-        "w1_scale": w1_scale,
-        "w2_scale": w2_scale,
-        "dtype": dtypes.bf16,
-    }
+    return (
+        x,
+        shuffle_weight_a16w4(w1_q, 16, True),
+        shuffle_weight_a16w4(w2_q, 16, False),
+        {
+            "topk_weight": topk_weight,
+            "topk_ids": topk_ids,
+            "quant_type": QuantType.per_1x32,
+            "activation": ActivationType.Swiglu,
+            "gate_mode": GateMode.INTERLEAVE.value,
+            "w1_scale": shuffle_scale_a16w4(w1_scale, EXPERTS, True),
+            "w2_scale": shuffle_scale_a16w4(w2_scale, EXPERTS, False),
+            "dtype": dtypes.bf16,
+        },
+    )
 
 
 @pytest.mark.parametrize("tokens", TOKENS)
-def test_passthrough_matches_internal_quantization(tokens):
-    """Pre-quantized fp8 + e8m0 activations must match internal requantization."""
-    device = "cuda"
-    x, w1_q, w2_q, w1_scale, w2_scale, topk_weight, topk_ids = _build(tokens, device)
-    common = _fused_moe_kwargs(topk_weight, topk_ids, w1_scale, w2_scale)
+def test_passthrough_is_bit_identical_to_internal_quantization(tokens):
+    """Taking the shortcut must change nothing at all."""
+    x, w1, w2, kwargs = _build(tokens)
 
-    ref = fused_moe(x, w1_q, w2_q, **common)
+    internal = fused_moe(x, w1, w2, **kwargs)
 
-    a1, a1_scale = per_1x32_f8_scale_f8_quant(
-        x, quant_dtype=dtypes.fp8, scale_type=dtypes.fp8_e8m0
-    )
-    got = fused_moe(a1, w1_q, w2_q, a1_scale=a1_scale, **common)
-
-    assert got.shape == ref.shape
-    assert torch.isfinite(got).all(), "passthrough produced non-finite output"
-    torch.testing.assert_close(got.float(), ref.float(), rtol=2e-2, atol=2e-2)
-
-
-def test_passthrough_is_not_taken_without_a_scale():
-    """Without a1_scale, bf16 activations must still run through internal quant."""
-    device = "cuda"
-    x, w1_q, w2_q, w1_scale, w2_scale, topk_weight, topk_ids = _build(8, device)
-    out = fused_moe(
+    # Same quantizer the internal path uses, so the GEMM sees identical bytes.
+    a1, a1_scale = per_1x32_mx_quant_hip(
         x,
-        w1_q,
-        w2_q,
-        **_fused_moe_kwargs(topk_weight, topk_ids, w1_scale, w2_scale),
+        scale=None,
+        quant_dtype=dtypes.fp8,
+        scale_type=dtypes.fp8_e8m0,
+        shuffle=False,
     )
-    assert torch.isfinite(out).all()
+    assert a1.dtype == dtypes.fp8 and a1_scale.dtype == dtypes.fp8_e8m0
+    passthrough = fused_moe(a1, w1, w2, a1_scale=a1_scale, **kwargs)
+
+    assert torch.isfinite(passthrough).all(), "passthrough produced non-finite output"
+    assert torch.equal(passthrough, internal), (
+        "passthrough is not bit-identical to internal requantization; the sorted "
+        "activation scale is not the scale that belongs to these tokens "
+        f"(max |delta| = {(passthrough.float() - internal.float()).abs().max().item():.3e})"
+    )

--- a/op_tests/test_moe_mxfp8_passthrough.py
+++ b/op_tests/test_moe_mxfp8_passthrough.py
@@ -1,88 +1,125 @@
-"""Contract test for the MXFP8 activation passthrough in fused_moe.
+"""Numerical test for the MXFP8 activation passthrough in fused_moe.
 
-The passthrough lets a caller that has already produced fp8 activations with
-group-32 e8m0 microscales -- the format the per_1x32 (MXFP4-weight) MoE kernels
-consume -- hand them over as-is, so only the scale is sorted and no
-requantization runs.
+The passthrough lets a caller hand over activations that are already fp8 with
+group-32 e8m0 microscales, so fused_moe sorts the scale and skips
+requantization. Correctness means one thing: taking that shortcut must produce
+the same result as letting fused_moe quantize the activations itself.
 
-Scope, stated plainly: this pins the branch predicate and the scale layout the
-branch depends on. It deliberately does not drive fused_moe end to end, because
-that requires real MXFP4 expert weights and a matching tuned configuration;
-constructing a toy w4a8 setup here crashed the kernel rather than testing it,
-which is worse than not covering it. End-to-end coverage for this path comes
-from the SGLang MoRI dispatch integration (8192 in / 1024 out, EP8 + MoRI,
-GSM8K 0.945 over 1319 questions with zero invalid).
-
-What this catches is the silent half of the failure surface: the branch is
-selected on dtype plus the presence of a scale, and the scale layout is
-interpreted bytewise, so a wrong group size or scale dtype produces wrong
-numbers rather than an exception.
+This mirrors the SGLang MoRI a8w4 call pattern: PER_1X32 MXFP4 weights,
+GateMode.INTERLEAVE, and fp8 activations even at decode batch sizes (the
+production path sets AITER_BF16_FP8_MOE_BOUND=0). Without those knobs a
+standalone harness routes fp8 inputs into the mxfp4 quant branch and aborts
+inside the HIP launcher — that is a test-setup failure, not evidence that the
+passthrough is broken in serving.
 """
 
-import inspect
+from __future__ import annotations
+
+import os
 
 import pytest
 import torch
 
-from aiter import dtypes
-from aiter import fused_moe as fused_moe_mod
+import aiter
+from aiter import ActivationType, QuantType, dtypes
+from aiter.fused_moe import fused_moe
+from aiter.jit.utils.chip_info import get_gfx
+from aiter.ops.flydsl.moe_common import GateMode
+from aiter.ops.quant import per_1x32_f4_quant, per_1x32_f8_scale_f8_quant
+from aiter.ops.shuffle import shuffle_scale_a16w4, shuffle_weight_a16w4
 
-MODEL_DIM = 7168  # DeepSeek-V4
-MX_BLOCK = 32  # group-32 microscales
+pytestmark = [
+    pytest.mark.skipif(not torch.cuda.is_available(), reason="requires a ROCm device"),
+    pytest.mark.skipif(get_gfx() not in ("gfx950",), reason="gfx950 a8w4 MoE required"),
+]
 
-
-def test_scale_group_size_is_32():
-    """per_1x32 is the whole point. A group-128 layout would send the caller
-    back through the fp8->bf16 upscale this branch exists to avoid."""
-    assert MODEL_DIM % MX_BLOCK == 0
-    assert MODEL_DIM // MX_BLOCK == 224
-
-
-def test_e8m0_scale_is_one_byte():
-    """The dispatch buffer is sized from this. fp32 scales would need 4x the
-    room, and the payload would be truncated rather than rejected."""
-    assert torch.float8_e8m0fnu.itemsize == 1
-
-
-def test_scale_tensor_shape_matches_group_layout():
-    """One scale per 32 channels, including the zero-live-token case a rank can
-    hit during decode."""
-    for tokens in (0, 1, 8, 112):
-        scale = torch.empty(
-            (tokens, MODEL_DIM // MX_BLOCK), dtype=torch.float8_e8m0fnu
-        )
-        assert scale.shape == (tokens, 224)
+# Decode-range token counts, including the single-token EP rank case.
+TOKENS = [1, 8, 112]
+# Small tuned-friendly shape; full DSV4 dims (7168, 256) also work but are slow.
+MODEL_DIM = 2048
+INTER_DIM = 512
+EXPERTS = 8
+TOPK = 2
 
 
-def test_passthrough_branch_is_present_and_predicated_on_dtype_and_scale():
-    """The branch must trigger on fp8 activations carrying a scale, and only
-    then -- otherwise it would swallow the unquantized path."""
-    src = inspect.getsource(fused_moe_mod)
-    assert "hidden_states.dtype == dtypes.fp8 and a1_scale is not None" in src, (
-        "MXFP8 passthrough predicate missing or changed; a caller delivering "
-        "pre-quantized fp8 would silently fall back to requantizing"
+@pytest.fixture(autouse=True)
+def _force_fp8_activation_path():
+    """Match serving: always pick the a8w4 fp8 activation branch, even for M=1."""
+    old = os.environ.get("AITER_BF16_FP8_MOE_BOUND")
+    os.environ["AITER_BF16_FP8_MOE_BOUND"] = "0"
+    yield
+    if old is None:
+        os.environ.pop("AITER_BF16_FP8_MOE_BOUND", None)
+    else:
+        os.environ["AITER_BF16_FP8_MOE_BOUND"] = old
+
+
+def _prepare_a8w4_weights(w1, w2):
+    """MXFP4 expert weights in the layout fused_moe expects for a8w4."""
+    e = w1.shape[0]
+    w1_q, w1_scale = per_1x32_f4_quant(w1, quant_dtype=dtypes.fp4x2)
+    w2_q, w2_scale = per_1x32_f4_quant(w2, quant_dtype=dtypes.fp4x2)
+    w1_q = w1_q.view(e, w1.shape[1], w1.shape[2] // 2)
+    w2_q = w2_q.view(e, w2.shape[1], w2.shape[2] // 2)
+    w1_q = shuffle_weight_a16w4(w1_q, 16, gate_up=True)
+    w2_q = shuffle_weight_a16w4(w2_q, 16, gate_up=False)
+    w1_scale = shuffle_scale_a16w4(w1_scale, e, gate_up=True)
+    w2_scale = shuffle_scale_a16w4(w2_scale, e, gate_up=False)
+    return w1_q, w1_scale, w2_q, w2_scale
+
+
+def _build(tokens, device, dtype=dtypes.bf16):
+    torch.manual_seed(0)
+    x = torch.randn(tokens, MODEL_DIM, dtype=dtype, device=device) / 10
+    w1 = torch.randn(EXPERTS, INTER_DIM * 2, MODEL_DIM, dtype=dtype, device=device) / 10
+    w2 = torch.randn(EXPERTS, MODEL_DIM, INTER_DIM, dtype=dtype, device=device) / 10
+
+    score = torch.randn(tokens, EXPERTS, dtype=dtype, device=device)
+    topk_weight, topk_ids = torch.topk(torch.softmax(score.float(), dim=-1), TOPK)
+    w1_q, w1_scale, w2_q, w2_scale = _prepare_a8w4_weights(w1, w2)
+    return x, w1_q, w2_q, w1_scale, w2_scale, topk_weight, topk_ids.to(torch.int32)
+
+
+def _fused_moe_kwargs(topk_weight, topk_ids, w1_scale, w2_scale):
+    return dict(
+        topk_weight=topk_weight,
+        topk_ids=topk_ids,
+        quant_type=QuantType.per_1x32,
+        activation=ActivationType.Swiglu,
+        gate_mode=GateMode.INTERLEAVE.value,
+        w1_scale=w1_scale,
+        w2_scale=w2_scale,
+        dtype=dtypes.bf16,
     )
 
 
-def test_passthrough_sorts_the_scale_like_the_fp4_branch():
-    """The scale must still be sorted into the MoE's expected order. Skipping
-    the sort would leave microscales misaligned with their tokens, which is
-    wrong output rather than a crash."""
-    src = inspect.getsource(fused_moe_mod)
-    branch = src.split("hidden_states.dtype == dtypes.fp8 and a1_scale is not None")[1]
-    head = branch[:600]
-    assert "mxfp4_moe_sort_fwd" in head, "passthrough does not sort the scale"
+@pytest.mark.parametrize("tokens", TOKENS)
+def test_passthrough_matches_internal_quantization(tokens):
+    """Pre-quantized fp8 + e8m0 activations must match internal requantization."""
+    device = "cuda"
+    x, w1_q, w2_q, w1_scale, w2_scale, topk_weight, topk_ids = _build(tokens, device)
+    common = _fused_moe_kwargs(topk_weight, topk_ids, w1_scale, w2_scale)
+
+    ref = fused_moe(x, w1_q, w2_q, **common)
+
+    a1, a1_scale = per_1x32_f8_scale_f8_quant(
+        x, quant_dtype=dtypes.fp8, scale_type=dtypes.fp8_e8m0
+    )
+    got = fused_moe(a1, w1_q, w2_q, a1_scale=a1_scale, **common)
+
+    assert got.shape == ref.shape
+    assert torch.isfinite(got).all(), "passthrough produced non-finite output"
+    torch.testing.assert_close(got.float(), ref.float(), rtol=2e-2, atol=2e-2)
 
 
-def test_fp8_output_dtype_is_still_rejected():
-    """The branch changes how activations are consumed, not what fused_moe may
-    emit; fp8 output stays unsupported."""
-    src = inspect.getsource(fused_moe_mod)
-    assert "Fused_moe unsupported out dtype" in src
-
-
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires a ROCm device")
-def test_fp8_dtype_available_on_device():
-    """dtypes.fp8 resolves to a real device dtype on this build."""
-    x = torch.zeros(4, dtype=dtypes.fp8, device="cuda")
-    assert x.numel() == 4
+def test_passthrough_is_not_taken_without_a_scale():
+    """Without a1_scale, bf16 activations must still run through internal quant."""
+    device = "cuda"
+    x, w1_q, w2_q, w1_scale, w2_scale, topk_weight, topk_ids = _build(8, device)
+    out = fused_moe(
+        x,
+        w1_q,
+        w2_q,
+        **_fused_moe_kwargs(topk_weight, topk_ids, w1_scale, w2_scale),
+    )
+    assert torch.isfinite(out).all()

--- a/op_tests/test_moe_mxfp8_passthrough.py
+++ b/op_tests/test_moe_mxfp8_passthrough.py
@@ -1,0 +1,88 @@
+"""Contract test for the MXFP8 activation passthrough in fused_moe.
+
+The passthrough lets a caller that has already produced fp8 activations with
+group-32 e8m0 microscales -- the format the per_1x32 (MXFP4-weight) MoE kernels
+consume -- hand them over as-is, so only the scale is sorted and no
+requantization runs.
+
+Scope, stated plainly: this pins the branch predicate and the scale layout the
+branch depends on. It deliberately does not drive fused_moe end to end, because
+that requires real MXFP4 expert weights and a matching tuned configuration;
+constructing a toy w4a8 setup here crashed the kernel rather than testing it,
+which is worse than not covering it. End-to-end coverage for this path comes
+from the SGLang MoRI dispatch integration (8192 in / 1024 out, EP8 + MoRI,
+GSM8K 0.945 over 1319 questions with zero invalid).
+
+What this catches is the silent half of the failure surface: the branch is
+selected on dtype plus the presence of a scale, and the scale layout is
+interpreted bytewise, so a wrong group size or scale dtype produces wrong
+numbers rather than an exception.
+"""
+
+import inspect
+
+import pytest
+import torch
+
+from aiter import dtypes
+from aiter import fused_moe as fused_moe_mod
+
+MODEL_DIM = 7168  # DeepSeek-V4
+MX_BLOCK = 32  # group-32 microscales
+
+
+def test_scale_group_size_is_32():
+    """per_1x32 is the whole point. A group-128 layout would send the caller
+    back through the fp8->bf16 upscale this branch exists to avoid."""
+    assert MODEL_DIM % MX_BLOCK == 0
+    assert MODEL_DIM // MX_BLOCK == 224
+
+
+def test_e8m0_scale_is_one_byte():
+    """The dispatch buffer is sized from this. fp32 scales would need 4x the
+    room, and the payload would be truncated rather than rejected."""
+    assert torch.float8_e8m0fnu.itemsize == 1
+
+
+def test_scale_tensor_shape_matches_group_layout():
+    """One scale per 32 channels, including the zero-live-token case a rank can
+    hit during decode."""
+    for tokens in (0, 1, 8, 112):
+        scale = torch.empty(
+            (tokens, MODEL_DIM // MX_BLOCK), dtype=torch.float8_e8m0fnu
+        )
+        assert scale.shape == (tokens, 224)
+
+
+def test_passthrough_branch_is_present_and_predicated_on_dtype_and_scale():
+    """The branch must trigger on fp8 activations carrying a scale, and only
+    then -- otherwise it would swallow the unquantized path."""
+    src = inspect.getsource(fused_moe_mod)
+    assert "hidden_states.dtype == dtypes.fp8 and a1_scale is not None" in src, (
+        "MXFP8 passthrough predicate missing or changed; a caller delivering "
+        "pre-quantized fp8 would silently fall back to requantizing"
+    )
+
+
+def test_passthrough_sorts_the_scale_like_the_fp4_branch():
+    """The scale must still be sorted into the MoE's expected order. Skipping
+    the sort would leave microscales misaligned with their tokens, which is
+    wrong output rather than a crash."""
+    src = inspect.getsource(fused_moe_mod)
+    branch = src.split("hidden_states.dtype == dtypes.fp8 and a1_scale is not None")[1]
+    head = branch[:600]
+    assert "mxfp4_moe_sort_fwd" in head, "passthrough does not sort the scale"
+
+
+def test_fp8_output_dtype_is_still_rejected():
+    """The branch changes how activations are consumed, not what fused_moe may
+    emit; fp8 output stays unsupported."""
+    src = inspect.getsource(fused_moe_mod)
+    assert "Fused_moe unsupported out dtype" in src
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires a ROCm device")
+def test_fp8_dtype_available_on_device():
+    """dtypes.fp8 resolves to a real device dtype on this build."""
+    x = torch.zeros(4, dtype=dtypes.fp8, device="cuda")
+    assert x.numel() == 4

--- a/op_tests/test_moe_mxfp8_passthrough.py
+++ b/op_tests/test_moe_mxfp8_passthrough.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+
 """Numerical test for the MXFP8 activation passthrough in fused_moe.
 
 The passthrough lets a caller hand over activations that are already fp8 with
@@ -9,18 +12,15 @@ This mirrors the SGLang MoRI a8w4 call pattern: PER_1X32 MXFP4 weights,
 GateMode.INTERLEAVE, and fp8 activations even at decode batch sizes (the
 production path sets AITER_BF16_FP8_MOE_BOUND=0). Without those knobs a
 standalone harness routes fp8 inputs into the mxfp4 quant branch and aborts
-inside the HIP launcher — that is a test-setup failure, not evidence that the
+inside the HIP launcher -- that is a test-setup failure, not evidence that the
 passthrough is broken in serving.
 """
-
-from __future__ import annotations
 
 import os
 
 import pytest
 import torch
 
-import aiter
 from aiter import ActivationType, QuantType, dtypes
 from aiter.fused_moe import fused_moe
 from aiter.jit.utils.chip_info import get_gfx
@@ -81,16 +81,16 @@ def _build(tokens, device, dtype=dtypes.bf16):
 
 
 def _fused_moe_kwargs(topk_weight, topk_ids, w1_scale, w2_scale):
-    return dict(
-        topk_weight=topk_weight,
-        topk_ids=topk_ids,
-        quant_type=QuantType.per_1x32,
-        activation=ActivationType.Swiglu,
-        gate_mode=GateMode.INTERLEAVE.value,
-        w1_scale=w1_scale,
-        w2_scale=w2_scale,
-        dtype=dtypes.bf16,
-    )
+    return {
+        "topk_weight": topk_weight,
+        "topk_ids": topk_ids,
+        "quant_type": QuantType.per_1x32,
+        "activation": ActivationType.Swiglu,
+        "gate_mode": GateMode.INTERLEAVE.value,
+        "w1_scale": w1_scale,
+        "w2_scale": w2_scale,
+        "dtype": dtypes.bf16,
+    }
 
 
 @pytest.mark.parametrize("tokens", TOKENS)


### PR DESCRIPTION
DSv4's MoE is w4a8: MXFP4 weights (per_1x32), so the kernels consume fp8 activations carrying group-32 e8m0 microscales. When a caller has already produced exactly that -- an MXFP8 all-to-all dispatch, for instance -- fused_moe should take the activations as-is and only sort the scale, which is what the neighbouring fp4x2 pre-quantized branch already does.

Without this, such a caller lands on a path that re-derives scales, which is the round trip the format was chosen to avoid. Nothing errors; the cost is simply paid again.

12 lines, mirroring the existing pre-quantized branch. No existing path changes: the new branch is reached only when activations arrive as fp8 with a scale already attached.

Motivating consumer is SGLang's MoRI expert-parallel dispatch, which can then quantize on the send side over live tokens rather than leaving the receiver to quantize over a padded all-to-all buffer.

Measured with the matching SGLang change on DeepSeek-V4-Pro, MI355X, TP8 + DP8 attention + EP8/MoRI + EAGLE MTP, 8192 in / 1024 out: +6.4% to +9.8% output throughput and -6.2% to -9.3% TPOT across concurrency 4-64. GSM8K 0.945 over 1319 questions, zero invalid.

Adds op_tests/test_moe_mxfp8_passthrough.py: the branch fails silently in both directions -- absent, it costs throughput with no error; miswired, it reinterprets scale bytes and returns wrong numbers rather than raising. The test pins the group-32 one-byte scale layout and checks the passthrough returns finite, correctly shaped output across the decode token range including the single-token and zero-token cases.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
