### PR TITLE
[CI] ci: fix Mori import smoke check quoting

### DIFF
--- a/.github/workflows/aiter-test.yaml
+++ b/.github/workflows/aiter-test.yaml
@@ -1009,7 +1009,7 @@ jobs:
             pip install --upgrade 'ninja>=1.11.1'
             pip install tabulate
             pip install 'amd-mori==1.2.2'
-            python3 -c 'import mori, mori.shmem; print("mori import ok")'
+            python3 -c 'import mori, mori.shmem'
             pip install '${AITER_WHEEL_PATH}'
             pip show amd-aiter
           "


### PR DESCRIPTION
Summary:
- fix the multi-GPU Mori import smoke check so it does not break the surrounding bash -lc quoting
- keep the amd-mori install limited to the Multi-GPU Tests job

Root cause:
- the previous check used print("mori import ok") inside a double-quoted bash -lc payload, which terminated the shell string early

Validation:
- git diff --check -- .github/workflows/aiter-test.yaml