### PR TITLE
[Triton/Gluon] Force fp4gemm preshuffle to triton on gfx1250

### DIFF
--- a/aiter/ops/triton/_triton_kernels/gemm/basic/gemm_afp4wfp4.py
+++ b/aiter/ops/triton/_triton_kernels/gemm/basic/gemm_afp4wfp4.py
@@ -720,6 +720,7 @@ def _get_config(
     N: int,
     K: int,
     shuffle: bool = False,
+    backend: str | None = None,
 ):
     # Note: Config files use K=2*K in their naming
     K = 2 * K
@@ -730,6 +731,7 @@ def _get_config(
             N,
             K,
             bounds=(4, 8, 16, 31, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192),
+            backend=backend,
         )
     else:
-        return get_gemm_config("GEMM-AFP4WFP4", M, N, K)
+        return get_gemm_config("GEMM-AFP4WFP4", M, N, K, backend=backend)

--- a/aiter/ops/triton/configs/gfx1250/gluon/gemm/gemm_afp4wfp4_preshuffled/DEFAULT.json
+++ b/aiter/ops/triton/configs/gfx1250/gluon/gemm/gemm_afp4wfp4_preshuffled/DEFAULT.json
@@ -1,0 +1,16 @@
+{
+  "M_LEQ_31": {
+    "BLOCK_SIZE_M": 16,
+    "BLOCK_SIZE_N": 64,
+    "BLOCK_SIZE_K": 256,
+    "num_warps": 4,
+    "NUM_BUFFERS": 2
+  },
+  "any": {
+    "BLOCK_SIZE_M": 256,
+    "BLOCK_SIZE_N": 256,
+    "BLOCK_SIZE_K": 256,
+    "num_warps": 4,
+    "NUM_BUFFERS": 4
+  }
+}

--- a/aiter/ops/triton/configs/gfx1250/triton/gemm/gemm_afp4wfp4_preshuffled/DEFAULT.json
+++ b/aiter/ops/triton/configs/gfx1250/triton/gemm/gemm_afp4wfp4_preshuffled/DEFAULT.json
@@ -1,16 +1,98 @@
 {
+  "M_LEQ_8": {
+    "BLOCK_SIZE_M": 8,
+    "BLOCK_SIZE_N": 64,
+    "BLOCK_SIZE_K": 256,
+    "GROUP_SIZE_M": 4,
+    "num_warps": 2,
+    "num_stages": 2,
+    "waves_per_eu": 1,
+    "matrix_instr_nonkdim": 16,
+    "cache_modifier": null,
+    "NUM_KSPLIT": 1
+  },
   "M_LEQ_31": {
     "BLOCK_SIZE_M": 16,
     "BLOCK_SIZE_N": 64,
     "BLOCK_SIZE_K": 256,
+    "GROUP_SIZE_M": 1,
+    "num_warps": 2,
+    "num_stages": 2,
+    "waves_per_eu": 1,
+    "matrix_instr_nonkdim": 16,
+    "cache_modifier": null,
+    "NUM_KSPLIT": 1
+  },
+  "M_LEQ_32": {
+    "BLOCK_SIZE_M": 32,
+    "BLOCK_SIZE_N": 64,
+    "BLOCK_SIZE_K": 256,
+    "GROUP_SIZE_M": 1,
+    "num_warps": 2,
+    "num_stages": 2,
+    "waves_per_eu": 1,
+    "matrix_instr_nonkdim": 16,
+    "cache_modifier": null,
+    "NUM_KSPLIT": 1
+  },
+  "M_LEQ_64": {
+    "BLOCK_SIZE_M": 32,
+    "BLOCK_SIZE_N": 64,
+    "BLOCK_SIZE_K": 256,
+    "GROUP_SIZE_M": 1,
+    "num_warps": 2,
+    "num_stages": 2,
+    "waves_per_eu": 1,
+    "matrix_instr_nonkdim": 16,
+    "cache_modifier": null,
+    "NUM_KSPLIT": 1
+  },
+  "M_LEQ_128": {
+    "BLOCK_SIZE_M": 64,
+    "BLOCK_SIZE_N": 64,
+    "BLOCK_SIZE_K": 256,
+    "GROUP_SIZE_M": 1,
     "num_warps": 4,
-    "NUM_BUFFERS": 2
+    "num_stages": 3,
+    "waves_per_eu": 1,
+    "matrix_instr_nonkdim": 16,
+    "cache_modifier": null,
+    "NUM_KSPLIT": 1
+  },
+  "M_LEQ_256": {
+    "BLOCK_SIZE_M": 128,
+    "BLOCK_SIZE_N": 64,
+    "BLOCK_SIZE_K": 256,
+    "GROUP_SIZE_M": 1,
+    "num_warps": 4,
+    "num_stages": 3,
+    "waves_per_eu": 1,
+    "matrix_instr_nonkdim": 16,
+    "cache_modifier": null,
+    "NUM_KSPLIT": 1
+  },
+  "M_LEQ_512": {
+    "BLOCK_SIZE_M": 64,
+    "BLOCK_SIZE_N": 128,
+    "BLOCK_SIZE_K": 256,
+    "GROUP_SIZE_M": 4,
+    "num_warps": 4,
+    "num_stages": 2,
+    "waves_per_eu": 2,
+    "matrix_instr_nonkdim": 16,
+    "cache_modifier": null,
+    "NUM_KSPLIT": 1
   },
   "any": {
-    "BLOCK_SIZE_M": 256,
-    "BLOCK_SIZE_N": 256,
+    "BLOCK_SIZE_M": 128,
+    "BLOCK_SIZE_N": 128,
     "BLOCK_SIZE_K": 256,
+    "GROUP_SIZE_M": 4,
     "num_warps": 4,
-    "NUM_BUFFERS": 4
+    "num_stages": 2,
+    "waves_per_eu": 2,
+    "matrix_instr_nonkdim": 16,
+    "cache_modifier": null,
+    "NUM_KSPLIT": 1
   }
 }

