### PR TITLE
[HIP] FIX MLA the nhead fold error for cp round robin

### DIFF
--- a/aiter/mla.py
+++ b/aiter/mla.py
@@ -398,6 +398,20 @@ def _persistent_mla_decode_max_batch():
         return _MLA_DECODE_PERSISTENT_MAX_BATCH_DEFAULT
 
 
+def _fold_seqlen_indptr(indptr, fold_factor):
+    """Repeat each batch's seqlen ``fold_factor`` times (head-folding pseudo-batches)."""
+    lens = indptr[1:] - indptr[:-1]
+    folded_lens = lens.repeat_interleave(fold_factor)
+    out = torch.empty(
+        indptr.shape[0] + (fold_factor - 1) * (indptr.shape[0] - 1),
+        dtype=indptr.dtype,
+        device=indptr.device,
+    )
+    out[0] = 0
+    out[1:] = torch.cumsum(folded_lens, dim=0).to(indptr.dtype)
+    return out
+
+
 def _use_persistent_mla_decode(bs, nhead, max_seqlen_q, q_dtype, kv_dtype):
     """Whether to keep the persistent MLA decode kernel.
 
@@ -838,23 +852,10 @@ def mla_decode_fwd(
 
             o = o.view(total_s, nhead, -1)
 
-            qo_indptr = torch.arange(
-                0,
-                (bs * fold_factor + 1) * max_seqlen_q,
-                max_seqlen_q,
-                dtype=qo_indptr.dtype,
-                device=device,
-            )
+            qo_indptr = _fold_seqlen_indptr(qo_indptr, fold_factor)
             if g_kv_indptr is not None:
-
-                g_len = (g_kv_indptr[1:] - g_kv_indptr[:-1]).repeat_interleave(
-                    fold_factor
-                )
-                folded_g_kv_indptr = torch.zeros(
-                    bs * fold_factor + 1, dtype=g_kv_indptr.dtype, device=device
-                )
-                folded_g_kv_indptr[1:] = torch.cumsum(g_len, 0).to(g_kv_indptr.dtype)
-                g_kv_indptr = folded_g_kv_indptr
+                g_kv_indptr = _fold_seqlen_indptr(g_kv_indptr, fold_factor)
+                # Each pseudo-batch shares the original batch's local kv begin.
                 kv_indptr = torch.cat(
                     [kv_indptr[:-1].repeat_interleave(fold_factor), kv_indptr[-1:]]
                 )

--- a/aiter/mla.py
+++ b/aiter/mla.py
@@ -827,6 +827,13 @@ def mla_decode_fwd(
                 and q.dtype == dtypes.bf16
                 and kv_buffer.dtype == dtypes.bf16
             )
+            or (
+                get_gfx() == "gfx950"
+                and nhead == 96
+                and q.dtype == dtypes.fp8
+                and kv_buffer.dtype == dtypes.fp8
+                and max_seqlen_q <= 6
+            )
         ):
             # Natively support cases
             pass

--- a/aiter/mla.py
+++ b/aiter/mla.py
@@ -837,6 +837,27 @@ def mla_decode_fwd(
                 o_orig = o
 
             o = o.view(total_s, nhead, -1)
+
+            qo_indptr = torch.arange(
+                0,
+                (bs * fold_factor + 1) * max_seqlen_q,
+                max_seqlen_q,
+                dtype=qo_indptr.dtype,
+                device=device,
+            )
+            if g_kv_indptr is not None:
+
+                g_len = (g_kv_indptr[1:] - g_kv_indptr[:-1]).repeat_interleave(
+                    fold_factor
+                )
+                folded_g_kv_indptr = torch.zeros(
+                    bs * fold_factor + 1, dtype=g_kv_indptr.dtype, device=device
+                )
+                folded_g_kv_indptr[1:] = torch.cumsum(g_len, 0).to(g_kv_indptr.dtype)
+                g_kv_indptr = folded_g_kv_indptr
+                kv_indptr = torch.cat(
+                    [kv_indptr[:-1].repeat_interleave(fold_factor), kv_indptr[-1:]]
+                )
             io_transformed = True
         else:
             assert False, f"{nhead=} and {max_seqlen_q=} not supported"

--- a/aiter/ops/attention.py
+++ b/aiter/ops/attention.py
@@ -1224,6 +1224,12 @@ def get_mla_metadata_info_v1(
         and kv_dtype == dtypes.bf16
         and q_dtype == dtypes.bf16
         and num_head_qo != 48
+    ) or (
+        get_gfx() == "gfx950"
+        and q_dtype == dtypes.fp8
+        and kv_dtype == dtypes.fp8
+        and num_head_qo == 96
+        and effective_seqlen_qo <= 6
     ):
         if num_head_qo * 2 > 128:
             max_qo_tiles_per_batch = effective_seqlen_qo
@@ -1633,6 +1639,13 @@ def decode_update_mla_metadata_v1(
             and num_heads_per_head_k == 128
             and q_is_fp8
             and kv_is_fp8
+        )
+        or (
+            arch_id == "gfx950"
+            and num_heads_per_head_k == 96
+            and q_is_fp8
+            and kv_is_fp8
+            and max_seqlen_qo <= 6
         )
     )
     cu_num = work_indptr.shape[0] - 1

--- a/csrc/kernels/mla/metadata/v1_2_device.cuh
+++ b/csrc/kernels/mla/metadata/v1_2_device.cuh
@@ -904,6 +904,8 @@ void get_mla_metadata_v1_2_device(const aiter_tensor_t& seqlens_qo_indptr, // [b
         ((arch_id == "gfx942") && (num_heads == 128) && q_is_fp8 && kv_is_fp8) ||
         ((arch_id == "gfx950") && q_is_fp8 && kv_is_fp8 &&
          ((num_heads == 32) || (num_heads == 64) || (num_heads == 128))) ||
+        ((arch_id == "gfx950") && q_is_fp8 && kv_is_fp8 && (num_heads == 96) &&
+         (max_seqlen_qo <= 6)) ||
         hk_mtp_experimental;
 
     if(!natively_supported && (num_heads % 16 == 0))

--- a/csrc/py_itfs_cu/asm_mla.cu
+++ b/csrc/py_itfs_cu/asm_mla.cu
@@ -983,7 +983,8 @@ void mla_decode_stage1_asm_fwd(
     } else if (arch_id == "gfx950" && q_type == "fp8" && kv_type == "fp8" && persistent
                && ((gqa_ratio == 32 && max_seqlen_q >= 4)
                    || (gqa_ratio == 64 && max_seqlen_q >= 2)
-                   || (gqa_ratio == 128))){
+                   || (gqa_ratio == 128)
+                   || (gqa_ratio == 96 && max_seqlen_q <= 6))){
         config_max_seqlen_q = 4;
         config_gqa_ratio = 32;
         args.s_MQA = gqa_ratio;

--- a/op_tests/test_mla_persistent.py
+++ b/op_tests/test_mla_persistent.py
@@ -714,9 +714,21 @@ def torch_mla_extend_split_kv(
         # For a split chunk, we need to account for the position offsets of Q and KV within the batch
         causal_diagonal = None
         if is_causal:
-            q_local_start = qo_start - qo_indptr[batch_idx].item()
+            if q_ratio > 1:
+                # Folded head layout: qo_start/qo_end index the folded token
+                # space, where every (batch, head-group) pair is its own batch of
+                # max_seqlen_q tokens starting at row[0] * max_seqlen_q. qo_indptr
+                # only describes the unfolded batches, so measuring the query
+                # offset against it shifts the diagonal by head_group *
+                # max_seqlen_q for every group past the first.
+                q_local_start = qo_start - row[0].item() * max_seqlen_q
+                total_q_len = max_seqlen_q
+            else:
+                q_local_start = qo_start - qo_indptr[batch_idx].item()
+                total_q_len = (
+                    qo_indptr[batch_idx + 1].item() - qo_indptr[batch_idx].item()
+                )
             kv_local_start = (kv_start - kv_indptr[batch_idx].item()) * page_size
-            total_q_len = qo_indptr[batch_idx + 1].item() - qo_indptr[batch_idx].item()
             causal_diagonal = (
                 q_local_start - kv_local_start + cur_real_kv_seq_len - total_q_len
             )

--- a/op_tests/test_mla_persistent.py
+++ b/op_tests/test_mla_persistent.py
@@ -649,6 +649,13 @@ def torch_mla_extend_split_kv(
             and max_seqlen_q == 1
         )
         or (get_gfx() == "gfx950" and not is_fp8_q and not is_fp8_kvc)
+        or (
+            get_gfx() == "gfx950"
+            and nheads == 96
+            and is_fp8_q
+            and is_fp8_kvc
+            and max_seqlen_q <= 6
+        )
     ):
         # Natively support cases
         pass

--- a/op_tests/test_mla_persistent_round_robin.py
+++ b/op_tests/test_mla_persistent_round_robin.py
@@ -736,7 +736,7 @@ parser.add_argument(
     type=dtypes.str2tuple,
     nargs="*",
     const=None,
-    default=[(16, 4), (32, 3), (64, 1), (64, 2), (128, 2), (16, 8), (64, 17)],
+    default=[(16, 4), (32, 3), (64, 1), (64, 2), (128, 2), (16, 8), (96, 8), (64, 17)],
     help="""Number of heads, decode_qlen pairs.
     e.g.: -n 16,4""",
 )


### PR DESCRIPTION
## Motivation
This PR updates the MLA persistent decode “nhead folding” path to rebuild/adjust indptr tensors (and CP global-KV indptr) after reshaping Q/O into a folded (nhead=16) representation, aiming to fix failures in context-parallel (round-robin) mode.

## Technical Details

Rebuilds qo_indptr for the folded layout in the persistent-mode nhead-fold branch.
When g_kv_indptr is provided, derives a folded g_kv_indptr and adjusts kv_indptr accordingly.

## Test Plan
Grid, per mode:

```
nhead x qlen : 48, 80, 96, 112  x  1..8      (32 pairs)
batch        : 1, 32, 128, 256              (4)
ctx (KV len) : 23, 500, 8000                (3)
CP only, W   : 2, 4                         (2)
```

Commands (one process per `(mode, nhead, qlen)` pair, 7 GPUs in parallel):

```bash
# non-CP
python3 op_tests/test_mla_persistent.py -d fp8 -kvd fp8 \
        -n <nhead>,<qlen> -b 1 32 128 256 -c 23 500 8000

# CP (round-robin context parallel)
python3 op_tests/test_mla_persistent_round_robin.py -d fp8 -kvd fp8 \
        -n <nhead>,<qlen> -b 1 32 128 256 -c 23 500 8000 -cpw 2 4 -lse

python3 op_tests/test_mla_persistent_round_robin.py -d fp8 -kvd fp8 -n 96,8
```

Configurations actually executed: **384 non-CP** and **576 CP**

## Test Result
| qlen | ctx | batch | nh96 (µs) | nh128 (µs) | 96/128 | 差距 | nh96 TFLOPS | nh128 TFLOPS |
|---:|---:|---:|---:|---:|---:|:---|---:|---:|
| 1 | 4096 | 16 | 41.89 | 49.93 | **0.839** | 96 快 19% | 327 | 366 |
| 1 | 4096 | 32 | 54.07 | 60.67 | **0.891** | 96 快 12% | 506 | 602 |
| 1 | 4096 | 64 | 82.20 | 88.41 | **0.930** | 96 快 8% | 666 | 826 |
| 1 | 8192 | 16 | 53.13 | 62.14 | **0.855** | 96 快 17% | 515 | 588 |
| 1 | 8192 | 32 | 80.19 | 86.77 | **0.924** | 96 快 8% | 683 | 842 |
| 1 | 8192 | 64 | 127.15 | 133.37 | **0.953** | 96 快 5% | 861 | 1095 |
| 1 | 16384 | 16 | 78.87 | 86.41 | **0.913** | 96 快 10% | 694 | 845 |
| 1 | 16384 | 32 | 125.36 | 134.84 | **0.930** | 96 快 8% | 874 | 1083 |
| 1 | 16384 | 64 | 210.16 | 221.65 | **0.948** | 96 快 5% | 1042 | 1318 |
| 4 | 4096 | 16 | 78.10 | 83.88 | **0.931** | 96 快 7% | 701 | 870 |
| 4 | 4096 | 32 | 123.16 | 130.62 | **0.943** | 96 快 6% | 889 | 1118 |
| 4 | 4096 | 64 | 191.86 | 197.84 | **0.970** | 96 快 3% | 1142 | 1476 |
| 4 | 8192 | 16 | 120.80 | 128.93 | **0.937** | 96 快 7% | 907 | 1133 |
| 4 | 8192 | 32 | 201.19 | 218.13 | **0.922** | 96 快 8% | 1089 | 1339 |
| 4 | 8192 | 64 | 337.49 | 355.52 | **0.949** | 96 快 5% | 1298 | 1643 |
| 4 | 16384 | 16 | 197.28 | 210.55 | **0.937** | 96 快 7% | 1110 | 1387 |
| 4 | 16384 | 32 | 353.90 | 370.47 | **0.955** | 96 快 5% | 1238 | 1577 |
| 4 | 16384 | 64 | 646.07 | 668.63 | **0.966** | 96 快 3% | 1356 | 1747 |
| 8 | 4096 | 16 | 150.64 | 127.33 | **1.183** | 128 快 18% | 727 | 1147 |
| 8 | 4096 | 32 | 225.11 | 196.70 | **1.144** | 128 快 14% | 973 | 1485 |
| 8 | 4096 | 64 | 360.85 | 361.13 | **0.999** | 持平 | 1214 | 1617 |
| 8 | 8192 | 16 | 210.41 | 206.74 | **1.018** | 128 快 2% | 1041 | 1413 |
| 8 | 8192 | 32 | 339.65 | 352.26 | **0.964** | 96 快 4% | 1290 | 1658 |
| 8 | 8192 | 64 | 581.28 | 678.87 | **0.856** | 96 快 17% | 1507 | 1721 |
| 8 | 16384 | 16 | 321.71 | 360.69 | **0.892** | 96 快 12% | 1362 | 1619 |
| 8 | 16384 | 32 | 562.37 | 660.29 | **0.852** | 96 快 17% | 1558 | 1769 |
| 8 | 16384 | 64 | 1081.13 | 1335.55 | **0.810** | 96 快 24% | 1621 | 1749 |

| | configs | authoritative comparison | failed |
| --- | ---: | --- | ---: |
| non-CP (run 1) | 384 | `golden fp8 vs aiter_asm` | **0** |
| non-CP (run 2) | 384 | `golden fp8 vs aiter_asm` | **0** |
| CP, out | 576 | `cp_ref vs aiter` (1728 per-rank checks) | **0** |
| CP, lse | 576 | `cp_ref vs aiter lse` (1728 per-rank checks) | **0** |

No configuration fails its authoritative comparison, and no configuration
produced NaN, a GPU memory fault, or a crash. Everything below is about the
size of the residual error and about two reference-side artifacts.

### Where the residual error sits (`golden fp8 vs aiter_asm`, run 2)

Worst max-abs-delta over all batches, by qlen x ctx:

| qlen | 23 | 500 | 8000 |
| ---: | ---: | ---: | ---: |
| 1 | 0.05664 | 0.01514 | 0 |
| 2 | 1.297 | 0.3984 | 0.2451 |
| 3 | 0.08594 | 0.1602 | 0.01562 |
| 4 | 0.0625 | 0.1289 | 0.01172 |
| 5 | 0.07031 | 0.01562 | 0 |
| 6 | 0.07227 | 0.01489 | 0 |
| 7 | 0.08984 | 0.01562 | 0 |
| 8 | 0.0625 | 0.01953 | 0 |

Worst max-abs-delta over all batches and ctx, by qlen x nhead:

| qlen | 48 | 80 | 96 | 112 |
| ---: | ---: | ---: | ---: | ---: |
| 1 | 0.03516 | 0.05664 | 0.04297 | 0.05078 |
| 2 | 0.9961 | 1.203 | 1.211 | 1.297 |
| 3 | 0.05078 | 0.1602 | 0.08594 | 0.1216 |
| 4 | 0.08789 | 0.04688 | 0.0625 | 0.1289 |
| 5 | 0.04883 | 0.07031 | 0.06641 | 0.06641 |
| 6 | 0.0625 | 0.05859 | 0.05859 | 0.07227 |
| 7 | 0.08984 | 0.07031 | 0.0625 | 0.0625 |
| 8 | 0.05469 | 0.05469 | 0.0625 | 0.0625 |

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
