### PR TITLE
[TRITON] Make RNG deterministic in unit tests

### DIFF
--- a/op_tests/triton_tests/attention/test_mha_v3.py
+++ b/op_tests/triton_tests/attention/test_mha_v3.py
@@ -896,6 +896,7 @@ def test_mha_fp8(
         pytest.skip(f"FP8 not supported on {_arch}")
 
     torch.cuda.empty_cache()
+    torch.manual_seed(20)
     q = torch.randn((BATCH, SEQLEN_Q, NUM_Q_HEADS, HEAD_SZ), device="cuda", dtype=dtype)
     k = torch.randn((BATCH, SEQLEN_K, NUM_K_HEADS, HEAD_SZ), device="cuda", dtype=dtype)
     v = torch.randn((BATCH, SEQLEN_K, NUM_K_HEADS, HEAD_SZ), device="cuda", dtype=dtype)

--- a/op_tests/triton_tests/attention/test_mla.py
+++ b/op_tests/triton_tests/attention/test_mla.py
@@ -278,10 +278,6 @@ def test_mla_decode_fwd(
     use_out_scale: bool,
     shuffled_kv_cache: bool,
 ):
-    torch.cuda.empty_cache()
-    num_query_heads, num_kv_heads = num_heads
-    qk_head_dim = kv_lora_rank + qk_rope_head_dim
-
     if DEVICE_ARCH not in (
         "gfx950",
         "gfx1250",
@@ -295,6 +291,12 @@ def test_mla_decode_fwd(
             pytest.skip(f"NVFP4 requires {DEVICE_ARCH}")
         if not shuffled_kv_cache:
             pytest.skip("NVFP4 requires shuffled KV cache")
+
+    torch.cuda.empty_cache()
+    random.seed(0)
+    torch.manual_seed(0)
+    num_query_heads, num_kv_heads = num_heads
+    qk_head_dim = kv_lora_rank + qk_rope_head_dim
 
     cu_seqlens_q = torch.zeros(batch_size + 1, dtype=torch.int, device="cuda")
     seq_lens_qo = torch.empty(batch_size, dtype=torch.int, device="cuda")
@@ -461,6 +463,9 @@ def test_mla_prefill_fwd(
     use_out_scale: bool,
 ):
     torch.cuda.empty_cache()
+    random.seed(0)
+    torch.manual_seed(0)
+
     num_query_heads, num_kv_heads = num_heads
     cu_seqlens_q = torch.zeros(batch_size + 1, dtype=torch.int, device="cuda")
     seq_lens_qo = torch.empty(batch_size, dtype=torch.int, device="cuda")

--- a/op_tests/triton_tests/conv/_helpers.py
+++ b/op_tests/triton_tests/conv/_helpers.py
@@ -356,6 +356,7 @@ def get_edge_case_shapes():
 
 
 def run_edge_cases(suite: TestSuite, activation: str = "none", method: str = "default"):
+    torch.manual_seed(0)
     for (
         N,
         C,
@@ -392,6 +393,7 @@ def run_edge_cases(suite: TestSuite, activation: str = "none", method: str = "de
 def run_activations(
     suite: TestSuite, method: str = "default", activation: str = "relu"
 ):
+    torch.manual_seed(0)
     N, C, H, W, K_out = 2, 32, 16, 16, 64
     R, S = 3, 3
     stride, padding, dilation = (1, 1), (1, 1), (1, 1)
@@ -413,6 +415,7 @@ def run_activations(
 
 
 def run_no_bias(suite: TestSuite, method: str = "default"):
+    torch.manual_seed(0)
     shapes = [
         (1, 64, 8, 8, 128, 1, 1, (1, 1), (0, 0), (1, 1), "1x1 no bias"),
         (2, 32, 16, 16, 64, 3, 3, (1, 1), (1, 1), (1, 1), "3x3 no bias"),
@@ -442,6 +445,7 @@ def run_cross_method(suite: TestSuite):
     cross-kernel equivalence: if kernel A and B both match the same
     F.conv2d output within tolerance, they match each other within ~2x.
     """
+    torch.manual_seed(0)
     for N, C, H, W, K_out, R, S, stride, padding, dilation, desc in COMMON_SHAPES:
         x = torch.randn((N, C, H, W), device=suite.device, dtype=suite.dtype)
         w = torch.randn((K_out, C, R, S), device=suite.device, dtype=suite.dtype)
@@ -472,6 +476,7 @@ def run_random_fuzzing(
     for ad-hoc development sweeps.
     """
     random.seed(seed)
+    torch.manual_seed(seed)
     for i in range(num_tests):
         N = random.randint(1, 8)
         C = random.choice([1, 3, 16, 32, 64, 128, 256])

--- a/op_tests/triton_tests/fusions/test_fused_kv_cache.py
+++ b/op_tests/triton_tests/fusions/test_fused_kv_cache.py
@@ -104,6 +104,7 @@ def test_fused_qk_rope_cat_and_cache_mla(
 ):
     if cache_dtype == torch.uint8 and DEVICE_ARCH not in ("gfx1250",):
         pytest.skip("NVFP4 quantization is only supported on GFX1250")
+    torch.manual_seed(0)
     dtype = torch.bfloat16
     pos = True
     _, _, _, _, freqs, positions, offsets, cos, sin = generate_rope_inputs(
@@ -756,7 +757,6 @@ def test_fused_qk_rope_cosine_cache_llama(
         )
     else:
         pytest.skip()
-    torch.manual_seed(0)
 
     if cache_dtype == torch.uint8:
         k_scale = torch.randn(

--- a/op_tests/triton_tests/fusions/test_fused_silu_mul.py
+++ b/op_tests/triton_tests/fusions/test_fused_silu_mul.py
@@ -43,6 +43,7 @@ def torch_silu_mul_last_dim_ref(x: torch.Tensor) -> torch.Tensor:
 def test_fused_silu_mul(shape, dtype, use_explicit_out):
     if not torch.cuda.is_available():
         pytest.skip("CUDA required")
+    torch.manual_seed(0)
     x = torch.randn(shape, dtype=dtype, device="cuda")
     ref = torch_silu_mul_last_dim_ref(x)
     if use_explicit_out:
@@ -81,6 +82,7 @@ def test_fused_silu_mul_tp4_moe_shapes(n_rows, last_dim, dtype):
     """MoE fused silu×mul tensor as (tokens * top_k, 2 * local_d) under TP4."""
     if not torch.cuda.is_available():
         pytest.skip("CUDA required")
+    torch.manual_seed(0)
     shape = (n_rows, last_dim)
     x = torch.randn(shape, dtype=dtype, device="cuda")
     ref = torch_silu_mul_last_dim_ref(x)
@@ -116,6 +118,7 @@ def test_fused_silu_mul_tp4_moe_shapes(n_rows, last_dim, dtype):
 def test_fused_silu_mul_tp4_prefill_bf16(n_rows, last_dim):
     if not torch.cuda.is_available():
         pytest.skip("CUDA required")
+    torch.manual_seed(0)
     dtype = torch.bfloat16
     shape = (n_rows, last_dim)
     x = torch.randn(shape, dtype=dtype, device="cuda")

--- a/op_tests/triton_tests/fusions/test_mhc.py
+++ b/op_tests/triton_tests/fusions/test_mhc.py
@@ -142,6 +142,7 @@ def test_mhc_correctness(M, n, C, dtype):
     """
     torch.cuda.empty_cache()
     torch.cuda.synchronize()
+    torch.manual_seed(0)
 
     x, phi, alpha_pre, alpha_post, alpha_res, bias, n_streams = generate_mhc_inputs(
         M, n, C, dtype
@@ -175,6 +176,7 @@ def test_mhc_correctness(M, n, C, dtype):
 def test_mhc_different_epsilon(eps, M, n, C):
     """Test mhc() with different epsilon values for RMSNorm (Eq 15)."""
     torch.cuda.empty_cache()
+    torch.manual_seed(0)
 
     x, phi, alpha_pre, alpha_post, alpha_res, bias, n_streams = generate_mhc_inputs(
         M, n, C
@@ -201,6 +203,7 @@ def test_mhc_different_epsilon(eps, M, n, C):
 def test_mhc_different_alpha(alpha_scale):
     """Test mhc() with different scaling factors α (Eq 16)."""
     torch.cuda.empty_cache()
+    torch.manual_seed(0)
 
     M, n, C = 32, 4, 1024
     x, phi, _, _, _, bias, n_streams = generate_mhc_inputs(M, n, C)
@@ -231,6 +234,7 @@ def test_mhc_different_alpha(alpha_scale):
 def test_mhc_zero_input():
     """Test mhc() with zero input (edge case for RMSNorm)."""
     torch.cuda.empty_cache()
+    torch.manual_seed(0)
 
     M, n, C = 16, 4, 512
     nC = n * C
@@ -251,6 +255,7 @@ def test_mhc_zero_input():
 def test_mhc_large_values():
     """Test mhc() numerical stability with large input values."""
     torch.cuda.empty_cache()
+    torch.manual_seed(0)
 
     M, n, C = 32, 4, 1024
     nC = n * C
@@ -276,6 +281,7 @@ def test_mhc_small_shapes(M, n, C, dtype):
     """Quick smoke test for mhc() with representative shapes."""
     torch.cuda.empty_cache()
     torch.cuda.synchronize()
+    torch.manual_seed(0)
 
     x, phi, alpha_pre, alpha_post, alpha_res, bias, n_streams = generate_mhc_inputs(
         M, n, C, dtype
@@ -306,6 +312,7 @@ def test_mhc_small_shapes(M, n, C, dtype):
 def test_mhc_output_range():
     """Validate output value ranges for mhc()."""
     torch.cuda.empty_cache()
+    torch.manual_seed(0)
 
     M, n, C = 64, 4, 1024
     x, phi, alpha_pre, alpha_post, alpha_res, bias, n_streams = generate_mhc_inputs(
@@ -385,6 +392,7 @@ def test_split_k_correctness(M, n, C, num_ksplit, dtype):
     """Test that split-K matches the PyTorch reference (no Sinkhorn)."""
     torch.cuda.empty_cache()
     torch.cuda.synchronize()
+    torch.manual_seed(0)
 
     x, phi, alpha_pre, alpha_post, alpha_res, bias, n_streams = generate_mhc_inputs(
         M, n, C, dtype
@@ -430,6 +438,7 @@ def test_split_k_mhc_full_pipeline(M, n, C, num_ksplit):
     """Test split-K with the full mhc() pipeline including Sinkhorn-Knopp."""
     torch.cuda.empty_cache()
     torch.cuda.synchronize()
+    torch.manual_seed(0)
 
     x, phi, alpha_pre, alpha_post, alpha_res, bias, n_streams = generate_mhc_inputs(
         M, n, C
@@ -471,6 +480,7 @@ def test_split_k_mhc_full_pipeline(M, n, C, num_ksplit):
 def test_split_k_various_splits(num_ksplit):
     """Test split-K with various split counts (skip Sinkhorn)."""
     torch.cuda.empty_cache()
+    torch.manual_seed(0)
 
     M, n, C = 32, 4, 1024
     x, phi, alpha_pre, alpha_post, alpha_res, bias, n_streams = generate_mhc_inputs(
@@ -525,6 +535,7 @@ def test_split_k_various_splits(num_ksplit):
 def test_split_k_large_k():
     """Test split-K with large K dimension where split-K should be beneficial."""
     torch.cuda.empty_cache()
+    torch.manual_seed(0)
 
     M, n, C = 64, 4, 2048  # K = n * C = 8192
     x, phi, alpha_pre, alpha_post, alpha_res, bias, n_streams = generate_mhc_inputs(
@@ -721,6 +732,7 @@ def test_triton_mhc_matches_hip(M, n, C):
 @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
 def test_mhc_post_correctness(M, n, C, dtype):
     """Test mhc_post against PyTorch reference."""
+    torch.manual_seed(0)
     layer_input, residual, post_mix, comb_mix = generate_mhc_post_inputs(M, n, C, dtype)
     ref = mhc_post_torch(layer_input, residual, post_mix, comb_mix)
     out = mhc_post(None, layer_input, residual, post_mix, comb_mix)
@@ -745,6 +757,7 @@ def test_mhc_post_preallocated_output():
     M, n, C = 128, 4, 1024
     dtype = torch.bfloat16
 
+    torch.manual_seed(0)
     layer_input, residual, post_mix, comb_mix = generate_mhc_post_inputs(M, n, C, dtype)
 
     out = torch.empty(M, n, C, dtype=dtype, device=layer_input.device)
@@ -774,6 +787,7 @@ def test_mhc_post_squeeze_post_mix():
     M, n, C = 64, 4, 512
     dtype = torch.bfloat16
 
+    torch.manual_seed(0)
     layer_input, residual, post_mix, comb_mix = generate_mhc_post_inputs(M, n, C, dtype)
 
     post_mix_3d = post_mix.unsqueeze(-1)  # (M, n, 1)
@@ -1062,6 +1076,7 @@ def test_mhc_e2e_correctness(M, n, C, dtype):
     3. h_post and h_res match reference
     """
     sinkhorn_iters = 20
+    torch.manual_seed(0)
     x_l_flat, phi, alpha_pre, alpha_post, alpha_res, bias, _ = generate_mhc_inputs(
         M, n, C, dtype
     )

--- a/op_tests/triton_tests/quant/test_fused_fp8_quant.py
+++ b/op_tests/triton_tests/quant/test_fused_fp8_quant.py
@@ -383,6 +383,7 @@ def run_torch_flatten_fp8_group_quant(x, dtype_quant, group_size):
 @pytest.mark.parametrize("N1, N2", [(16, 128), (16, 7168)])
 @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
 def test_fused_flatten_fp8_group_quant(M: int, N1: int, N2: int, dtype):
+    torch.manual_seed(0)
     group_size = 128
     dtype_quant = aiter.dtypes.fp8
     x = torch.randn((N1, M, N2), dtype=dtype, device="cuda") / 10

--- a/op_tests/triton_tests/quant/test_fused_rms_gated_fp8_group_quant.py
+++ b/op_tests/triton_tests/quant/test_fused_rms_gated_fp8_group_quant.py
@@ -170,6 +170,7 @@ def test_fused_rms_gated_fp8_group_quant_sweep(M: int, N: int, group_size: int):
 
 @cuda_ok
 def test_fused_rms_gated_fp8_group_quant_group_size_errors():
+    torch.manual_seed(0)
     device = "cuda"
     x = torch.randn(2, 128, device=device, dtype=torch.bfloat16)
     z = torch.randn_like(x)


### PR DESCRIPTION
## Motivation

Triton unit test `op_tests/triton_tests/attention/test_mla.py` was failing in a non-deterministic way. This PR fixes this issue, as well as other non-deterministic unit tests.

## Technical Details

The fix it to deterministically set the RNG seed in the unit tests, on a case by case basis.

## Test Plan

Run the entire Triton test suite on `gfx942` and `gfx950`, through CI AITER runners.

## Test Result

Triton test suite passed on both `gfx942` and `gfx950`. ✅

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
