### PR TITLE
fix(mha): select sink kernel when only sink_ptr is provided

### DIFF
--- a/aiter/ops/mha.py
+++ b/aiter/ops/mha.py
@@ -1524,11 +1524,11 @@ def cmdGenFunc_mha_batch_prefill(
     # Per-page descale for KV_BLOCKSCALE mode (Q per-tensor, K/V per-page)
     # Mutually exclusive with k_descale/v_descale
     kv_block_descale: Tensor | None = None,  # [num_block, num_kv_head, 2]
-    sink_ptr: Tensor | None = None,
-    gen: Generator | None = None,
     kv_last_page_lens: Tensor | None = None,
     block_table: Tensor | None = None,
     seqlen_k: Tensor | None = None,
+    sink_ptr: Tensor | None = None,
+    gen: Generator | None = None,
 ):
     # causal=true is the same as causal=false in this case
     causal = is_causal
@@ -1595,7 +1595,7 @@ def cmdGenFunc_mha_batch_prefill(
         filter_fwd += "_pertensor*"
     # Sink only applies when there is a causal/window mask; full attention
     # (window_size_left==-1 and window_size_right==-1) ignores sink_size.
-    has_effective_sink = sink_size > 0 and (
+    has_effective_sink = (sink_size > 0 or sink_ptr is not None) and (
         causal or not (window_size_left == -1 and window_size_right == -1)
     )
     if has_effective_sink:


### PR DESCRIPTION
mha_batch_prefill_func aborts with "no matching kernel found" for any caller that supplies a learned per-head sink logit via sink_ptr without also setting sink_size (e.g. gpt-oss on SGLang's AITER backend):

  RuntimeError: invalid argument for batch_prefill: no matching kernel
  found. page_size=1, num_pages=6, dtype=bf16.

The message blames KV-cache size and GPU generation; neither is the cause. Two bugs combine:

1. cmdGenFunc_mha_batch_prefill's trailing parameters were ordered sink_ptr, gen, kv_last_page_lens, block_table, seqlen_k, while _mha_batch_prefill invokes the op all-positionally as kv_last_page_lens, block_table, seqlen_k, sink_ptr, gen. compile_ops forwards that same tuple to the generator, so it read kv_last_page_lens as sink_ptr and never saw a sink.

2. has_effective_sink tested sink_size > 0 only, while the C++ side (csrc/cpp_itfs/mha_fwd_batch_prefill.cu:52) uses has_sink = args.sink_size > 0 || args.sink_ptr != nullptr.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
