### PR TITLE
[CI] ci: install Mori for multi-GPU tests

### DIFF
--- a/.github/workflows/aiter-test.yaml
+++ b/.github/workflows/aiter-test.yaml
@@ -1008,6 +1008,8 @@ jobs:
             pip install --upgrade 'pybind11>=3.0.1'
             pip install --upgrade 'ninja>=1.11.1'
             pip install tabulate
+            pip install 'amd-mori==1.2.2'
+            python3 -c 'import mori, mori.shmem; print("mori import ok")'
             pip install '${AITER_WHEEL_PATH}'
             pip show amd-aiter
           "


### PR DESCRIPTION
Summary:
- install amd-mori==1.2.2 only in the Multi-GPU Tests job
- add an import smoke check before running multi-GPU tests

Validation:
- git diff --check -- .github/workflows/aiter-test.yaml