### PR TITLE
[MLA] Fix gfx942 gqa64 sparse-MLA decode GPU fault (route to capture-safe fold)

### DIFF
--- a/aiter/mla.py
+++ b/aiter/mla.py
@@ -802,7 +802,13 @@ def mla_decode_fwd(
                 and max_seqlen_q == 2
             )
             or (
-                get_gfx() == "gfx942"
+                # [glm-dsa gqa64 fix] DISABLED: this native-support claim routes GLM-5.1
+                # gqa64 fp8 decode to mla_a8w8_qh64_qseqlen1_gqaratio64_v3_ps, which
+                # GPU-faults on gfx942. Force False so gqa64 falls through to the
+                # capture-safe persistent view-fold (nhead in range(32,128,16) below),
+                # which keeps cudagraph decode working (no in-forward allocations).
+                False
+                and get_gfx() == "gfx942"
                 and nhead == 64
                 and q.dtype == dtypes.fp8
                 and kv_buffer.dtype == dtypes.fp8


### PR DESCRIPTION
## Problem

On **gfx942 (MI300X)**, `mla_decode_fwd` in `aiter/mla.py` claims native support for the case `nhead == 64 && q/kv fp8 && max_seqlen_q == 1` and routes it to the asm kernel `mla_a8w8_qh64_qseqlen1_gqaratio64_v3_ps`. That kernel **GPU-faults** (HSA memory access fault, `HSA_STATUS_ERROR_EXCEPTION` code 0x1016) during decode.

This breaks any **gqa-ratio-64** model on gfx942 — e.g. GLM-5.1 (`num_attention_heads=64`, `num_key_value_heads=64`) at TP=1. The worker dies at CUDA-graph capture / first decode:

```
[aiter] LoadKernel: _ZN5aiter39mla_a8w8_qh64_qseqlen1_gqaratio64_v3_psE ...
Memory access fault by GPU node-N ... Reason: Unknown.
```

The clause was added after `e03fa6040` (which did not fault, because it folded gqa64 through the gqa16 kernel).

## Fix

Disable that single native-support clause (`False and ...`) so gqa64 falls through to the **already-present, capture-safe persistent view-fold** a few lines below (`elif nhead in range(32, 128 + 1, 16) and persistent_mode:`), which reshapes q/o with `.view()` only — **no in-forward allocations**, so CUDA-graph decode keeps working.

```python
             or (
+                # gqa64 on gfx942: this native-support claim routes to
+                # mla_a8w8_qh64_qseqlen1_gqaratio64_v3_ps, which GPU-faults.
+                # Force False so gqa64 falls through to the capture-safe
+                # persistent view-fold (nhead in range(32,128,16) below).
+                False
+                and get_gfx() == "gfx942"
                 and nhead == 64
                 and q.dtype == dtypes.fp8
                 and kv_buffer.dtype == dtypes.fp8
                 and max_seqlen_q == 1
             )
```

One-line functional change + comment. **No-op for gqa != 64.**

## Validation

GLM-5.1-FP8, MoRI-EP WideEP **disaggregated** serving on MI300X/gfx942, with `FULL_AND_PIECEWISE` cudagraph decode (persistent MLA on):

- NIAH long-context retrieval: **1P/1D EP8** — 2k 10/10, 8k 9/10; **2P/2D EP16** — 2k 10/10, 8k 10/10.
- Perf 2P/2D EP16, 8192/1024 con=32: **TPOT ~59 ms** (median), 100% successful requests, no faults — i.e. cudagraph decode is preserved (the folded path is capture-safe).

## Notes

Complements #4088 (which folds the **non-persistent** gqa64 path for chunked-prefill accuracy). This PR covers the **persistent decode** path so cudagraph-captured decode no longer routes to the faulting native kernel.
