### PR TITLE
[CI] ci: install Mori grpc runtime for multi-GPU tests

### DIFF
--- a/.github/workflows/aiter-test.yaml
+++ b/.github/workflows/aiter-test.yaml
@@ -1002,7 +1002,10 @@ jobs:
           -w /workspace \
           aiter_test \
           bash -lc "
+            set -euo pipefail
             pip uninstall -y amd-aiter aiter || true
+            apt-get update
+            DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends libgrpc++1.51t64
             pip install -r requirements.txt
             pip install --upgrade pandas pyzmq einops numpy==1.26.2
             pip install --upgrade 'pybind11>=3.0.1'


### PR DESCRIPTION
Summary:
- install the Ubuntu gRPC C++ runtime required by amd-mori in the Multi-GPU Tests job
- enable strict shell error handling inside the docker exec install script so the Mori import smoke check fails early when dependencies are missing

Root cause:
- amd-mori installed successfully, but importing mori.shmem failed with: libgrpc++.so.1.51: cannot open shared object file
- the docker exec bash payload did not use set -e, so the smoke check failure did not stop the install step

Validation:
- git diff --check -- .github/workflows/aiter-test.yaml