--- a/aiter/ops/triton/gemm/basic/gemm_afp4wfp4.py
+++ b/aiter/ops/triton/gemm/basic/gemm_afp4wfp4.py
@@ -28,10 +28,23 @@ _LOGGER = AiterTritonLogger()
 
 _USE_GEMM_SPLITK_BF16 = False
 
+# gfx1250 runs the triton preshuffle kernel; flip this to hand it back to gluon.
+_USE_GLUON_PRESHUFFLE = False
+
 
 def set_use_gemm_splitk_bf16(value: bool):
     global _USE_GEMM_SPLITK_BF16
     _USE_GEMM_SPLITK_BF16 = value
+
+
+def use_gluon_preshuffle() -> bool:
+    """Whether gemm_afp4wfp4_preshuffle dispatches to the gluon kernel.
+
+    The two kernels consume different scale layouts (gluon: preshuffle_factor
+    16 / scale_kwidth 4, triton: 32 / 8), so callers that shuffle scales
+    themselves must pick the layout according to this predicate.
+    """
+    return _USE_GLUON_PRESHUFFLE and arch_info.get_arch() == "gfx1250"
 
 
 def get_splitk(K: int, BLOCK_SIZE_K: int, NUM_KSPLIT: int):
@@ -449,7 +462,7 @@ def gemm_afp4wfp4_preshuffle(
     """
 
     assert arch_info.is_fp4_avail(), "MXFP4 is not available on your device"
-    use_gluon = arch_info.get_arch() == "gfx1250"
+    use_gluon = use_gluon_preshuffle()
 
     M, K_bytes = x_fp4.shape
     n16, _ = w_preshuf.shape
@@ -458,8 +471,12 @@ def gemm_afp4wfp4_preshuffle(
 
     if config is None:
         # _get_config doubles K itself (logical K = 2 * K_bytes) — pass bytes,
-        # matching the non-preshuffled path.
-        config, _ = _get_config(M, N, K_bytes, True)
+        # matching the non-preshuffled path. The two backends take disjoint
+        # params (gluon: NUM_BUFFERS, triton: NUM_KSPLIT/GROUP_SIZE_M/...), so
+        # the config must come from the dir of the backend we actually launch.
+        config, _ = _get_config(
+            M, N, K_bytes, True, backend="gluon" if use_gluon else "triton"
+        )
 
     config["BLOCK_SIZE_N"] = max(config["BLOCK_SIZE_N"], 32)
     if M < 32:

--- a/aiter/ops/triton/gemm/basic/gemm_afp4wfp4.py
+++ b/aiter/ops/triton/gemm/basic/gemm_afp4wfp4.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: MIT
 # Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
 
+import os
+
 import torch
 import triton
 
@@ -28,8 +30,10 @@ _LOGGER = AiterTritonLogger()
 
 _USE_GEMM_SPLITK_BF16 = False
 
-# gfx1250 runs the triton preshuffle kernel; flip this to hand it back to gluon.
-_USE_GLUON_PRESHUFFLE = False
+# gfx1250 runs the triton preshuffle kernel by default; set
+# AITER_FORCE_GFX1250_GLUON_FP4=1 to force the gluon path back on. This is a
+# workaround switch kept for validation until the Triton-side fix lands.
+_USE_GLUON_PRESHUFFLE = os.environ.get("AITER_FORCE_GFX1250_GLUON_FP4", "0") == "1"
 
 
 def set_use_gemm_splitk_bf16(value: bool):
@@ -39,6 +43,9 @@ def set_use_gemm_splitk_bf16(value: bool):
 
 def use_gluon_preshuffle() -> bool:
     """Whether gemm_afp4wfp4_preshuffle dispatches to the gluon kernel.
+
+    Defaults to the triton kernel on gfx1250; set AITER_FORCE_GFX1250_GLUON_FP4=1
+    to force gluon. The env var is a no-op on every other arch.
 
     The two kernels consume different scale layouts (gluon: preshuffle_factor
     16 / scale_kwidth 4, triton: 32 / 8), so callers that shuffle scales

--- a/op_tests/triton_tests/gemm/basic/test_gemm_afp4wfp4.py
+++ b/op_tests/triton_tests/gemm/basic/test_gemm_afp4wfp4.py
@@ -9,6 +9,7 @@ from aiter.ops.triton.gemm.basic.gemm_afp4wfp4 import (
 )
 from aiter.ops.triton.gemm.basic.gemm_afp4wfp4 import (
     gemm_afp4wfp4_preshuffle,
+    use_gluon_preshuffle,
 )
 from aiter.ops.triton.gluon.gemm_afp4wfp4 import (
     gemm_afp4wfp4 as gluon_gemm_afp4wfp4_CDNA4,
@@ -79,7 +80,10 @@ def generate_gemm_afp4wfp4_inputs(
     x_scales = x_scales.T
     w_scales = w_scales.T
     if shuffle_scales_fg:
-        if DEVICE_ARCH == "gfx1250":
+        # The scale layout is dictated by the kernel the wrapper dispatches to,
+        # not by the arch: gfx1250 also runs the triton kernel while the gluon
+        # preshuffle path is disabled.
+        if use_gluon_preshuffle():
             if M >= 32:
                 x_scales_shuffled = shuffle_scale_gemm(
                     x_scales, arch="gfx1250", preshuffle_factor=16, scale_kwidth=4


### PR DESCRIPTION
## Summary

On gfx1250, `gemm_afp4wfp4_preshuffle` hard-selected the gluon kernel from the arch string:

```python
use_gluon = arch_info.get_arch() == "gfx1250"
```

That single arch check silently governs three separate things, because the gluon and triton
preshuffle kernels are not interchangeable:

| | gluon | triton |
|---|---|---|
| scale layout | `preshuffle_factor=16`, `scale_kwidth=4` | `32`, `8` |
| config params | `NUM_BUFFERS` | `NUM_KSPLIT`, `GROUP_SIZE_M`, `num_stages`, `matrix_instr_nonkdim`, ... |
| config dir | `configs/gfx1250/gluon/...` | `configs/gfx1250/triton/...` |

So "which kernel runs" also decides which config directory is valid and which scale layout
callers must produce. With the arch check, those three could not be moved together.

This PR routes gfx1250 fp4 preshuffle GEMM to the **triton** kernel, and replaces the arch
check with a single predicate that all three sites consult.

## Changes

1. **`aiter/ops/triton/gemm/basic/gemm_afp4wfp4.py`** — arch check becomes a flippable predicate:
   ```python
   _USE_GLUON_PRESHUFFLE = False
   def use_gluon_preshuffle() -> bool:
       return _USE_GLUON_PRESHUFFLE and arch_info.get_arch() == "gfx1250"
   ```
   Default `False` — gfx1250 now runs the triton kernel; flipping one flag hands it back to gluon.

2. **Config resolution follows the backend, not the arch** — `_get_config(..., backend="gluon" if
   use_gluon else "triton")` threaded through to `get_gemm_config`. The `backend` parameter already
   exists in `aiter/ops/triton/utils/gemm_config_utils.py`; this only wires it up. Since the two
   backends take disjoint params, the config must come from the directory of the backend actually
   launched.

3. **Configs** — the existing gluon tuning moves to a new
   `configs/gfx1250/gluon/gemm/gemm_afp4wfp4_preshuffled/DEFAULT.json`, and the triton config is
   expanded from 2 buckets to 8 (`M_LEQ_8/31/32/64/128/256/512/any`) with per-bucket
   `num_stages` / `waves_per_eu` / `matrix_instr_nonkdim` / `NUM_KSPLIT`.

4. **`op_tests/triton_tests/gemm/basic/test_gemm_afp4wfp4.py`** — scale shuffling now keys off
   `use_gluon_preshuffle()` instead of `DEVICE_ARCH == "gfx1250"`. Without this the test would build
   scales in the gluon layout while the triton kernel runs, i.e. feed the wrong layout silently.

## Notes for reviewers

- The behavior change is limited to gfx1250 fp4 preshuffle GEMM; other arches are untouched.
- `use_gluon_preshuffle()` is exported deliberately: any caller that shuffles scales itself must
  pick the layout from this predicate rather than from the arch.
- Authored by @valarLip on branch `gfx1250/test_main_823`; I am taking the branch over and opening
  the PR for review.
- The branch is currently a few commits behind `main` — happy to rebase if preferred.
- gfx1250 accuracy/performance numbers to be attached from a CI run on gfx1250 hardware.
