### PR TITLE
[FlyDSL] [CI] [JIT] comm fused moe

### DIFF
--- a/.github/scripts/aiter_test.sh
+++ b/.github/scripts/aiter_test.sh
@@ -106,6 +106,26 @@ for file in "${sharded_files[@]}"; do
                 _ "$file"
             )
             ;;
+        op_tests/multigpu_tests/test_comm_fused_moe.py)
+            {
+                echo "Running gfx950 comm-fused MoE production accuracy on 8 GPUs when supported"
+            } | tee -a latest_test.log
+            test_cmd=(
+                timeout 60m
+                bash -c '
+                    set -euo pipefail
+                    test_file=$1
+                    arch=$(python3 -c \
+                        "from aiter.jit.utils.chip_info import get_gfx; print(get_gfx())")
+                    if [[ "$arch" != "gfx950" ]]; then
+                        echo "Skipping $test_file: requires gfx950, got $arch"
+                        exit 0
+                    fi
+                    exec torchrun --standalone --nproc_per_node=8 "$test_file" --full
+                '
+                _ "$file"
+            )
+            ;;
         op_tests/test_mla_persistent.py|op_tests/test_mla_persistent_round_robin.py)
             {
                 echo "Using AITER_MLA_DECODE_PERSISTENT_MAX_BATCH=0 for $file"

--- a/.github/scripts/aiter_test.sh
+++ b/.github/scripts/aiter_test.sh
@@ -108,22 +108,14 @@ for file in "${sharded_files[@]}"; do
             ;;
         op_tests/multigpu_tests/test_comm_fused_moe.py)
             {
-                echo "Running gfx950 comm-fused MoE production accuracy on 8 GPUs when supported"
+                echo "Running comm-fused MoE production validation on 8 GPUs when supported"
             } | tee -a latest_test.log
             test_cmd=(
                 timeout 60m
-                bash -c '
-                    set -euo pipefail
-                    test_file=$1
-                    arch=$(python3 -c \
-                        "from aiter.jit.utils.chip_info import get_gfx; print(get_gfx())")
-                    if [[ "$arch" != "gfx950" ]]; then
-                        echo "Skipping $test_file: requires gfx950, got $arch"
-                        exit 0
-                    fi
-                    exec torchrun --standalone --nproc_per_node=8 "$test_file" --full
-                '
-                _ "$file"
+                torchrun
+                --standalone
+                --nproc_per_node=8
+                "$file"
             )
             ;;
         op_tests/test_mla_persistent.py|op_tests/test_mla_persistent_round_robin.py)

--- a/aiter/configs/comm_fused_moe.csv
+++ b/aiter/configs/comm_fused_moe.csv
@@ -1,0 +1,1 @@
+gfx,cu_num,token,model_dim,inter_dim,expert,topk,tp,act_type,dtype,q_dtype_a,q_dtype_w,q_type,use_g1u1,doweight_stage1,block_m,us,kernelName,max_abs,rel_l2

--- a/aiter/configs/model_configs/dsv4_fp8fp4_tuned_comm_fused_moe.csv
+++ b/aiter/configs/model_configs/dsv4_fp8fp4_tuned_comm_fused_moe.csv
@@ -1,0 +1,17 @@
+gfx,cu_num,token,model_dim,inter_dim,expert,topk,tp,act_type,dtype,q_dtype_a,q_dtype_w,q_type,use_g1u1,doweight_stage1,block_m,us,kernelName,max_abs,rel_l2
+gfx950,256,1,7168,384,384,6,8,ActivationType.Silu,torch.bfloat16,torch.float8_e4m3fn,torch.float4_e2m1fn_x2,QuantType.per_1x32,1,0,32,15.1514,flydsl_comm_moe2_afp8_wfp4_bf16_t32x256x128_cg6_w2,0.1875,0.015044
+gfx950,256,2,7168,384,384,6,8,ActivationType.Silu,torch.bfloat16,torch.float8_e4m3fn,torch.float4_e2m1fn_x2,QuantType.per_1x32,1,0,32,15.9805,flydsl_comm_moe2_afp8_wfp4_bf16_t32x256x128_cg12,0.1875,0.014550
+gfx950,256,4,7168,384,384,6,8,ActivationType.Silu,torch.bfloat16,torch.float8_e4m3fn,torch.float4_e2m1fn_x2,QuantType.per_1x32,1,0,32,18.1024,flydsl_comm_moe2_afp8_wfp4_bf16_t32x256x128_cg24_v8_bnt2,0.25,0.014027
+gfx950,256,8,7168,384,384,6,8,ActivationType.Silu,torch.bfloat16,torch.float8_e4m3fn,torch.float4_e2m1fn_x2,QuantType.per_1x32,1,0,32,25.1407,flydsl_comm_moe2_afp8_wfp4_bf16_t32x256x128_cg48_v8_bnt2,0.25,0.013463
+gfx950,256,16,7168,384,384,6,8,ActivationType.Silu,torch.bfloat16,torch.float8_e4m3fn,torch.float4_e2m1fn_x2,QuantType.per_1x32,1,0,32,36.6273,flydsl_comm_moe2_afp8_wfp4_bf16_t32x256x128_cg24_v8_w2,0.25,0.013395
+gfx950,256,32,7168,384,384,6,8,ActivationType.Silu,torch.bfloat16,torch.float8_e4m3fn,torch.float4_e2m1fn_x2,QuantType.per_1x32,1,0,32,,fallback,,
+gfx950,256,64,7168,384,384,6,8,ActivationType.Silu,torch.bfloat16,torch.float8_e4m3fn,torch.float4_e2m1fn_x2,QuantType.per_1x32,1,0,32,,fallback,,
+gfx950,256,128,7168,384,384,6,8,ActivationType.Silu,torch.bfloat16,torch.float8_e4m3fn,torch.float4_e2m1fn_x2,QuantType.per_1x32,1,0,32,,fallback,,
+gfx950,256,256,7168,384,384,6,8,ActivationType.Silu,torch.bfloat16,torch.float8_e4m3fn,torch.float4_e2m1fn_x2,QuantType.per_1x32,1,0,32,,fallback,,
+gfx950,256,512,7168,384,384,6,8,ActivationType.Silu,torch.bfloat16,torch.float8_e4m3fn,torch.float4_e2m1fn_x2,QuantType.per_1x32,1,0,32,,fallback,,
+gfx950,256,1024,7168,384,384,6,8,ActivationType.Silu,torch.bfloat16,torch.float8_e4m3fn,torch.float4_e2m1fn_x2,QuantType.per_1x32,1,0,32,,fallback,,
+gfx950,256,2048,7168,384,384,6,8,ActivationType.Silu,torch.bfloat16,torch.float8_e4m3fn,torch.float4_e2m1fn_x2,QuantType.per_1x32,1,0,64,,fallback,,
+gfx950,256,4096,7168,384,384,6,8,ActivationType.Silu,torch.bfloat16,torch.float8_e4m3fn,torch.float4_e2m1fn_x2,QuantType.per_1x32,1,0,64,,fallback,,
+gfx950,256,8192,7168,384,384,6,8,ActivationType.Silu,torch.bfloat16,torch.float8_e4m3fn,torch.float4_e2m1fn_x2,QuantType.per_1x32,1,0,64,,fallback,,
+gfx950,256,16384,7168,384,384,6,8,ActivationType.Silu,torch.bfloat16,torch.float8_e4m3fn,torch.float4_e2m1fn_x2,QuantType.per_1x32,1,0,64,,fallback,,
+gfx950,256,32768,7168,384,384,6,8,ActivationType.Silu,torch.bfloat16,torch.float8_e4m3fn,torch.float4_e2m1fn_x2,QuantType.per_1x32,1,0,64,,fallback,,

--- a/aiter/configs/model_configs/dsv4_fp8fp4_tuned_comm_fused_moe.csv
+++ b/aiter/configs/model_configs/dsv4_fp8fp4_tuned_comm_fused_moe.csv
@@ -3,7 +3,7 @@ gfx950,256,1,7168,384,384,6,8,ActivationType.Silu,torch.bfloat16,torch.float8_e4
 gfx950,256,2,7168,384,384,6,8,ActivationType.Silu,torch.bfloat16,torch.float8_e4m3fn,torch.float4_e2m1fn_x2,QuantType.per_1x32,1,0,32,15.9805,flydsl_comm_moe2_afp8_wfp4_bf16_t32x256x128_cg12,0.1875,0.014550
 gfx950,256,4,7168,384,384,6,8,ActivationType.Silu,torch.bfloat16,torch.float8_e4m3fn,torch.float4_e2m1fn_x2,QuantType.per_1x32,1,0,32,18.1024,flydsl_comm_moe2_afp8_wfp4_bf16_t32x256x128_cg24_v8_bnt2,0.25,0.014027
 gfx950,256,8,7168,384,384,6,8,ActivationType.Silu,torch.bfloat16,torch.float8_e4m3fn,torch.float4_e2m1fn_x2,QuantType.per_1x32,1,0,32,25.1407,flydsl_comm_moe2_afp8_wfp4_bf16_t32x256x128_cg48_v8_bnt2,0.25,0.013463
-gfx950,256,16,7168,384,384,6,8,ActivationType.Silu,torch.bfloat16,torch.float8_e4m3fn,torch.float4_e2m1fn_x2,QuantType.per_1x32,1,0,32,36.6273,flydsl_comm_moe2_afp8_wfp4_bf16_t32x256x128_cg24_v8_w2,0.25,0.013395
+gfx950,256,16,7168,384,384,6,8,ActivationType.Silu,torch.bfloat16,torch.float8_e4m3fn,torch.float4_e2m1fn_x2,QuantType.per_1x32,1,0,32,37.3598,flydsl_comm_moe2_afp8_wfp4_bf16_t32x256x128_v8_bnt2,0.25,0.013402
 gfx950,256,32,7168,384,384,6,8,ActivationType.Silu,torch.bfloat16,torch.float8_e4m3fn,torch.float4_e2m1fn_x2,QuantType.per_1x32,1,0,32,,fallback,,
 gfx950,256,64,7168,384,384,6,8,ActivationType.Silu,torch.bfloat16,torch.float8_e4m3fn,torch.float4_e2m1fn_x2,QuantType.per_1x32,1,0,32,,fallback,,
 gfx950,256,128,7168,384,384,6,8,ActivationType.Silu,torch.bfloat16,torch.float8_e4m3fn,torch.float4_e2m1fn_x2,QuantType.per_1x32,1,0,32,,fallback,,

--- a/aiter/configs/untuned_comm_fused_moe.csv
+++ b/aiter/configs/untuned_comm_fused_moe.csv
@@ -1,0 +1,1 @@
+gfx,cu_num,token,model_dim,inter_dim,expert,topk,tp,act_type,dtype,q_dtype_a,q_dtype_w,q_type,use_g1u1,doweight_stage1

--- a/aiter/fused_moe.py
+++ b/aiter/fused_moe.py
@@ -822,6 +822,7 @@ def _fused_moe_impl(
     _metadata_config_file: str | None = None,
     _stage1_extra_args: dict | None = None,
     _stage2_extra_args: dict | None = None,
+    _stage2_override: Callable | None = None,
 ) -> torch.Tensor:
     # We do such convert since custom_op schema restriction on block_size_M, and Enum type
     activation = ActivationType(activation)
@@ -1099,6 +1100,8 @@ def _fused_moe_impl(
     _opus_a8w4.check_route_bucket_metadata(metadata, sorted_expert_ids, logger)
 
     if metadata.run_1stage:
+        if _stage2_override is not None:
+            raise RuntimeError("_stage2_override requires a two-stage MoE config")
         _stage1_call = functools.partial(
             metadata.stage1,
             hidden_states,
@@ -1169,6 +1172,7 @@ def _fused_moe_impl(
             _stage1_extra_args=_stage1_extra_args,
             _stage2_extra_args=_stage2_extra_args,
             output=output,
+            _stage2_override=_stage2_override,
         )
         return _return_output(ret, output)
 
@@ -3143,6 +3147,7 @@ def fused_moe_2stages(
     _stage1_extra_args: dict | None = None,
     _stage2_extra_args: dict | None = None,
     output=None,
+    _stage2_override: Callable | None = None,
 ):
     quant_func = get_quant(quant_type)
     gate_mode = GateMode(gate_mode)
@@ -3480,8 +3485,7 @@ def fused_moe_2stages(
         a2 = a2.view(token_num, topk, inter_dim)
 
     stage2_sorted_weights = sorted_weights if not doweight_stage1 else None
-    _stage2_call = functools.partial(
-        metadata.stage2,
+    stage2_args = (
         a2,
         w1,
         w2,
@@ -3490,6 +3494,8 @@ def fused_moe_2stages(
         num_valid_ids,
         moe_out,
         topk,
+    )
+    stage2_kwargs = dict(
         w2_scale=(
             # See stage1 w1_scale note: only reinterpret packed (e8m0) scales;
             # per_Token fp8 uses an fp32 scale and must be passed through as-is
@@ -3505,11 +3511,23 @@ def fused_moe_2stages(
         sorted_weights=stage2_sorted_weights,
         **extra_stage2_args,
     )
+    if _stage2_override is None:
+        _stage2_call = functools.partial(
+            metadata.stage2,
+            *stage2_args,
+            **stage2_kwargs,
+        )
+    else:
+        _stage2_call = functools.partial(
+            _stage2_override,
+            ordinary_stage2=metadata.stage2,
+            stage2_args=stage2_args,
+            stage2_kwargs=stage2_kwargs,
+        )
     if kernel_bench_callable is not None:
         kernel_bench_callable.append(("stage2", _stage2_call))
-    _stage2_call()
-
-    return moe_out
+    stage2_output = _stage2_call()
+    return moe_out if _stage2_override is None else stage2_output
 
 
 def torch_moe_act(act_input, torch_act, inter_dim):

--- a/aiter/jit/core.py
+++ b/aiter/jit/core.py
@@ -118,6 +118,11 @@ AITER_CONFIG_FMOE = os.getenv(
     f"{AITER_ROOT_DIR}/aiter/configs/tuned_fmoe.csv",
 )
 
+AITER_CONFIG_COMM_FUSED_MOE = os.getenv(
+    "AITER_CONFIG_COMM_FUSED_MOE",
+    f"{AITER_ROOT_DIR}/aiter/configs/comm_fused_moe.csv",
+)
+
 AITER_CONFIG_FHMOE = os.getenv(
     "AITER_CONFIG_FHMOE",
     f"{AITER_ROOT_DIR}/aiter/configs/tuned_fhmoe.csv",
@@ -225,6 +230,14 @@ class AITER_CONFIG:
     def AITER_CONFIG_FMOE_FILE(self):
         return self.get_config_file(
             "AITER_CONFIG_FMOE", AITER_CONFIG_FMOE, "tuned_fmoe"
+        )
+
+    @property
+    def AITER_CONFIG_COMM_FUSED_MOE_FILE(self):
+        return self.get_config_file(
+            "AITER_CONFIG_COMM_FUSED_MOE",
+            AITER_CONFIG_COMM_FUSED_MOE,
+            "tuned_comm_fused_moe",
         )
 
     @property

--- a/aiter/ops/comm_fused_moe_runtime.py
+++ b/aiter/ops/comm_fused_moe_runtime.py
@@ -1,0 +1,99 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2026, Advanced Micro Devices, Inc. All rights reserved.
+"""Lightweight runtime for communication-compute fused MoE Stage2."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+import torch
+
+
+class CommFusedMoeRuntime:
+    """Reuse ordinary MoE through Stage1, then run fused Stage2 + TP AR.
+
+    Each prepared runner owns one exact token bucket and returns the complete
+    replicated ``[M, H]`` output.
+    """
+
+    def __init__(
+        self,
+        *,
+        runners: dict[int, Callable],
+    ) -> None:
+        self.runners = runners
+
+    def supports(self, tokens: int) -> bool:
+        from aiter.fused_moe import get_padded_M
+
+        return int(get_padded_M(tokens)) in self.runners
+
+    def run(
+        self,
+        *,
+        shared_partial: torch.Tensor | None,
+        before_stage2: Callable[[], torch.Tensor] | None = None,
+        stage2_stream: torch.cuda.Stream | None = None,
+        **moe_args: Any,
+    ) -> torch.Tensor:
+        """Run ordinary MoE through Stage1 and fuse the complete Stage2 result."""
+
+        from aiter.fused_moe import _fused_moe_impl, get_padded_M
+
+        hidden_states = moe_args["hidden_states"]
+        raw_tokens = int(hidden_states.shape[0])
+        bucket = int(get_padded_M(raw_tokens))
+        if bucket < raw_tokens:
+            raise KeyError(f"no comm_fused bucket for {raw_tokens} tokens")
+        runner = self.runners[bucket]
+
+        if bucket != raw_tokens:
+            topk_weight = moe_args["topk_weight"]
+            topk_ids = moe_args["topk_ids"]
+            padded_hidden = hidden_states.new_zeros((bucket, hidden_states.shape[1]))
+            padded_weight = topk_weight.new_zeros((bucket, topk_weight.shape[1]))
+            padded_ids = topk_ids.new_zeros((bucket, topk_ids.shape[1]))
+            padded_hidden[:raw_tokens].copy_(hidden_states)
+            padded_weight[:raw_tokens].copy_(topk_weight)
+            padded_ids[:raw_tokens].copy_(topk_ids)
+            moe_args["hidden_states"] = padded_hidden
+            moe_args["topk_weight"] = padded_weight
+            moe_args["topk_ids"] = padded_ids
+
+        def stage2_override(**kwargs: Any):
+            def launch():
+                current_shared = shared_partial
+                if before_stage2 is not None:
+                    current_shared = before_stage2()
+                if current_shared is None:
+                    raise RuntimeError("comm-fused Stage2 requires shared_partial")
+                if bucket != raw_tokens:
+                    padded_shared = runner.output
+                    padded_shared[:raw_tokens].copy_(current_shared)
+                    padded_shared[raw_tokens:].zero_()
+                    current_shared = padded_shared
+                prepare_shared_partial = getattr(runner, "prepare_shared_partial", None)
+                if prepare_shared_partial is not None:
+                    current_shared = prepare_shared_partial(current_shared)
+                return runner(shared_partial=current_shared, **kwargs)
+
+            if stage2_stream is None:
+                return launch()
+            caller_stream = torch.cuda.current_stream(hidden_states.device)
+            if stage2_stream == caller_stream:
+                return launch()
+            stage2_stream.wait_stream(caller_stream)
+            with torch.cuda.stream(stage2_stream):
+                output = launch()
+            caller_stream.wait_stream(stage2_stream)
+            return output
+
+        output = _fused_moe_impl(
+            **moe_args,
+            _stage2_override=stage2_override,
+        )
+        return output if raw_tokens == bucket else output[:raw_tokens]
+
+
+__all__ = ["CommFusedMoeRuntime"]

--- a/aiter/ops/flydsl/comm_fused_moe_host.py
+++ b/aiter/ops/flydsl/comm_fused_moe_host.py
@@ -1,0 +1,852 @@
+# SPDX-License-Identifier: MIT
+"""Production host runtime for communication-fused FlyDSL MoE."""
+
+import csv
+import math
+import re
+from dataclasses import MISSING, dataclass, fields
+from functools import cache
+from pathlib import Path
+
+import flydsl.expr as fx
+import torch
+import torch.distributed._symmetric_memory as symm_mem
+
+from aiter.dist.device_communicators.rocm_version import get_rocm_version
+from aiter.jit.core import AITER_CONFIGS
+from aiter.jit.utils.chip_info import get_cu_num, get_gfx_runtime
+from aiter.ops.flydsl.kernels.comm_fused_moe.gfx950.a8w4 import (
+    atomic,
+    megakernel,
+    window,
+)
+from aiter.ops.flydsl.kernels.comm_fused_moe.gfx950.a8w4.collectives import (
+    FLAT_VA_RANK_STRIDE,
+    compile_epoch_barrier,
+)
+from aiter.ops.flydsl.kernels.comm_fused_moe.gfx950.a8w4.config import (
+    SLOTS,
+    AtomicConfig,
+    MegakernelConfig,
+    PipelineConfig,
+    Shape,
+    WindowConfig,
+)
+from aiter.ops.flydsl.kernels.tensor_shim import ptr_arg
+from aiter.ops.flydsl.moe_kernels import _run_compiled
+
+_PEER_VMM_ALLOCATION_ALIGNMENT = 2 * 1024 * 1024
+_MIN_ROCM_VERSION = (7, 2)
+_MAX_ABS_ERROR = 1.0
+_MAX_REL_L2_ERROR = 0.05
+_ACT_TYPE = "ActivationType.Silu"
+_DTYPE = "torch.bfloat16"
+_Q_DTYPE_A = "torch.float8_e4m3fn"
+_Q_DTYPE_W = "torch.float4_e2m1fn_x2"
+_Q_TYPE = "QuantType.per_1x32"
+
+
+@dataclass(frozen=True, slots=True)
+class ShapeKey:
+    gfx: str
+    model_dim: int
+    inter_dim: int
+    experts: int
+    topk: int
+    tp: int
+    cu_num: int | None = None
+    act_type: str = _ACT_TYPE
+    dtype: str = _DTYPE
+    q_dtype_a: str = _Q_DTYPE_A
+    q_dtype_w: str = _Q_DTYPE_W
+    q_type: str = _Q_TYPE
+    use_g1u1: int = 1
+    doweight_stage1: int = 0
+
+    def kernel_shape(self) -> Shape:
+        return Shape(
+            self.model_dim,
+            self.inter_dim,
+            self.experts,
+            self.topk,
+            self.tp,
+        )
+
+
+_CONFIG_NAME_PREFIX = "flydsl_comm_moe2_afp8_wfp4_bf16_"
+_RUNNER_CACHE = {}
+
+
+@cache
+def _mori_communicator():
+    from mori.cco import Communicator
+
+    return Communicator
+
+
+@cache
+def is_flydsl_comm_fused_moe_available() -> bool:
+    rocm_version = get_rocm_version()
+    if rocm_version is None or rocm_version < _MIN_ROCM_VERSION:
+        return False
+    try:
+        communicator = _mori_communicator()
+    except (ImportError, OSError):
+        return False
+    return all(
+        hasattr(communicator, name)
+        for name in ("get_unique_id", "init", "register_external_window")
+    )
+
+
+def _int_value(raw, name: str) -> int:
+    numeric = float(raw)
+    integer = int(numeric)
+    if numeric != integer:
+        raise ValueError(f"{name} must be an integer, got {raw!r}")
+    return integer
+
+
+def _mega_defaults() -> dict:
+    defaults = {}
+    for field in fields(MegakernelConfig):
+        if field.name in ("shape", "m"):
+            continue
+        if field.default is MISSING:
+            raise TypeError(f"missing megakernel default for {field.name}")
+        defaults[field.name] = field.default
+    return defaults
+
+
+def config_name(config: PipelineConfig) -> str:
+    prefix = _CONFIG_NAME_PREFIX
+    if isinstance(config, AtomicConfig):
+        return (
+            f"{prefix}atomic_rs{config.reduce_scatter_grid}"
+            f"_ag{config.all_gather_grid}"
+        )
+    if isinstance(config, WindowConfig):
+        return (
+            f"{prefix}window_t{config.tile_m}x{config.tile_n}x{config.tile_k}"
+            f"_sbm{config.sort_block_m}_win{config.window}"
+            f"_lw{config.local_workers}_rs{config.reduce_scatter_grid}"
+            f"_ag{config.all_gather_grid}"
+        )
+    if not isinstance(config, MegakernelConfig):
+        raise TypeError(f"unsupported comm_fused config {type(config)!r}")
+
+    defaults = _mega_defaults()
+    parts = [
+        f"{prefix}t{config.tile_m}x{config.tile_n}x{config.tile_k}",
+    ]
+    numeric_tags = (
+        ("sort_block_m", "sbm"),
+        ("compute_groups", "cg"),
+        ("block_threads", "bt"),
+        ("vector_width", "v"),
+        ("waves_per_eu", "w"),
+        ("b_cache_modifier", "bnt"),
+        ("local_load_cache_modifier", "ll"),
+        ("remote_load_cache_modifier", "rl"),
+        ("gather_load_cache_modifier", "gl"),
+        ("remote_store_cache_modifier", "rs"),
+        ("n_tile_cohort", "ntc"),
+    )
+    for field_name, tag in numeric_tags:
+        value = getattr(config, field_name)
+        if value != defaults[field_name]:
+            parts.append(f"{tag}{value}")
+    if config.route_store_scope != defaults["route_store_scope"]:
+        parts.append(f"rts{config.route_store_scope}")
+    if config.collective != defaults["collective"]:
+        parts.append(
+            {
+                "rs_broadcast": "rsbcast",
+                "rsag": "rsag",
+            }[config.collective]
+        )
+    if config.service_groups != defaults["service_groups"]:
+        parts.append(f"sg{config.service_groups}")
+    if config.service_tile_group != defaults["service_tile_group"]:
+        parts.append(f"stg{config.service_tile_group}")
+    if config.producer_mode != defaults["producer_mode"]:
+        parts.append("patomic")
+    if config.flat_producer_grid:
+        parts.append("flat")
+    return "_".join(parts)
+
+
+def _parse_megakernel_name(name: str, shape: Shape, m: int):
+    prefix = _CONFIG_NAME_PREFIX
+    if not name.startswith(prefix):
+        return None
+    parts = name[len(prefix) :].split("_")
+    tile = re.fullmatch(r"t(\d+)x(\d+)x(\d+)", parts.pop(0))
+    if tile is None:
+        raise ValueError(f"invalid megakernel tile in {name!r}")
+    values = _mega_defaults()
+    values.update(
+        tile_m=int(tile.group(1)),
+        tile_n=int(tile.group(2)),
+        tile_k=int(tile.group(3)),
+    )
+    numeric_tags = {
+        "sbm": "sort_block_m",
+        "cg": "compute_groups",
+        "bt": "block_threads",
+        "v": "vector_width",
+        "w": "waves_per_eu",
+        "bnt": "b_cache_modifier",
+        "ll": "local_load_cache_modifier",
+        "rl": "remote_load_cache_modifier",
+        "gl": "gather_load_cache_modifier",
+        "rs": "remote_store_cache_modifier",
+        "ntc": "n_tile_cohort",
+        "sg": "service_groups",
+        "stg": "service_tile_group",
+    }
+    collective = values["collective"]
+    for part in parts:
+        if part in ("direct", "rsbcast", "rsag"):
+            if collective != values["collective"]:
+                raise ValueError(f"duplicate collective in {name!r}")
+            collective = {
+                "direct": "direct",
+                "rsbcast": "rs_broadcast",
+                "rsag": "rsag",
+            }[part]
+        elif part == "patomic":
+            values["producer_mode"] = "atomic_shared"
+        elif part == "flat":
+            values["flat_producer_grid"] = True
+        elif part.startswith("rts"):
+            values["route_store_scope"] = part[3:]
+        else:
+            for tag, field_name in sorted(
+                numeric_tags.items(), key=lambda item: -len(item[0])
+            ):
+                if part.startswith(tag):
+                    values[field_name] = _int_value(part[len(tag) :], field_name)
+                    break
+            else:
+                raise ValueError(f"unknown megakernel option {part!r} in {name!r}")
+    values["collective"] = collective
+    return MegakernelConfig(shape=shape, m=m, **values)
+
+
+def _config(row, shape: Shape) -> PipelineConfig:
+    name = row["kernelName"]
+    m = _int_value(row["token"], "token")
+    atomic = re.fullmatch(
+        rf"{re.escape(_CONFIG_NAME_PREFIX)}atomic_rs(\d+)_ag(\d+)", name
+    )
+    if atomic is not None:
+        return AtomicConfig(shape, m, int(atomic.group(1)), int(atomic.group(2)))
+    window = re.fullmatch(
+        rf"{re.escape(_CONFIG_NAME_PREFIX)}window_"
+        r"t(\d+)x(\d+)x(\d+)_sbm(\d+)_win(\d+)_lw(\d+)_rs(\d+)_ag(\d+)",
+        name,
+    )
+    if window is not None:
+        config = WindowConfig(shape, m, *(int(value) for value in window.groups()))
+    else:
+        config = _parse_megakernel_name(name, shape, m)
+        if config is None:
+            raise ValueError(f"unknown comm_fused kernelName {name!r}")
+    block_m = _int_value(row["block_m"], "block_m")
+    if config.sort_block_m != block_m:
+        raise ValueError(
+            f"kernelName sort_block_m={config.sort_block_m} does not match "
+            f"CSV block_m={block_m}"
+        )
+    return config
+
+
+def _optional_float(row, name: str) -> float | None:
+    raw = row.get(name)
+    if raw in (None, ""):
+        return None
+    value = float(raw)
+    return value if math.isfinite(value) else None
+
+
+def _row_is_accurate(row) -> bool:
+    max_abs = _optional_float(row, "max_abs")
+    rel_l2 = _optional_float(row, "rel_l2")
+    return (max_abs is None or max_abs <= _MAX_ABS_ERROR) and (
+        rel_l2 is None or rel_l2 <= _MAX_REL_L2_ERROR
+    )
+
+
+def _select_row(key, rows):
+    accurate = [row for row in rows if _row_is_accurate(row)]
+    if not accurate:
+        raise ValueError(f"all comm_fused configs fail accuracy for {key}")
+    if len(accurate) == 1:
+        return accurate[0]
+    measured = [
+        (latency, row)
+        for row in accurate
+        if (latency := _optional_float(row, "us")) is not None
+    ]
+    if len(measured) != len(accurate):
+        raise ValueError(
+            f"duplicate comm_fused configs require measured 'us' for {key}"
+        )
+    return min(measured, key=lambda item: item[0])[1]
+
+
+@cache
+def _winner_table() -> dict[ShapeKey, dict[int, PipelineConfig]]:
+    candidates = {}
+    config_path = Path(AITER_CONFIGS.AITER_CONFIG_COMM_FUSED_MOE_FILE)
+    with config_path.open(newline="") as file:
+        for row in csv.DictReader(file):
+            # Skip ordinary Stage2 + TP AllReduce fallback rows.
+            if row["kernelName"].strip().lower() == "fallback":
+                continue
+            shape = ShapeKey(
+                row["gfx"],
+                int(row["model_dim"]),
+                int(row["inter_dim"]),
+                int(row["expert"]),
+                int(row["topk"]),
+                int(row["tp"]),
+                int(row["cu_num"]),
+                row["act_type"],
+                row["dtype"],
+                row["q_dtype_a"],
+                row["q_dtype_w"],
+                row["q_type"],
+                _int_value(row["use_g1u1"], "use_g1u1"),
+                _int_value(row["doweight_stage1"], "doweight_stage1"),
+            )
+            key = (shape, int(row["token"]))
+            candidates.setdefault(key, []).append(row)
+    table = {}
+    for (shape, m), rows in candidates.items():
+        row = _select_row((shape, m), rows)
+        table.setdefault(shape, {})[m] = _config(row, shape.kernel_shape())
+    return table
+
+
+def winners_for(shape: ShapeKey) -> dict[int, PipelineConfig]:
+    if not is_flydsl_comm_fused_moe_available():
+        return {}
+    if shape.cu_num is None:
+        shape = ShapeKey(
+            shape.gfx,
+            shape.model_dim,
+            shape.inter_dim,
+            shape.experts,
+            shape.topk,
+            shape.tp,
+            get_cu_num(),
+            shape.act_type,
+            shape.dtype,
+            shape.q_dtype_a,
+            shape.q_dtype_w,
+            shape.q_type,
+            shape.use_g1u1,
+            shape.doweight_stage1,
+        )
+    table = _winner_table()
+    try:
+        return table[shape]
+    except KeyError:
+        raise KeyError(f"unsupported comm_fused shape {shape}") from None
+
+
+def _symmetric(device, size: int) -> torch.Tensor:
+    requested_bytes = int(size)
+    alignment = _PEER_VMM_ALLOCATION_ALIGNMENT
+    allocated_bytes = max(
+        alignment,
+        (requested_bytes + alignment - 1) // alignment * alignment,
+    )
+    return symm_mem.empty((allocated_bytes,), dtype=torch.uint8, device=device)
+
+
+def _packed_symmetric(
+    device, sizes: tuple[int, ...]
+) -> tuple[torch.Tensor, tuple[torch.Tensor, ...], tuple[int, ...]]:
+    """Carve aligned views from one peer-VMM allocation and CCO window."""
+    offsets = []
+    total_bytes = 0
+    for size in sizes:
+        total_bytes = (total_bytes + 255) // 256 * 256
+        offsets.append(total_bytes)
+        total_bytes += int(size)
+    workspace = _symmetric(device, total_bytes)
+    tensors = tuple(
+        workspace.narrow(0, offset, int(size)) for offset, size in zip(offsets, sizes)
+    )
+    return workspace, tensors, tuple(offsets)
+
+
+def _register(tp_group, rank: int, tp: int, tensors):
+    Communicator = _mori_communicator()
+    uid = Communicator.get_unique_id() if rank == 0 else None
+    comm = Communicator.init(
+        tp, rank, tp_group.broadcast_object(uid), per_rank_vmm=FLAT_VA_RANK_STRIDE
+    )
+    windows = tuple(
+        comm.register_external_window(tensor.data_ptr(), tensor.nbytes)
+        for tensor in tensors
+    )
+    bases = tuple(w.local_ptr - rank * FLAT_VA_RANK_STRIDE for w in windows)
+    return comm, windows, bases
+
+
+def _barrier(tensor, flat_base, ready_offset, tp_size, stream) -> None:
+    _run_compiled(
+        compile_epoch_barrier(tp_size),
+        (ptr_arg(tensor), fx.Int64(flat_base), fx.Int64(ready_offset), stream),
+    )
+
+
+def _stage2_args(args, kwargs, config):
+    inter_states, w2 = args[0], args[2]
+    sorted_token_ids, sorted_expert_ids, num_valid_ids = args[3:6]
+    shape = config.shape
+    runtime_sort_block_m = int(kwargs["block_m"])
+    if runtime_sort_block_m != config.sort_block_m:
+        raise RuntimeError(
+            "comm_fused sort_block_m does not match ordinary fused MoE: "
+            f"config={config.sort_block_m}, runtime={runtime_sort_block_m}, "
+            f"M={config.m}, shape={shape.tag}"
+        )
+    return (
+        ptr_arg(inter_states),
+        ptr_arg(w2),
+        ptr_arg(kwargs["a2_scale"].view(-1)),
+        ptr_arg(kwargs["w2_scale"].view(-1)),
+        ptr_arg(sorted_token_ids),
+        ptr_arg(sorted_expert_ids),
+        ptr_arg(kwargs["sorted_weights"]),
+        ptr_arg(num_valid_ids),
+        ptr_arg(inter_states),
+        config.m,
+        shape.model_dim,
+        shape.inter_dim,
+        int(sorted_expert_ids.shape[0]) * config.sort_block_m // config.tile_m,
+    )
+
+
+class _AtomicRunner:
+    def __init__(
+        self,
+        tp_group,
+        config: AtomicConfig,
+    ) -> None:
+        self.config = config
+        self.rank = int(tp_group.rank_in_group)
+        self.device = torch.device(tp_group.device)
+        shape = config.shape
+        self.partial_ready = config.m * (shape.model_dim + shape.model_dim // 32)
+        self.reduced_ready = config.shard_rows * shape.model_dim
+        sizes = (
+            (self.partial_ready + 8 + 255) // 256 * 256,
+            (self.reduced_ready + 8 + 255) // 256 * 256,
+            config.shard_rows * (shape.model_dim // 32),
+        )
+        self.workspace, tensors, offsets = _packed_symmetric(self.device, sizes)
+        self.partial, self.reduced_payload, self.reduced_scale = tensors
+        self.partial[self.partial_ready : self.partial_ready + 8].zero_()
+        self.reduced_payload[self.reduced_ready : self.reduced_ready + 8].zero_()
+        self.output = torch.empty(
+            (config.m, shape.model_dim),
+            dtype=torch.bfloat16,
+            device=self.device,
+        )
+        self.comm, self.windows, (workspace_base,) = _register(
+            tp_group, self.rank, shape.tp_size, (self.workspace,)
+        )
+        (
+            self.partial_flat_base,
+            self.reduced_payload_base,
+            self.reduced_scale_base,
+        ) = tuple(workspace_base + offset for offset in offsets)
+        shard_begin = self.rank * config.shard_rows
+        self.reduced_shard = self.output[shard_begin : shard_begin + config.shard_rows]
+
+    def __call__(
+        self,
+        *,
+        stage2_args: tuple,
+        stage2_kwargs: dict,
+        shared_partial,
+        ordinary_stage2,
+    ):
+        config = self.config
+        ordinary_stage2(
+            *stage2_args[:6],
+            shared_partial,
+            *stage2_args[7:],
+            **stage2_kwargs,
+        )
+        stream = torch.cuda.current_stream(self.device)
+        _run_compiled(
+            atomic.compile_quantize(config),
+            (ptr_arg(shared_partial), ptr_arg(self.partial), stream),
+        )
+        _barrier(
+            self.partial,
+            self.partial_flat_base,
+            self.partial_ready,
+            config.shape.tp_size,
+            stream,
+        )
+        _run_compiled(
+            atomic.compile_reduce_scatter(config),
+            (
+                fx.Int64(self.partial_flat_base),
+                ptr_arg(self.reduced_shard),
+                ptr_arg(self.reduced_payload),
+                ptr_arg(self.reduced_scale),
+                self.rank,
+                stream,
+            ),
+        )
+        _barrier(
+            self.reduced_payload,
+            self.reduced_payload_base,
+            self.reduced_ready,
+            config.shape.tp_size,
+            stream,
+        )
+        _run_compiled(
+            atomic.compile_all_gather(config),
+            (
+                fx.Int64(self.reduced_payload_base),
+                fx.Int64(self.reduced_scale_base),
+                ptr_arg(self.output),
+                self.rank,
+                stream,
+            ),
+        )
+        return self.output
+
+
+class _MegakernelRunner:
+    """Single-launch GEMM2 with per-N-tile TP collective services."""
+
+    def __init__(
+        self,
+        tp_group,
+        config: MegakernelConfig,
+    ) -> None:
+        shape = config.shape
+        self.config = config
+        self.rank = int(tp_group.rank_in_group)
+        self.device = torch.device(tp_group.device)
+        self.workspace = _symmetric(self.device, config.workspace_bytes)
+        self.workspace.zero_()
+        self.output = (
+            self.workspace.narrow(0, config.output_offset, config.payload_bytes)
+            .view(torch.bfloat16)
+            .view(config.m, shape.model_dim)
+        )
+        self.comm, self.windows, bases = _register(
+            tp_group,
+            self.rank,
+            shape.tp_size,
+            (self.workspace,),
+        )
+        # Register all peer windows before launching a peer-dereferencing kernel.
+        tp_group.barrier()
+        self.shared_partial_window = None
+        self.shared_partial_ptr = None
+        self.shared_partial_flat_base = 0
+        (self.workspace_flat_base,) = bases
+        self.workspace.narrow(0, config.flat_base_offset, 8).view(torch.int64).fill_(
+            self.workspace_flat_base
+        )
+
+    def prepare_shared_partial(self, shared_partial: torch.Tensor) -> torch.Tensor:
+        """Stage a normal shared contribution in the registered output window."""
+
+        if not self.config.shared_bf16_partials:
+            return shared_partial
+        if shared_partial.data_ptr() != self.output.data_ptr():
+            self.output.copy_(shared_partial)
+        return self.output
+
+    def __call__(
+        self,
+        *,
+        stage2_args: tuple,
+        stage2_kwargs: dict,
+        shared_partial,
+        ordinary_stage2,
+    ):
+        del ordinary_stage2
+        stream = torch.cuda.current_stream(self.device)
+        if self.config.shared_bf16_partials:
+            shared_partial_ptr = shared_partial.data_ptr()
+            if shared_partial_ptr == self.output.data_ptr():
+                if self.shared_partial_ptr not in (None, shared_partial_ptr):
+                    raise RuntimeError(
+                        "GEMM2 TP megakernel shared_partial storage changed after "
+                        "symmetric registration"
+                    )
+                self.shared_partial_ptr = shared_partial_ptr
+                self.shared_partial_flat_base = (
+                    self.workspace_flat_base + self.config.output_offset
+                )
+            elif self.shared_partial_window is None:
+                self.shared_partial_window = self.comm.register_external_window(
+                    shared_partial_ptr,
+                    shared_partial.nbytes,
+                )
+                self.shared_partial_ptr = shared_partial_ptr
+                self.shared_partial_flat_base = (
+                    self.shared_partial_window.local_ptr
+                    - self.rank * FLAT_VA_RANK_STRIDE
+                )
+            elif shared_partial_ptr != self.shared_partial_ptr:
+                raise RuntimeError(
+                    "GEMM2 TP megakernel shared_partial storage changed after "
+                    "symmetric registration"
+                )
+        common = _stage2_args(stage2_args, stage2_kwargs, self.config)
+        _run_compiled(
+            megakernel.compile_megakernel(self.config, self.rank),
+            (
+                ptr_arg(self.workspace),
+                ptr_arg(shared_partial),
+                fx.Int64(self.shared_partial_flat_base),
+                *common[:8],
+                *common[9:],
+                stream,
+            ),
+        )
+        return self.output
+
+
+class _WindowRunner:
+    def __init__(
+        self,
+        tp_group,
+        config: WindowConfig,
+    ) -> None:
+        shape = config.shape
+        self.config = config
+        self.rank = int(tp_group.rank_in_group)
+        self.device = torch.device(tp_group.device)
+        self.routes = tuple(
+            torch.empty(
+                (
+                    config.m,
+                    shape.topk,
+                    config.window + config.window // 8,
+                ),
+                dtype=torch.uint8,
+                device=self.device,
+            )
+            for _ in range(SLOTS)
+        )
+        self.partial_ready = config.m * (config.window + config.window // 32)
+        self.reduced_ready = config.shard_rows * config.window
+        sizes = (
+            ((self.partial_ready + 8 + 255) // 256 * 256,) * SLOTS
+            + ((self.reduced_ready + 8 + 255) // 256 * 256,) * SLOTS
+            + (config.shard_rows * (config.window // 32),) * SLOTS
+        )
+        self.workspace, tensors, offsets = _packed_symmetric(self.device, sizes)
+        self.partials = tensors[:SLOTS]
+        self.reduced_payloads = tensors[SLOTS : 2 * SLOTS]
+        self.reduced_scales = tensors[2 * SLOTS :]
+        for partial in self.partials:
+            partial[self.partial_ready : self.partial_ready + 8].zero_()
+        for payload in self.reduced_payloads:
+            payload[self.reduced_ready : self.reduced_ready + 8].zero_()
+        self.output = torch.empty(
+            (config.m, shape.model_dim),
+            dtype=torch.bfloat16,
+            device=self.device,
+        )
+        self.comm, self.windows, (workspace_base,) = _register(
+            tp_group, self.rank, shape.tp_size, (self.workspace,)
+        )
+        bases = tuple(workspace_base + offset for offset in offsets)
+        self.partial_bases = bases[:SLOTS]
+        self.reduced_payload_bases = bases[SLOTS : 2 * SLOTS]
+        self.reduced_scale_bases = bases[2 * SLOTS :]
+        shard_begin = self.rank * config.shard_rows
+        self.reduced_shards = tuple(
+            self.output[
+                shard_begin : shard_begin + config.shard_rows,
+                phase * config.window : (phase + 1) * config.window,
+            ]
+            for phase in range(shape.model_dim // config.window)
+        )
+        self.gathered_outputs = tuple(
+            self.output[:, phase * config.window : (phase + 1) * config.window]
+            for phase in range(shape.model_dim // config.window)
+        )
+
+    def _local_args(self, phase, shared_partial):
+        slot = phase % SLOTS
+        shared = shared_partial[:, phase * self.config.window :]
+        return (
+            ptr_arg(self.routes[slot]),
+            ptr_arg(self.partials[slot]),
+            ptr_arg(shared),
+        )
+
+    def _collective_args(self, reduce_scatter, all_gather):
+        reduce_slot = reduce_scatter % SLOTS
+        gather_slot = all_gather % SLOTS
+        return (
+            fx.Int64(self.partial_bases[reduce_slot]),
+            ptr_arg(self.reduced_shards[reduce_scatter]),
+            ptr_arg(self.reduced_payloads[reduce_slot]),
+            ptr_arg(self.reduced_scales[reduce_slot]),
+            fx.Int64(self.reduced_payload_bases[gather_slot]),
+            fx.Int64(self.reduced_scale_bases[gather_slot]),
+            ptr_arg(self.gathered_outputs[all_gather]),
+        )
+
+    def _drain(self, local, reduce_scatter, all_gather, shared_partial, stream):
+        _run_compiled(
+            window.compile_drain(
+                self.config,
+                local is not None,
+                reduce_scatter is not None,
+                all_gather is not None,
+            ),
+            (
+                *self._local_args(0 if local is None else local, shared_partial),
+                *self._collective_args(
+                    0 if reduce_scatter is None else reduce_scatter,
+                    0 if all_gather is None else all_gather,
+                ),
+                self.rank,
+                stream,
+            ),
+        )
+
+    def __call__(
+        self,
+        *,
+        stage2_args: tuple,
+        stage2_kwargs: dict,
+        shared_partial,
+        ordinary_stage2,
+    ):
+        k = window
+        config = self.config
+        stream = torch.cuda.current_stream(self.device)
+        common = _stage2_args(stage2_args, stage2_kwargs, config)
+        _run_compiled(
+            k.compile_compute(config, 0),
+            (ptr_arg(self.routes[0]), *common, stream),
+        )
+        for local in range(len(self.reduced_shards) - 1):
+            reduce_scatter = local - 1
+            all_gather = local - 2
+            _run_compiled(
+                k.compile_cycle(
+                    config,
+                    local + 1,
+                    reduce_scatter >= 0,
+                    all_gather >= 0,
+                ),
+                (
+                    ptr_arg(self.routes[(local + 1) % SLOTS]),
+                    *common,
+                    *self._local_args(local, shared_partial),
+                    *self._collective_args(max(reduce_scatter, 0), max(all_gather, 0)),
+                    self.rank,
+                    stream,
+                ),
+            )
+            local_slot = local % SLOTS
+            _barrier(
+                self.partials[local_slot],
+                self.partial_bases[local_slot],
+                self.partial_ready,
+                config.shape.tp_size,
+                stream,
+            )
+            if reduce_scatter >= 0:
+                reduce_slot = reduce_scatter % SLOTS
+                _barrier(
+                    self.reduced_payloads[reduce_slot],
+                    self.reduced_payload_bases[reduce_slot],
+                    self.reduced_ready,
+                    config.shape.tp_size,
+                    stream,
+                )
+
+        last = len(self.reduced_shards) - 1
+        self._drain(last, last - 1, last - 2, shared_partial, stream)
+        last_slot = last % SLOTS
+        reduce_slot = (last - 1) % SLOTS
+        _barrier(
+            self.partials[last_slot],
+            self.partial_bases[last_slot],
+            self.partial_ready,
+            config.shape.tp_size,
+            stream,
+        )
+        _barrier(
+            self.reduced_payloads[reduce_slot],
+            self.reduced_payload_bases[reduce_slot],
+            self.reduced_ready,
+            config.shape.tp_size,
+            stream,
+        )
+        self._drain(None, last, last - 1, shared_partial, stream)
+        _barrier(
+            self.reduced_payloads[last_slot],
+            self.reduced_payload_bases[last_slot],
+            self.reduced_ready,
+            config.shape.tp_size,
+            stream,
+        )
+        self._drain(None, None, last, shared_partial, stream)
+        return self.output
+
+
+_RUNNER_TYPES = {
+    AtomicConfig: _AtomicRunner,
+    MegakernelConfig: _MegakernelRunner,
+    WindowConfig: _WindowRunner,
+}
+
+
+def create_runner(tp_group, config: PipelineConfig):
+    return _RUNNER_TYPES[type(config)](tp_group, config)
+
+
+class _LazyRunners:
+    def __init__(self, tp_group, configs: dict[int, PipelineConfig]) -> None:
+        self.tp_group = tp_group
+        self.configs = configs
+        self.instances = {}
+
+    def __contains__(self, tokens: int) -> bool:
+        return tokens in self.configs
+
+    def __getitem__(self, tokens: int):
+        if tokens not in self.instances:
+            self.instances[tokens] = create_runner(self.tp_group, self.configs[tokens])
+        return self.instances[tokens]
+
+
+def create_flydsl_comm_fused_runners(*, tp_group, model_dim, inter_dim, experts, topk):
+    shape = ShapeKey(
+        get_gfx_runtime(),
+        model_dim,
+        inter_dim,
+        experts,
+        topk,
+        int(tp_group.world_size),
+        get_cu_num(),
+    )
+    key = (id(tp_group), shape)
+    if key not in _RUNNER_CACHE:
+        _RUNNER_CACHE[key] = _LazyRunners(tp_group, winners_for(shape))
+    return _RUNNER_CACHE[key]

--- a/aiter/ops/flydsl/comm_fused_moe_host.py
+++ b/aiter/ops/flydsl/comm_fused_moe_host.py
@@ -13,6 +13,7 @@ import torch
 import torch.distributed._symmetric_memory as symm_mem
 
 from aiter.dist.device_communicators.rocm_version import get_rocm_version
+from aiter.fused_moe import stage2_uses_route_reduce
 from aiter.jit.core import AITER_CONFIGS
 from aiter.jit.utils.chip_info import get_cu_num, get_gfx_runtime
 from aiter.ops.flydsl.kernels.comm_fused_moe.gfx950.a8w4 import (
@@ -32,8 +33,7 @@ from aiter.ops.flydsl.kernels.comm_fused_moe.gfx950.a8w4.config import (
     Shape,
     WindowConfig,
 )
-from aiter.ops.flydsl.kernels.tensor_shim import ptr_arg
-from aiter.ops.flydsl.moe_kernels import _run_compiled
+from aiter.ops.flydsl.kernels.tensor_shim import _run_compiled, ptr_arg
 
 _PEER_VMM_ALLOCATION_ALIGNMENT = 2 * 1024 * 1024
 _MIN_ROCM_VERSION = (7, 2)
@@ -156,8 +156,6 @@ def config_name(config: PipelineConfig) -> str:
         value = getattr(config, field_name)
         if value != defaults[field_name]:
             parts.append(f"{tag}{value}")
-    if config.route_store_scope != defaults["route_store_scope"]:
-        parts.append(f"rts{config.route_store_scope}")
     if config.collective != defaults["collective"]:
         parts.append(
             {
@@ -219,8 +217,6 @@ def _parse_megakernel_name(name: str, shape: Shape, m: int):
             values["producer_mode"] = "atomic_shared"
         elif part == "flat":
             values["flat_producer_grid"] = True
-        elif part.startswith("rts"):
-            values["route_store_scope"] = part[3:]
         else:
             for tag, field_name in sorted(
                 numeric_tags.items(), key=lambda item: -len(item[0])
@@ -401,7 +397,10 @@ def _register(tp_group, rank: int, tp: int, tensors):
 def _barrier(tensor, flat_base, ready_offset, tp_size, stream) -> None:
     _run_compiled(
         compile_epoch_barrier(tp_size),
-        (ptr_arg(tensor), fx.Int64(flat_base), fx.Int64(ready_offset), stream),
+        ptr_arg(tensor),
+        fx.Int64(flat_base),
+        fx.Int64(ready_offset),
+        stream,
     )
 
 
@@ -462,6 +461,7 @@ class _AtomicRunner:
         self.comm, self.windows, (workspace_base,) = _register(
             tp_group, self.rank, shape.tp_size, (self.workspace,)
         )
+        tp_group.barrier()
         (
             self.partial_flat_base,
             self.reduced_payload_base,
@@ -479,16 +479,22 @@ class _AtomicRunner:
         ordinary_stage2,
     ):
         config = self.config
+        add_shared = stage2_uses_route_reduce(ordinary_stage2)
+        if not add_shared:
+            self.output.copy_(shared_partial)
         ordinary_stage2(
             *stage2_args[:6],
-            shared_partial,
+            self.output,
             *stage2_args[7:],
             **stage2_kwargs,
         )
         stream = torch.cuda.current_stream(self.device)
         _run_compiled(
-            atomic.compile_quantize(config),
-            (ptr_arg(shared_partial), ptr_arg(self.partial), stream),
+            atomic.compile_quantize(config, add_shared),
+            ptr_arg(self.output),
+            ptr_arg(shared_partial),
+            ptr_arg(self.partial),
+            stream,
         )
         _barrier(
             self.partial,
@@ -499,14 +505,12 @@ class _AtomicRunner:
         )
         _run_compiled(
             atomic.compile_reduce_scatter(config),
-            (
-                fx.Int64(self.partial_flat_base),
-                ptr_arg(self.reduced_shard),
-                ptr_arg(self.reduced_payload),
-                ptr_arg(self.reduced_scale),
-                self.rank,
-                stream,
-            ),
+            fx.Int64(self.partial_flat_base),
+            ptr_arg(self.reduced_shard),
+            ptr_arg(self.reduced_payload),
+            ptr_arg(self.reduced_scale),
+            self.rank,
+            stream,
         )
         _barrier(
             self.reduced_payload,
@@ -517,13 +521,11 @@ class _AtomicRunner:
         )
         _run_compiled(
             atomic.compile_all_gather(config),
-            (
-                fx.Int64(self.reduced_payload_base),
-                fx.Int64(self.reduced_scale_base),
-                ptr_arg(self.output),
-                self.rank,
-                stream,
-            ),
+            fx.Int64(self.reduced_payload_base),
+            fx.Int64(self.reduced_scale_base),
+            ptr_arg(self.output),
+            self.rank,
+            stream,
         )
         return self.output
 
@@ -568,6 +570,8 @@ class _MegakernelRunner:
 
         if not self.config.shared_bf16_partials:
             return shared_partial
+        if self.config.producer_mode == "atomic_shared":
+            return shared_partial
         if shared_partial.data_ptr() != self.output.data_ptr():
             self.output.copy_(shared_partial)
         return self.output
@@ -582,7 +586,10 @@ class _MegakernelRunner:
     ):
         del ordinary_stage2
         stream = torch.cuda.current_stream(self.device)
-        if self.config.shared_bf16_partials:
+        if (
+            self.config.shared_bf16_partials
+            and self.config.producer_mode != "atomic_shared"
+        ):
             shared_partial_ptr = shared_partial.data_ptr()
             if shared_partial_ptr == self.output.data_ptr():
                 if self.shared_partial_ptr not in (None, shared_partial_ptr):
@@ -612,14 +619,12 @@ class _MegakernelRunner:
         common = _stage2_args(stage2_args, stage2_kwargs, self.config)
         _run_compiled(
             megakernel.compile_megakernel(self.config, self.rank),
-            (
-                ptr_arg(self.workspace),
-                ptr_arg(shared_partial),
-                fx.Int64(self.shared_partial_flat_base),
-                *common[:8],
-                *common[9:],
-                stream,
-            ),
+            ptr_arg(self.workspace),
+            ptr_arg(shared_partial),
+            fx.Int64(self.shared_partial_flat_base),
+            *common[:8],
+            *common[9:],
+            stream,
         )
         return self.output
 
@@ -669,6 +674,7 @@ class _WindowRunner:
         self.comm, self.windows, (workspace_base,) = _register(
             tp_group, self.rank, shape.tp_size, (self.workspace,)
         )
+        tp_group.barrier()
         bases = tuple(workspace_base + offset for offset in offsets)
         self.partial_bases = bases[:SLOTS]
         self.reduced_payload_bases = bases[SLOTS : 2 * SLOTS]
@@ -716,15 +722,13 @@ class _WindowRunner:
                 reduce_scatter is not None,
                 all_gather is not None,
             ),
-            (
-                *self._local_args(0 if local is None else local, shared_partial),
-                *self._collective_args(
-                    0 if reduce_scatter is None else reduce_scatter,
-                    0 if all_gather is None else all_gather,
-                ),
-                self.rank,
-                stream,
+            *self._local_args(0 if local is None else local, shared_partial),
+            *self._collective_args(
+                0 if reduce_scatter is None else reduce_scatter,
+                0 if all_gather is None else all_gather,
             ),
+            self.rank,
+            stream,
         )
 
     def __call__(
@@ -741,7 +745,9 @@ class _WindowRunner:
         common = _stage2_args(stage2_args, stage2_kwargs, config)
         _run_compiled(
             k.compile_compute(config, 0),
-            (ptr_arg(self.routes[0]), *common, stream),
+            ptr_arg(self.routes[0]),
+            *common,
+            stream,
         )
         for local in range(len(self.reduced_shards) - 1):
             reduce_scatter = local - 1
@@ -750,17 +756,13 @@ class _WindowRunner:
                 k.compile_cycle(
                     config,
                     local + 1,
-                    reduce_scatter >= 0,
-                    all_gather >= 0,
                 ),
-                (
-                    ptr_arg(self.routes[(local + 1) % SLOTS]),
-                    *common,
-                    *self._local_args(local, shared_partial),
-                    *self._collective_args(max(reduce_scatter, 0), max(all_gather, 0)),
-                    self.rank,
-                    stream,
-                ),
+                ptr_arg(self.routes[(local + 1) % SLOTS]),
+                *common,
+                *self._local_args(local, shared_partial),
+                *self._collective_args(max(reduce_scatter, 0), max(all_gather, 0)),
+                self.rank,
+                stream,
             )
             local_slot = local % SLOTS
             _barrier(

--- a/aiter/ops/flydsl/kernels/comm_fused_moe/gfx950/a8w4/__init__.py
+++ b/aiter/ops/flydsl/kernels/comm_fused_moe/gfx950/a8w4/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
+"""A8W4 communication-fused MoE kernels for gfx950."""

--- a/aiter/ops/flydsl/kernels/comm_fused_moe/gfx950/a8w4/atomic.py
+++ b/aiter/ops/flydsl/kernels/comm_fused_moe/gfx950/a8w4/atomic.py
@@ -1,0 +1,367 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Multi-launch atomic BF16 and MXFP8 communication family."""
+
+import functools
+
+import flydsl.compiler as flyc
+import flydsl.expr as fx
+from flydsl.expr import const_expr, gpu, ptrtoint, range_constexpr
+from flydsl.expr import math as fmath
+from flydsl.expr.typing import ReductionOp, T
+
+from .... import buffer_ops
+from .collectives import (
+    decode_scaled_fp8_f32,
+    e8m0_scale,
+    load_e8m0_scale,
+    load_fp8_words,
+    pack_fp8_words,
+    peer_base,
+    store_fp8_words,
+)
+from .config import BLOCK, AtomicConfig
+
+VECTOR_WIDTH = 16
+QUANT_BLOCK = 256
+
+
+@flyc.jit
+def _emit_quantize_item(config, local, shared, partial, item, add_shared):
+    shape = config.shape
+    h = shape.model_dim
+    groups_per_row = h // 32
+    column_tiles = (h + QUANT_BLOCK * VECTOR_WIDTH - 1) // (QUANT_BLOCK * VECTOR_WIDTH)
+    token = item // fx.Int32(column_tiles)
+    tile = item - token * fx.Int32(column_tiles)
+    column = tile * fx.Int32(QUANT_BLOCK * VECTOR_WIDTH) + fx.Int32(
+        gpu.thread_id("x")
+    ) * fx.Int32(VECTOR_WIDTH)
+    if column < fx.Int32(h):
+        local_row = buffer_ops.create_buffer_resource_from_addr(
+            fx.Int64(ptrtoint(local)) + fx.Int64(token) * fx.Int64(h * 2),
+            num_records_bytes=h * 2,
+        )
+        if const_expr(add_shared):
+            shared_row = buffer_ops.create_buffer_resource_from_addr(
+                fx.Int64(ptrtoint(shared)) + fx.Int64(token) * fx.Int64(h * 2),
+                num_records_bytes=h * 2,
+            )
+        values = []
+        for chunk in range_constexpr(VECTOR_WIDTH // 8):
+            loaded = fx.Vector(
+                buffer_ops.buffer_load(
+                    local_row,
+                    column + fx.Int32(chunk * 8),
+                    vec_width=8,
+                    dtype=T.bf16,
+                    cache_modifier=2,
+                )
+            ).extf(T.vec(8, T.f32))
+            if const_expr(add_shared):
+                shared_values = fx.Vector(
+                    buffer_ops.buffer_load(
+                        shared_row,
+                        column + fx.Int32(chunk * 8),
+                        vec_width=8,
+                        dtype=T.bf16,
+                        cache_modifier=2,
+                    )
+                ).extf(T.vec(8, T.f32))
+                loaded = (
+                    (loaded + shared_values)
+                    .truncf(T.vec(8, T.bf16))
+                    .extf(T.vec(8, T.f32))
+                )
+            values.extend(loaded[element] for element in range_constexpr(8))
+
+        vector = fx.Vector.from_elements(values, fx.Float32)
+        local_max = fx.Float32(1e-10).maximumf(
+            fmath.absf(vector).reduce(ReductionOp.MAX)
+        )
+        lane = fx.Int32(gpu.thread_id("x")) & fx.Int32(63)
+        remote_bits = fx.rocdl.ds_bpermute(
+            T.i32,
+            (lane ^ fx.Int32(1)) * fx.Int32(4),
+            local_max.bitcast(fx.Int32),
+        )
+        local_max = local_max.maximumf(fx.Int32(remote_bits).bitcast(fx.Float32))
+        e8m0, quant_scale = e8m0_scale(local_max)
+        packed = pack_fp8_words(vector, quant_scale, VECTOR_WIDTH // 4)
+
+        payload_row = buffer_ops.create_buffer_resource_from_addr(
+            fx.Int64(ptrtoint(partial)) + fx.Int64(token) * fx.Int64(h),
+            num_records_bytes=h,
+        )
+        store_fp8_words(
+            payload_row,
+            column,
+            packed,
+            VECTOR_WIDTH // 4,
+        )
+        if lane % fx.Int32(32 // VECTOR_WIDTH) == fx.Int32(0):
+            scale_row = buffer_ops.create_buffer_resource_from_addr(
+                fx.Int64(ptrtoint(partial))
+                + fx.Int64(config.m * h)
+                + fx.Int64(token) * fx.Int64(groups_per_row),
+                num_records_bytes=groups_per_row,
+            )
+            buffer_ops.buffer_store(
+                e8m0.to(fx.Int8),
+                scale_row,
+                column // fx.Int32(32),
+                offset_is_bytes=True,
+            )
+
+
+@functools.cache
+def compile_quantize(config: AtomicConfig, add_shared: bool):
+    """Optionally add shared BF16 output, then quantize to MXFP8."""
+    m = config.m
+    shape = config.shape
+    column_tiles = (shape.model_dim + QUANT_BLOCK * VECTOR_WIDTH - 1) // (
+        QUANT_BLOCK * VECTOR_WIDTH
+    )
+
+    @flyc.kernel(
+        name=(
+            f"gemm2_tp_atomic_pipeline_{shape.tag}_m{m}_quant"
+            f"{'_add_shared' if add_shared else ''}_v16_b256"
+        ),
+        known_block_size=[QUANT_BLOCK, 1, 1],
+    )
+    def kernel(local: fx.Pointer, shared: fx.Pointer, partial: fx.Pointer):
+        item = fx.Int32(gpu.block_id("x"))
+        _emit_quantize_item(config, local, shared, partial, item, add_shared)
+
+    @flyc.jit
+    def launch(local, shared, partial, stream):
+        kernel(local, shared, partial).launch(
+            grid=(m * column_tiles, 1, 1),
+            block=(QUANT_BLOCK, 1, 1),
+            stream=stream,
+        )
+
+    return launch
+
+
+def _store_bf16(resource, offset, values):
+    for chunk in range_constexpr(VECTOR_WIDTH // 8):
+        buffer_ops.buffer_store(
+            fx.Vector.from_elements(
+                [values[chunk * 8 + element] for element in range_constexpr(8)],
+                fx.BFloat16,
+            ),
+            resource,
+            offset + fx.Int32(chunk * 8),
+        )
+
+
+@functools.cache
+def compile_reduce_scatter(config: AtomicConfig):
+    shape = config.shape
+    h = shape.model_dim
+    groups_per_row = h // 32
+    packs_per_group = 32 // VECTOR_WIDTH
+    work_items = config.shard_rows * groups_per_row * packs_per_group
+
+    @flyc.kernel(
+        name=(
+            f"gemm2_tp_atomic_pipeline_{shape.tag}_m{config.m}"
+            f"_rs_g{config.reduce_scatter_grid}"
+        ),
+        known_block_size=[BLOCK, 1, 1],
+    )
+    def kernel(
+        partial_base: fx.Int64,
+        output: fx.Pointer,
+        payload: fx.Pointer,
+        scales: fx.Pointer,
+        rank: fx.Int32,
+    ):
+        start = fx.Int32(gpu.block_id("x")) * fx.Int32(BLOCK) + fx.Int32(
+            gpu.thread_id("x")
+        )
+        for item in range(
+            start,
+            fx.Int32(work_items),
+            fx.Int32(config.reduce_scatter_grid * BLOCK),
+        ):
+            group_item = item // fx.Int32(packs_per_group)
+            pack_in_group = item - group_item * fx.Int32(packs_per_group)
+            local_token = group_item // fx.Int32(groups_per_row)
+            group = group_item - local_token * fx.Int32(groups_per_row)
+            column = group * fx.Int32(32) + pack_in_group * fx.Int32(VECTOR_WIDTH)
+            global_token = rank * fx.Int32(config.shard_rows) + local_token
+            lane = fx.Int32(gpu.thread_id("x")) & fx.Int32(63)
+            acc = fx.Vector.filled(VECTOR_WIDTH, 0.0, fx.Float32)
+            for source_round in range_constexpr(shape.tp_size):
+                source = (rank + local_token + fx.Int32(source_round)) % fx.Int32(
+                    shape.tp_size
+                )
+                source_base = peer_base(partial_base, source)
+                source_row = buffer_ops.create_buffer_resource_from_addr(
+                    source_base + fx.Int64(global_token) * fx.Int64(h),
+                    num_records_bytes=h,
+                )
+                words = load_fp8_words(
+                    source_row,
+                    column // fx.Int32(4),
+                    word_count=VECTOR_WIDTH // 4,
+                    load_width=4,
+                    cache_modifier=2,
+                )
+                scale_row = buffer_ops.create_buffer_resource_from_addr(
+                    source_base
+                    + fx.Int64(config.m * h)
+                    + fx.Int64(global_token) * fx.Int64(groups_per_row),
+                    num_records_bytes=groups_per_row,
+                )
+                values = decode_scaled_fp8_f32(
+                    words, load_e8m0_scale(scale_row, group, 2)
+                )
+                acc = acc + fx.Vector.from_elements(values, fx.Float32)
+
+            local_max = fx.Float32(1e-10).maximumf(
+                fmath.absf(acc).reduce(ReductionOp.MAX)
+            )
+            max_bits = local_max.bitcast(fx.Int32)
+            for xor_lane in range_constexpr(1, 2):
+                remote_bits = fx.rocdl.ds_bpermute(
+                    T.i32,
+                    (lane ^ fx.Int32(xor_lane)) * fx.Int32(4),
+                    max_bits,
+                )
+                local_max = local_max.maximumf(
+                    fx.Int32(remote_bits).bitcast(fx.Float32)
+                )
+                max_bits = local_max.bitcast(fx.Int32)
+            e8m0, quant_scale = e8m0_scale(local_max)
+            packed = pack_fp8_words(acc, quant_scale, VECTOR_WIDTH // 4)
+
+            payload_row = buffer_ops.create_buffer_resource_from_addr(
+                fx.Int64(ptrtoint(payload)) + fx.Int64(local_token) * fx.Int64(h),
+                num_records_bytes=h,
+            )
+            store_fp8_words(
+                payload_row,
+                column,
+                packed,
+                4,
+            )
+            if pack_in_group == fx.Int32(0):
+                scale_row = buffer_ops.create_buffer_resource_from_addr(
+                    fx.Int64(ptrtoint(scales))
+                    + fx.Int64(local_token) * fx.Int64(groups_per_row),
+                    num_records_bytes=groups_per_row,
+                )
+                buffer_ops.buffer_store(
+                    e8m0.to(fx.Int8),
+                    scale_row,
+                    group,
+                    offset_is_bytes=True,
+                )
+
+            decoded = decode_scaled_fp8_f32(
+                packed,
+                (fx.Uint32(e8m0) << fx.Uint32(23)).bitcast(fx.Float32),
+            )
+            output_row = buffer_ops.create_buffer_resource_from_addr(
+                fx.Int64(ptrtoint(output)) + fx.Int64(local_token) * fx.Int64(h * 2),
+                num_records_bytes=h * 2,
+            )
+            _store_bf16(output_row, column, decoded)
+
+    @flyc.jit
+    def launch(partial_base, output, payload, scales, rank, stream):
+        kernel(partial_base, output, payload, scales, rank).launch(
+            grid=(config.reduce_scatter_grid, 1, 1),
+            block=(BLOCK, 1, 1),
+            stream=stream,
+        )
+
+    return launch
+
+
+@functools.cache
+def compile_all_gather(config: AtomicConfig):
+    shape = config.shape
+    h = shape.model_dim
+    groups_per_row = h // 32
+    packs_per_group = 32 // VECTOR_WIDTH
+    work_items = config.shard_rows * groups_per_row * packs_per_group
+    source_count = shape.tp_size - 1
+    workers_per_source = config.all_gather_grid // source_count
+
+    @flyc.kernel(
+        name=(
+            f"gemm2_tp_atomic_pipeline_{shape.tag}_m{config.m}"
+            f"_ag_g{config.all_gather_grid}"
+        ),
+        known_block_size=[BLOCK, 1, 1],
+    )
+    def kernel(
+        payload_base: fx.Int64,
+        scale_base: fx.Int64,
+        output: fx.Pointer,
+        rank: fx.Int32,
+    ):
+        worker = fx.Int32(gpu.block_id("x"))
+        source_slot = worker % fx.Int32(source_count)
+        source_block = worker // fx.Int32(source_count)
+        source = (rank + source_slot + fx.Int32(1)) % fx.Int32(shape.tp_size)
+        payload = buffer_ops.create_buffer_resource_from_addr(
+            peer_base(payload_base, source), num_records_bytes=0xFFFFFFFF
+        )
+        scales = buffer_ops.create_buffer_resource_from_addr(
+            peer_base(scale_base, source), num_records_bytes=0xFFFFFFFF
+        )
+        output_resource = buffer_ops.create_buffer_resource_from_addr(
+            fx.Int64(ptrtoint(output)), num_records_bytes=0xFFFFFFFF
+        )
+        start = source_block * fx.Int32(BLOCK) + fx.Int32(gpu.thread_id("x"))
+        for item in range(
+            start,
+            fx.Int32(work_items),
+            fx.Int32(workers_per_source * BLOCK),
+        ):
+            group_item = item // fx.Int32(packs_per_group)
+            pack_in_group = item - group_item * fx.Int32(packs_per_group)
+            words = load_fp8_words(
+                payload,
+                item * fx.Int32(VECTOR_WIDTH // 4),
+                word_count=VECTOR_WIDTH // 4,
+                load_width=4,
+                cache_modifier=1,
+            )
+            loaded = fx.Uint32(
+                fx.Uint8(
+                    buffer_ops.buffer_load(
+                        scales,
+                        group_item,
+                        vec_width=1,
+                        dtype=T.i8,
+                        cache_modifier=1,
+                    )
+                )
+            )
+            scale = (loaded << fx.Uint32(23)).bitcast(fx.Float32)
+            values = decode_scaled_fp8_f32(words, scale)
+            shard_row = group_item // fx.Int32(groups_per_row)
+            group = group_item - shard_row * fx.Int32(groups_per_row)
+            output_column = (
+                source * fx.Int32(config.shard_rows * h)
+                + shard_row * fx.Int32(h)
+                + group * fx.Int32(32)
+                + pack_in_group * fx.Int32(VECTOR_WIDTH)
+            )
+            _store_bf16(output_resource, output_column, values)
+
+    @flyc.jit
+    def launch(payload_base, scale_base, output, rank, stream):
+        kernel(payload_base, scale_base, output, rank).launch(
+            grid=(config.all_gather_grid, 1, 1),
+            block=(BLOCK, 1, 1),
+            stream=stream,
+        )
+
+    return launch

--- a/aiter/ops/flydsl/kernels/comm_fused_moe/gfx950/a8w4/atomic.py
+++ b/aiter/ops/flydsl/kernels/comm_fused_moe/gfx950/a8w4/atomic.py
@@ -9,14 +9,18 @@ from flydsl.expr import const_expr, gpu, ptrtoint, range_constexpr
 from flydsl.expr import math as fmath
 from flydsl.expr.typing import ReductionOp, T
 
-from .... import buffer_ops
 from .collectives import (
+    buffer_tensor_from_addr,
     decode_scaled_fp8_f32,
     e8m0_scale,
+    load_bf16,
+    load_buffer,
     load_e8m0_scale,
     load_fp8_words,
     pack_fp8_words,
     peer_base,
+    store_bf16,
+    store_buffer,
     store_fp8_words,
 )
 from .config import BLOCK, AtomicConfig
@@ -37,41 +41,24 @@ def _emit_quantize_item(config, local, shared, partial, item, add_shared):
         gpu.thread_id("x")
     ) * fx.Int32(VECTOR_WIDTH)
     if column < fx.Int32(h):
-        local_row = buffer_ops.create_buffer_resource_from_addr(
+        local_row = buffer_tensor_from_addr(
             fx.Int64(ptrtoint(local)) + fx.Int64(token) * fx.Int64(h * 2),
-            num_records_bytes=h * 2,
+            fx.BFloat16,
+            h * 2,
         )
         if const_expr(add_shared):
-            shared_row = buffer_ops.create_buffer_resource_from_addr(
+            shared_row = buffer_tensor_from_addr(
                 fx.Int64(ptrtoint(shared)) + fx.Int64(token) * fx.Int64(h * 2),
-                num_records_bytes=h * 2,
+                fx.BFloat16,
+                h * 2,
             )
         values = []
         for chunk in range_constexpr(VECTOR_WIDTH // 8):
-            loaded = fx.Vector(
-                buffer_ops.buffer_load(
-                    local_row,
-                    column + fx.Int32(chunk * 8),
-                    vec_width=8,
-                    dtype=T.bf16,
-                    cache_modifier=2,
-                )
-            ).extf(T.vec(8, T.f32))
+            chunk_offset = column + fx.Int32(chunk * 8)
+            loaded = load_bf16(local_row, chunk_offset, 8, 2).to(fx.Float32)
             if const_expr(add_shared):
-                shared_values = fx.Vector(
-                    buffer_ops.buffer_load(
-                        shared_row,
-                        column + fx.Int32(chunk * 8),
-                        vec_width=8,
-                        dtype=T.bf16,
-                        cache_modifier=2,
-                    )
-                ).extf(T.vec(8, T.f32))
-                loaded = (
-                    (loaded + shared_values)
-                    .truncf(T.vec(8, T.bf16))
-                    .extf(T.vec(8, T.f32))
-                )
+                shared_values = load_bf16(shared_row, chunk_offset, 8, 2).to(fx.Float32)
+                loaded = (loaded + shared_values).to(fx.BFloat16).to(fx.Float32)
             values.extend(loaded[element] for element in range_constexpr(8))
 
         vector = fx.Vector.from_elements(values, fx.Float32)
@@ -88,9 +75,10 @@ def _emit_quantize_item(config, local, shared, partial, item, add_shared):
         e8m0, quant_scale = e8m0_scale(local_max)
         packed = pack_fp8_words(vector, quant_scale, VECTOR_WIDTH // 4)
 
-        payload_row = buffer_ops.create_buffer_resource_from_addr(
+        payload_row = buffer_tensor_from_addr(
             fx.Int64(ptrtoint(partial)) + fx.Int64(token) * fx.Int64(h),
-            num_records_bytes=h,
+            fx.Int32,
+            h,
         )
         store_fp8_words(
             payload_row,
@@ -99,17 +87,18 @@ def _emit_quantize_item(config, local, shared, partial, item, add_shared):
             VECTOR_WIDTH // 4,
         )
         if lane % fx.Int32(32 // VECTOR_WIDTH) == fx.Int32(0):
-            scale_row = buffer_ops.create_buffer_resource_from_addr(
+            scale_row = buffer_tensor_from_addr(
                 fx.Int64(ptrtoint(partial))
                 + fx.Int64(config.m * h)
                 + fx.Int64(token) * fx.Int64(groups_per_row),
-                num_records_bytes=groups_per_row,
+                fx.Int8,
+                groups_per_row,
             )
-            buffer_ops.buffer_store(
-                e8m0.to(fx.Int8),
+            store_buffer(
                 scale_row,
                 column // fx.Int32(32),
-                offset_is_bytes=True,
+                e8m0.to(fx.Int8),
+                fx.Int8,
             )
 
 
@@ -142,18 +131,6 @@ def compile_quantize(config: AtomicConfig, add_shared: bool):
         )
 
     return launch
-
-
-def _store_bf16(resource, offset, values):
-    for chunk in range_constexpr(VECTOR_WIDTH // 8):
-        buffer_ops.buffer_store(
-            fx.Vector.from_elements(
-                [values[chunk * 8 + element] for element in range_constexpr(8)],
-                fx.BFloat16,
-            ),
-            resource,
-            offset + fx.Int32(chunk * 8),
-        )
 
 
 @functools.cache
@@ -199,9 +176,10 @@ def compile_reduce_scatter(config: AtomicConfig):
                     shape.tp_size
                 )
                 source_base = peer_base(partial_base, source)
-                source_row = buffer_ops.create_buffer_resource_from_addr(
+                source_row = buffer_tensor_from_addr(
                     source_base + fx.Int64(global_token) * fx.Int64(h),
-                    num_records_bytes=h,
+                    fx.Int32,
+                    h,
                 )
                 words = load_fp8_words(
                     source_row,
@@ -210,11 +188,12 @@ def compile_reduce_scatter(config: AtomicConfig):
                     load_width=4,
                     cache_modifier=2,
                 )
-                scale_row = buffer_ops.create_buffer_resource_from_addr(
+                scale_row = buffer_tensor_from_addr(
                     source_base
                     + fx.Int64(config.m * h)
                     + fx.Int64(global_token) * fx.Int64(groups_per_row),
-                    num_records_bytes=groups_per_row,
+                    fx.Int8,
+                    groups_per_row,
                 )
                 values = decode_scaled_fp8_f32(
                     words, load_e8m0_scale(scale_row, group, 2)
@@ -238,9 +217,10 @@ def compile_reduce_scatter(config: AtomicConfig):
             e8m0, quant_scale = e8m0_scale(local_max)
             packed = pack_fp8_words(acc, quant_scale, VECTOR_WIDTH // 4)
 
-            payload_row = buffer_ops.create_buffer_resource_from_addr(
+            payload_row = buffer_tensor_from_addr(
                 fx.Int64(ptrtoint(payload)) + fx.Int64(local_token) * fx.Int64(h),
-                num_records_bytes=h,
+                fx.Int32,
+                h,
             )
             store_fp8_words(
                 payload_row,
@@ -249,27 +229,29 @@ def compile_reduce_scatter(config: AtomicConfig):
                 4,
             )
             if pack_in_group == fx.Int32(0):
-                scale_row = buffer_ops.create_buffer_resource_from_addr(
+                scale_row = buffer_tensor_from_addr(
                     fx.Int64(ptrtoint(scales))
                     + fx.Int64(local_token) * fx.Int64(groups_per_row),
-                    num_records_bytes=groups_per_row,
+                    fx.Int8,
+                    groups_per_row,
                 )
-                buffer_ops.buffer_store(
-                    e8m0.to(fx.Int8),
+                store_buffer(
                     scale_row,
                     group,
-                    offset_is_bytes=True,
+                    e8m0.to(fx.Int8),
+                    fx.Int8,
                 )
 
             decoded = decode_scaled_fp8_f32(
                 packed,
                 (fx.Uint32(e8m0) << fx.Uint32(23)).bitcast(fx.Float32),
             )
-            output_row = buffer_ops.create_buffer_resource_from_addr(
+            output_row = buffer_tensor_from_addr(
                 fx.Int64(ptrtoint(output)) + fx.Int64(local_token) * fx.Int64(h * 2),
-                num_records_bytes=h * 2,
+                fx.BFloat16,
+                h * 2,
             )
-            _store_bf16(output_row, column, decoded)
+            store_bf16(output_row, column, decoded, VECTOR_WIDTH)
 
     @flyc.jit
     def launch(partial_base, output, payload, scales, rank, stream):
@@ -309,14 +291,20 @@ def compile_all_gather(config: AtomicConfig):
         source_slot = worker % fx.Int32(source_count)
         source_block = worker // fx.Int32(source_count)
         source = (rank + source_slot + fx.Int32(1)) % fx.Int32(shape.tp_size)
-        payload = buffer_ops.create_buffer_resource_from_addr(
-            peer_base(payload_base, source), num_records_bytes=0xFFFFFFFF
+        payload = buffer_tensor_from_addr(
+            peer_base(payload_base, source),
+            fx.Int32,
+            config.shard_rows * h,
         )
-        scales = buffer_ops.create_buffer_resource_from_addr(
-            peer_base(scale_base, source), num_records_bytes=0xFFFFFFFF
+        scales = buffer_tensor_from_addr(
+            peer_base(scale_base, source),
+            fx.Int8,
+            config.shard_rows * groups_per_row,
         )
-        output_resource = buffer_ops.create_buffer_resource_from_addr(
-            fx.Int64(ptrtoint(output)), num_records_bytes=0xFFFFFFFF
+        output_resource = buffer_tensor_from_addr(
+            fx.Int64(ptrtoint(output)),
+            fx.BFloat16,
+            shape.tp_size * config.shard_rows * h * 2,
         )
         start = source_block * fx.Int32(BLOCK) + fx.Int32(gpu.thread_id("x"))
         for item in range(
@@ -334,15 +322,7 @@ def compile_all_gather(config: AtomicConfig):
                 cache_modifier=1,
             )
             loaded = fx.Uint32(
-                fx.Uint8(
-                    buffer_ops.buffer_load(
-                        scales,
-                        group_item,
-                        vec_width=1,
-                        dtype=T.i8,
-                        cache_modifier=1,
-                    )
-                )
+                fx.Uint8(load_buffer(scales, group_item, fx.Int8, cache_modifier=1))
             )
             scale = (loaded << fx.Uint32(23)).bitcast(fx.Float32)
             values = decode_scaled_fp8_f32(words, scale)
@@ -354,7 +334,7 @@ def compile_all_gather(config: AtomicConfig):
                 + group * fx.Int32(32)
                 + pack_in_group * fx.Int32(VECTOR_WIDTH)
             )
-            _store_bf16(output_resource, output_column, values)
+            store_bf16(output_resource, output_column, values, VECTOR_WIDTH)
 
     @flyc.jit
     def launch(payload_base, scale_base, output, rank, stream):

--- a/aiter/ops/flydsl/kernels/comm_fused_moe/gfx950/a8w4/collectives.py
+++ b/aiter/ops/flydsl/kernels/comm_fused_moe/gfx950/a8w4/collectives.py
@@ -1,0 +1,435 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Communication and synchronization primitives for comm-fused MoE."""
+
+import functools
+
+import flydsl.compiler as flyc
+import flydsl.expr as fx
+from flydsl._mlir import ir
+from flydsl._mlir.dialects import llvm as llvm_d
+from flydsl._mlir.dialects import scf
+from flydsl.expr import arith, gpu, ptrtoint, range_constexpr
+from flydsl.expr import math as fmath
+from flydsl.expr.typing import ReductionOp, T, as_ir_value
+
+from .... import buffer_ops
+from .... import communication_ops_utils as comm_ops
+
+FLAT_VA_RANK_STRIDE = 1 << 32
+
+
+def peer_base(flat_base, peer):
+    return flat_base + fx.Int64(peer) * fx.Int64(FLAT_VA_RANK_STRIDE)
+
+
+@functools.cache
+def compile_epoch_barrier(tp_size: int):
+    """Publish one symmetric workspace epoch and acquire all TP peers."""
+
+    @flyc.kernel(
+        name=f"comm_fused_moe_epoch_tp{tp_size}",
+        known_block_size=[64, 1, 1],
+    )
+    def kernel(
+        workspace: fx.Pointer,
+        flat_base: fx.Int64,
+        ready_offset: fx.Int64,
+    ):
+        tid = fx.Int32(gpu.thread_id("x"))
+        local_base = fx.Int64(ptrtoint(workspace))
+        expected = fx.Int64(
+            comm_ops.load_i64_global(local_base + ready_offset)
+        ) + fx.Int64(1)
+        if tid == fx.Int32(0):
+            comm_ops.store_i64_global_system(local_base + ready_offset, expected)
+        gpu.barrier()
+        if tid < fx.Int32(tp_size):
+            peer_addr = peer_base(flat_base, tid)
+            comm_ops.spin_until_ge_i64(peer_addr + ready_offset, expected)
+            comm_ops.fence_system_acquire()
+
+    def launch(workspace, flat_base, ready_offset, stream):
+        kernel(workspace, flat_base, ready_offset).launch(
+            grid=(1, 1, 1), block=(64, 1, 1), stream=stream
+        )
+
+    launch.__name__ = f"launch_comm_fused_moe_epoch_tp{tp_size}"
+    return flyc.jit(launch)
+
+
+def atomic_add_i32_agent(addr, value):
+    return llvm_d.AtomicRMWOp(
+        llvm_d.AtomicBinOp.add,
+        comm_ops._to_ptr_global(addr),
+        as_ir_value(value),
+        llvm_d.AtomicOrdering.monotonic,
+        syncscope=fx.rocdl.SyncScope.AgentOneAs,
+    ).res
+
+
+def wait_i32_system_until_at_least(addr, expected, *, acquire=False, sleep=True):
+    def load():
+        return llvm_d.LoadOp(
+            ir.IntegerType.get_signless(32),
+            comm_ops._to_ptr_global(addr),
+            alignment=4,
+            volatile_=True,
+            ordering=(
+                llvm_d.AtomicOrdering.acquire
+                if acquire
+                else llvm_d.AtomicOrdering.monotonic
+            ),
+            syncscope=fx.rocdl.SyncScope.OneAs,
+        ).result
+
+    loop = scf.WhileOp([T.i32], [load()])
+    before = ir.Block.create_at_start(loop.before, [T.i32])
+    after = ir.Block.create_at_start(loop.after, [T.i32])
+    with ir.InsertionPoint(before):
+        current = before.arguments[0]
+        waiting = arith.CmpIOp(
+            arith.CmpIPredicate.slt, current, as_ir_value(expected)
+        ).result
+        scf.ConditionOp(waiting, [current])
+    with ir.InsertionPoint(after):
+        if sleep:
+            llvm_d.InlineAsmOp(None, [], "s_sleep 1", "", has_side_effects=True)
+        scf.YieldOp([load()])
+    return loop.results[0]
+
+
+def wait_i32_agent_until_at_least(addr, expected, *, sleep=True):
+    def load():
+        return llvm_d.LoadOp(
+            ir.IntegerType.get_signless(32),
+            comm_ops._to_ptr_global(addr),
+            alignment=4,
+            volatile_=True,
+            ordering=llvm_d.AtomicOrdering.monotonic,
+            syncscope=fx.rocdl.SyncScope.AgentOneAs,
+        ).result
+
+    loop = scf.WhileOp([T.i32], [load()])
+    before = ir.Block.create_at_start(loop.before, [T.i32])
+    after = ir.Block.create_at_start(loop.after, [T.i32])
+    with ir.InsertionPoint(before):
+        current = before.arguments[0]
+        waiting = arith.CmpIOp(
+            arith.CmpIPredicate.slt, current, as_ir_value(expected)
+        ).result
+        scf.ConditionOp(waiting, [current])
+    with ir.InsertionPoint(after):
+        if sleep:
+            llvm_d.InlineAsmOp(None, [], "s_sleep 1", "", has_side_effects=True)
+        scf.YieldOp([load()])
+    return loop.results[0]
+
+
+def store_i32_relaxed(addr, value):
+    llvm_d.StoreOp(
+        as_ir_value(value),
+        comm_ops._to_ptr_global(addr),
+        alignment=4,
+    )
+
+
+def store_i32_agent_release(addr, value):
+    llvm_d.StoreOp(
+        as_ir_value(value),
+        comm_ops._to_ptr_global(addr),
+        alignment=4,
+        ordering=llvm_d.AtomicOrdering.release,
+        syncscope=fx.rocdl.SyncScope.AgentOneAs,
+    )
+
+
+def store_i32_system_monotonic(addr, value):
+    llvm_d.StoreOp(
+        as_ir_value(value),
+        comm_ops._to_ptr_global(addr),
+        alignment=4,
+        ordering=llvm_d.AtomicOrdering.monotonic,
+        syncscope=fx.rocdl.SyncScope.OneAs,
+    )
+
+
+def store_i32_system_release(addr, value):
+    llvm_d.StoreOp(
+        as_ir_value(value),
+        comm_ops._to_ptr_global(addr),
+        alignment=4,
+        ordering=llvm_d.AtomicOrdering.release,
+        syncscope=fx.rocdl.SyncScope.OneAs,
+    )
+
+
+def store_i64_relaxed(addr, value):
+    llvm_d.StoreOp(
+        as_ir_value(value),
+        comm_ops._to_ptr_global(addr),
+        alignment=8,
+    )
+
+
+def e8m0_scale(local_max):
+    working = (local_max * fx.Int32(0x3B124925).bitcast(fx.Float32)).bitcast(fx.Int32)
+    mantissa = working & fx.Int32(0x7FFFFF)
+    exponent = (working >> fx.Int32(23)) & fx.Int32(0xFF)
+    e8m0 = (mantissa != fx.Int32(0)).select(exponent + fx.Int32(1), exponent)
+    e8m0 = (e8m0 > fx.Int32(0xFF)).select(fx.Int32(0xFF), e8m0)
+    scale = ((fx.Int32(254) - e8m0) << fx.Int32(23)).bitcast(fx.Float32)
+    return e8m0, scale
+
+
+def pack_fp8_words(values, scale, word_count):
+    packed = []
+    for word in range_constexpr(word_count):
+        base = word * 4
+        value = fx.rocdl.cvt_pk_fp8_f32(
+            T.i32,
+            values[base] * scale,
+            values[base + 1] * scale,
+            fx.Int32(0),
+            0,
+        )
+        packed.append(
+            fx.rocdl.cvt_pk_fp8_f32(
+                T.i32,
+                values[base + 2] * scale,
+                values[base + 3] * scale,
+                value,
+                1,
+            )
+        )
+    return packed
+
+
+def quantize_group32(acc):
+    local_max = fx.Float32(1e-10).maximumf(fmath.absf(acc).reduce(ReductionOp.MAX))
+    e8m0, scale = e8m0_scale(local_max)
+    return e8m0, pack_fp8_words(acc, scale, 8)
+
+
+def decode_scaled_fp8_f32(words, scale):
+    values = []
+    for word in range_constexpr(len(words)):
+        for half in range_constexpr(2):
+            pair = fx.Vector(
+                fx.rocdl.cvt_scalef32_pk_bf16_fp8(
+                    T.vec(2, T.bf16),
+                    as_ir_value(words[word]),
+                    as_ir_value(scale),
+                    bool(half),
+                )
+            ).extf(T.vec(2, T.f32))
+            values.extend((pair[0], pair[1]))
+    return values
+
+
+def decode_group32(e8m0, packed):
+    scale = (fx.Uint32(e8m0) << fx.Uint32(23)).bitcast(fx.Float32)
+    values = []
+    for word in range_constexpr(8):
+        for half in range_constexpr(2):
+            pair = fx.Vector(
+                fx.rocdl.cvt_scalef32_pk_bf16_fp8(
+                    T.vec(2, T.bf16),
+                    as_ir_value(packed[word]),
+                    as_ir_value(scale),
+                    bool(half),
+                )
+            )
+            values.extend((pair[0], pair[1]))
+    return values
+
+
+def load_fp8_words(
+    resource,
+    offset,
+    *,
+    word_count,
+    load_width,
+    cache_modifier,
+):
+    words = []
+    for chunk in range_constexpr(word_count // load_width):
+        raw = fx.Vector(
+            buffer_ops.buffer_load(
+                resource,
+                offset + fx.Int32(chunk * load_width),
+                vec_width=load_width,
+                dtype=T.i32,
+                cache_modifier=cache_modifier,
+            )
+        )
+        words.extend(raw[word] for word in range_constexpr(load_width))
+    return words
+
+
+def load_e8m0_scale(resource, offset, cache_modifier):
+    e8m0 = buffer_ops.buffer_load(
+        resource,
+        offset,
+        vec_width=1,
+        dtype=T.i8,
+        cache_modifier=cache_modifier,
+    )
+    return (fx.Uint32(fx.Uint8(e8m0)) << fx.Uint32(23)).bitcast(fx.Float32)
+
+
+def store_fp8_words(resource, offset, packed, store_width, cache_modifier=0):
+    for chunk in range_constexpr(len(packed) // store_width):
+        begin = chunk * store_width
+        buffer_ops.buffer_store(
+            fx.Vector.from_elements(packed[begin : begin + store_width], fx.Int32),
+            resource,
+            offset + fx.Int32(begin * 4),
+            cache_modifier=cache_modifier,
+            offset_is_bytes=True,
+        )
+
+
+def _store_bf16_group32(resource, offset, values):
+    for chunk in range_constexpr(4):
+        buffer_ops.buffer_store(
+            fx.Vector.from_elements(
+                [values[chunk * 8 + element] for element in range_constexpr(8)],
+                fx.BFloat16,
+            ),
+            resource,
+            offset + fx.Int32(chunk * 8),
+        )
+
+
+@flyc.jit
+def emit_tp_reduce_scatter(
+    flat_base,
+    output,
+    payload,
+    scales,
+    rank,
+    worker,
+    *,
+    tokens,
+    output_width,
+    payload_width,
+    shard_rows,
+    tp,
+    block,
+    reduce_scatter_grid,
+):
+    groups_per_row = payload_width // 32
+    start = worker * fx.Int32(block) + fx.Int32(gpu.thread_id("x"))
+    for pack in range(
+        start,
+        fx.Int32(shard_rows * groups_per_row),
+        fx.Int32(reduce_scatter_grid * block),
+    ):
+        local_token = pack // fx.Int32(groups_per_row)
+        group = pack - local_token * fx.Int32(groups_per_row)
+        column = group * fx.Int32(32)
+        global_token = rank * fx.Int32(shard_rows) + local_token
+        acc = fx.Vector.filled(32, 0.0, fx.Float32)
+
+        for source_round in range_constexpr(tp):
+            source = (rank + local_token + fx.Int32(source_round)) % fx.Int32(tp)
+            base = peer_base(flat_base, source)
+            source_row = buffer_ops.create_buffer_resource_from_addr(
+                base + fx.Int64(global_token) * fx.Int64(payload_width),
+                num_records_bytes=payload_width,
+            )
+            words = load_fp8_words(
+                source_row,
+                column // fx.Int32(4),
+                word_count=8,
+                load_width=4,
+                cache_modifier=2,
+            )
+            scale_row = buffer_ops.create_buffer_resource_from_addr(
+                base
+                + fx.Int64(tokens * payload_width)
+                + fx.Int64(global_token) * fx.Int64(groups_per_row),
+                num_records_bytes=groups_per_row,
+            )
+            scale = load_e8m0_scale(scale_row, group, 2)
+            values = decode_scaled_fp8_f32(words, scale)
+            acc = acc + fx.Vector.from_elements(values, fx.Float32)
+
+        e8m0, packed = quantize_group32(acc)
+        payload_row = buffer_ops.create_buffer_resource_from_addr(
+            fx.Int64(ptrtoint(payload))
+            + fx.Int64(local_token) * fx.Int64(payload_width),
+            num_records_bytes=payload_width,
+        )
+        store_fp8_words(payload_row, column, packed, 4)
+        scale_row = buffer_ops.create_buffer_resource_from_addr(
+            fx.Int64(ptrtoint(scales))
+            + fx.Int64(local_token) * fx.Int64(groups_per_row),
+            num_records_bytes=groups_per_row,
+        )
+        buffer_ops.buffer_store(
+            e8m0.to(fx.Int8), scale_row, group, offset_is_bytes=True
+        )
+
+        decoded = decode_group32(e8m0, packed)
+        output_row = buffer_ops.create_buffer_resource_from_addr(
+            fx.Int64(ptrtoint(output))
+            + fx.Int64(local_token) * fx.Int64(output_width * 2),
+            num_records_bytes=output_width * 2,
+        )
+        _store_bf16_group32(output_row, column, decoded)
+
+
+@flyc.jit
+def emit_tp_all_gather(
+    payload_base,
+    scale_base,
+    output,
+    rank,
+    worker,
+    *,
+    output_width,
+    payload_width,
+    shard_rows,
+    tp,
+    block,
+    all_gather_grid,
+):
+    groups_per_row = payload_width // 32
+    source_slot = worker % fx.Int32(tp - 1)
+    source_block = worker // fx.Int32(tp - 1)
+    source = (rank + fx.Int32(1) + source_slot) % fx.Int32(tp)
+    payload = buffer_ops.create_buffer_resource_from_addr(
+        peer_base(payload_base, source), num_records_bytes=0xFFFFFFFF
+    )
+    scales = buffer_ops.create_buffer_resource_from_addr(
+        peer_base(scale_base, source), num_records_bytes=0xFFFFFFFF
+    )
+    output_rsrc = buffer_ops.create_buffer_resource_from_addr(
+        fx.Int64(ptrtoint(output)), num_records_bytes=0xFFFFFFFF
+    )
+    start = source_block * fx.Int32(block) + fx.Int32(gpu.thread_id("x"))
+    for group in range(
+        start,
+        fx.Int32(shard_rows * groups_per_row),
+        fx.Int32(all_gather_grid // (tp - 1) * block),
+    ):
+        words = load_fp8_words(
+            payload,
+            group * fx.Int32(8),
+            word_count=8,
+            load_width=4,
+            cache_modifier=1,
+        )
+        scale_raw = buffer_ops.buffer_load(
+            scales, group, vec_width=1, dtype=T.i8, cache_modifier=1
+        )
+        values = decode_group32(fx.Uint8(scale_raw), words)
+        shard_row = group // fx.Int32(groups_per_row)
+        group_in_row = group - shard_row * fx.Int32(groups_per_row)
+        output_column = (
+            source * fx.Int32(shard_rows * output_width)
+            + shard_row * fx.Int32(output_width)
+            + group_in_row * fx.Int32(32)
+        )
+        _store_bf16_group32(output_rsrc, output_column, values)

--- a/aiter/ops/flydsl/kernels/comm_fused_moe/gfx950/a8w4/collectives.py
+++ b/aiter/ops/flydsl/kernels/comm_fused_moe/gfx950/a8w4/collectives.py
@@ -5,21 +5,110 @@ import functools
 
 import flydsl.compiler as flyc
 import flydsl.expr as fx
-from flydsl._mlir import ir
-from flydsl._mlir.dialects import llvm as llvm_d
-from flydsl._mlir.dialects import scf
-from flydsl.expr import arith, gpu, ptrtoint, range_constexpr
+from flydsl.expr import gpu, ptrtoint, range_constexpr
 from flydsl.expr import math as fmath
 from flydsl.expr.typing import ReductionOp, T, as_ir_value
 
-from .... import buffer_ops
 from .... import communication_ops_utils as comm_ops
+from ....mxfp4_gemm_common import global_typed_ptr
+from ....tensor_shim import ptr_buf_tensor
 
 FLAT_VA_RANK_STRIDE = 1 << 32
 
 
 def peer_base(flat_base, peer):
     return flat_base + fx.Int64(peer) * fx.Int64(FLAT_VA_RANK_STRIDE)
+
+
+def buffer_tensor_from_addr(addr, elem, num_records_bytes):
+    """Create a bounded flat V# view over a raw global address."""
+    return ptr_buf_tensor(
+        global_typed_ptr(addr, elem.ir_type, align=max(1, elem.width // 8)),
+        elem,
+        num_records_bytes=num_records_bytes,
+    )
+
+
+def _buffer_copy_atom(elem, width, cache_modifier):
+    return fx.make_copy_atom(
+        fx.rocdl.BufferCopy(elem.width * width, cache_modifier), elem
+    )
+
+
+def load_buffer(buffer, offset, elem, *, width=1, cache_modifier=0):
+    fragment = fx.make_rmem_tensor(width, elem)
+    fx.copy(
+        _buffer_copy_atom(elem, width, cache_modifier),
+        fx.slice(
+            fx.logical_divide(buffer, fx.make_layout(width, 1)),
+            (None, offset // fx.Int32(width)),
+        ),
+        fragment,
+    )
+    value = fx.Vector(fx.memref_load_vec(fragment))
+    return value[0] if width == 1 else value
+
+
+def store_buffer(buffer, offset, value, elem, *, width=1, cache_modifier=0):
+    fragment = fx.make_rmem_tensor(width, elem)
+    if width == 1:
+        value = fx.Vector.from_elements([value], elem)
+    fx.memref_store_vec(value, fragment)
+    fx.copy(
+        _buffer_copy_atom(elem, width, cache_modifier),
+        fragment,
+        fx.slice(
+            fx.logical_divide(buffer, fx.make_layout(width, 1)),
+            (None, offset // fx.Int32(width)),
+        ),
+    )
+
+
+def load_bf16(buffer, offset, vector_width, cache_modifier):
+    if vector_width == 8:
+        return load_buffer(
+            buffer,
+            offset,
+            fx.BFloat16,
+            width=8,
+            cache_modifier=cache_modifier,
+        )
+    values = []
+    for chunk in range_constexpr(vector_width // 8):
+        loaded = load_buffer(
+            buffer,
+            offset + fx.Int32(chunk * 8),
+            fx.BFloat16,
+            width=8,
+            cache_modifier=cache_modifier,
+        )
+        values.extend(loaded[element] for element in range_constexpr(8))
+    return fx.Vector.from_elements(values, fx.BFloat16)
+
+
+def store_bf16(buffer, offset, values, vector_width, cache_modifier=0):
+    if vector_width == 8:
+        store_buffer(
+            buffer,
+            offset,
+            values,
+            fx.BFloat16,
+            width=8,
+            cache_modifier=cache_modifier,
+        )
+        return
+    for chunk in range_constexpr(vector_width // 8):
+        store_buffer(
+            buffer,
+            offset + fx.Int32(chunk * 8),
+            fx.Vector.from_elements(
+                [values[chunk * 8 + element] for element in range_constexpr(8)],
+                fx.BFloat16,
+            ),
+            fx.BFloat16,
+            width=8,
+            cache_modifier=cache_modifier,
+        )
 
 
 @functools.cache
@@ -55,120 +144,6 @@ def compile_epoch_barrier(tp_size: int):
 
     launch.__name__ = f"launch_comm_fused_moe_epoch_tp{tp_size}"
     return flyc.jit(launch)
-
-
-def atomic_add_i32_agent(addr, value):
-    return llvm_d.AtomicRMWOp(
-        llvm_d.AtomicBinOp.add,
-        comm_ops._to_ptr_global(addr),
-        as_ir_value(value),
-        llvm_d.AtomicOrdering.monotonic,
-        syncscope=fx.rocdl.SyncScope.AgentOneAs,
-    ).res
-
-
-def wait_i32_system_until_at_least(addr, expected, *, acquire=False, sleep=True):
-    def load():
-        return llvm_d.LoadOp(
-            ir.IntegerType.get_signless(32),
-            comm_ops._to_ptr_global(addr),
-            alignment=4,
-            volatile_=True,
-            ordering=(
-                llvm_d.AtomicOrdering.acquire
-                if acquire
-                else llvm_d.AtomicOrdering.monotonic
-            ),
-            syncscope=fx.rocdl.SyncScope.OneAs,
-        ).result
-
-    loop = scf.WhileOp([T.i32], [load()])
-    before = ir.Block.create_at_start(loop.before, [T.i32])
-    after = ir.Block.create_at_start(loop.after, [T.i32])
-    with ir.InsertionPoint(before):
-        current = before.arguments[0]
-        waiting = arith.CmpIOp(
-            arith.CmpIPredicate.slt, current, as_ir_value(expected)
-        ).result
-        scf.ConditionOp(waiting, [current])
-    with ir.InsertionPoint(after):
-        if sleep:
-            llvm_d.InlineAsmOp(None, [], "s_sleep 1", "", has_side_effects=True)
-        scf.YieldOp([load()])
-    return loop.results[0]
-
-
-def wait_i32_agent_until_at_least(addr, expected, *, sleep=True):
-    def load():
-        return llvm_d.LoadOp(
-            ir.IntegerType.get_signless(32),
-            comm_ops._to_ptr_global(addr),
-            alignment=4,
-            volatile_=True,
-            ordering=llvm_d.AtomicOrdering.monotonic,
-            syncscope=fx.rocdl.SyncScope.AgentOneAs,
-        ).result
-
-    loop = scf.WhileOp([T.i32], [load()])
-    before = ir.Block.create_at_start(loop.before, [T.i32])
-    after = ir.Block.create_at_start(loop.after, [T.i32])
-    with ir.InsertionPoint(before):
-        current = before.arguments[0]
-        waiting = arith.CmpIOp(
-            arith.CmpIPredicate.slt, current, as_ir_value(expected)
-        ).result
-        scf.ConditionOp(waiting, [current])
-    with ir.InsertionPoint(after):
-        if sleep:
-            llvm_d.InlineAsmOp(None, [], "s_sleep 1", "", has_side_effects=True)
-        scf.YieldOp([load()])
-    return loop.results[0]
-
-
-def store_i32_relaxed(addr, value):
-    llvm_d.StoreOp(
-        as_ir_value(value),
-        comm_ops._to_ptr_global(addr),
-        alignment=4,
-    )
-
-
-def store_i32_agent_release(addr, value):
-    llvm_d.StoreOp(
-        as_ir_value(value),
-        comm_ops._to_ptr_global(addr),
-        alignment=4,
-        ordering=llvm_d.AtomicOrdering.release,
-        syncscope=fx.rocdl.SyncScope.AgentOneAs,
-    )
-
-
-def store_i32_system_monotonic(addr, value):
-    llvm_d.StoreOp(
-        as_ir_value(value),
-        comm_ops._to_ptr_global(addr),
-        alignment=4,
-        ordering=llvm_d.AtomicOrdering.monotonic,
-        syncscope=fx.rocdl.SyncScope.OneAs,
-    )
-
-
-def store_i32_system_release(addr, value):
-    llvm_d.StoreOp(
-        as_ir_value(value),
-        comm_ops._to_ptr_global(addr),
-        alignment=4,
-        ordering=llvm_d.AtomicOrdering.release,
-        syncscope=fx.rocdl.SyncScope.OneAs,
-    )
-
-
-def store_i64_relaxed(addr, value):
-    llvm_d.StoreOp(
-        as_ir_value(value),
-        comm_ops._to_ptr_global(addr),
-        alignment=8,
-    )
 
 
 def e8m0_scale(local_max):
@@ -221,7 +196,7 @@ def decode_scaled_fp8_f32(words, scale):
                     as_ir_value(scale),
                     bool(half),
                 )
-            ).extf(T.vec(2, T.f32))
+            ).to(fx.Float32)
             values.extend((pair[0], pair[1]))
     return values
 
@@ -244,8 +219,8 @@ def decode_group32(e8m0, packed):
 
 
 def load_fp8_words(
-    resource,
-    offset,
+    buffer,
+    word_offset,
     *,
     word_count,
     load_width,
@@ -253,51 +228,33 @@ def load_fp8_words(
 ):
     words = []
     for chunk in range_constexpr(word_count // load_width):
-        raw = fx.Vector(
-            buffer_ops.buffer_load(
-                resource,
-                offset + fx.Int32(chunk * load_width),
-                vec_width=load_width,
-                dtype=T.i32,
-                cache_modifier=cache_modifier,
-            )
+        raw = load_buffer(
+            buffer,
+            word_offset + fx.Int32(chunk * load_width),
+            fx.Int32,
+            width=load_width,
+            cache_modifier=cache_modifier,
         )
         words.extend(raw[word] for word in range_constexpr(load_width))
     return words
 
 
-def load_e8m0_scale(resource, offset, cache_modifier):
-    e8m0 = buffer_ops.buffer_load(
-        resource,
-        offset,
-        vec_width=1,
-        dtype=T.i8,
-        cache_modifier=cache_modifier,
-    )
+def load_e8m0_scale(buffer, offset, cache_modifier):
+    e8m0 = load_buffer(buffer, offset, fx.Int8, cache_modifier=cache_modifier)
     return (fx.Uint32(fx.Uint8(e8m0)) << fx.Uint32(23)).bitcast(fx.Float32)
 
 
-def store_fp8_words(resource, offset, packed, store_width, cache_modifier=0):
+def store_fp8_words(buffer, byte_offset, packed, store_width, cache_modifier=0):
+    word_offset = byte_offset // fx.Int32(4)
     for chunk in range_constexpr(len(packed) // store_width):
         begin = chunk * store_width
-        buffer_ops.buffer_store(
+        store_buffer(
+            buffer,
+            word_offset + fx.Int32(begin),
             fx.Vector.from_elements(packed[begin : begin + store_width], fx.Int32),
-            resource,
-            offset + fx.Int32(begin * 4),
+            fx.Int32,
+            width=store_width,
             cache_modifier=cache_modifier,
-            offset_is_bytes=True,
-        )
-
-
-def _store_bf16_group32(resource, offset, values):
-    for chunk in range_constexpr(4):
-        buffer_ops.buffer_store(
-            fx.Vector.from_elements(
-                [values[chunk * 8 + element] for element in range_constexpr(8)],
-                fx.BFloat16,
-            ),
-            resource,
-            offset + fx.Int32(chunk * 8),
         )
 
 
@@ -334,9 +291,10 @@ def emit_tp_reduce_scatter(
         for source_round in range_constexpr(tp):
             source = (rank + local_token + fx.Int32(source_round)) % fx.Int32(tp)
             base = peer_base(flat_base, source)
-            source_row = buffer_ops.create_buffer_resource_from_addr(
+            source_row = buffer_tensor_from_addr(
                 base + fx.Int64(global_token) * fx.Int64(payload_width),
-                num_records_bytes=payload_width,
+                fx.Int32,
+                payload_width,
             )
             words = load_fp8_words(
                 source_row,
@@ -345,39 +303,46 @@ def emit_tp_reduce_scatter(
                 load_width=4,
                 cache_modifier=2,
             )
-            scale_row = buffer_ops.create_buffer_resource_from_addr(
+            scale_row = buffer_tensor_from_addr(
                 base
                 + fx.Int64(tokens * payload_width)
                 + fx.Int64(global_token) * fx.Int64(groups_per_row),
-                num_records_bytes=groups_per_row,
+                fx.Int8,
+                groups_per_row,
             )
             scale = load_e8m0_scale(scale_row, group, 2)
             values = decode_scaled_fp8_f32(words, scale)
             acc = acc + fx.Vector.from_elements(values, fx.Float32)
 
         e8m0, packed = quantize_group32(acc)
-        payload_row = buffer_ops.create_buffer_resource_from_addr(
+        payload_row = buffer_tensor_from_addr(
             fx.Int64(ptrtoint(payload))
             + fx.Int64(local_token) * fx.Int64(payload_width),
-            num_records_bytes=payload_width,
+            fx.Int32,
+            payload_width,
         )
         store_fp8_words(payload_row, column, packed, 4)
-        scale_row = buffer_ops.create_buffer_resource_from_addr(
+        scale_row = buffer_tensor_from_addr(
             fx.Int64(ptrtoint(scales))
             + fx.Int64(local_token) * fx.Int64(groups_per_row),
-            num_records_bytes=groups_per_row,
+            fx.Int8,
+            groups_per_row,
         )
-        buffer_ops.buffer_store(
-            e8m0.to(fx.Int8), scale_row, group, offset_is_bytes=True
+        store_buffer(
+            scale_row,
+            group,
+            e8m0.to(fx.Int8),
+            fx.Int8,
         )
 
         decoded = decode_group32(e8m0, packed)
-        output_row = buffer_ops.create_buffer_resource_from_addr(
+        output_row = buffer_tensor_from_addr(
             fx.Int64(ptrtoint(output))
             + fx.Int64(local_token) * fx.Int64(output_width * 2),
-            num_records_bytes=output_width * 2,
+            fx.BFloat16,
+            output_width * 2,
         )
-        _store_bf16_group32(output_row, column, decoded)
+        store_bf16(output_row, column, decoded, 32)
 
 
 @flyc.jit
@@ -399,14 +364,20 @@ def emit_tp_all_gather(
     source_slot = worker % fx.Int32(tp - 1)
     source_block = worker // fx.Int32(tp - 1)
     source = (rank + fx.Int32(1) + source_slot) % fx.Int32(tp)
-    payload = buffer_ops.create_buffer_resource_from_addr(
-        peer_base(payload_base, source), num_records_bytes=0xFFFFFFFF
+    payload = buffer_tensor_from_addr(
+        peer_base(payload_base, source),
+        fx.Int32,
+        shard_rows * payload_width,
     )
-    scales = buffer_ops.create_buffer_resource_from_addr(
-        peer_base(scale_base, source), num_records_bytes=0xFFFFFFFF
+    scales = buffer_tensor_from_addr(
+        peer_base(scale_base, source),
+        fx.Int8,
+        shard_rows * groups_per_row,
     )
-    output_rsrc = buffer_ops.create_buffer_resource_from_addr(
-        fx.Int64(ptrtoint(output)), num_records_bytes=0xFFFFFFFF
+    output_buffer = buffer_tensor_from_addr(
+        fx.Int64(ptrtoint(output)),
+        fx.BFloat16,
+        tp * shard_rows * output_width * 2,
     )
     start = source_block * fx.Int32(block) + fx.Int32(gpu.thread_id("x"))
     for group in range(
@@ -421,9 +392,7 @@ def emit_tp_all_gather(
             load_width=4,
             cache_modifier=1,
         )
-        scale_raw = buffer_ops.buffer_load(
-            scales, group, vec_width=1, dtype=T.i8, cache_modifier=1
-        )
+        scale_raw = load_buffer(scales, group, fx.Int8, cache_modifier=1)
         values = decode_group32(fx.Uint8(scale_raw), words)
         shard_row = group // fx.Int32(groups_per_row)
         group_in_row = group - shard_row * fx.Int32(groups_per_row)
@@ -432,4 +401,4 @@ def emit_tp_all_gather(
             + shard_row * fx.Int32(output_width)
             + group_in_row * fx.Int32(32)
         )
-        _store_bf16_group32(output_rsrc, output_column, values)
+        store_bf16(output_buffer, output_column, values, 32)

--- a/aiter/ops/flydsl/kernels/comm_fused_moe/gfx950/a8w4/config.py
+++ b/aiter/ops/flydsl/kernels/comm_fused_moe/gfx950/a8w4/config.py
@@ -1,0 +1,537 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Configuration and workspace layouts for gfx950 A8W4 comm-fused MoE."""
+
+from dataclasses import dataclass
+
+BLOCK = 256
+SLOTS = 2
+PRODUCER_COUNTER_STRIDE = 64
+
+SUPPORTED_TP_SIZES = (2, 4, 8)
+
+
+@dataclass(frozen=True, slots=True)
+class Shape:
+    """Model dimensions specialized into one generated kernel."""
+
+    model_dim: int
+    inter_dim: int
+    experts: int
+    topk: int
+    tp_size: int = 8
+
+    def __post_init__(self):
+        for name, value in (
+            ("model_dim", self.model_dim),
+            ("inter_dim", self.inter_dim),
+            ("experts", self.experts),
+            ("topk", self.topk),
+        ):
+            if value <= 0:
+                raise ValueError(f"{name} must be positive, got {value}")
+        if self.model_dim % 32:
+            raise ValueError(
+                "model_dim must be divisible by the 32-column MXFP8 scale "
+                f"group, got {self.model_dim}"
+            )
+        if self.inter_dim % 128:
+            raise ValueError(
+                "inter_dim must be divisible by the 128-element shuffled "
+                f"A8W4 K block, got {self.inter_dim}"
+            )
+        if self.tp_size not in SUPPORTED_TP_SIZES:
+            raise ValueError(
+                "gfx950 A8W4 GEMM2/TP currently requires TP in "
+                f"{SUPPORTED_TP_SIZES}, "
+                f"got {self.tp_size}"
+            )
+
+    @property
+    def tag(self) -> str:
+        return (
+            f"h{self.model_dim}_i{self.inter_dim}_e{self.experts}"
+            f"_k{self.topk}_tp{self.tp_size}"
+        )
+
+
+def _align_up(value: int, alignment: int) -> int:
+    return (value + alignment - 1) // alignment * alignment
+
+
+def _mxfp8_scale_bytes(payload_bytes: int, vector_width: int) -> int:
+    if vector_width == 8:
+        return payload_bytes // 32
+    return payload_bytes * 4 // vector_width
+
+
+@dataclass(frozen=True)
+class MegakernelConfig:
+    """Configuration for the single-launch GEMM2 + TP collective kernel."""
+
+    shape: Shape
+    m: int
+    tile_m: int = 16
+    tile_n: int = 256
+    tile_k: int = 128
+    sort_block_m: int = 32
+    compute_groups: int = 96
+    block_threads: int = BLOCK
+    vector_width: int = 16
+    waves_per_eu: int = 0
+    b_cache_modifier: int = 0
+    local_load_cache_modifier: int = 1
+    remote_load_cache_modifier: int = 1
+    gather_load_cache_modifier: int = -1
+    remote_store_cache_modifier: int = 0
+    n_tile_cohort: int = 0
+    collective: str = "direct"
+    service_groups: int = 1
+    service_tile_group: int = 1
+    producer_mode: str = "routes"
+    flat_producer_grid: bool = False
+
+    def __post_init__(self):
+        if self.m <= 0:
+            raise ValueError(f"m must be positive, got {self.m}")
+        if self.vector_width not in (8, 16):
+            raise ValueError(
+                "production GEMM2 TP megakernel requires vector_width 8 or 16"
+            )
+        if self.sort_block_m <= 0:
+            raise ValueError(f"sort_block_m must be positive, got {self.sort_block_m}")
+        if self.tile_m <= 0 or self.tile_n <= 0 or self.tile_k <= 0:
+            raise ValueError(
+                "tile sizes must be positive, got "
+                f"{(self.tile_m, self.tile_n, self.tile_k)}"
+            )
+        if self.tile_m not in (16, 32, 64, 128):
+            raise ValueError(f"unsupported tile_m={self.tile_m}")
+        if self.tile_n not in (128, 256, 512):
+            raise ValueError(f"unsupported tile_n={self.tile_n}")
+        if self.tile_k not in (128, 256):
+            raise ValueError(f"unsupported tile_k={self.tile_k}")
+        if self.shape.model_dim % self.tile_n:
+            raise ValueError(
+                f"model_dim={self.shape.model_dim} must be divisible by "
+                f"tile_n={self.tile_n}"
+            )
+        if self.shape.inter_dim % self.tile_k:
+            raise ValueError(
+                f"inter_dim={self.shape.inter_dim} must be divisible by "
+                f"tile_k={self.tile_k}"
+            )
+        if self.sort_block_m % self.tile_m:
+            raise ValueError(
+                "sort_block_m must be divisible by tile_m, got "
+                f"sort_block_m={self.sort_block_m}, tile_m={self.tile_m}"
+            )
+        if self.tile_n % self.vector_width:
+            raise ValueError(
+                "tile_n must be divisible by vector_width, got "
+                f"tile_n={self.tile_n}, vector_width={self.vector_width}"
+            )
+        if self.b_cache_modifier not in (0, 2):
+            raise ValueError(
+                "MXMoE GEMM2 producer requires b_cache_modifier 0 or 2, got "
+                f"{self.b_cache_modifier}"
+            )
+        if not 0 <= self.waves_per_eu <= 10:
+            raise ValueError(
+                f"waves_per_eu must be in [0, 10], got {self.waves_per_eu}"
+            )
+        if self.compute_groups <= 0:
+            raise ValueError(
+                f"compute_groups must be positive, got {self.compute_groups}"
+            )
+        if self.block_threads != BLOCK:
+            raise ValueError(
+                f"MXMoE GEMM2 producer requires block_threads={BLOCK}, "
+                f"got {self.block_threads}"
+            )
+        num_waves = self.block_threads // 64
+        if self.tile_n % (num_waves * 16):
+            raise ValueError(
+                "tile_n must provide an integral number of 16-column MFMA "
+                "tiles per wave, got "
+                f"tile_n={self.tile_n}, block_threads={self.block_threads}"
+            )
+        if self.local_load_cache_modifier not in (0, 1, 2, 3):
+            raise ValueError("local_load_cache_modifier must be in [0, 3]")
+        if self.remote_load_cache_modifier not in (0, 1, 2, 3):
+            raise ValueError("remote_load_cache_modifier must be in [0, 3]")
+        if self.gather_load_cache_modifier not in (-1, 0, 1, 2, 3):
+            raise ValueError("gather_load_cache_modifier must be -1 or in [0, 3]")
+        if self.remote_store_cache_modifier not in (0, 1, 2, 3):
+            raise ValueError("remote_store_cache_modifier must be in [0, 3]")
+        if self.n_tile_cohort < 0:
+            raise ValueError(
+                f"n_tile_cohort must be non-negative, got {self.n_tile_cohort}"
+            )
+        if self.n_tile_cohort and self.n_tiles % self.n_tile_cohort:
+            raise ValueError(
+                "n_tile_cohort must divide n_tiles, got "
+                f"n_tile_cohort={self.n_tile_cohort}, n_tiles={self.n_tiles}"
+            )
+        if self.collective not in (
+            "direct",
+            "rsag",
+            "rs_broadcast",
+        ):
+            raise ValueError(
+                "collective must be 'direct', 'rsag', or 'rs_broadcast', got "
+                f"{self.collective!r}"
+            )
+        if not 1 <= self.service_groups <= self.compute_groups:
+            raise ValueError(
+                "service_groups must be in [1, compute_groups], got "
+                f"service_groups={self.service_groups}, "
+                f"compute_groups={self.compute_groups}"
+            )
+        if self.collective != "rsag" and self.service_groups != 1:
+            raise ValueError(
+                "direct and rs_broadcast collectives require service_groups=1"
+            )
+        if self.collective == "rsag" and (
+            self.service_groups not in (1, 2, 4, 8)
+            or self.service_groups > self.shape.tp_size
+            or self.shape.tp_size % self.service_groups
+        ):
+            raise ValueError(
+                "rsag service_groups must be a supported divisor of TP, got "
+                f"service_groups={self.service_groups}, "
+                f"TP={self.shape.tp_size}"
+            )
+        if self.service_tile_group <= 0 or self.n_tiles % self.service_tile_group:
+            raise ValueError(
+                "service_tile_group must be a positive divisor of n_tiles, got "
+                f"service_tile_group={self.service_tile_group}, "
+                f"n_tiles={self.n_tiles}"
+            )
+        if self.service_tile_group > 1 and (
+            self.collective != "rsag" or self.service_groups == 1
+        ):
+            raise ValueError(
+                "grouped service synchronization requires collective='rsag' "
+                "and service_groups > 1"
+            )
+        if self.producer_mode not in ("routes", "atomic_shared"):
+            raise ValueError(
+                "producer_mode must be 'routes' or 'atomic_shared', got "
+                f"{self.producer_mode!r}"
+            )
+        if self.flat_producer_grid and self.collective == "direct":
+            raise ValueError("flat_producer_grid requires a dynamic collective path")
+        if self.flat_producer_grid and self.n_tile_cohort:
+            raise ValueError(
+                "flat_producer_grid and n_tile_cohort are mutually exclusive"
+            )
+        if self.collective == "direct" and self.producer_mode != "routes":
+            raise ValueError("direct production path requires producer_mode='routes'")
+        if self.collective != "rsag" and self.gather_load_cache_modifier != -1:
+            raise ValueError("gather_load_cache_modifier only applies to rsag")
+        if self.collective == "direct" and self.remote_store_cache_modifier != 0:
+            raise ValueError("remote_store_cache_modifier does not apply to direct")
+        if self.producer_mode == "atomic_shared" and self.collective != "rs_broadcast":
+            raise ValueError(
+                "atomic_shared production requires collective='rs_broadcast'"
+            )
+        if self.uses_rsag and self.m % self.shape.tp_size:
+            raise ValueError(
+                f"m={self.m} must be divisible by TP={self.shape.tp_size} "
+                f"for collective={self.collective!r}"
+            )
+        if (
+            self.uses_rsag
+            and (self.m * self.tile_n // self.vector_width) % self.shape.tp_size
+        ):
+            raise ValueError("rsag vector items must divide evenly across TP ranks")
+
+    @property
+    def n_tiles(self) -> int:
+        return self.shape.model_dim // self.tile_n
+
+    @property
+    def uses_rsag(self) -> bool:
+        return self.collective in ("rsag", "rs_broadcast")
+
+    @property
+    def shared_bf16_partials(self) -> bool:
+        return self.collective == "rs_broadcast"
+
+    @property
+    def wide_partial_scales(self) -> bool:
+        return (
+            self.collective == "direct"
+            and self.tile_n == 256
+            and (
+                self.m == 4
+                or (self.m in (1, 2) and self.vector_width == 8)
+                or (self.m == 8 and self.vector_width == 16)
+            )
+        )
+
+    @property
+    def single_pass_direct(self) -> bool:
+        return bool(
+            self.collective == "direct"
+            and self.m * self.tile_n // self.vector_width <= self.block_threads
+        )
+
+    @property
+    def producer_rows(self) -> int:
+        route_rows = self.m * self.shape.topk
+        # Sorting pads each non-empty expert independently to sort_block_m.
+        max_sort_blocks = (
+            route_rows
+            if route_rows <= self.shape.experts
+            else self.shape.experts
+            + (route_rows - self.shape.experts) // self.sort_block_m
+        )
+        return max_sort_blocks * self.sort_block_m // self.tile_m
+
+    @property
+    def payload_bytes(self) -> int:
+        return self.m * self.shape.model_dim * 2
+
+    @property
+    def partial_bytes(self) -> int:
+        return _align_up(self.partial_payload_bytes + self.partial_scale_bytes, 16)
+
+    @property
+    def partial_payload_bytes(self) -> int:
+        return self.m * self.shape.model_dim
+
+    @property
+    def partial_scale_bytes(self) -> int:
+        if self.shared_bf16_partials:
+            return 0
+        if self.wide_partial_scales:
+            return self.partial_payload_bytes // 8
+        return _mxfp8_scale_bytes(self.partial_payload_bytes, self.vector_width)
+
+    @property
+    def reduced_payload_bytes(self) -> int:
+        if not self.uses_rsag:
+            return 0
+        element_bytes = 2 if self.shared_bf16_partials else 1
+        return self.m * self.shape.model_dim * element_bytes // self.shape.tp_size
+
+    @property
+    def reduced_scale_bytes(self) -> int:
+        if not self.uses_rsag or self.shared_bf16_partials:
+            return 0
+        return _mxfp8_scale_bytes(self.reduced_payload_bytes, self.vector_width)
+
+    @property
+    def reduced_shard_bytes(self) -> int:
+        return _align_up(self.reduced_payload_bytes + self.reduced_scale_bytes, 16)
+
+    @property
+    def reduced_offset(self) -> int:
+        return SLOTS * self.partial_bytes
+
+    @property
+    def route_offset(self) -> int:
+        return self.reduced_offset + SLOTS * self.reduced_shard_bytes
+
+    @property
+    def route_bytes(self) -> int:
+        if self.producer_mode == "routes":
+            return self.m * self.shape.topk * self.shape.model_dim * 2
+        return SLOTS * self.payload_bytes
+
+    @property
+    def output_offset(self) -> int:
+        return self.route_offset + self.route_bytes
+
+    @property
+    def producer_done_offset(self) -> int:
+        return self.output_offset + self.payload_bytes
+
+    @property
+    def producer_counter_slots(self) -> int:
+        return SLOTS if self.producer_mode == "atomic_shared" else 1
+
+    @property
+    def epoch_offset(self) -> int:
+        return self.gather_service_done_offset + self.n_tiles * 8
+
+    @property
+    def service_done_offset(self) -> int:
+        return (
+            self.producer_done_offset
+            + self.n_tiles * self.producer_counter_slots * PRODUCER_COUNTER_STRIDE
+        )
+
+    @property
+    def reduce_done_offset(self) -> int:
+        return self.service_done_offset + self.n_tiles * 8
+
+    @property
+    def gather_service_done_offset(self) -> int:
+        return self.reduce_done_offset + self.n_tiles * 8
+
+    @property
+    def rank_ready_offset(self) -> int:
+        return self.epoch_offset + self.n_tiles * 8
+
+    @property
+    def flat_base_offset(self) -> int:
+        return _align_up(
+            self.gather_done_offset
+            + (self.n_tiles * self.shape.tp_size * 4 if self.uses_rsag else 0),
+            8,
+        )
+
+    @property
+    def gather_done_offset(self) -> int:
+        return self.owner_ready_offset + (
+            self.n_tiles * self.shape.tp_size * 4
+            if self.uses_rsag
+            else self.n_tiles * 4
+        )
+
+    @property
+    def owner_ready_offset(self) -> int:
+        return self.reduced_collective_ready_offset + self.n_tiles * 4
+
+    @property
+    def reduced_collective_ready_offset(self) -> int:
+        return self.collective_ready_offset + self.n_tiles * 4
+
+    @property
+    def collective_ready_offset(self) -> int:
+        return self.rank_ready_offset + self.n_tiles * self.shape.tp_size * 4
+
+    @property
+    def workspace_bytes(self) -> int:
+        return _align_up(self.flat_base_offset + 8, 256)
+
+
+@dataclass(frozen=True)
+class AtomicConfig:
+    shape: Shape
+    m: int
+    reduce_scatter_grid: int
+    all_gather_grid: int
+
+    def __post_init__(self):
+        if self.m <= 0 or self.m % self.shape.tp_size:
+            raise ValueError(
+                f"m={self.m} must be a positive multiple of " f"TP={self.shape.tp_size}"
+            )
+        if self.reduce_scatter_grid <= 0:
+            raise ValueError(
+                "reduce_scatter_grid must be positive, got "
+                f"{self.reduce_scatter_grid}"
+            )
+        source_count = self.shape.tp_size - 1
+        if self.all_gather_grid < source_count or self.all_gather_grid % source_count:
+            raise ValueError(
+                "all_gather_grid must be a positive multiple of TP-1, got "
+                f"all_gather_grid={self.all_gather_grid}, TP={self.shape.tp_size}"
+            )
+
+    @property
+    def shard_rows(self) -> int:
+        return self.m // self.shape.tp_size
+
+
+@dataclass(frozen=True)
+class WindowConfig:
+    shape: Shape
+    m: int
+    tile_m: int
+    tile_n: int
+    tile_k: int
+    sort_block_m: int
+    window: int
+    local_workers: int
+    reduce_scatter_grid: int
+    all_gather_grid: int
+
+    def __post_init__(self):
+        if self.m <= 0:
+            raise ValueError(f"m must be positive, got {self.m}")
+        for name, value in (
+            ("tile_m", self.tile_m),
+            ("tile_n", self.tile_n),
+            ("tile_k", self.tile_k),
+            ("sort_block_m", self.sort_block_m),
+            ("window", self.window),
+            ("local_workers", self.local_workers),
+            ("reduce_scatter_grid", self.reduce_scatter_grid),
+            ("all_gather_grid", self.all_gather_grid),
+        ):
+            if value <= 0:
+                raise ValueError(f"{name} must be positive, got {value}")
+        if self.tile_m not in (16, 32, 64, 128):
+            raise ValueError(f"unsupported tile_m={self.tile_m}")
+        if self.tile_n not in (128, 256, 512):
+            raise ValueError(f"unsupported tile_n={self.tile_n}")
+        if self.tile_k not in (128, 256):
+            raise ValueError(f"unsupported tile_k={self.tile_k}")
+        divisibility = (
+            ("m", self.m, "tp_size", self.shape.tp_size),
+            ("model_dim", self.shape.model_dim, "window", self.window),
+            ("window", self.window, "tile_n", self.tile_n),
+            ("window", self.window, "MXFP8 group", 32),
+            ("inter_dim", self.shape.inter_dim, "tile_k", self.tile_k),
+            ("sort_block_m", self.sort_block_m, "tile_m", self.tile_m),
+        )
+        for value_name, value, divisor_name, divisor in divisibility:
+            if divisor <= 0 or value % divisor:
+                raise ValueError(
+                    f"{value_name}={value} must be divisible by "
+                    f"{divisor_name}={divisor}"
+                )
+        if self.shape.model_dim // self.window < 3:
+            raise ValueError(
+                "window pipeline requires at least three phases, got "
+                f"model_dim={self.shape.model_dim}, window={self.window}"
+            )
+        source_count = self.shape.tp_size - 1
+        if self.all_gather_grid % source_count:
+            raise ValueError(
+                "all_gather_grid must be a multiple of TP-1, got "
+                f"all_gather_grid={self.all_gather_grid}, TP={self.shape.tp_size}"
+            )
+        if self.local_workers > self.compute_workers:
+            raise ValueError(
+                "local_workers cannot exceed the compute grid, got "
+                f"local_workers={self.local_workers}, "
+                f"compute_workers={self.compute_workers}"
+            )
+        service_grid = max(self.reduce_scatter_grid, self.all_gather_grid)
+        if self.compute_workers < 2 * service_grid:
+            raise ValueError(
+                "paired window services require at least two compute workers "
+                "per service worker, got "
+                f"compute_workers={self.compute_workers}, service_grid={service_grid}"
+            )
+
+    @property
+    def shard_rows(self) -> int:
+        return self.m // self.shape.tp_size
+
+    @property
+    def tiles_per_window(self) -> int:
+        return self.window // self.tile_n
+
+    @property
+    def groups_per_row(self) -> int:
+        return self.window // 32
+
+    @property
+    def compute_workers(self) -> int:
+        max_sorted = (
+            self.m * self.shape.topk
+            + self.shape.experts * self.sort_block_m
+            - self.shape.topk
+        )
+        sort_blocks = (max_sorted + self.sort_block_m - 1) // self.sort_block_m
+        producer_rows = sort_blocks * self.sort_block_m // self.tile_m
+        return producer_rows * self.tiles_per_window
+
+
+PipelineConfig = MegakernelConfig | AtomicConfig | WindowConfig

--- a/aiter/ops/flydsl/kernels/comm_fused_moe/gfx950/a8w4/megakernel.py
+++ b/aiter/ops/flydsl/kernels/comm_fused_moe/gfx950/a8w4/megakernel.py
@@ -12,52 +12,30 @@ import hashlib
 
 import flydsl.compiler as flyc
 import flydsl.expr as fx
-from flydsl._mlir import ir
-from flydsl.compiler.kernel_function import CompilationContext
 from flydsl.expr import const_expr, gpu, ptrtoint, range_constexpr, rocdl
 from flydsl.expr import math as fmath
 from flydsl.expr.typing import ReductionOp, T, as_ir_value
 
-from .... import buffer_ops
 from .... import communication_ops_utils as comm_ops
 from ....mxfp4_gemm_common import global_typed_ptr, lds_typed_ptr
 from .collectives import (
-    atomic_add_i32_agent,
+    buffer_tensor_from_addr,
     decode_scaled_fp8_f32,
     e8m0_scale,
+    load_bf16,
+    load_buffer,
     load_e8m0_scale,
     load_fp8_words,
     pack_fp8_words,
     peer_base,
+    store_bf16,
+    store_buffer,
     store_fp8_words,
-    store_i32_agent_release,
-    store_i32_relaxed,
-    store_i32_system_monotonic,
-    store_i32_system_release,
-    store_i64_relaxed,
-    wait_i32_agent_until_at_least,
-    wait_i32_system_until_at_least,
 )
 from .config import PRODUCER_COUNTER_STRIDE, SLOTS, MegakernelConfig
 from .producer import compile_megakernel_producer
 
 CPOL_COHERENT = 0x1 | 0x10
-
-
-def _load_bf16(resource, offset, vector_width, cache_modifier):
-    values = []
-    for chunk in range_constexpr(vector_width // 8):
-        loaded = fx.Vector(
-            buffer_ops.buffer_load(
-                resource,
-                offset + fx.Int32(chunk * 8),
-                vec_width=8,
-                dtype=T.bf16,
-                cache_modifier=cache_modifier,
-            )
-        )
-        values.extend(loaded[element] for element in range_constexpr(8))
-    return fx.Vector.from_elements(values, fx.BFloat16)
 
 
 def _decode_scaled_fp8_bf16(words, scale):
@@ -96,8 +74,8 @@ def _mxfp8_scale(values, lane, vector_width):
 
 @flyc.jit
 def _store_mxfp8_scale(
-    payload_resource,
-    scale_resource,
+    payload_buffer,
+    scale_buffer,
     payload_bytes,
     offset,
     vector_width,
@@ -107,33 +85,35 @@ def _store_mxfp8_scale(
 ):
     if const_expr(wide_scale):
         if offset % fx.Int32(32) == fx.Int32(0):
-            buffer_ops.buffer_store(
-                e8m0 << fx.Int32(23),
-                scale_resource,
+            store_buffer(
+                scale_buffer,
                 offset // fx.Int32(32),
+                e8m0 << fx.Int32(23),
+                fx.Int32,
                 cache_modifier=cache_modifier,
             )
     elif const_expr(vector_width == 8):
         if offset % fx.Int32(32) == fx.Int32(0):
-            buffer_ops.buffer_store(
-                e8m0.to(fx.Int8),
-                scale_resource,
+            store_buffer(
+                scale_buffer,
                 offset // fx.Int32(32),
+                e8m0.to(fx.Int8),
+                fx.Int8,
                 cache_modifier=cache_modifier,
-                offset_is_bytes=True,
             )
     else:
-        buffer_ops.buffer_store(
-            e8m0 << fx.Int32(23),
-            payload_resource,
+        store_buffer(
+            payload_buffer,
             fx.Int32(payload_bytes // 4) + offset // fx.Int32(vector_width),
+            e8m0 << fx.Int32(23),
+            fx.Int32,
             cache_modifier=cache_modifier,
         )
 
 
 def _load_mxfp8_scale(
-    payload_resource,
-    scale_resource,
+    payload_buffer,
+    scale_buffer,
     payload_bytes,
     offset,
     vector_width,
@@ -142,46 +122,27 @@ def _load_mxfp8_scale(
 ):
     if const_expr(wide_scale):
         return fx.Int32(
-            buffer_ops.buffer_load(
-                scale_resource,
+            load_buffer(
+                scale_buffer,
                 offset // fx.Int32(32),
-                vec_width=1,
-                dtype=T.i32,
+                fx.Int32,
                 cache_modifier=cache_modifier,
             )
         ).bitcast(fx.Float32)
     if const_expr(vector_width == 8):
         return load_e8m0_scale(
-            scale_resource,
+            scale_buffer,
             offset // fx.Int32(32),
             cache_modifier,
         )
     return fx.Int32(
-        buffer_ops.buffer_load(
-            payload_resource,
+        load_buffer(
+            payload_buffer,
             fx.Int32(payload_bytes // 4) + offset // fx.Int32(vector_width),
-            vec_width=1,
-            dtype=T.i32,
+            fx.Int32,
             cache_modifier=cache_modifier,
         )
     ).bitcast(fx.Float32)
-
-
-def _store_bf16(resource, offset, values, vector_width, cache_modifier=0):
-    if vector_width == 8:
-        buffer_ops.buffer_store(values, resource, offset, cache_modifier=cache_modifier)
-        return
-    for chunk in range_constexpr(vector_width // 8):
-        chunk_values = fx.Vector.from_elements(
-            [values[chunk * 8 + element] for element in range_constexpr(8)],
-            fx.BFloat16,
-        )
-        buffer_ops.buffer_store(
-            chunk_values,
-            resource,
-            offset + fx.Int32(chunk * 8),
-            cache_modifier=cache_modifier,
-        )
 
 
 @flyc.jit
@@ -221,55 +182,61 @@ def emit_service_tile(
     expected = fx.Int64(comm_ops.load_i64_global(epoch_address)) + fx.Int64(1)
     expected_i32 = fx.Int32(expected)
     slot = expected & fx.Int64(1)
-    output_resource = buffer_ops.create_buffer_resource_from_addr(
+    output_resource = buffer_tensor_from_addr(
         local_workspace_base + fx.Int64(config.output_offset),
-        num_records_bytes=payload_bytes,
+        fx.BFloat16,
+        payload_bytes,
     )
-    shared_resource = buffer_ops.create_buffer_resource_from_addr(
+    shared_resource = buffer_tensor_from_addr(
         fx.Int64(ptrtoint(shared_partial)),
-        num_records_bytes=payload_bytes,
+        fx.BFloat16,
+        payload_bytes,
     )
     route_resource = None
     accumulator_resource = None
     clear_accumulator_resource = None
     if const_expr(config.producer_mode == "atomic_shared"):
-        accumulator_resource = buffer_ops.create_buffer_resource_from_addr(
+        accumulator_resource = buffer_tensor_from_addr(
             local_workspace_base
             + fx.Int64(config.route_offset)
             + slot * fx.Int64(payload_bytes),
-            num_records_bytes=payload_bytes,
+            fx.BFloat16,
+            payload_bytes,
         )
-        clear_accumulator_resource = buffer_ops.create_buffer_resource_from_addr(
+        clear_accumulator_resource = buffer_tensor_from_addr(
             local_workspace_base
             + fx.Int64(config.route_offset)
             + (slot ^ fx.Int64(1)) * fx.Int64(payload_bytes),
-            num_records_bytes=payload_bytes,
+            fx.BFloat16,
+            payload_bytes,
         )
     else:
-        route_resource = buffer_ops.create_buffer_resource_from_addr(
+        route_resource = buffer_tensor_from_addr(
             local_workspace_base + fx.Int64(config.route_offset),
-            num_records_bytes=config.route_bytes,
+            fx.BFloat16,
+            config.route_bytes,
         )
-    partial_resource = buffer_ops.create_buffer_resource_from_addr(
+    partial_resource = buffer_tensor_from_addr(
         local_workspace_base + slot * fx.Int64(partial_bytes),
-        num_records_bytes=(
-            partial_payload_bytes if partial_scale_sideband else partial_bytes
-        ),
+        fx.Int32,
+        (partial_payload_bytes if partial_scale_sideband else partial_bytes),
     )
     partial_scale_resource = None
     if const_expr(partial_scale_sideband):
-        partial_scale_resource = buffer_ops.create_buffer_resource_from_addr(
+        partial_scale_resource = buffer_tensor_from_addr(
             local_workspace_base
             + slot * fx.Int64(partial_bytes)
             + fx.Int64(partial_payload_bytes),
-            num_records_bytes=config.partial_scale_bytes,
+            fx.Int32 if config.wide_partial_scales else fx.Int8,
+            config.partial_scale_bytes,
         )
     if const_expr(config.collective == "rsag"):
-        reduced_resource = buffer_ops.create_buffer_resource_from_addr(
+        reduced_resource = buffer_tensor_from_addr(
             local_workspace_base
             + fx.Int64(config.reduced_offset)
             + slot * fx.Int64(config.reduced_shard_bytes),
-            num_records_bytes=(
+            fx.Int32,
+            (
                 config.reduced_payload_bytes
                 if const_expr(config.vector_width == 8)
                 else config.reduced_shard_bytes
@@ -277,12 +244,13 @@ def emit_service_tile(
         )
         reduced_scale_resource = None
         if const_expr(config.vector_width == 8):
-            reduced_scale_resource = buffer_ops.create_buffer_resource_from_addr(
+            reduced_scale_resource = buffer_tensor_from_addr(
                 local_workspace_base
                 + fx.Int64(config.reduced_offset)
                 + slot * fx.Int64(config.reduced_shard_bytes)
                 + fx.Int64(config.reduced_payload_bytes),
-                num_records_bytes=config.reduced_scale_bytes,
+                fx.Int8,
+                config.reduced_scale_bytes,
             )
     service_stride = config.block_threads * config.service_groups
     service_start = tid + service_group * fx.Int32(config.block_threads)
@@ -303,7 +271,7 @@ def emit_service_tile(
     if const_expr(config.uses_rsag):
         if tid < fx.Int32(tp_size):
             gather_slot = state_n_tile * fx.Int32(tp_size) + tid
-            wait_i32_system_until_at_least(
+            comm_ops.spin_until_ge_i32_system(
                 local_workspace_base
                 + fx.Int64(config.gather_done_offset)
                 + fx.Int64(gather_slot) * fx.Int64(4),
@@ -320,25 +288,25 @@ def emit_service_tile(
             + tile_item * fx.Int32(config.vector_width)
         )
         if const_expr(config.producer_mode == "atomic_shared"):
-            shared_values = _load_bf16(
+            shared_values = load_bf16(
                 shared_resource,
                 output_offset,
                 config.vector_width,
                 config.local_load_cache_modifier,
-            ).extf(T.vec(config.vector_width, T.f32))
-            reduced_f32 = shared_values + _load_bf16(
+            ).to(fx.Float32)
+            reduced_f32 = shared_values + load_bf16(
                 accumulator_resource,
                 output_offset,
                 config.vector_width,
                 config.local_load_cache_modifier,
-            ).extf(T.vec(config.vector_width, T.f32))
+            ).to(fx.Float32)
         else:
-            shared_values = _load_bf16(
+            shared_values = load_bf16(
                 shared_resource,
                 output_offset,
                 config.vector_width,
                 config.local_load_cache_modifier,
-            ).extf(T.vec(config.vector_width, T.f32))
+            ).to(fx.Float32)
 
             def load_bf16_route(route_slot):
                 route_offset = (
@@ -347,12 +315,12 @@ def emit_service_tile(
                     + n_tile * fx.Int32(config.tile_n)
                     + tile_item * fx.Int32(config.vector_width)
                 )
-                return _load_bf16(
+                return load_bf16(
                     route_resource,
                     route_offset,
                     config.vector_width,
                     config.local_load_cache_modifier,
-                ).extf(T.vec(config.vector_width, T.f32))
+                ).to(fx.Float32)
 
             local_even = shared_values + load_bf16_route(0)
             if const_expr(topk == 1):
@@ -368,14 +336,14 @@ def emit_service_tile(
 
         if const_expr(config.shared_bf16_partials):
             if const_expr(config.producer_mode == "atomic_shared"):
-                _store_bf16(
+                store_bf16(
                     output_resource,
                     output_offset,
-                    reduced_f32.truncf(T.vec(config.vector_width, T.bf16)),
+                    reduced_f32.to(fx.BFloat16),
                     config.vector_width,
                 )
                 zero_bf16 = fx.Float32(0.0).to(fx.BFloat16)
-                _store_bf16(
+                store_bf16(
                     clear_accumulator_resource,
                     output_offset,
                     fx.Vector.from_elements(
@@ -386,10 +354,10 @@ def emit_service_tile(
                     cache_modifier=2,
                 )
             else:
-                _store_bf16(
+                store_bf16(
                     shared_resource,
                     output_offset,
-                    reduced_f32.truncf(T.vec(config.vector_width, T.bf16)),
+                    reduced_f32.to(fx.BFloat16),
                     config.vector_width,
                 )
             return None
@@ -462,17 +430,19 @@ def emit_service_tile(
         def load_peer(peer, cache_modifier=None, use_retained=False):
             if const_expr(config.shared_bf16_partials):
                 if const_expr(config.producer_mode == "atomic_shared"):
-                    peer_resource = buffer_ops.create_buffer_resource_from_addr(
+                    peer_resource = buffer_tensor_from_addr(
                         peer_base(workspace_flat_base, peer)
                         + fx.Int64(config.output_offset),
-                        num_records_bytes=payload_bytes,
+                        fx.BFloat16,
+                        payload_bytes,
                     )
                 else:
-                    peer_resource = buffer_ops.create_buffer_resource_from_addr(
+                    peer_resource = buffer_tensor_from_addr(
                         peer_base(shared_partial_flat_base, peer),
-                        num_records_bytes=payload_bytes,
+                        fx.BFloat16,
+                        payload_bytes,
                     )
-                return _load_bf16(
+                return load_bf16(
                     peer_resource,
                     offset,
                     load_vector_width,
@@ -485,7 +455,7 @@ def emit_service_tile(
                             else config.local_load_cache_modifier
                         )
                     ),
-                ).extf(T.vec(load_vector_width, T.f32))
+                ).to(fx.Float32)
             if const_expr(use_retained):
                 retained_packed, retained_e8m0 = retained_local_partial
                 scale = (fx.Uint32(retained_e8m0) << fx.Uint32(23)).bitcast(fx.Float32)
@@ -494,11 +464,10 @@ def emit_service_tile(
                     fx.Float32,
                 )
             load_offset = offset
-            peer_resource = buffer_ops.create_buffer_resource_from_addr(
+            peer_resource = buffer_tensor_from_addr(
                 peer_base(workspace_flat_base, peer) + slot * fx.Int64(partial_bytes),
-                num_records_bytes=(
-                    partial_payload_bytes if partial_scale_sideband else partial_bytes
-                ),
+                fx.Int32,
+                (partial_payload_bytes if partial_scale_sideband else partial_bytes),
             )
             if const_expr(cache_modifier is None):
                 cache_modifier = (
@@ -508,11 +477,12 @@ def emit_service_tile(
                 )
             peer_scale_resource = None
             if const_expr(partial_scale_sideband):
-                peer_scale_resource = buffer_ops.create_buffer_resource_from_addr(
+                peer_scale_resource = buffer_tensor_from_addr(
                     peer_base(workspace_flat_base, peer)
                     + slot * fx.Int64(partial_bytes)
                     + fx.Int64(partial_payload_bytes),
-                    num_records_bytes=config.partial_scale_bytes,
+                    fx.Int32 if config.wide_partial_scales else fx.Int8,
+                    config.partial_scale_bytes,
                 )
             if const_expr(config.wide_partial_scales):
                 scale = _load_mxfp8_scale(
@@ -615,10 +585,10 @@ def emit_service_tile(
                 offset,
                 retained_local_partial,
             )
-            _store_bf16(
+            store_bf16(
                 output_resource,
                 offset,
-                reduced.truncf(T.vec(config.vector_width, T.bf16)),
+                reduced.to(fx.BFloat16),
                 config.vector_width,
             )
 
@@ -649,7 +619,7 @@ def emit_service_tile(
             counter_slot = fx.Int64(0)
             if const_expr(config.producer_mode == "atomic_shared"):
                 counter_slot = slot ^ fx.Int64(1)
-            store_i32_relaxed(
+            counter_address = (
                 local_workspace_base
                 + fx.Int64(config.producer_done_offset)
                 + (
@@ -657,29 +627,41 @@ def emit_service_tile(
                     * fx.Int64(config.producer_counter_slots)
                     + counter_slot
                 )
-                * fx.Int64(PRODUCER_COUNTER_STRIDE),
+                * fx.Int64(PRODUCER_COUNTER_STRIDE)
+            )
+            fx.ptr_store(
                 fx.Int32(0),
+                global_typed_ptr(counter_address, T.i32),
             )
         if const_expr(config.service_groups > 1):
-            store_i32_relaxed(
-                local_workspace_base
-                + fx.Int64(config.service_done_offset)
-                + tile_byte_offset,
+            fx.ptr_store(
                 fx.Int32(0),
+                global_typed_ptr(
+                    local_workspace_base
+                    + fx.Int64(config.service_done_offset)
+                    + tile_byte_offset,
+                    T.i32,
+                ),
             )
-            store_i32_relaxed(
-                local_workspace_base
-                + fx.Int64(config.reduce_done_offset)
-                + tile_byte_offset,
+            fx.ptr_store(
                 fx.Int32(0),
+                global_typed_ptr(
+                    local_workspace_base
+                    + fx.Int64(config.reduce_done_offset)
+                    + tile_byte_offset,
+                    T.i32,
+                ),
             )
-            store_i32_relaxed(
-                local_workspace_base
-                + fx.Int64(config.gather_service_done_offset)
-                + tile_byte_offset,
+            fx.ptr_store(
                 fx.Int32(0),
+                global_typed_ptr(
+                    local_workspace_base
+                    + fx.Int64(config.gather_service_done_offset)
+                    + tile_byte_offset,
+                    T.i32,
+                ),
             )
-        store_i64_relaxed(epoch_address, expected)
+        fx.ptr_store(expected, global_typed_ptr(epoch_address, T.i64, align=8))
 
     def emit_rsag_reduce():
         collective_vector_width = config.vector_width
@@ -687,7 +669,7 @@ def emit_service_tile(
         def emit_gather_ack(barrier=True):
             if tid < fx.Int32(tp_size):
                 remote_slot = state_n_tile * fx.Int32(tp_size) + rank
-                store_i32_system_monotonic(
+                comm_ops.store_i32_global_system_monotonic(
                     peer_base(workspace_flat_base, tid)
                     + fx.Int64(config.gather_done_offset)
                     + fx.Int64(remote_slot) * fx.Int64(4),
@@ -703,7 +685,7 @@ def emit_service_tile(
             ):
                 if tid < fx.Int32(tp_size):
                     local_slot = state_n_tile * fx.Int32(tp_size) + tid
-                    wait_i32_system_until_at_least(
+                    comm_ops.spin_until_ge_i32_system(
                         local_workspace_base
                         + fx.Int64(config.gather_done_offset)
                         + fx.Int64(local_slot) * fx.Int64(4),
@@ -733,7 +715,9 @@ def emit_service_tile(
                 if tid == fx.Int32(0):
                     comm_ops.fence_agent_release()
                     arrival = fx.Int32(
-                        atomic_add_i32_agent(gather_done_address, fx.Int32(1))
+                        comm_ops.atomic_add_agent_one_as(
+                            gather_done_address, fx.Int32(1)
+                        )
                     )
                     fx.ptr_store(arrival, service_marker_ptr)
                 gpu.barrier()
@@ -782,10 +766,10 @@ def emit_service_tile(
                     ),
                     vector_width=collective_vector_width,
                 )
-                reduced_bf16 = reduced.truncf(T.vec(collective_vector_width, T.bf16))
+                reduced_bf16 = reduced.to(fx.BFloat16)
                 if const_expr(config.collective == "rsag"):
                     # Publish the local RS/AG shard directly.
-                    _store_bf16(
+                    store_bf16(
                         output_resource,
                         offset,
                         reduced_bf16,
@@ -803,14 +787,13 @@ def emit_service_tile(
                         if const_expr(peer == specialized_rank):
                             peer_output_resource = output_resource
                         else:
-                            peer_output_resource = (
-                                buffer_ops.create_buffer_resource_from_addr(
-                                    peer_base(workspace_flat_base, peer)
-                                    + fx.Int64(config.output_offset),
-                                    num_records_bytes=payload_bytes,
-                                )
+                            peer_output_resource = buffer_tensor_from_addr(
+                                peer_base(workspace_flat_base, peer)
+                                + fx.Int64(config.output_offset),
+                                fx.BFloat16,
+                                payload_bytes,
                             )
-                        _store_bf16(
+                        store_bf16(
                             peer_output_resource,
                             offset,
                             reduced_bf16,
@@ -853,14 +836,14 @@ def emit_service_tile(
         def emit_reduced_exchange(propagate_acquire):
             if tid < fx.Int32(tp_size):
                 remote_slot = state_n_tile * fx.Int32(tp_size) + rank
-                store_i32_system_monotonic(
+                comm_ops.store_i32_global_system_monotonic(
                     peer_base(workspace_flat_base, tid)
                     + fx.Int64(config.owner_ready_offset)
                     + fx.Int64(remote_slot) * fx.Int64(4),
                     expected_i32,
                 )
                 local_slot = state_n_tile * fx.Int32(tp_size) + tid
-                wait_i32_system_until_at_least(
+                comm_ops.spin_until_ge_i32_system(
                     local_workspace_base
                     + fx.Int64(config.owner_ready_offset)
                     + fx.Int64(local_slot) * fx.Int64(4),
@@ -886,7 +869,7 @@ def emit_service_tile(
             if tid == fx.Int32(0):
                 comm_ops.fence_agent_release()
                 arrival = fx.Int32(
-                    atomic_add_i32_agent(reduce_done_address, fx.Int32(1))
+                    comm_ops.atomic_add_agent_one_as(reduce_done_address, fx.Int32(1))
                 )
                 fx.ptr_store(arrival, service_marker_ptr)
             gpu.barrier()
@@ -900,7 +883,7 @@ def emit_service_tile(
                 gpu.barrier()
                 emit_reduced_exchange(False)
                 if tid == fx.Int32(0):
-                    store_i32_agent_release(
+                    comm_ops.store_i32_global_agent_release(
                         local_workspace_base
                         + fx.Int64(config.reduced_collective_ready_offset)
                         + fx.Int64(state_n_tile) * fx.Int64(4),
@@ -908,7 +891,7 @@ def emit_service_tile(
                     )
 
             if tid == fx.Int32(0):
-                wait_i32_agent_until_at_least(
+                comm_ops.spin_until_ge_i32_agent(
                     local_workspace_base
                     + fx.Int64(config.reduced_collective_ready_offset)
                     + fx.Int64(state_n_tile) * fx.Int64(4),
@@ -928,11 +911,12 @@ def emit_service_tile(
             shard_tokens = config.m // tp_size
             first_token = source_start // fx.Int32(vectors_per_token)
             vector_lane = source_start - first_token * fx.Int32(vectors_per_token)
-            source_resource = buffer_ops.create_buffer_resource_from_addr(
+            source_resource = buffer_tensor_from_addr(
                 peer_base(workspace_flat_base, source)
                 + fx.Int64(config.reduced_offset)
                 + slot * fx.Int64(config.reduced_shard_bytes),
-                num_records_bytes=(
+                fx.Int32,
+                (
                     config.reduced_payload_bytes
                     if const_expr(config.vector_width == 8)
                     else config.reduced_shard_bytes
@@ -940,12 +924,13 @@ def emit_service_tile(
             )
             source_scale_resource = None
             if const_expr(config.vector_width == 8):
-                source_scale_resource = buffer_ops.create_buffer_resource_from_addr(
+                source_scale_resource = buffer_tensor_from_addr(
                     peer_base(workspace_flat_base, source)
                     + fx.Int64(config.reduced_offset)
                     + slot * fx.Int64(config.reduced_shard_bytes)
                     + fx.Int64(config.reduced_payload_bytes),
-                    num_records_bytes=config.reduced_scale_bytes,
+                    fx.Int8,
+                    config.reduced_scale_bytes,
                 )
             for source_token in range(
                 first_token,
@@ -982,7 +967,7 @@ def emit_service_tile(
                     _decode_scaled_fp8_bf16(words, scale),
                     fx.BFloat16,
                 )
-                _store_bf16(
+                store_bf16(
                     output_resource,
                     offset,
                     values,
@@ -1039,7 +1024,7 @@ def emit_service_tile(
 
         if tid < fx.Int32(tp_size):
             remote_slot = state_n_tile * fx.Int32(tp_size) + rank
-            store_i32_system_monotonic(
+            comm_ops.store_i32_global_system_monotonic(
                 peer_base(workspace_flat_base, tid)
                 + fx.Int64(config.rank_ready_offset)
                 + fx.Int64(remote_slot) * fx.Int64(4),
@@ -1052,14 +1037,14 @@ def emit_service_tile(
                 + fx.Int64(local_slot) * fx.Int64(4)
             )
             if const_expr(config.single_pass_direct):
-                wait_i32_system_until_at_least(
+                comm_ops.spin_until_ge_i32_system(
                     ready_address,
                     expected_i32,
                     acquire=not optimized_m8_direct,
                     sleep=False,
                 )
             else:
-                wait_i32_system_until_at_least(
+                comm_ops.spin_until_ge_i32_system(
                     ready_address,
                     expected_i32,
                 )
@@ -1078,7 +1063,7 @@ def emit_service_tile(
             if tid == fx.Int32(0):
                 comm_ops.fence_agent_release()
                 arrival = fx.Int32(
-                    atomic_add_i32_agent(service_done_address, fx.Int32(1))
+                    comm_ops.atomic_add_agent_one_as(service_done_address, fx.Int32(1))
                 )
                 fx.ptr_store(arrival, service_marker_ptr)
             gpu.barrier()
@@ -1089,7 +1074,7 @@ def emit_service_tile(
                 if tid == fx.Int32(0):
                     comm_ops.fence_agent_acquire()
                     local_ready_slot = state_n_tile * fx.Int32(tp_size) + rank
-                    store_i32_system_release(
+                    comm_ops.store_i32_global_system_release(
                         local_workspace_base
                         + fx.Int64(config.rank_ready_offset)
                         + fx.Int64(local_ready_slot) * fx.Int64(4),
@@ -1099,7 +1084,7 @@ def emit_service_tile(
 
                 if tid < fx.Int32(tp_size):
                     peer_ready_slot = state_n_tile * fx.Int32(tp_size) + tid
-                    wait_i32_system_until_at_least(
+                    comm_ops.spin_until_ge_i32_system(
                         peer_base(workspace_flat_base, tid)
                         + fx.Int64(config.rank_ready_offset)
                         + fx.Int64(peer_ready_slot) * fx.Int64(4),
@@ -1108,7 +1093,7 @@ def emit_service_tile(
                 gpu.barrier()
                 if tid == fx.Int32(0):
                     comm_ops.fence_system_acquire()
-                    store_i32_agent_release(
+                    comm_ops.store_i32_global_agent_release(
                         local_workspace_base
                         + fx.Int64(config.collective_ready_offset)
                         + fx.Int64(state_n_tile) * fx.Int64(4),
@@ -1119,7 +1104,7 @@ def emit_service_tile(
 
         def wait_for_collective():
             if tid == fx.Int32(0):
-                wait_i32_agent_until_at_least(
+                comm_ops.spin_until_ge_i32_agent(
                     local_workspace_base
                     + fx.Int64(config.collective_ready_offset)
                     + fx.Int64(state_n_tile) * fx.Int64(4),
@@ -1299,7 +1284,7 @@ def compile_megakernel(
             gpu.barrier()
             if tid == fx.Int32(0):
                 ticket = fx.Int32(
-                    atomic_add_i32_agent(
+                    comm_ops.atomic_add_agent_one_as(
                         local_workspace_base
                         + fx.Int64(config.producer_done_offset)
                         + (
@@ -1325,7 +1310,7 @@ def compile_megakernel(
                 service_group = service_marker - fx.Int32(1)
                 if config.service_groups > 1:
                     if tid == fx.Int32(0):
-                        wait_i32_agent_until_at_least(
+                        comm_ops.spin_until_ge_i32_agent(
                             local_workspace_base
                             + fx.Int64(config.producer_done_offset)
                             + (
@@ -1372,13 +1357,6 @@ def compile_megakernel(
             size_expert_ids,
             stream,
         ):
-            if const_expr(config.waves_per_eu > 0):
-                context = CompilationContext.get_current()
-                for op in context.gpu_module_body.operations:
-                    if hasattr(op, "attributes") and op.OPERATION_NAME == "gpu.func":
-                        op.attributes["rocdl.waves_per_eu"] = ir.IntegerAttr.get(
-                            T.i32, config.waves_per_eu
-                        )
             kernel(
                 workspace,
                 x,
@@ -1395,6 +1373,11 @@ def compile_megakernel(
                 model_dim,
                 inter_dim,
                 size_expert_ids,
+                value_attrs=(
+                    {"rocdl.waves_per_eu": config.waves_per_eu}
+                    if config.waves_per_eu > 0
+                    else None
+                ),
             ).launch(
                 grid=launch_grid,
                 block=(config.block_threads, 1, 1),

--- a/aiter/ops/flydsl/kernels/comm_fused_moe/gfx950/a8w4/megakernel.py
+++ b/aiter/ops/flydsl/kernels/comm_fused_moe/gfx950/a8w4/megakernel.py
@@ -1,0 +1,1409 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Single-launch Stage2 producer/consumer kernel.
+
+Producer workgroups run the natural-grid route GEMM. Completion is tracked per
+N tile; the final ``service_groups`` producers become communication consumers
+and execute the selected direct, reduce-broadcast, or reduce-scatter/all-gather
+path. This keeps the native GEMM tiling and avoids an artificial window.
+"""
+
+import functools
+import hashlib
+
+import flydsl.compiler as flyc
+import flydsl.expr as fx
+from flydsl._mlir import ir
+from flydsl.compiler.kernel_function import CompilationContext
+from flydsl.expr import const_expr, gpu, ptrtoint, range_constexpr, rocdl
+from flydsl.expr import math as fmath
+from flydsl.expr.typing import ReductionOp, T, as_ir_value
+
+from .... import buffer_ops
+from .... import communication_ops_utils as comm_ops
+from ....mxfp4_gemm_common import global_typed_ptr, lds_typed_ptr
+from .collectives import (
+    atomic_add_i32_agent,
+    decode_scaled_fp8_f32,
+    e8m0_scale,
+    load_e8m0_scale,
+    load_fp8_words,
+    pack_fp8_words,
+    peer_base,
+    store_fp8_words,
+    store_i32_agent_release,
+    store_i32_relaxed,
+    store_i32_system_monotonic,
+    store_i32_system_release,
+    store_i64_relaxed,
+    wait_i32_agent_until_at_least,
+    wait_i32_system_until_at_least,
+)
+from .config import PRODUCER_COUNTER_STRIDE, SLOTS, MegakernelConfig
+from .producer import compile_megakernel_producer
+
+CPOL_COHERENT = 0x1 | 0x10
+
+
+def _load_bf16(resource, offset, vector_width, cache_modifier):
+    values = []
+    for chunk in range_constexpr(vector_width // 8):
+        loaded = fx.Vector(
+            buffer_ops.buffer_load(
+                resource,
+                offset + fx.Int32(chunk * 8),
+                vec_width=8,
+                dtype=T.bf16,
+                cache_modifier=cache_modifier,
+            )
+        )
+        values.extend(loaded[element] for element in range_constexpr(8))
+    return fx.Vector.from_elements(values, fx.BFloat16)
+
+
+def _decode_scaled_fp8_bf16(words, scale):
+    """Decode packed FP8 directly to the BF16 final-output representation."""
+
+    values = []
+    for word in range_constexpr(len(words)):
+        for half in range_constexpr(2):
+            pair = fx.Vector(
+                fx.rocdl.cvt_scalef32_pk_bf16_fp8(
+                    T.vec(2, T.bf16),
+                    as_ir_value(words[word]),
+                    as_ir_value(scale),
+                    bool(half),
+                )
+            )
+            values.extend((pair[0], pair[1]))
+    return values
+
+
+def _mxfp8_scale(values, lane, vector_width):
+    local_max = fx.Float32(1e-10).maximumf(fmath.absf(values).reduce(ReductionOp.MAX))
+    max_bits = local_max.bitcast(fx.Int32)
+    remote_bits = fx.rocdl.ds_bpermute(
+        T.i32, (lane ^ fx.Int32(1)) * fx.Int32(4), max_bits
+    )
+    local_max = local_max.maximumf(fx.Int32(remote_bits).bitcast(fx.Float32))
+    if const_expr(vector_width == 8):
+        max_bits = local_max.bitcast(fx.Int32)
+        remote_bits = fx.rocdl.ds_bpermute(
+            T.i32, (lane ^ fx.Int32(2)) * fx.Int32(4), max_bits
+        )
+        local_max = local_max.maximumf(fx.Int32(remote_bits).bitcast(fx.Float32))
+    return e8m0_scale(local_max)
+
+
+@flyc.jit
+def _store_mxfp8_scale(
+    payload_resource,
+    scale_resource,
+    payload_bytes,
+    offset,
+    vector_width,
+    e8m0,
+    wide_scale=False,
+    cache_modifier=0,
+):
+    if const_expr(wide_scale):
+        if offset % fx.Int32(32) == fx.Int32(0):
+            buffer_ops.buffer_store(
+                e8m0 << fx.Int32(23),
+                scale_resource,
+                offset // fx.Int32(32),
+                cache_modifier=cache_modifier,
+            )
+    elif const_expr(vector_width == 8):
+        if offset % fx.Int32(32) == fx.Int32(0):
+            buffer_ops.buffer_store(
+                e8m0.to(fx.Int8),
+                scale_resource,
+                offset // fx.Int32(32),
+                cache_modifier=cache_modifier,
+                offset_is_bytes=True,
+            )
+    else:
+        buffer_ops.buffer_store(
+            e8m0 << fx.Int32(23),
+            payload_resource,
+            fx.Int32(payload_bytes // 4) + offset // fx.Int32(vector_width),
+            cache_modifier=cache_modifier,
+        )
+
+
+def _load_mxfp8_scale(
+    payload_resource,
+    scale_resource,
+    payload_bytes,
+    offset,
+    vector_width,
+    cache_modifier,
+    wide_scale=False,
+):
+    if const_expr(wide_scale):
+        return fx.Int32(
+            buffer_ops.buffer_load(
+                scale_resource,
+                offset // fx.Int32(32),
+                vec_width=1,
+                dtype=T.i32,
+                cache_modifier=cache_modifier,
+            )
+        ).bitcast(fx.Float32)
+    if const_expr(vector_width == 8):
+        return load_e8m0_scale(
+            scale_resource,
+            offset // fx.Int32(32),
+            cache_modifier,
+        )
+    return fx.Int32(
+        buffer_ops.buffer_load(
+            payload_resource,
+            fx.Int32(payload_bytes // 4) + offset // fx.Int32(vector_width),
+            vec_width=1,
+            dtype=T.i32,
+            cache_modifier=cache_modifier,
+        )
+    ).bitcast(fx.Float32)
+
+
+def _store_bf16(resource, offset, values, vector_width, cache_modifier=0):
+    if vector_width == 8:
+        buffer_ops.buffer_store(values, resource, offset, cache_modifier=cache_modifier)
+        return
+    for chunk in range_constexpr(vector_width // 8):
+        chunk_values = fx.Vector.from_elements(
+            [values[chunk * 8 + element] for element in range_constexpr(8)],
+            fx.BFloat16,
+        )
+        buffer_ops.buffer_store(
+            chunk_values,
+            resource,
+            offset + fx.Int32(chunk * 8),
+            cache_modifier=cache_modifier,
+        )
+
+
+@flyc.jit
+def emit_service_tile(
+    config,
+    workspace,
+    workspace_flat_base,
+    shared_partial,
+    shared_partial_flat_base,
+    specialized_rank,
+    n_tile,
+    tid,
+    service_group,
+    service_marker_ptr,
+):
+    hidden_dim = config.shape.model_dim
+    topk = config.shape.topk
+    tp_size = config.shape.tp_size
+    rank = fx.Int32(specialized_rank)
+    payload_bytes = config.payload_bytes
+    partial_payload_bytes = config.partial_payload_bytes
+    partial_bytes = config.partial_bytes
+    partial_scale_sideband = not config.shared_bf16_partials and (
+        config.vector_width == 8 or config.wide_partial_scales
+    )
+    reduce_items = config.m * config.tile_n // config.vector_width
+    optimized_m8_direct = config.collective == "direct" and config.m == 8
+    partial_store_cache_modifier = CPOL_COHERENT if optimized_m8_direct else 0
+    local_workspace_base = fx.Int64(ptrtoint(workspace))
+    state_n_tile = (n_tile // fx.Int32(config.service_tile_group)) * fx.Int32(
+        config.service_tile_group
+    )
+    tile_byte_offset = fx.Int64(state_n_tile) * fx.Int64(8)
+    epoch_address = (
+        local_workspace_base + fx.Int64(config.epoch_offset) + tile_byte_offset
+    )
+    expected = fx.Int64(comm_ops.load_i64_global(epoch_address)) + fx.Int64(1)
+    expected_i32 = fx.Int32(expected)
+    slot = expected & fx.Int64(1)
+    output_resource = buffer_ops.create_buffer_resource_from_addr(
+        local_workspace_base + fx.Int64(config.output_offset),
+        num_records_bytes=payload_bytes,
+    )
+    shared_resource = buffer_ops.create_buffer_resource_from_addr(
+        fx.Int64(ptrtoint(shared_partial)),
+        num_records_bytes=payload_bytes,
+    )
+    route_resource = None
+    accumulator_resource = None
+    clear_accumulator_resource = None
+    if const_expr(config.producer_mode == "atomic_shared"):
+        accumulator_resource = buffer_ops.create_buffer_resource_from_addr(
+            local_workspace_base
+            + fx.Int64(config.route_offset)
+            + slot * fx.Int64(payload_bytes),
+            num_records_bytes=payload_bytes,
+        )
+        clear_accumulator_resource = buffer_ops.create_buffer_resource_from_addr(
+            local_workspace_base
+            + fx.Int64(config.route_offset)
+            + (slot ^ fx.Int64(1)) * fx.Int64(payload_bytes),
+            num_records_bytes=payload_bytes,
+        )
+    else:
+        route_resource = buffer_ops.create_buffer_resource_from_addr(
+            local_workspace_base + fx.Int64(config.route_offset),
+            num_records_bytes=config.route_bytes,
+        )
+    partial_resource = buffer_ops.create_buffer_resource_from_addr(
+        local_workspace_base + slot * fx.Int64(partial_bytes),
+        num_records_bytes=(
+            partial_payload_bytes if partial_scale_sideband else partial_bytes
+        ),
+    )
+    partial_scale_resource = None
+    if const_expr(partial_scale_sideband):
+        partial_scale_resource = buffer_ops.create_buffer_resource_from_addr(
+            local_workspace_base
+            + slot * fx.Int64(partial_bytes)
+            + fx.Int64(partial_payload_bytes),
+            num_records_bytes=config.partial_scale_bytes,
+        )
+    if const_expr(config.collective == "rsag"):
+        reduced_resource = buffer_ops.create_buffer_resource_from_addr(
+            local_workspace_base
+            + fx.Int64(config.reduced_offset)
+            + slot * fx.Int64(config.reduced_shard_bytes),
+            num_records_bytes=(
+                config.reduced_payload_bytes
+                if const_expr(config.vector_width == 8)
+                else config.reduced_shard_bytes
+            ),
+        )
+        reduced_scale_resource = None
+        if const_expr(config.vector_width == 8):
+            reduced_scale_resource = buffer_ops.create_buffer_resource_from_addr(
+                local_workspace_base
+                + fx.Int64(config.reduced_offset)
+                + slot * fx.Int64(config.reduced_shard_bytes)
+                + fx.Int64(config.reduced_payload_bytes),
+                num_records_bytes=config.reduced_scale_bytes,
+            )
+    service_stride = config.block_threads * config.service_groups
+    service_start = tid + service_group * fx.Int32(config.block_threads)
+    retain_underfilled_local_partial = (
+        config.collective == "direct"
+        and not config.shared_bf16_partials
+        and reduce_items < service_stride
+    )
+    retain_full_local_partials = (
+        config.collective == "direct"
+        and not config.shared_bf16_partials
+        and reduce_items % service_stride == 0
+        and reduce_items <= 4 * service_stride
+    )
+    retain_local_partials = (
+        retain_underfilled_local_partial or retain_full_local_partials
+    )
+    if const_expr(config.uses_rsag):
+        if tid < fx.Int32(tp_size):
+            gather_slot = state_n_tile * fx.Int32(tp_size) + tid
+            wait_i32_system_until_at_least(
+                local_workspace_base
+                + fx.Int64(config.gather_done_offset)
+                + fx.Int64(gather_slot) * fx.Int64(4),
+                expected_i32 - fx.Int32(SLOTS),
+            )
+        gpu.barrier()
+
+    def emit_local_reduce_item(item):
+        token = item // fx.Int32(config.tile_n // config.vector_width)
+        tile_item = item - token * fx.Int32(config.tile_n // config.vector_width)
+        output_offset = (
+            token * fx.Int32(hidden_dim)
+            + n_tile * fx.Int32(config.tile_n)
+            + tile_item * fx.Int32(config.vector_width)
+        )
+        if const_expr(config.producer_mode == "atomic_shared"):
+            shared_values = _load_bf16(
+                shared_resource,
+                output_offset,
+                config.vector_width,
+                config.local_load_cache_modifier,
+            ).extf(T.vec(config.vector_width, T.f32))
+            reduced_f32 = shared_values + _load_bf16(
+                accumulator_resource,
+                output_offset,
+                config.vector_width,
+                config.local_load_cache_modifier,
+            ).extf(T.vec(config.vector_width, T.f32))
+        else:
+            shared_values = _load_bf16(
+                shared_resource,
+                output_offset,
+                config.vector_width,
+                config.local_load_cache_modifier,
+            ).extf(T.vec(config.vector_width, T.f32))
+
+            def load_bf16_route(route_slot):
+                route_offset = (
+                    (token * fx.Int32(topk) + fx.Int32(route_slot))
+                    * fx.Int32(hidden_dim)
+                    + n_tile * fx.Int32(config.tile_n)
+                    + tile_item * fx.Int32(config.vector_width)
+                )
+                return _load_bf16(
+                    route_resource,
+                    route_offset,
+                    config.vector_width,
+                    config.local_load_cache_modifier,
+                ).extf(T.vec(config.vector_width, T.f32))
+
+            local_even = shared_values + load_bf16_route(0)
+            if const_expr(topk == 1):
+                reduced_f32 = local_even
+            else:
+                local_odd = load_bf16_route(1)
+                for route_slot in range_constexpr(2, topk):
+                    if const_expr(route_slot == topk - 1 or route_slot % 2 == 0):
+                        local_odd = local_odd + load_bf16_route(route_slot)
+                    else:
+                        local_even = local_even + load_bf16_route(route_slot)
+                reduced_f32 = local_even + local_odd
+
+        if const_expr(config.shared_bf16_partials):
+            if const_expr(config.producer_mode == "atomic_shared"):
+                _store_bf16(
+                    output_resource,
+                    output_offset,
+                    reduced_f32.truncf(T.vec(config.vector_width, T.bf16)),
+                    config.vector_width,
+                )
+                zero_bf16 = fx.Float32(0.0).to(fx.BFloat16)
+                _store_bf16(
+                    clear_accumulator_resource,
+                    output_offset,
+                    fx.Vector.from_elements(
+                        [zero_bf16 for _ in range_constexpr(config.vector_width)],
+                        fx.BFloat16,
+                    ),
+                    config.vector_width,
+                    cache_modifier=2,
+                )
+            else:
+                _store_bf16(
+                    shared_resource,
+                    output_offset,
+                    reduced_f32.truncf(T.vec(config.vector_width, T.bf16)),
+                    config.vector_width,
+                )
+            return None
+
+        partial_e8m0, quant_scale = _mxfp8_scale(
+            reduced_f32,
+            tid & fx.Int32(63),
+            config.vector_width,
+        )
+        packed_words = config.vector_width // 4
+        packed = pack_fp8_words(reduced_f32, quant_scale, packed_words)
+        store_fp8_words(
+            partial_resource,
+            output_offset,
+            packed,
+            packed_words,
+            cache_modifier=partial_store_cache_modifier,
+        )
+        _store_mxfp8_scale(
+            partial_resource,
+            partial_scale_resource,
+            partial_payload_bytes,
+            output_offset,
+            config.vector_width,
+            partial_e8m0,
+            config.wide_partial_scales,
+            cache_modifier=partial_store_cache_modifier,
+        )
+        return packed, partial_e8m0
+
+    retained_local_partials = []
+
+    def emit_local_reduce_items():
+        if const_expr(retain_underfilled_local_partial):
+            initial = [fx.Int32(0) for _ in range_constexpr(config.vector_width // 4)]
+            initial.append(fx.Int32(0))
+            for item, _ in range(
+                service_start,
+                fx.Int32(reduce_items),
+                fx.Int32(service_stride),
+                init=initial,
+            ):
+                packed, partial_e8m0 = emit_local_reduce_item(fx.Int32(item))
+                retained = yield [*packed, partial_e8m0]
+            retained_local_partials.append((retained[:-1], retained[-1]))
+        elif const_expr(retain_full_local_partials):
+            for iteration in range_constexpr(reduce_items // service_stride):
+                item = service_start + fx.Int32(iteration * service_stride)
+                retained_local_partials.append(emit_local_reduce_item(item))
+        else:
+            for item in range(
+                service_start,
+                fx.Int32(reduce_items),
+                fx.Int32(service_stride),
+            ):
+                emit_local_reduce_item(item)
+        fx.rocdl.s_waitcnt(vmcnt=0, lgkmcnt=0)
+        gpu.barrier()
+
+    emit_local_reduce_items()
+
+    def load_reduced_partials(
+        offset,
+        retained_local_partial=None,
+        source_rotation=None,
+        vector_width=None,
+    ):
+        load_vector_width = vector_width or config.vector_width
+
+        def load_peer(peer, cache_modifier=None, use_retained=False):
+            if const_expr(config.shared_bf16_partials):
+                if const_expr(config.producer_mode == "atomic_shared"):
+                    peer_resource = buffer_ops.create_buffer_resource_from_addr(
+                        peer_base(workspace_flat_base, peer)
+                        + fx.Int64(config.output_offset),
+                        num_records_bytes=payload_bytes,
+                    )
+                else:
+                    peer_resource = buffer_ops.create_buffer_resource_from_addr(
+                        peer_base(shared_partial_flat_base, peer),
+                        num_records_bytes=payload_bytes,
+                    )
+                return _load_bf16(
+                    peer_resource,
+                    offset,
+                    load_vector_width,
+                    (
+                        cache_modifier
+                        if const_expr(cache_modifier is not None)
+                        else (
+                            config.remote_load_cache_modifier
+                            if const_expr(peer != specialized_rank)
+                            else config.local_load_cache_modifier
+                        )
+                    ),
+                ).extf(T.vec(load_vector_width, T.f32))
+            if const_expr(use_retained):
+                retained_packed, retained_e8m0 = retained_local_partial
+                scale = (fx.Uint32(retained_e8m0) << fx.Uint32(23)).bitcast(fx.Float32)
+                return fx.Vector.from_elements(
+                    decode_scaled_fp8_f32(retained_packed, scale),
+                    fx.Float32,
+                )
+            load_offset = offset
+            peer_resource = buffer_ops.create_buffer_resource_from_addr(
+                peer_base(workspace_flat_base, peer) + slot * fx.Int64(partial_bytes),
+                num_records_bytes=(
+                    partial_payload_bytes if partial_scale_sideband else partial_bytes
+                ),
+            )
+            if const_expr(cache_modifier is None):
+                cache_modifier = (
+                    config.remote_load_cache_modifier
+                    if const_expr(peer != specialized_rank)
+                    else config.local_load_cache_modifier
+                )
+            peer_scale_resource = None
+            if const_expr(partial_scale_sideband):
+                peer_scale_resource = buffer_ops.create_buffer_resource_from_addr(
+                    peer_base(workspace_flat_base, peer)
+                    + slot * fx.Int64(partial_bytes)
+                    + fx.Int64(partial_payload_bytes),
+                    num_records_bytes=config.partial_scale_bytes,
+                )
+            if const_expr(config.wide_partial_scales):
+                scale = _load_mxfp8_scale(
+                    peer_resource,
+                    peer_scale_resource,
+                    partial_payload_bytes,
+                    load_offset,
+                    config.vector_width,
+                    cache_modifier,
+                    config.wide_partial_scales,
+                )
+            words = load_fp8_words(
+                peer_resource,
+                load_offset // fx.Int32(4),
+                word_count=load_vector_width // 4,
+                load_width=load_vector_width // 4,
+                cache_modifier=cache_modifier,
+            )
+            if const_expr(not config.wide_partial_scales):
+                scale = _load_mxfp8_scale(
+                    peer_resource,
+                    peer_scale_resource,
+                    partial_payload_bytes,
+                    load_offset,
+                    config.vector_width,
+                    cache_modifier,
+                    config.wide_partial_scales,
+                )
+            return fx.Vector.from_elements(
+                decode_scaled_fp8_f32(words, scale),
+                fx.Float32,
+            )
+
+        if const_expr(config.wide_partial_scales):
+            reduced_even = load_peer(
+                specialized_rank,
+                use_retained=retain_local_partials,
+            )
+            source_rotation = n_tile
+            first_delta = source_rotation % fx.Int32(tp_size - 1) + fx.Int32(1)
+            first_peer = (rank + first_delta) & fx.Int32(tp_size - 1)
+            reduced_odd = load_peer(first_peer, config.remote_load_cache_modifier)
+            for remote_step in range_constexpr(1, tp_size - 1):
+                remote_delta = (
+                    (source_rotation + fx.Int32(remote_step)) % fx.Int32(tp_size - 1)
+                ) + fx.Int32(1)
+                peer = (rank + remote_delta) & fx.Int32(tp_size - 1)
+                if const_expr(remote_step % 2 == 1):
+                    reduced_even = reduced_even + load_peer(
+                        peer, config.remote_load_cache_modifier
+                    )
+                else:
+                    reduced_odd = reduced_odd + load_peer(
+                        peer, config.remote_load_cache_modifier
+                    )
+            reduced = reduced_even + reduced_odd
+        elif const_expr(source_rotation is not None):
+            first_peer = (rank + source_rotation + fx.Int32(1)) & fx.Int32(tp_size - 1)
+            second_peer = (rank + source_rotation + fx.Int32(2)) & fx.Int32(tp_size - 1)
+            reduced_even = load_peer(first_peer, config.remote_load_cache_modifier)
+            reduced_odd = load_peer(second_peer, config.remote_load_cache_modifier)
+            for peer_step in range_constexpr(3, tp_size + 1):
+                peer = (rank + source_rotation + fx.Int32(peer_step)) & fx.Int32(
+                    tp_size - 1
+                )
+                if const_expr(peer_step % 2 == 1):
+                    reduced_even = reduced_even + load_peer(
+                        peer, config.remote_load_cache_modifier
+                    )
+                else:
+                    reduced_odd = reduced_odd + load_peer(
+                        peer, config.remote_load_cache_modifier
+                    )
+            reduced = reduced_even + reduced_odd
+        else:
+            reduced_even = load_peer(
+                specialized_rank,
+                use_retained=retain_local_partials,
+            )
+            reduced_odd = load_peer((specialized_rank + 1) % tp_size)
+            for peer_step in range_constexpr(2, tp_size):
+                peer = (specialized_rank + peer_step) % tp_size
+                if const_expr(peer_step % 2 == 0):
+                    reduced_even = reduced_even + load_peer(peer)
+                else:
+                    reduced_odd = reduced_odd + load_peer(peer)
+            reduced = reduced_even + reduced_odd
+        return reduced
+
+    def emit_direct_reduce():
+        def emit_allreduce_item(item, retained_local_partial=None):
+            token = item // fx.Int32(config.tile_n // config.vector_width)
+            tile_item = item - token * fx.Int32(config.tile_n // config.vector_width)
+            offset = (
+                token * fx.Int32(hidden_dim)
+                + n_tile * fx.Int32(config.tile_n)
+                + tile_item * fx.Int32(config.vector_width)
+            )
+            reduced = load_reduced_partials(
+                offset,
+                retained_local_partial,
+            )
+            _store_bf16(
+                output_resource,
+                offset,
+                reduced.truncf(T.vec(config.vector_width, T.bf16)),
+                config.vector_width,
+            )
+
+        if const_expr(retain_underfilled_local_partial):
+            for item in range(
+                service_start,
+                fx.Int32(reduce_items),
+                fx.Int32(service_stride),
+            ):
+                emit_allreduce_item(item, retained_local_partials[0])
+        elif const_expr(retain_full_local_partials):
+            for iteration in range_constexpr(reduce_items // service_stride):
+                item = service_start + fx.Int32(iteration * service_stride)
+                emit_allreduce_item(
+                    item,
+                    retained_local_partials[iteration],
+                )
+        else:
+            for item in range(
+                service_start,
+                fx.Int32(reduce_items),
+                fx.Int32(service_stride),
+            ):
+                emit_allreduce_item(item)
+
+    def reset_tile_state_values():
+        for tile_delta in range_constexpr(config.service_tile_group):
+            counter_slot = fx.Int64(0)
+            if const_expr(config.producer_mode == "atomic_shared"):
+                counter_slot = slot ^ fx.Int64(1)
+            store_i32_relaxed(
+                local_workspace_base
+                + fx.Int64(config.producer_done_offset)
+                + (
+                    fx.Int64(state_n_tile + fx.Int32(tile_delta))
+                    * fx.Int64(config.producer_counter_slots)
+                    + counter_slot
+                )
+                * fx.Int64(PRODUCER_COUNTER_STRIDE),
+                fx.Int32(0),
+            )
+        if const_expr(config.service_groups > 1):
+            store_i32_relaxed(
+                local_workspace_base
+                + fx.Int64(config.service_done_offset)
+                + tile_byte_offset,
+                fx.Int32(0),
+            )
+            store_i32_relaxed(
+                local_workspace_base
+                + fx.Int64(config.reduce_done_offset)
+                + tile_byte_offset,
+                fx.Int32(0),
+            )
+            store_i32_relaxed(
+                local_workspace_base
+                + fx.Int64(config.gather_service_done_offset)
+                + tile_byte_offset,
+                fx.Int32(0),
+            )
+        store_i64_relaxed(epoch_address, expected)
+
+    def emit_rsag_reduce():
+        collective_vector_width = config.vector_width
+
+        def emit_gather_ack(barrier=True):
+            if tid < fx.Int32(tp_size):
+                remote_slot = state_n_tile * fx.Int32(tp_size) + rank
+                store_i32_system_monotonic(
+                    peer_base(workspace_flat_base, tid)
+                    + fx.Int64(config.gather_done_offset)
+                    + fx.Int64(remote_slot) * fx.Int64(4),
+                    expected_i32,
+                )
+            if const_expr(barrier):
+                gpu.barrier()
+
+        def wait_for_gather_acks():
+            if const_expr(
+                config.collective == "rs_broadcast"
+                and config.producer_mode == "atomic_shared"
+            ):
+                if tid < fx.Int32(tp_size):
+                    local_slot = state_n_tile * fx.Int32(tp_size) + tid
+                    wait_i32_system_until_at_least(
+                        local_workspace_base
+                        + fx.Int64(config.gather_done_offset)
+                        + fx.Int64(local_slot) * fx.Int64(4),
+                        expected_i32,
+                    )
+                gpu.barrier()
+                if tid == fx.Int32(0):
+                    comm_ops.fence_system_acquire()
+                gpu.barrier()
+
+        def publish_gather_completion():
+            if const_expr(config.service_groups == 1):
+                if const_expr(config.collective == "rs_broadcast"):
+                    emit_gather_ack()
+                    wait_for_gather_acks()
+                else:
+                    if tid == fx.Int32(0):
+                        comm_ops.fence_system_release()
+                    gpu.barrier()
+                    emit_gather_ack()
+            else:
+                gather_done_address = (
+                    local_workspace_base
+                    + fx.Int64(config.gather_service_done_offset)
+                    + tile_byte_offset
+                )
+                if tid == fx.Int32(0):
+                    comm_ops.fence_agent_release()
+                    arrival = fx.Int32(
+                        atomic_add_i32_agent(gather_done_address, fx.Int32(1))
+                    )
+                    fx.ptr_store(arrival, service_marker_ptr)
+                gpu.barrier()
+                gather_arrival = fx.Int32(fx.ptr_load(service_marker_ptr))
+                if gather_arrival == fx.Int32(
+                    config.service_groups * config.service_tile_group - 1
+                ):
+                    if tid == fx.Int32(0):
+                        comm_ops.fence_agent_acquire()
+                        comm_ops.fence_system_release()
+                    gpu.barrier()
+                    emit_gather_ack(barrier=False)
+                    wait_for_gather_acks()
+                    fx.rocdl.s_waitcnt(vmcnt=0, lgkmcnt=0)
+                    if tid == fx.Int32(0):
+                        reset_tile_state_values()
+
+        def emit_reduce_scatter_items():
+            vectors_per_token = config.tile_n // collective_vector_width
+            shard_tokens = config.m // tp_size
+            service_item = tid + service_group * fx.Int32(config.block_threads)
+            first_shard_token = service_item // fx.Int32(vectors_per_token)
+            vector_lane = service_item - first_shard_token * fx.Int32(vectors_per_token)
+
+            for shard_token in range(
+                first_shard_token,
+                fx.Int32(shard_tokens),
+                fx.Int32(
+                    config.block_threads * config.service_groups // vectors_per_token,
+                ),
+            ):
+                token = rank * fx.Int32(shard_tokens) + shard_token
+                offset = (
+                    token * fx.Int32(hidden_dim)
+                    + n_tile * fx.Int32(config.tile_n)
+                    + vector_lane * fx.Int32(collective_vector_width)
+                )
+                reduced = load_reduced_partials(
+                    offset,
+                    source_rotation=(
+                        shard_token
+                        if const_expr(
+                            config.collective == "rsag" and config.service_groups > 1
+                        )
+                        else None
+                    ),
+                    vector_width=collective_vector_width,
+                )
+                reduced_bf16 = reduced.truncf(T.vec(collective_vector_width, T.bf16))
+                if const_expr(config.collective == "rsag"):
+                    # Publish the local RS/AG shard directly.
+                    _store_bf16(
+                        output_resource,
+                        offset,
+                        reduced_bf16,
+                        collective_vector_width,
+                        config.remote_store_cache_modifier,
+                    )
+                reduced_offset = (
+                    n_tile * fx.Int32(config.m * config.tile_n // tp_size)
+                    + shard_token * fx.Int32(config.tile_n)
+                    + vector_lane * fx.Int32(collective_vector_width)
+                )
+                if const_expr(config.collective == "rs_broadcast"):
+                    for peer_step in range_constexpr(tp_size):
+                        peer = (specialized_rank + peer_step + 1) % tp_size
+                        if const_expr(peer == specialized_rank):
+                            peer_output_resource = output_resource
+                        else:
+                            peer_output_resource = (
+                                buffer_ops.create_buffer_resource_from_addr(
+                                    peer_base(workspace_flat_base, peer)
+                                    + fx.Int64(config.output_offset),
+                                    num_records_bytes=payload_bytes,
+                                )
+                            )
+                        _store_bf16(
+                            peer_output_resource,
+                            offset,
+                            reduced_bf16,
+                            collective_vector_width,
+                            config.remote_store_cache_modifier,
+                        )
+                else:
+                    reduced_e8m0, reduced_quant_scale = _mxfp8_scale(
+                        reduced,
+                        tid & fx.Int32(63),
+                        collective_vector_width,
+                    )
+                    store_fp8_words(
+                        reduced_resource,
+                        reduced_offset,
+                        pack_fp8_words(
+                            reduced,
+                            reduced_quant_scale,
+                            collective_vector_width // 4,
+                        ),
+                        collective_vector_width // 4,
+                    )
+                    _store_mxfp8_scale(
+                        reduced_resource,
+                        reduced_scale_resource,
+                        config.reduced_payload_bytes,
+                        reduced_offset,
+                        collective_vector_width,
+                        reduced_e8m0,
+                    )
+            fx.rocdl.s_waitcnt(vmcnt=0, lgkmcnt=0)
+            gpu.barrier()
+
+        emit_reduce_scatter_items()
+
+        if const_expr(config.collective == "rs_broadcast"):
+            publish_gather_completion()
+            return
+
+        def emit_reduced_exchange(propagate_acquire):
+            if tid < fx.Int32(tp_size):
+                remote_slot = state_n_tile * fx.Int32(tp_size) + rank
+                store_i32_system_monotonic(
+                    peer_base(workspace_flat_base, tid)
+                    + fx.Int64(config.owner_ready_offset)
+                    + fx.Int64(remote_slot) * fx.Int64(4),
+                    expected_i32,
+                )
+                local_slot = state_n_tile * fx.Int32(tp_size) + tid
+                wait_i32_system_until_at_least(
+                    local_workspace_base
+                    + fx.Int64(config.owner_ready_offset)
+                    + fx.Int64(local_slot) * fx.Int64(4),
+                    expected_i32,
+                )
+            gpu.barrier()
+            if tid == fx.Int32(0):
+                comm_ops.fence_system_acquire()
+            if const_expr(propagate_acquire):
+                gpu.barrier()
+
+        if const_expr(config.service_groups == 1):
+            if tid == fx.Int32(0):
+                comm_ops.fence_system_release()
+            gpu.barrier()
+            emit_reduced_exchange(True)
+        else:
+            reduce_done_address = (
+                local_workspace_base
+                + fx.Int64(config.reduce_done_offset)
+                + tile_byte_offset
+            )
+            if tid == fx.Int32(0):
+                comm_ops.fence_agent_release()
+                arrival = fx.Int32(
+                    atomic_add_i32_agent(reduce_done_address, fx.Int32(1))
+                )
+                fx.ptr_store(arrival, service_marker_ptr)
+            gpu.barrier()
+            reduce_arrival = fx.Int32(fx.ptr_load(service_marker_ptr))
+            if reduce_arrival == fx.Int32(
+                config.service_groups * config.service_tile_group - 1
+            ):
+                if tid == fx.Int32(0):
+                    comm_ops.fence_agent_acquire()
+                    comm_ops.fence_system_release()
+                gpu.barrier()
+                emit_reduced_exchange(False)
+                if tid == fx.Int32(0):
+                    store_i32_agent_release(
+                        local_workspace_base
+                        + fx.Int64(config.reduced_collective_ready_offset)
+                        + fx.Int64(state_n_tile) * fx.Int64(4),
+                        expected_i32,
+                    )
+
+            if tid == fx.Int32(0):
+                wait_i32_agent_until_at_least(
+                    local_workspace_base
+                    + fx.Int64(config.reduced_collective_ready_offset)
+                    + fx.Int64(state_n_tile) * fx.Int64(4),
+                    expected_i32,
+                )
+                comm_ops.fence_agent_acquire()
+            gpu.barrier()
+
+        def emit_gather_source(source, source_start, source_stride):
+            gather_vector_width = config.vector_width
+            gather_cache_modifier = (
+                config.remote_load_cache_modifier
+                if const_expr(config.gather_load_cache_modifier < 0)
+                else config.gather_load_cache_modifier
+            )
+            vectors_per_token = config.tile_n // gather_vector_width
+            shard_tokens = config.m // tp_size
+            first_token = source_start // fx.Int32(vectors_per_token)
+            vector_lane = source_start - first_token * fx.Int32(vectors_per_token)
+            source_resource = buffer_ops.create_buffer_resource_from_addr(
+                peer_base(workspace_flat_base, source)
+                + fx.Int64(config.reduced_offset)
+                + slot * fx.Int64(config.reduced_shard_bytes),
+                num_records_bytes=(
+                    config.reduced_payload_bytes
+                    if const_expr(config.vector_width == 8)
+                    else config.reduced_shard_bytes
+                ),
+            )
+            source_scale_resource = None
+            if const_expr(config.vector_width == 8):
+                source_scale_resource = buffer_ops.create_buffer_resource_from_addr(
+                    peer_base(workspace_flat_base, source)
+                    + fx.Int64(config.reduced_offset)
+                    + slot * fx.Int64(config.reduced_shard_bytes)
+                    + fx.Int64(config.reduced_payload_bytes),
+                    num_records_bytes=config.reduced_scale_bytes,
+                )
+            for source_token in range(
+                first_token,
+                fx.Int32(shard_tokens),
+                fx.Int32(source_stride // vectors_per_token),
+            ):
+                offset = (
+                    (source * fx.Int32(shard_tokens) + source_token)
+                    * fx.Int32(hidden_dim)
+                    + n_tile * fx.Int32(config.tile_n)
+                    + vector_lane * fx.Int32(gather_vector_width)
+                )
+                reduced_offset = (
+                    n_tile * fx.Int32(config.m * config.tile_n // tp_size)
+                    + source_token * fx.Int32(config.tile_n)
+                    + vector_lane * fx.Int32(gather_vector_width)
+                )
+                words = load_fp8_words(
+                    source_resource,
+                    reduced_offset // fx.Int32(4),
+                    word_count=gather_vector_width // 4,
+                    load_width=gather_vector_width // 4,
+                    cache_modifier=gather_cache_modifier,
+                )
+                scale = _load_mxfp8_scale(
+                    source_resource,
+                    source_scale_resource,
+                    config.reduced_payload_bytes,
+                    reduced_offset,
+                    gather_vector_width,
+                    gather_cache_modifier,
+                )
+                values = fx.Vector.from_elements(
+                    _decode_scaled_fp8_bf16(words, scale),
+                    fx.BFloat16,
+                )
+                _store_bf16(
+                    output_resource,
+                    offset,
+                    values,
+                    gather_vector_width,
+                    config.remote_store_cache_modifier,
+                )
+
+        def emit_remote_gather_source(source, source_start, source_stride):
+            if source != rank:
+                emit_gather_source(source, source_start, source_stride)
+
+        # Split SG4 waves across its two source shards.
+        if const_expr(config.service_groups == 1):
+            parallel_sources = min(4, tp_size)
+            threads_per_source = config.block_threads // parallel_sources
+            source_lane = tid // fx.Int32(threads_per_source)
+            for source_iteration in range_constexpr(tp_size // parallel_sources):
+                source = (
+                    n_tile + source_lane + fx.Int32(source_iteration * parallel_sources)
+                ) % fx.Int32(tp_size)
+                emit_remote_gather_source(
+                    source,
+                    tid % fx.Int32(threads_per_source),
+                    threads_per_source,
+                )
+        elif const_expr(config.service_groups == 4):
+            sources_per_group = tp_size // config.service_groups
+            threads_per_source = config.block_threads // sources_per_group
+            source_lane = tid // fx.Int32(threads_per_source)
+            source_phase = (n_tile + source_lane) % fx.Int32(sources_per_group)
+            source = service_group + source_phase * fx.Int32(config.service_groups)
+            emit_remote_gather_source(
+                source,
+                tid % fx.Int32(threads_per_source),
+                threads_per_source,
+            )
+        else:
+            # Assign each service workgroup to one source rank at a time.
+            for source_iteration in range_constexpr(tp_size // config.service_groups):
+                source_phase = (n_tile + fx.Int32(source_iteration)) % fx.Int32(
+                    tp_size // config.service_groups
+                )
+                source = service_group + source_phase * fx.Int32(config.service_groups)
+                emit_remote_gather_source(source, tid, config.block_threads)
+        fx.rocdl.s_waitcnt(vmcnt=0, lgkmcnt=0)
+        gpu.barrier()
+        publish_gather_completion()
+
+    if const_expr(config.service_groups == 1):
+        if tid == fx.Int32(0):
+            comm_ops.fence_system_release()
+        if const_expr(config.single_pass_direct):
+            gpu.barrier()
+
+        if tid < fx.Int32(tp_size):
+            remote_slot = state_n_tile * fx.Int32(tp_size) + rank
+            store_i32_system_monotonic(
+                peer_base(workspace_flat_base, tid)
+                + fx.Int64(config.rank_ready_offset)
+                + fx.Int64(remote_slot) * fx.Int64(4),
+                expected_i32,
+            )
+            local_slot = state_n_tile * fx.Int32(tp_size) + tid
+            ready_address = (
+                local_workspace_base
+                + fx.Int64(config.rank_ready_offset)
+                + fx.Int64(local_slot) * fx.Int64(4)
+            )
+            if const_expr(config.single_pass_direct):
+                wait_i32_system_until_at_least(
+                    ready_address,
+                    expected_i32,
+                    acquire=not optimized_m8_direct,
+                    sleep=False,
+                )
+            else:
+                wait_i32_system_until_at_least(
+                    ready_address,
+                    expected_i32,
+                )
+        if const_expr(not config.single_pass_direct):  # noqa: SIM102
+            if tid == fx.Int32(0):
+                comm_ops.fence_system_acquire()
+        gpu.barrier()
+    else:
+        service_done_address = (
+            local_workspace_base
+            + fx.Int64(config.service_done_offset)
+            + tile_byte_offset
+        )
+
+        def publish_partials_and_exchange():
+            if tid == fx.Int32(0):
+                comm_ops.fence_agent_release()
+                arrival = fx.Int32(
+                    atomic_add_i32_agent(service_done_address, fx.Int32(1))
+                )
+                fx.ptr_store(arrival, service_marker_ptr)
+            gpu.barrier()
+            service_arrival = fx.Int32(fx.ptr_load(service_marker_ptr))
+            if service_arrival == fx.Int32(
+                config.service_groups * config.service_tile_group - 1
+            ):
+                if tid == fx.Int32(0):
+                    comm_ops.fence_agent_acquire()
+                    local_ready_slot = state_n_tile * fx.Int32(tp_size) + rank
+                    store_i32_system_release(
+                        local_workspace_base
+                        + fx.Int64(config.rank_ready_offset)
+                        + fx.Int64(local_ready_slot) * fx.Int64(4),
+                        expected_i32,
+                    )
+                gpu.barrier()
+
+                if tid < fx.Int32(tp_size):
+                    peer_ready_slot = state_n_tile * fx.Int32(tp_size) + tid
+                    wait_i32_system_until_at_least(
+                        peer_base(workspace_flat_base, tid)
+                        + fx.Int64(config.rank_ready_offset)
+                        + fx.Int64(peer_ready_slot) * fx.Int64(4),
+                        expected_i32,
+                    )
+                gpu.barrier()
+                if tid == fx.Int32(0):
+                    comm_ops.fence_system_acquire()
+                    store_i32_agent_release(
+                        local_workspace_base
+                        + fx.Int64(config.collective_ready_offset)
+                        + fx.Int64(state_n_tile) * fx.Int64(4),
+                        expected_i32,
+                    )
+
+        publish_partials_and_exchange()
+
+        def wait_for_collective():
+            if tid == fx.Int32(0):
+                wait_i32_agent_until_at_least(
+                    local_workspace_base
+                    + fx.Int64(config.collective_ready_offset)
+                    + fx.Int64(state_n_tile) * fx.Int64(4),
+                    expected_i32,
+                )
+                comm_ops.fence_agent_acquire()
+            gpu.barrier()
+
+    if const_expr(config.uses_rsag):
+        if const_expr(config.service_groups > 1):
+            wait_for_collective()
+        emit_rsag_reduce()
+    else:
+        emit_direct_reduce()
+    fx.rocdl.s_waitcnt(vmcnt=0, lgkmcnt=0)
+    if const_expr(not (config.uses_rsag and config.service_groups > 1)):  # noqa: SIM102
+        if tid == fx.Int32(0):
+            reset_tile_state_values()
+
+
+@functools.cache
+def compile_megakernel(
+    config: MegakernelConfig,
+    specialized_rank: int,
+):
+    """Compile the single MXMoE GEMM2 + TP kernel."""
+
+    shape = config.shape
+    if not 0 <= specialized_rank < shape.tp_size:
+        raise ValueError(f"invalid TP rank {specialized_rank}")
+    if config.collective == "direct" and config.producer_rows % config.compute_groups:
+        raise ValueError("compute_groups must divide the producer row bound")
+
+    dynamic_producer = config.collective != "direct"
+    rows_per_group = (
+        config.producer_rows // config.compute_groups if not dynamic_producer else None
+    )
+    launch_grid = (
+        (config.compute_groups * config.n_tiles, 1, 1)
+        if config.n_tile_cohort or config.flat_producer_grid
+        else (config.n_tiles, config.compute_groups, 1)
+    )
+    legacy_config_repr = (
+        repr(config)
+        .replace("MegakernelConfig(", "Gemm2TPMegakernelConfig(", 1)
+        .replace("shape=Shape(", "shape=Gemm2TPShape(", 1)
+    )
+    cache_config = hashlib.sha256(
+        f"mxmoe_bf16_route_dynamic_scale_v5:{legacy_config_repr}".encode()
+    ).hexdigest()[:16]
+
+    def compose(*, module_name, emit_gemm2_tile, shared_storage):
+        @flyc.kernel(
+            name=(
+                f"{module_name}_gemm2_tp_mega_r{specialized_rank}_m{config.m}"
+                f"_cg{config.compute_groups}_v{config.vector_width}"
+            ),
+            known_block_size=[config.block_threads, 1, 1],
+        )
+        def kernel(
+            workspace: fx.Pointer,
+            x: fx.Pointer,
+            w: fx.Pointer,
+            scale_x: fx.Pointer,
+            scale_w: fx.Pointer,
+            sorted_token_ids: fx.Pointer,
+            expert_ids: fx.Pointer,
+            sorted_weights: fx.Pointer,
+            num_valid_ids: fx.Pointer,
+            shared_partial: fx.Pointer,
+            shared_partial_flat_base: fx.Int64,
+            tokens: fx.Int32,
+            model_dim: fx.Int32,
+            inter_dim: fx.Int32,
+            size_expert_ids: fx.Int32,
+        ):
+            local_workspace_base = fx.Int64(ptrtoint(workspace))
+            workspace_flat_base = fx.Int64(
+                comm_ops.load_i64_global(
+                    local_workspace_base + fx.Int64(config.flat_base_offset)
+                )
+            )
+            tid = fx.Int32(gpu.thread_id("x"))
+            lane = tid % fx.Int32(64)
+            wave = rocdl.readfirstlane(T.i32, tid // fx.Int32(64))
+            if const_expr(config.flat_producer_grid):
+                physical_block = fx.Int32(gpu.block_id("x"))
+                n_tile = physical_block % fx.Int32(config.n_tiles)
+                compute_group = physical_block // fx.Int32(config.n_tiles)
+            elif const_expr(config.n_tile_cohort):
+                physical_block = fx.Int32(gpu.block_id("x"))
+                cohort_size = fx.Int32(config.n_tile_cohort)
+                cohort_span = fx.Int32(config.n_tile_cohort * config.compute_groups)
+                cohort_base = physical_block // cohort_span * cohort_size
+                within_cohort = physical_block % cohort_span
+                n_tile = cohort_base + within_cohort % cohort_size
+                compute_group = within_cohort // cohort_size
+            else:
+                n_tile = fx.Int32(gpu.block_id("x"))
+                compute_group = fx.Int32(gpu.block_id("y"))
+            producer_output_address = local_workspace_base + fx.Int64(
+                config.route_offset
+            )
+            producer_counter_slot = fx.Int64(0)
+            if const_expr(config.producer_mode == "atomic_shared"):
+                producer_epoch = fx.Int64(
+                    comm_ops.load_i64_global(
+                        local_workspace_base
+                        + fx.Int64(config.epoch_offset)
+                        + fx.Int64(n_tile) * fx.Int64(8)
+                    )
+                )
+                producer_slot = (producer_epoch + fx.Int64(1)) & fx.Int64(1)
+                producer_counter_slot = producer_slot
+                producer_output_address = (
+                    producer_output_address
+                    + producer_slot * fx.Int64(config.payload_bytes)
+                )
+            producer_output = global_typed_ptr(
+                producer_output_address,
+                T.i8,
+                align=1,
+            )
+            lds = fx.SharedAllocator().allocate(shared_storage).peek()
+            service_marker_ptr = lds_typed_ptr(fx.Int32(ptrtoint(lds.buf.ptr)), T.i32)
+            valid_rows = global_typed_ptr(fx.Int64(ptrtoint(num_valid_ids)), T.i32)[0]
+
+            def emit_gemm(m_block):
+                emit_gemm2_tile(
+                    fx.Int64(ptrtoint(x)),
+                    fx.Int64(ptrtoint(scale_x)),
+                    fx.Int64(ptrtoint(w)),
+                    fx.Int64(ptrtoint(scale_w)),
+                    fx.Int64(ptrtoint(expert_ids)),
+                    fx.Int64(ptrtoint(sorted_token_ids)),
+                    fx.Int64(ptrtoint(sorted_weights)),
+                    fx.Int64(ptrtoint(w)),
+                    fx.Int64(ptrtoint(producer_output)),
+                    m_block,
+                    n_tile,
+                    lane,
+                    wave,
+                    tokens,
+                    size_expert_ids,
+                    inter_dim,
+                    model_dim,
+                    lds,
+                )
+
+            if const_expr(dynamic_producer):
+                total_m_tiles = (valid_rows + fx.Int32(config.tile_m - 1)) // fx.Int32(
+                    config.tile_m
+                )
+                base_iterations = total_m_tiles // fx.Int32(config.compute_groups)
+                remainder = total_m_tiles - base_iterations * fx.Int32(
+                    config.compute_groups
+                )
+                has_extra = compute_group < remainder
+                iteration_count = base_iterations + has_extra.select(
+                    fx.Int32(1), fx.Int32(0)
+                )
+                start_tail = has_extra.select(compute_group, remainder)
+                start_m_block = compute_group * base_iterations + start_tail
+                for iteration in range(fx.Int32(0), iteration_count, fx.Int32(1)):
+                    gpu.barrier()
+                    emit_gemm(start_m_block + fx.Int32(iteration))
+            else:
+                for iteration in range_constexpr(rows_per_group):
+                    if iteration:
+                        gpu.barrier()
+                    m_block = compute_group * fx.Int32(rows_per_group) + fx.Int32(
+                        iteration
+                    )
+                    if m_block * fx.Int32(config.tile_m) < valid_rows:
+                        emit_gemm(m_block)
+            fx.rocdl.s_waitcnt(vmcnt=0, lgkmcnt=0)
+            gpu.barrier()
+            if tid == fx.Int32(0):
+                ticket = fx.Int32(
+                    atomic_add_i32_agent(
+                        local_workspace_base
+                        + fx.Int64(config.producer_done_offset)
+                        + (
+                            fx.Int64(n_tile) * fx.Int64(config.producer_counter_slots)
+                            + producer_counter_slot
+                        )
+                        * fx.Int64(PRODUCER_COUNTER_STRIDE),
+                        fx.Int32(1),
+                    )
+                )
+                service_begin = fx.Int32(config.compute_groups - config.service_groups)
+                fx.ptr_store(
+                    (ticket >= service_begin).select(
+                        ticket - service_begin + fx.Int32(1),
+                        fx.Int32(0),
+                    ),
+                    service_marker_ptr,
+                )
+            gpu.barrier()
+
+            service_marker = fx.Int32(fx.ptr_load(service_marker_ptr))
+            if service_marker > fx.Int32(0):
+                service_group = service_marker - fx.Int32(1)
+                if config.service_groups > 1:
+                    if tid == fx.Int32(0):
+                        wait_i32_agent_until_at_least(
+                            local_workspace_base
+                            + fx.Int64(config.producer_done_offset)
+                            + (
+                                fx.Int64(n_tile)
+                                * fx.Int64(config.producer_counter_slots)
+                                + producer_counter_slot
+                            )
+                            * fx.Int64(PRODUCER_COUNTER_STRIDE),
+                            fx.Int32(config.compute_groups),
+                        )
+                        comm_ops.fence_agent_acquire()
+                else:
+                    if tid == fx.Int32(0):
+                        comm_ops.fence_agent_acquire()
+                gpu.barrier()
+                emit_service_tile(
+                    config,
+                    workspace,
+                    workspace_flat_base,
+                    shared_partial,
+                    shared_partial_flat_base,
+                    specialized_rank,
+                    n_tile,
+                    tid,
+                    service_group,
+                    service_marker_ptr,
+                )
+
+        def launch(
+            workspace,
+            shared_partial,
+            shared_partial_flat_base,
+            x,
+            w,
+            scale_x,
+            scale_w,
+            sorted_token_ids,
+            expert_ids,
+            sorted_weights,
+            num_valid_ids,
+            tokens,
+            model_dim,
+            inter_dim,
+            size_expert_ids,
+            stream,
+        ):
+            if const_expr(config.waves_per_eu > 0):
+                context = CompilationContext.get_current()
+                for op in context.gpu_module_body.operations:
+                    if hasattr(op, "attributes") and op.OPERATION_NAME == "gpu.func":
+                        op.attributes["rocdl.waves_per_eu"] = ir.IntegerAttr.get(
+                            T.i32, config.waves_per_eu
+                        )
+            kernel(
+                workspace,
+                x,
+                w,
+                scale_x,
+                scale_w,
+                sorted_token_ids,
+                expert_ids,
+                sorted_weights,
+                num_valid_ids,
+                shared_partial,
+                shared_partial_flat_base,
+                tokens,
+                model_dim,
+                inter_dim,
+                size_expert_ids,
+            ).launch(
+                grid=launch_grid,
+                block=(config.block_threads, 1, 1),
+                stream=stream,
+            )
+
+        launch.__name__ = (
+            f"launch_gemm2_tp_mega_mxmoe_r{specialized_rank}_{cache_config}"
+        )
+        return flyc.jit(launch)
+
+    return compile_megakernel_producer(config, compose)

--- a/aiter/ops/flydsl/kernels/comm_fused_moe/gfx950/a8w4/producer.py
+++ b/aiter/ops/flydsl/kernels/comm_fused_moe/gfx950/a8w4/producer.py
@@ -3,37 +3,22 @@
 
 import flydsl.compiler as flyc
 import flydsl.expr as fx
-from flydsl._mlir import ir
-from flydsl._mlir.dialects import llvm as llvm_d
-from flydsl.expr.typing import Int32, as_ir_value
 
 from ....mxmoe_dispatcher import compile_gemm2_a4w4_port
 from .config import MegakernelConfig, WindowConfig
 
+_ROUTE_STORE_CACHE_MODIFIER = 0x10  # sc1
+
 
 @flyc.jit
 def resolve_route_input_row(packed, tokens, topk):
-    packed = fx.Int32(as_ir_value(packed))
+    packed = fx.Int32(packed)
     token = packed & fx.Int32(0x00FFFFFF)
     route_slot = packed >> fx.Int32(24)
     valid = (token < tokens) & (route_slot < fx.Int32(topk))
     return valid.select(
         token * fx.Int32(topk) + route_slot,
         fx.Int32(0),
-    )
-
-
-def store_bf16_route(arg_out, element_offset, values):
-    byte_address = fx.Int64(arg_out) + fx.Int64(element_offset) * fx.Int64(2)
-    pointer = llvm_d.IntToPtrOp(
-        ir.Type.parse("!llvm.ptr<1>"), as_ir_value(byte_address)
-    ).result
-    llvm_d.InlineAsmOp(
-        None,
-        [pointer, as_ir_value(values.bitcast(Int32))],
-        "global_store_dwordx4 $0, $1, off sc1",
-        "v,v",
-        has_side_effects=True,
     )
 
 
@@ -64,7 +49,9 @@ def compile_megakernel_producer(config: MegakernelConfig, composition):
         out_dtype="bf16",
         enable_bias=False,
         _composition=composition,
-        _reduce_store=(store_bf16_route if config.producer_mode == "routes" else None),
+        _reduce_store_cache_modifier=(
+            _ROUTE_STORE_CACHE_MODIFIER if config.producer_mode == "routes" else None
+        ),
         _input_row_resolver=input_row_resolver,
     )
 

--- a/aiter/ops/flydsl/kernels/comm_fused_moe/gfx950/a8w4/producer.py
+++ b/aiter/ops/flydsl/kernels/comm_fused_moe/gfx950/a8w4/producer.py
@@ -1,0 +1,102 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Adapt the communication-fused route ABI to the MXMoE GEMM2 producer."""
+
+import flydsl.compiler as flyc
+import flydsl.expr as fx
+from flydsl._mlir import ir
+from flydsl._mlir.dialects import llvm as llvm_d
+from flydsl.expr.typing import Int32, as_ir_value
+
+from ....mxmoe_dispatcher import compile_gemm2_a4w4_port
+from .config import MegakernelConfig, WindowConfig
+
+
+@flyc.jit
+def resolve_route_input_row(packed, tokens, topk):
+    packed = fx.Int32(as_ir_value(packed))
+    token = packed & fx.Int32(0x00FFFFFF)
+    route_slot = packed >> fx.Int32(24)
+    valid = (token < tokens) & (route_slot < fx.Int32(topk))
+    return valid.select(
+        token * fx.Int32(topk) + route_slot,
+        fx.Int32(0),
+    )
+
+
+def store_bf16_route(arg_out, element_offset, values):
+    byte_address = fx.Int64(arg_out) + fx.Int64(element_offset) * fx.Int64(2)
+    pointer = llvm_d.IntToPtrOp(
+        ir.Type.parse("!llvm.ptr<1>"), as_ir_value(byte_address)
+    ).result
+    llvm_d.InlineAsmOp(
+        None,
+        [pointer, as_ir_value(values.bitcast(Int32))],
+        "global_store_dwordx4 $0, $1, off sc1",
+        "v,v",
+        has_side_effects=True,
+    )
+
+
+def compile_megakernel_producer(config: MegakernelConfig, composition):
+    shape = config.shape
+
+    def input_row_resolver(packed, tokens):
+        return resolve_route_input_row(packed, tokens, shape.topk)
+
+    return compile_gemm2_a4w4_port(
+        BM=config.tile_m,
+        BN=config.tile_n,
+        BK=config.tile_k,
+        use_nt=config.b_cache_modifier == 2,
+        HIDDEN_MAX=shape.model_dim,
+        epilog=("atomic" if config.producer_mode == "atomic_shared" else "reduce"),
+        INTER_MAX=shape.inter_dim,
+        a_dtype="fp8",
+        b_dtype="fp4",
+        topk=shape.topk,
+        SBM=config.sort_block_m,
+        persist=False,
+        g2_bhoist=True,
+        g2_ascale_pf=True,
+        g2_spart=0,
+        g2_bf16_lds=False,
+        g2_kstatic=True,
+        out_dtype="bf16",
+        enable_bias=False,
+        _composition=composition,
+        _reduce_store=(store_bf16_route if config.producer_mode == "routes" else None),
+        _input_row_resolver=input_row_resolver,
+    )
+
+
+def compile_window_producer(config: WindowConfig, window: int, composition):
+    shape = config.shape
+    n_start = window * config.window
+    n_end = n_start + config.window
+
+    def input_row_resolver(packed, tokens):
+        return resolve_route_input_row(packed, tokens, shape.topk)
+
+    return compile_gemm2_a4w4_port(
+        BM=config.tile_m,
+        BN=config.tile_n,
+        BK=config.tile_k,
+        HIDDEN_MAX=shape.model_dim,
+        epilog="reduce",
+        INTER_MAX=shape.inter_dim,
+        a_dtype="fp8",
+        b_dtype="fp4",
+        topk=shape.topk,
+        SBM=config.sort_block_m,
+        persist=False,
+        g2_bhoist=False,
+        g2_ascale_pf=True,
+        g2_spart=0,
+        g2_bf16_lds=True,
+        g2_kstatic=True,
+        out_dtype="fp8",
+        enable_bias=False,
+        _composition=composition,
+        _input_row_resolver=input_row_resolver,
+        _output_n_range=(n_start, n_end),
+    )

--- a/aiter/ops/flydsl/kernels/comm_fused_moe/gfx950/a8w4/window.py
+++ b/aiter/ops/flydsl/kernels/comm_fused_moe/gfx950/a8w4/window.py
@@ -9,16 +9,18 @@ from flydsl.expr import const_expr, gpu, ptrtoint, range_constexpr, rocdl
 from flydsl.expr import math as fmath
 from flydsl.expr.typing import ReductionOp, T
 
-from .... import buffer_ops
 from ....mxfp4_gemm_common import global_typed_ptr
 from .collectives import (
+    buffer_tensor_from_addr,
     decode_scaled_fp8_f32,
     e8m0_scale,
     emit_tp_all_gather,
     emit_tp_reduce_scatter,
+    load_bf16,
     load_e8m0_scale,
     load_fp8_words,
     pack_fp8_words,
+    store_buffer,
     store_fp8_words,
 )
 from .config import BLOCK, WindowConfig
@@ -150,10 +152,17 @@ def _emit_local(config: WindowConfig, route, partial, shared, worker):
             column = tid * fx.Int32(8) + fx.Int32(column_pass * columns_per_pass)
             if column < fx.Int32(window):
                 route_row_bytes = window + window // 8
-                route_row = buffer_ops.create_buffer_resource_from_addr(
+                route_row = buffer_tensor_from_addr(
                     fx.Int64(ptrtoint(route))
                     + fx.Int64(token) * fx.Int64(shape.topk * route_row_bytes),
-                    num_records_bytes=shape.topk * route_row_bytes,
+                    fx.Int32,
+                    shape.topk * route_row_bytes,
+                )
+                route_scale_row = buffer_tensor_from_addr(
+                    fx.Int64(ptrtoint(route))
+                    + fx.Int64(token) * fx.Int64(shape.topk * route_row_bytes),
+                    fx.Int8,
+                    shape.topk * route_row_bytes,
                 )
                 acc = fx.Vector.filled(8, 0.0, fx.Float32)
                 for slot in range_constexpr(shape.topk):
@@ -165,7 +174,7 @@ def _emit_local(config: WindowConfig, route, partial, shared, worker):
                         cache_modifier=2,
                     )
                     scale = load_e8m0_scale(
-                        route_row,
+                        route_scale_row,
                         fx.Int32(slot * route_row_bytes + window)
                         + column // fx.Int32(8),
                         2,
@@ -173,20 +182,13 @@ def _emit_local(config: WindowConfig, route, partial, shared, worker):
                     values = decode_scaled_fp8_f32(words, scale)
                     acc = acc + fx.Vector.from_elements(values, fx.Float32)
 
-                shared_row = buffer_ops.create_buffer_resource_from_addr(
+                shared_row = buffer_tensor_from_addr(
                     fx.Int64(ptrtoint(shared))
                     + fx.Int64(token) * fx.Int64(shape.model_dim * 2),
-                    num_records_bytes=shape.model_dim * 2,
+                    fx.BFloat16,
+                    shape.model_dim * 2,
                 )
-                shared_values = fx.Vector(
-                    buffer_ops.buffer_load(
-                        shared_row,
-                        column,
-                        vec_width=8,
-                        dtype=T.bf16,
-                        cache_modifier=2,
-                    )
-                ).extf(T.vec(8, T.f32))
+                shared_values = load_bf16(shared_row, column, 8, 2).to(fx.Float32)
                 acc = acc + shared_values
 
                 lane = tid & fx.Int32(63)
@@ -206,23 +208,25 @@ def _emit_local(config: WindowConfig, route, partial, shared, worker):
                     max_bits = local_max.bitcast(fx.Int32)
                 e8m0, quant_scale = e8m0_scale(local_max)
                 packed = pack_fp8_words(acc, quant_scale, 2)
-                payload_row = buffer_ops.create_buffer_resource_from_addr(
+                payload_row = buffer_tensor_from_addr(
                     fx.Int64(ptrtoint(partial)) + fx.Int64(token) * fx.Int64(window),
-                    num_records_bytes=window,
+                    fx.Int32,
+                    window,
                 )
                 store_fp8_words(payload_row, column, packed, 2)
                 if lane & fx.Int32(3) == fx.Int32(0):
-                    scale_row = buffer_ops.create_buffer_resource_from_addr(
+                    scale_row = buffer_tensor_from_addr(
                         fx.Int64(ptrtoint(partial))
                         + fx.Int64(m * window)
                         + fx.Int64(token) * fx.Int64(groups_per_row),
-                        num_records_bytes=groups_per_row,
+                        fx.Int8,
+                        groups_per_row,
                     )
-                    buffer_ops.buffer_store(
-                        e8m0.to(fx.Int8),
+                    store_buffer(
                         scale_row,
                         column // fx.Int32(32),
-                        offset_is_bytes=True,
+                        e8m0.to(fx.Int8),
+                        fx.Int8,
                     )
 
 

--- a/aiter/ops/flydsl/kernels/comm_fused_moe/gfx950/a8w4/window.py
+++ b/aiter/ops/flydsl/kernels/comm_fused_moe/gfx950/a8w4/window.py
@@ -1,0 +1,587 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Windowed GEMM2 and TP communication family."""
+
+import functools
+
+import flydsl.compiler as flyc
+import flydsl.expr as fx
+from flydsl.expr import const_expr, gpu, ptrtoint, range_constexpr, rocdl
+from flydsl.expr import math as fmath
+from flydsl.expr.typing import ReductionOp, T
+
+from .... import buffer_ops
+from ....mxfp4_gemm_common import global_typed_ptr
+from .collectives import (
+    decode_scaled_fp8_f32,
+    e8m0_scale,
+    emit_tp_all_gather,
+    emit_tp_reduce_scatter,
+    load_e8m0_scale,
+    load_fp8_words,
+    pack_fp8_words,
+    store_fp8_words,
+)
+from .config import BLOCK, WindowConfig
+from .producer import compile_window_producer
+
+
+def _compose_compute(config: WindowConfig, window_index: int):
+    tiles_per_window = config.tiles_per_window
+
+    def compose(*, module_name, emit_gemm2_tile, shared_storage):
+        @flyc.kernel(
+            name=f"{module_name}_window_{window_index}",
+            known_block_size=[BLOCK, 1, 1],
+        )
+        def kernel(
+            route_out: fx.Pointer,
+            x: fx.Pointer,
+            w: fx.Pointer,
+            scale_x: fx.Pointer,
+            scale_w: fx.Pointer,
+            sorted_token_ids: fx.Pointer,
+            expert_ids: fx.Pointer,
+            sorted_weights: fx.Pointer,
+            num_valid_ids: fx.Pointer,
+            bias: fx.Pointer,
+            tokens: fx.Int32,
+            model_dim: fx.Int32,
+            inter_dim: fx.Int32,
+            size_expert_ids: fx.Int32,
+        ):
+            worker = fx.Int32(gpu.block_id("x"))
+            m_block = worker // fx.Int32(tiles_per_window)
+            n_block = fx.Int32(window_index * tiles_per_window) + worker % fx.Int32(
+                tiles_per_window
+            )
+            tid = fx.Int32(gpu.thread_id("x"))
+            lane = tid % fx.Int32(64)
+            wave = rocdl.readfirstlane(T.i32, tid // fx.Int32(64))
+            lds = fx.SharedAllocator().allocate(shared_storage).peek()
+            valid_rows = global_typed_ptr(fx.Int64(ptrtoint(num_valid_ids)), T.i32)[0]
+            if m_block * fx.Int32(config.tile_m) < valid_rows:
+                emit_gemm2_tile(
+                    fx.Int64(ptrtoint(x)),
+                    fx.Int64(ptrtoint(scale_x)),
+                    fx.Int64(ptrtoint(w)),
+                    fx.Int64(ptrtoint(scale_w)),
+                    fx.Int64(ptrtoint(expert_ids)),
+                    fx.Int64(ptrtoint(sorted_token_ids)),
+                    fx.Int64(ptrtoint(sorted_weights)),
+                    fx.Int64(ptrtoint(bias)),
+                    fx.Int64(ptrtoint(route_out)),
+                    m_block,
+                    n_block,
+                    lane,
+                    wave,
+                    tokens,
+                    size_expert_ids,
+                    inter_dim,
+                    model_dim,
+                    lds,
+                )
+
+        @flyc.jit
+        def launch(
+            route_out,
+            x,
+            w,
+            scale_x,
+            scale_w,
+            sorted_token_ids,
+            expert_ids,
+            sorted_weights,
+            num_valid_ids,
+            bias,
+            tokens,
+            model_dim,
+            inter_dim,
+            size_expert_ids,
+            stream,
+        ):
+            grid = fx.Int32(size_expert_ids) * fx.Int32(tiles_per_window)
+            kernel(
+                route_out,
+                x,
+                w,
+                scale_x,
+                scale_w,
+                sorted_token_ids,
+                expert_ids,
+                sorted_weights,
+                num_valid_ids,
+                bias,
+                tokens,
+                model_dim,
+                inter_dim,
+                size_expert_ids,
+            ).launch(grid=(grid, 1, 1), block=(BLOCK, 1, 1), stream=stream)
+
+        return launch
+
+    return compose
+
+
+def _compile_compute(config: WindowConfig, window: int, compose=None):
+    return compile_window_producer(
+        config,
+        window,
+        compose or _compose_compute(config, window),
+    )
+
+
+@functools.cache
+def compile_compute(config: WindowConfig, window: int):
+    """Compile one compact Stage2 window."""
+    return _compile_compute(config, window)
+
+
+@flyc.jit
+def _emit_local(config: WindowConfig, route, partial, shared, worker):
+    shape = config.shape
+    m = config.m
+    window = config.window
+    groups_per_row = config.groups_per_row
+    for token in range(worker, fx.Int32(m), fx.Int32(config.local_workers)):
+        tid = fx.Int32(gpu.thread_id("x"))
+        columns_per_pass = BLOCK * 8
+        column_passes = (window + columns_per_pass - 1) // columns_per_pass
+        for column_pass in range_constexpr(column_passes):
+            column = tid * fx.Int32(8) + fx.Int32(column_pass * columns_per_pass)
+            if column < fx.Int32(window):
+                route_row_bytes = window + window // 8
+                route_row = buffer_ops.create_buffer_resource_from_addr(
+                    fx.Int64(ptrtoint(route))
+                    + fx.Int64(token) * fx.Int64(shape.topk * route_row_bytes),
+                    num_records_bytes=shape.topk * route_row_bytes,
+                )
+                acc = fx.Vector.filled(8, 0.0, fx.Float32)
+                for slot in range_constexpr(shape.topk):
+                    words = load_fp8_words(
+                        route_row,
+                        fx.Int32(slot * (route_row_bytes // 4)) + column // fx.Int32(4),
+                        word_count=2,
+                        load_width=2,
+                        cache_modifier=2,
+                    )
+                    scale = load_e8m0_scale(
+                        route_row,
+                        fx.Int32(slot * route_row_bytes + window)
+                        + column // fx.Int32(8),
+                        2,
+                    )
+                    values = decode_scaled_fp8_f32(words, scale)
+                    acc = acc + fx.Vector.from_elements(values, fx.Float32)
+
+                shared_row = buffer_ops.create_buffer_resource_from_addr(
+                    fx.Int64(ptrtoint(shared))
+                    + fx.Int64(token) * fx.Int64(shape.model_dim * 2),
+                    num_records_bytes=shape.model_dim * 2,
+                )
+                shared_values = fx.Vector(
+                    buffer_ops.buffer_load(
+                        shared_row,
+                        column,
+                        vec_width=8,
+                        dtype=T.bf16,
+                        cache_modifier=2,
+                    )
+                ).extf(T.vec(8, T.f32))
+                acc = acc + shared_values
+
+                lane = tid & fx.Int32(63)
+                local_max = fx.Float32(1e-10).maximumf(
+                    fmath.absf(acc).reduce(ReductionOp.MAX)
+                )
+                max_bits = local_max.bitcast(fx.Int32)
+                for xor_lane in (1, 2):
+                    remote_bits = fx.rocdl.ds_bpermute(
+                        T.i32,
+                        (lane ^ fx.Int32(xor_lane)) * fx.Int32(4),
+                        max_bits,
+                    )
+                    local_max = local_max.maximumf(
+                        fx.Int32(remote_bits).bitcast(fx.Float32)
+                    )
+                    max_bits = local_max.bitcast(fx.Int32)
+                e8m0, quant_scale = e8m0_scale(local_max)
+                packed = pack_fp8_words(acc, quant_scale, 2)
+                payload_row = buffer_ops.create_buffer_resource_from_addr(
+                    fx.Int64(ptrtoint(partial)) + fx.Int64(token) * fx.Int64(window),
+                    num_records_bytes=window,
+                )
+                store_fp8_words(payload_row, column, packed, 2)
+                if lane & fx.Int32(3) == fx.Int32(0):
+                    scale_row = buffer_ops.create_buffer_resource_from_addr(
+                        fx.Int64(ptrtoint(partial))
+                        + fx.Int64(m * window)
+                        + fx.Int64(token) * fx.Int64(groups_per_row),
+                        num_records_bytes=groups_per_row,
+                    )
+                    buffer_ops.buffer_store(
+                        e8m0.to(fx.Int8),
+                        scale_row,
+                        column // fx.Int32(32),
+                        offset_is_bytes=True,
+                    )
+
+
+def _compose_cycle(
+    config: WindowConfig,
+    window_index: int,
+):
+    shape = config.shape
+    m = config.m
+    shard_rows = config.shard_rows
+    window = config.window
+    local_workers = config.local_workers
+    reduce_scatter_grid = config.reduce_scatter_grid
+    all_gather_grid = config.all_gather_grid
+    has_reduce_scatter = window_index >= 2
+    has_all_gather = window_index >= 3
+    service_grid = max(
+        reduce_scatter_grid if has_reduce_scatter else 0,
+        all_gather_grid if has_all_gather else 0,
+    )
+    tiles_per_window = config.tiles_per_window
+
+    def compose(
+        *,
+        module_name,
+        emit_gemm2_tile,
+        shared_storage,
+    ):
+        @flyc.kernel(
+            name=(
+                f"gemm2_tp_window_pipeline_{shape.tag}"
+                f"_cycle_p{window_index}_sr{shard_rows}"
+                f"_t{config.tile_m}x{config.tile_n}x{config.tile_k}"
+                f"_sbm{config.sort_block_m}_w{window}_lw{local_workers}"
+                f"_rsg{reduce_scatter_grid}_agg{all_gather_grid}"
+                f"_rs{int(has_reduce_scatter)}ag{int(has_all_gather)}"
+            ),
+            known_block_size=[BLOCK, 1, 1],
+        )
+        def kernel(
+            route_out: fx.Pointer,
+            x: fx.Pointer,
+            w: fx.Pointer,
+            scale_x: fx.Pointer,
+            scale_w: fx.Pointer,
+            sorted_token_ids: fx.Pointer,
+            expert_ids: fx.Pointer,
+            sorted_weights: fx.Pointer,
+            num_valid_ids: fx.Pointer,
+            bias: fx.Pointer,
+            tokens: fx.Int32,
+            model_dim: fx.Int32,
+            inter_dim: fx.Int32,
+            size_expert_ids: fx.Int32,
+            local_route: fx.Pointer,
+            local_partial: fx.Pointer,
+            local_shared: fx.Pointer,
+            partial_flat_base: fx.Int64,
+            reduced_shard: fx.Pointer,
+            reduced_payload: fx.Pointer,
+            reduced_scale: fx.Pointer,
+            gather_payload_base: fx.Int64,
+            gather_scale_base: fx.Int64,
+            gathered_output: fx.Pointer,
+            rank: fx.Int32,
+        ):
+            linear = fx.Int32(gpu.block_id("x"))
+            tid = fx.Int32(gpu.thread_id("x"))
+            lane = tid % fx.Int32(64)
+            wave = rocdl.readfirstlane(T.i32, tid // fx.Int32(64))
+            lds = fx.SharedAllocator().allocate(shared_storage).peek()
+            valid_rows = global_typed_ptr(fx.Int64(ptrtoint(num_valid_ids)), T.i32)[0]
+
+            def emit_compute(worker):
+                m_block = worker // fx.Int32(tiles_per_window)
+                n_block = fx.Int32(window_index * tiles_per_window) + worker % fx.Int32(
+                    tiles_per_window
+                )
+                if m_block * fx.Int32(config.tile_m) < valid_rows:
+                    emit_gemm2_tile(
+                        fx.Int64(ptrtoint(x)),
+                        fx.Int64(ptrtoint(scale_x)),
+                        fx.Int64(ptrtoint(w)),
+                        fx.Int64(ptrtoint(scale_w)),
+                        fx.Int64(ptrtoint(expert_ids)),
+                        fx.Int64(ptrtoint(sorted_token_ids)),
+                        fx.Int64(ptrtoint(sorted_weights)),
+                        fx.Int64(ptrtoint(bias)),
+                        fx.Int64(ptrtoint(route_out)),
+                        m_block,
+                        n_block,
+                        lane,
+                        wave,
+                        tokens,
+                        size_expert_ids,
+                        inter_dim,
+                        model_dim,
+                        lds,
+                    )
+
+            if const_expr(service_grid > 0):
+                paired = linear < fx.Int32(service_grid * 3)
+                slot = linear % fx.Int32(3)
+                is_service = paired & (slot == fx.Int32(0))
+                is_compute = (linear >= fx.Int32(service_grid * 3)) | (
+                    paired & (slot != fx.Int32(0))
+                )
+                raw_compute = paired.select(
+                    (linear // fx.Int32(3)) * fx.Int32(2) + slot - fx.Int32(1),
+                    linear - fx.Int32(service_grid),
+                )
+                compute_worker = is_compute.select(raw_compute, fx.Int32(0))
+                service_worker = linear // fx.Int32(3)
+            else:
+                compute_worker = linear
+
+            if const_expr(service_grid > 0):
+                if is_compute:
+                    emit_compute(compute_worker)
+            else:
+                emit_compute(compute_worker)
+
+            local_active = compute_worker < fx.Int32(local_workers)
+            if const_expr(service_grid > 0):
+                local_active = is_compute & local_active
+            if local_active:
+                _emit_local(
+                    config,
+                    local_route,
+                    local_partial,
+                    local_shared,
+                    compute_worker,
+                )
+
+            if const_expr(service_grid > 0):  # noqa: SIM102
+                if is_service:
+                    if const_expr(has_reduce_scatter):  # noqa: SIM102
+                        if service_worker < fx.Int32(reduce_scatter_grid):
+                            emit_tp_reduce_scatter(
+                                partial_flat_base,
+                                reduced_shard,
+                                reduced_payload,
+                                reduced_scale,
+                                rank,
+                                service_worker,
+                                tokens=m,
+                                output_width=shape.model_dim,
+                                payload_width=window,
+                                shard_rows=shard_rows,
+                                tp=shape.tp_size,
+                                block=BLOCK,
+                                reduce_scatter_grid=reduce_scatter_grid,
+                            )
+                    if const_expr(has_all_gather):  # noqa: SIM102
+                        if service_worker < fx.Int32(all_gather_grid):
+                            emit_tp_all_gather(
+                                gather_payload_base,
+                                gather_scale_base,
+                                gathered_output,
+                                rank,
+                                service_worker,
+                                output_width=shape.model_dim,
+                                payload_width=window,
+                                shard_rows=shard_rows,
+                                tp=shape.tp_size,
+                                block=BLOCK,
+                                all_gather_grid=all_gather_grid,
+                            )
+
+        @flyc.jit
+        def launch(
+            route_out,
+            x,
+            w,
+            scale_x,
+            scale_w,
+            sorted_token_ids,
+            expert_ids,
+            sorted_weights,
+            num_valid_ids,
+            bias,
+            tokens,
+            model_dim,
+            inter_dim,
+            size_expert_ids,
+            local_route,
+            local_partial,
+            local_shared,
+            partial_flat_base,
+            reduced_shard,
+            reduced_payload,
+            reduced_scale,
+            gather_payload_base,
+            gather_scale_base,
+            gathered_output,
+            rank,
+            stream,
+        ):
+            compute_workers = fx.Int32(size_expert_ids) * fx.Int32(tiles_per_window)
+            grid = compute_workers + fx.Int32(service_grid)
+            kernel(
+                route_out,
+                x,
+                w,
+                scale_x,
+                scale_w,
+                sorted_token_ids,
+                expert_ids,
+                sorted_weights,
+                num_valid_ids,
+                bias,
+                tokens,
+                model_dim,
+                inter_dim,
+                size_expert_ids,
+                local_route,
+                local_partial,
+                local_shared,
+                partial_flat_base,
+                reduced_shard,
+                reduced_payload,
+                reduced_scale,
+                gather_payload_base,
+                gather_scale_base,
+                gathered_output,
+                rank,
+            ).launch(grid=(grid, 1, 1), block=(BLOCK, 1, 1), stream=stream)
+
+        return launch
+
+    return compose
+
+
+@functools.cache
+def compile_cycle(
+    config: WindowConfig,
+    window: int,
+):
+    """Compile G/L with optional TP reduce-scatter/all-gather service CTAs."""
+    return _compile_compute(
+        config,
+        window,
+        _compose_cycle(config, window),
+    )
+
+
+@functools.cache
+def compile_drain(
+    config: WindowConfig,
+    has_local: bool,
+    has_reduce_scatter: bool,
+    has_all_gather: bool,
+):
+    """Compile the fixed pipeline tail without reserving GEMM LDS."""
+    shape = config.shape
+    m = config.m
+    shard_rows = config.shard_rows
+    window = config.window
+    local_workers = config.local_workers
+    reduce_scatter_grid = config.reduce_scatter_grid
+    all_gather_grid = config.all_gather_grid
+    service_grid = max(
+        reduce_scatter_grid if has_reduce_scatter else 0,
+        all_gather_grid if has_all_gather else 0,
+    )
+
+    @flyc.kernel(
+        name=(
+            f"gemm2_tp_window_pipeline_{shape.tag}_drain_sr{shard_rows}"
+            f"_w{window}_lw{local_workers}"
+            f"_rsg{reduce_scatter_grid}_agg{all_gather_grid}"
+            f"_l{int(has_local)}"
+            f"rs{int(has_reduce_scatter)}ag{int(has_all_gather)}"
+        ),
+        known_block_size=[BLOCK, 1, 1],
+    )
+    def kernel(
+        route: fx.Pointer,
+        partial: fx.Pointer,
+        shared: fx.Pointer,
+        partial_flat_base: fx.Int64,
+        reduced_shard: fx.Pointer,
+        reduced_payload: fx.Pointer,
+        reduced_scale: fx.Pointer,
+        gather_payload_base: fx.Int64,
+        gather_scale_base: fx.Int64,
+        gathered_output: fx.Pointer,
+        rank: fx.Int32,
+    ):
+        worker = fx.Int32(gpu.block_id("x"))
+        if const_expr(has_reduce_scatter):  # noqa: SIM102
+            if worker < fx.Int32(reduce_scatter_grid):
+                emit_tp_reduce_scatter(
+                    partial_flat_base,
+                    reduced_shard,
+                    reduced_payload,
+                    reduced_scale,
+                    rank,
+                    worker,
+                    tokens=m,
+                    output_width=shape.model_dim,
+                    payload_width=window,
+                    shard_rows=shard_rows,
+                    tp=shape.tp_size,
+                    block=BLOCK,
+                    reduce_scatter_grid=reduce_scatter_grid,
+                )
+        if const_expr(has_all_gather):  # noqa: SIM102
+            if worker < fx.Int32(all_gather_grid):
+                emit_tp_all_gather(
+                    gather_payload_base,
+                    gather_scale_base,
+                    gathered_output,
+                    rank,
+                    worker,
+                    output_width=shape.model_dim,
+                    payload_width=window,
+                    shard_rows=shard_rows,
+                    tp=shape.tp_size,
+                    block=BLOCK,
+                    all_gather_grid=all_gather_grid,
+                )
+
+        if const_expr(has_local):
+            local_worker = worker - fx.Int32(service_grid)
+            if worker >= fx.Int32(service_grid):
+                _emit_local(config, route, partial, shared, local_worker)
+
+    @flyc.jit
+    def launch(
+        route,
+        partial,
+        shared,
+        partial_flat_base,
+        reduced_shard,
+        reduced_payload,
+        reduced_scale,
+        gather_payload_base,
+        gather_scale_base,
+        gathered_output,
+        rank,
+        stream,
+    ):
+        kernel(
+            route,
+            partial,
+            shared,
+            partial_flat_base,
+            reduced_shard,
+            reduced_payload,
+            reduced_scale,
+            gather_payload_base,
+            gather_scale_base,
+            gathered_output,
+            rank,
+        ).launch(
+            grid=(service_grid + (local_workers if has_local else 0), 1, 1),
+            block=(BLOCK, 1, 1),
+            stream=stream,
+        )
+
+    return launch

--- a/aiter/ops/flydsl/kernels/communication_ops_utils.py
+++ b/aiter/ops/flydsl/kernels/communication_ops_utils.py
@@ -27,6 +27,7 @@ from flydsl.expr.typing import T
 __all__ = [
     "GeometryTuningTable",
     "atomic_add_agent",
+    "atomic_add_agent_one_as",
     "atomic_add_global_at",
     "atomic_add_system",
     "fence_acquire",
@@ -36,13 +37,20 @@ __all__ = [
     "fence_system_acquire",
     "fence_system_release",
     "load_i32_acquire",
+    "load_i32_global_agent",
+    "load_i32_global_system",
     "load_i32_nt",
     "load_i64_acquire",
     "load_i64_global",
     "load_v4i32_nt",
     "spin_until_eq_i32",
+    "spin_until_ge_i32_agent",
+    "spin_until_ge_i32_system",
     "spin_until_ge_i64",
     "spin_until_gt_i32",
+    "store_i32_global_agent_release",
+    "store_i32_global_system_monotonic",
+    "store_i32_global_system_release",
     "store_i32_system",
     "store_i64_global_system",
     "traced",
@@ -94,6 +102,34 @@ def load_i32_acquire(addr_i64):
     ).res
 
 
+def load_i32_global_system(addr_i64, *, acquire=False):
+    """Volatile i32 load with system visibility for a spin-wait."""
+    return _llvm_d.LoadOp(
+        T.i32,
+        _to_ptr_global(addr_i64),
+        alignment=4,
+        volatile_=True,
+        ordering=(
+            _llvm_d.AtomicOrdering.acquire
+            if acquire
+            else _llvm_d.AtomicOrdering.monotonic
+        ),
+        syncscope=fx.rocdl.SyncScope.OneAs,
+    ).res
+
+
+def load_i32_global_agent(addr_i64):
+    """Volatile monotonic i32 load with agent-one-as visibility."""
+    return _llvm_d.LoadOp(
+        T.i32,
+        _to_ptr_global(addr_i64),
+        alignment=4,
+        volatile_=True,
+        ordering=_llvm_d.AtomicOrdering.monotonic,
+        syncscope=fx.rocdl.SyncScope.AgentOneAs,
+    ).res
+
+
 def load_i64_acquire(addr_i64):
     """Volatile monotonic i64 load suitable for a spin-wait."""
     return _llvm_d.LoadOp(
@@ -126,6 +162,28 @@ def spin_until_ge_i64(addr_i64, val):
     cur = fx.Int64(load_i64_acquire(addr_i64))
     while cur < fx.Int64(val):
         cur = fx.Int64(load_i64_acquire(addr_i64))
+    return cur
+
+
+@traced
+def spin_until_ge_i32_system(addr_i64, val, *, acquire=False, sleep=True):
+    """Spin on a system-visible i32 flag until it reaches ``val``."""
+    cur = fx.Int32(load_i32_global_system(addr_i64, acquire=acquire))
+    while cur < fx.Int32(val):
+        if fx.const_expr(sleep):
+            fx.rocdl.s_sleep(1)
+        cur = fx.Int32(load_i32_global_system(addr_i64, acquire=acquire))
+    return cur
+
+
+@traced
+def spin_until_ge_i32_agent(addr_i64, val, *, sleep=True):
+    """Spin on an agent-visible i32 flag until it reaches ``val``."""
+    cur = fx.Int32(load_i32_global_agent(addr_i64))
+    while cur < fx.Int32(val):
+        if fx.const_expr(sleep):
+            fx.rocdl.s_sleep(1)
+        cur = fx.Int32(load_i32_global_agent(addr_i64))
     return cur
 
 
@@ -182,6 +240,39 @@ def store_i64_global_system(addr_i64, val):
     )
 
 
+def store_i32_global_agent_release(addr_i64, val):
+    """Agent-one-as release store to a global i32 address."""
+    _llvm_d.StoreOp(
+        val.ir_value(),
+        _to_ptr_global(addr_i64),
+        alignment=4,
+        ordering=_llvm_d.AtomicOrdering.release,
+        syncscope=fx.rocdl.SyncScope.AgentOneAs,
+    )
+
+
+def store_i32_global_system_monotonic(addr_i64, val):
+    """System-visible monotonic store to a global i32 address."""
+    _llvm_d.StoreOp(
+        val.ir_value(),
+        _to_ptr_global(addr_i64),
+        alignment=4,
+        ordering=_llvm_d.AtomicOrdering.monotonic,
+        syncscope=fx.rocdl.SyncScope.OneAs,
+    )
+
+
+def store_i32_global_system_release(addr_i64, val):
+    """System-visible release store to a global i32 address."""
+    _llvm_d.StoreOp(
+        val.ir_value(),
+        _to_ptr_global(addr_i64),
+        alignment=4,
+        ordering=_llvm_d.AtomicOrdering.release,
+        syncscope=fx.rocdl.SyncScope.OneAs,
+    )
+
+
 def fence_acquire(syncscope):
     """Emit an acquire fence for the selected AMDGPU memory scope."""
     _llvm_d.FenceOp(_llvm_d.AtomicOrdering.acquire, syncscope=syncscope)
@@ -235,6 +326,11 @@ def atomic_add_global_at(addr_i64, val, syncscope="one-as"):
 def atomic_add_agent(addr_i64, val):
     """Agent-scope monotonic global fetch-and-add."""
     return atomic_add_global_at(addr_i64, val, syncscope=fx.rocdl.SyncScope.Agent)
+
+
+def atomic_add_agent_one_as(addr_i64, val):
+    """Agent-one-as monotonic global fetch-and-add."""
+    return atomic_add_global_at(addr_i64, val, syncscope=fx.rocdl.SyncScope.AgentOneAs)
 
 
 def atomic_add_system(addr_i64, val):

--- a/aiter/ops/flydsl/kernels/mxmoe_dispatcher.py
+++ b/aiter/ops/flydsl/kernels/mxmoe_dispatcher.py
@@ -129,6 +129,10 @@ def compile_gemm2_a4w4_port(
     g2_kstatic=False,
     out_dtype="bf16",
     enable_bias=False,
+    _composition=None,
+    _reduce_store=None,
+    _input_row_resolver=None,
+    _output_n_range=None,
 ):
     """Compile gemm2 a4w4 down-proj; epilog 'atomic' (weighted atomic-fadd) or 'reduce' (store into out[token_id*topk+slot]). inter_dim runtime; SBM None -> SBM==BM byte-identical."""
     SBM = _norm_sbm(SBM, BM)
@@ -144,6 +148,10 @@ def compile_gemm2_a4w4_port(
         )
     if SBM % BM != 0:
         raise AssertionError(f"SBM ({SBM}) must be a multiple of BM ({BM})")
+    if (_composition is None) != (_input_row_resolver is None):
+        raise ValueError("a composed GEMM2 requires an input row resolver")
+    if _reduce_store is not None and _composition is None:
+        raise ValueError("a custom reduce store requires a composition")
     use_reduce = epilog == "reduce"
     out_dtype = str(out_dtype).strip().lower()
     if out_dtype not in ("bf16", "fp8"):
@@ -152,7 +160,14 @@ def compile_gemm2_a4w4_port(
     if route_out_fp8 and not use_reduce:
         raise AssertionError("out_dtype='fp8' is supported only with epilog='reduce'")
     g2_kstatic = bool(g2_kstatic)
-    if g2_kstatic and route_out_fp8:
+    compact_route = _output_n_range is not None
+    if compact_route:
+        if not route_out_fp8:
+            raise ValueError("weighted compact routes require FP8 reduce output")
+        g2_defer_weight = False
+        g2_out_pitch_align = 0
+        g2_scale_blk = 8
+    elif g2_kstatic and route_out_fp8:
         from .mxfp4_gemm_common import FP8OUT_PITCH_ALIGN, FP8OUT_SCALE_BLK
 
         g2_defer_weight = True
@@ -204,12 +219,34 @@ def compile_gemm2_a4w4_port(
     assert (
         HIDDEN_MAX % BN == 0
     ), f"HIDDEN_MAX must be a multiple of {BN}, got {HIDDEN_MAX}"
+    if _output_n_range is None:
+        output_n_base = 0
+        output_width = None
+        output_range_tag = ""
+    else:
+        output_n_base, output_n_end = _output_n_range
+        if (
+            output_n_base < 0
+            or output_n_end > HIDDEN_MAX
+            or output_n_base >= output_n_end
+            or output_n_base % BN
+            or output_n_end % BN
+        ):
+            raise ValueError(
+                f"invalid output N range {_output_n_range} for "
+                f"HIDDEN_MAX={HIDDEN_MAX}, BN={BN}"
+            )
+        if _composition is None:
+            raise ValueError("output N range requires a composition")
+        output_width = output_n_end - output_n_base
+        output_range_tag = f"_nr{output_n_base}x{output_n_end}"
 
     # Kernel-name tags empty on the default so its name/IR stays byte-identical (each variant distinct).
     atag = "_a8" if is_f8 else ""
     btag = "_w8" if b_dtype == "fp8" else ""
     etag = "atomic" if not use_reduce else f"reduce_tk{topk}"
     sbm_tag = "" if SBM == BM else f"_sbm{SBM}"
+    shared_scale_tag = "_shared_scale" if BM < 32 and SBM != BM else ""
     if persist and cu_num <= 0:
         raise AssertionError(f"persist=True requires cu_num>0, got {cu_num}")
     if persist and is_f8:
@@ -223,6 +260,7 @@ def compile_gemm2_a4w4_port(
     apf_tag = "_apf" if g2_ascale_pf else ""
     spart_tag = f"_spart{g2_group_num}x{g2_m01}" if g2_spart > 0 else ""
     bf16lds_tag = "_bf16lds" if g2_bf16_lds else ""
+    noil_tag = "_noil" if g2_kstatic and g2_bf16_lds and compact_route else ""
     dw_tag = "_dw" if g2_defer_weight else ""
     kst_tag = "_kst" if g2_kstatic else ""
     pitch_tag = (
@@ -230,15 +268,35 @@ def compile_gemm2_a4w4_port(
     )
     sblk_tag = f"_sblk{g2_scale_blk}" if (route_out_fp8 and g2_scale_blk != 8) else ""
     out_tag = "_fp8out" if route_out_fp8 else ""
+    compact_tag = "_weighted_compact_s8" if compact_route else ""
+    route_guard_tag = "_routeguard" if use_reduce else ""
     tile_tag = "" if (BN, BK) == (256, 256) else f"_bn{BN}_bk{BK}"
     bias_tag = "_bias" if enable_bias else ""
     g2_epi_lanes = _pick_epi_lanes(BM, BN, route_out_fp8, g2_scale_blk)
-    tag = f"hmax{HIDDEN_MAX}_imax{INTER_MAX}_bm{BM}{tile_tag}{'_nt' if use_nt else ''}_{etag}{atag}{btag}{sbm_tag}{persist_tag}{bh_tag}{apf_tag}{spart_tag}{bf16lds_tag}{dw_tag}{kst_tag}{pitch_tag}{sblk_tag}{out_tag}{bias_tag}_v2_biasabi7"
+    tag = f"hmax{HIDDEN_MAX}_imax{INTER_MAX}_bm{BM}{tile_tag}{'_nt' if use_nt else ''}_{etag}{atag}{btag}{sbm_tag}{shared_scale_tag}{persist_tag}{bh_tag}{apf_tag}{spart_tag}{bf16lds_tag}{noil_tag}{dw_tag}{kst_tag}{pitch_tag}{sblk_tag}{out_tag}{compact_tag}{bias_tag}{output_range_tag}_v2_biasabi7{route_guard_tag}"
     name = f"gemm2_a4w4_port_{tag}"
 
     @fx.struct
     class SharedStorage:
         buf: fx.Array[Int8, lds_bytes, 16]
+
+    def resolve_input_rows(arg_stids, i32_M, m_row, wave, lane):
+        lanes_per_row = KH_TILE_A // 16
+        rows_per_call = 64 // lanes_per_row
+        rows_per_wave = BM // 4
+        if rows_per_wave < rows_per_call:
+            gather_base_row = (wave % fx.Int32(BM // rows_per_call)) * rows_per_call
+            n_row_groups = 1
+        else:
+            gather_base_row = wave * rows_per_wave
+            n_row_groups = rows_per_wave // rows_per_call
+        lane_row = lane // lanes_per_row
+        rows = []
+        for g in range_constexpr(n_row_groups):
+            local_row = gather_base_row + g * rows_per_call + lane_row
+            packed = global_typed_ptr(arg_stids, T.i32)[m_row + local_row]
+            rows.append(_input_row_resolver(packed, i32_M))
+        return rows
 
     @flyc.jit
     def _gemm2_kernel_body(
@@ -260,11 +318,18 @@ def compile_gemm2_a4w4_port(
         i32_inter,
         i32_hidden,
         i32_grid_blocks,
+        lds,
+        mn_idx=None,
+        resolved_input_rows=(),
     ):
         num_n_blocks = _udiv(i32_hidden, BN)
         k_bytes = _udiv(i32_inter, 1 if is_f8 else 2)
-        aq_num = fx.Int64(i32_max_m_blocks) * fx.Int64(BM * k_bytes)
-        lds = fx.SharedAllocator().allocate(SharedStorage).peek()
+        aq_rows = (
+            fx.Int64(i32_M) * fx.Int64(topk)
+            if len(resolved_input_rows) > 0
+            else fx.Int64(i32_max_m_blocks) * fx.Int64(BM)
+        )
+        aq_num = aq_rows * fx.Int64(k_bytes)
         lds_base_i32 = fx.Int32(fx.ptrtoint(lds.buf.ptr))
 
         def issue_all_a_loads(m_row0):
@@ -282,9 +347,9 @@ def compile_gemm2_a4w4_port(
                     KH_TILE_A,
                     k_bytes,
                     BM=BM,
+                    resolved_rows=resolved_input_rows,
                 )
 
-        # One (m_block, n_block) unit for a synthesized unit_bx; non-persist calls once, persist per m-tile.
         def run_unit(unit_bx, mn_idx=None):
             gemm2_body_v2(
                 lds_base_i32,
@@ -328,9 +393,17 @@ def compile_gemm2_a4w4_port(
                 g2_apre=g2_apre,
                 enable_bias=enable_bias,
                 mn_idx=mn_idx,
+                reduce_store=_reduce_store,
+                resolved_input_rows=resolved_input_rows,
+                output_n_base=output_n_base,
+                output_width=output_width,
             )
 
-        if const_expr(not persist and g2_spart <= 0):
+        if const_expr(mn_idx is not None):
+            issue_all_a_loads(mn_idx[0] * fx.Int32(BM))
+            rocdl.sched_barrier(0)
+            run_unit(fx.Int32(0), mn_idx=mn_idx)
+        elif const_expr(not persist and g2_spart <= 0):
             # One-shot naive linear block->(m,n): issue A->LDS before the cumsum load (latency overlap).
             issue_all_a_loads(_udiv(bx_i32, num_n_blocks) * fx.Int32(BM))
             rocdl.sched_barrier(0)
@@ -384,6 +457,63 @@ def compile_gemm2_a4w4_port(
                 if fx.Int32(m_block) < total_m_blocks:
                     run_unit(unit_bx)
 
+    @flyc.jit
+    def _gemm2_tile(
+        arg_aq,
+        arg_ascale,
+        arg_bq,
+        arg_bscale,
+        arg_eids,
+        arg_stids,
+        arg_sweights,
+        arg_bias,
+        arg_out,
+        m_block_idx,
+        n_block_idx,
+        lane,
+        wave,
+        i32_M,
+        i32_max_m_blocks,
+        i32_inter,
+        i32_hidden,
+        lds,
+    ):
+        m_row = m_block_idx * fx.Int32(BM)
+        resolved_rows = resolve_input_rows(arg_stids, i32_M, m_row, wave, lane)
+        _gemm2_kernel_body(
+            arg_aq,
+            arg_ascale,
+            arg_bq,
+            arg_bscale,
+            arg_eids,
+            arg_stids,
+            arg_stids,
+            arg_sweights,
+            arg_bias,
+            arg_out,
+            fx.Int32(0),
+            lane,
+            wave,
+            i32_M,
+            i32_max_m_blocks,
+            i32_inter,
+            i32_hidden,
+            fx.Int32(0),
+            lds,
+            mn_idx=(m_block_idx, n_block_idx),
+            resolved_input_rows=resolved_rows,
+        )
+
+    if _composition is not None:
+        launch_gemm2 = _composition(
+            module_name=name,
+            emit_gemm2_tile=_gemm2_tile,
+            shared_storage=SharedStorage,
+        )
+        if BM == 16:
+            launch_gemm2.compile_hints["llvm_options"] = {"enable-post-misched": False}
+        return launch_gemm2
+
     @flyc.kernel(name=name, known_block_size=[256, 1, 1])
     def gemm2_kernel(
         arg_aq: fx.Int64,
@@ -409,6 +539,7 @@ def compile_gemm2_a4w4_port(
         bx_i32 = fx.Int32(bx)
         lane = tx_i32 % fx.Int32(64)
         wave = rocdl.readfirstlane(T.i32, tx_i32 // fx.Int32(64))
+        lds = fx.SharedAllocator().allocate(SharedStorage).peek()
         _gemm2_kernel_body(
             arg_aq,
             arg_ascale,
@@ -428,6 +559,7 @@ def compile_gemm2_a4w4_port(
             i32_inter,
             i32_hidden,
             i32_grid_blocks,
+            lds,
         )
 
     @flyc.jit

--- a/aiter/ops/flydsl/kernels/mxmoe_dispatcher.py
+++ b/aiter/ops/flydsl/kernels/mxmoe_dispatcher.py
@@ -130,7 +130,7 @@ def compile_gemm2_a4w4_port(
     out_dtype="bf16",
     enable_bias=False,
     _composition=None,
-    _reduce_store=None,
+    _reduce_store_cache_modifier=None,
     _input_row_resolver=None,
     _output_n_range=None,
 ):
@@ -150,8 +150,8 @@ def compile_gemm2_a4w4_port(
         raise AssertionError(f"SBM ({SBM}) must be a multiple of BM ({BM})")
     if (_composition is None) != (_input_row_resolver is None):
         raise ValueError("a composed GEMM2 requires an input row resolver")
-    if _reduce_store is not None and _composition is None:
-        raise ValueError("a custom reduce store requires a composition")
+    if _reduce_store_cache_modifier is not None and _composition is None:
+        raise ValueError("a custom reduce-store cache policy requires a composition")
     use_reduce = epilog == "reduce"
     out_dtype = str(out_dtype).strip().lower()
     if out_dtype not in ("bf16", "fp8"):
@@ -393,7 +393,7 @@ def compile_gemm2_a4w4_port(
                 g2_apre=g2_apre,
                 enable_bias=enable_bias,
                 mn_idx=mn_idx,
-                reduce_store=_reduce_store,
+                reduce_store_cache_modifier=_reduce_store_cache_modifier,
                 resolved_input_rows=resolved_input_rows,
                 output_n_base=output_n_base,
                 output_width=output_width,

--- a/aiter/ops/flydsl/kernels/mxmoe_gemm_v2.py
+++ b/aiter/ops/flydsl/kernels/mxmoe_gemm_v2.py
@@ -168,13 +168,13 @@ def issue_a_load_lds_dt(
     KH_TILE_A,
     K_BYTES,
     BM=32,
+    resolved_rows=(),
 ):
     """A->LDS DMA for one K-tile; gemm2 A is the already-sorted row, OOB-zero via the flat buffer view bounds."""
     lanes_per_row = KH_TILE_A // 16  # 8 (fp4) / 16 (fp8)
     rows_per_call = 64 // lanes_per_row  # 8 (fp4) / 4 (fp8)
     a_lane_row = lane // lanes_per_row
-    rows_per_wave = BM // 4  # rows each wave loads (BM32: 8, BM64: 16)
-    # BM16 fp4: partial-wave round-robin (waves 2,3 re-load, harmless); BM>=32 byte-identical per-wave blocks.
+    rows_per_wave = BM // 4
     partial_wave_gather = rows_per_wave < rows_per_call
     if const_expr(partial_wave_gather):
         n_gather_calls = BM // rows_per_call
@@ -201,7 +201,8 @@ def issue_a_load_lds_dt(
             if const_expr(is_f8)
             else lds_swizzle_mask(lds_row + a_lane_row, KH_TILE_A)
         )
-        car = m_row + lds_row + a_lane_row  # direct sorted row
+        sorted_row = m_row + lds_row + a_lane_row
+        car = resolved_rows[g] if const_expr(len(resolved_rows) > 0) else sorted_row
         voffset = (lane_col ^ mask) + car * K_BYTES
         off = fx.Int32(slot * (BM * KH_TILE_A)) + lds_row * KH_TILE_A
         # The byte offset is non-negative and 4-byte aligned; avoid signed-division fixup VGPRs.
@@ -255,6 +256,10 @@ def gemm2_body_v2(
     g2_epi_lanes=None,
     g2_apre=False,
     enable_bias=False,
+    reduce_store=None,
+    resolved_input_rows=(),
+    output_n_base=0,
+    output_width=None,
 ):
     # GEMM2 double-buffers B weight and scale one tile ahead. bhoist issues that
     # prefetch above the LDS barrier; ascale_pf prefetches A-scale one tile ahead.
@@ -310,7 +315,10 @@ def gemm2_body_v2(
     lds_acc_base = lds_base_i32
     mma_atoms = scale_mma_atoms(a_dtype, b_dtype)
 
-    aq_num_records = fx.Int64(i32_max_m_blocks) * fx.Int64(BM * K_BYTES)
+    if const_expr(len(resolved_input_rows) > 0):
+        aq_num_records = fx.Int64(i32_M) * fx.Int64(topk) * fx.Int64(K_BYTES)
+    else:
+        aq_num_records = fx.Int64(i32_max_m_blocks) * fx.Int64(BM) * fx.Int64(K_BYTES)
     A_NDW = 8 if is_f8_a else 4
     a_frags = [
         [fx.make_rmem_tensor(A_NDW, Int32) for _ in range_constexpr(kHalves)]
@@ -331,6 +339,7 @@ def gemm2_body_v2(
             KH_TILE_A,
             K_BYTES,
             BM=BM,
+            resolved_rows=resolved_input_rows,
         )
 
     def issue_a_ds_read(slot):
@@ -382,7 +391,9 @@ def gemm2_body_v2(
 
     asc_per_mb = fx.Int32(kScaleSubBlocks) * kAS_per_chunk_dw * fx.Int32(4)
     asc_num = fx.Int64(i32_max_m_blocks) * fx.Int64(asc_per_mb)
-    scale_chunk0 = m_block_idx if const_expr(is_bm16) else m_row // 32
+    scale_chunk0 = (
+        m_block_idx if const_expr(is_bm16 and SBM == BM) else m_row // fx.Int32(32)
+    )
 
     def make_ascale_view(sub):
         base_dw = (scale_chunk0 + fx.Int32(sub)) * kAS_per_chunk_dw
@@ -415,7 +426,11 @@ def gemm2_body_v2(
                 ascale_views[sub][lane_div_16, lane_mod_16, chunk_kt, None],
                 saf,
             )
-            out.append(Vec(saf.load())[0])
+            scale = Vec(saf.load())[0]
+            if const_expr(is_bm16 and SBM != BM):
+                scale_shift = ((m_row // 16) & fx.Int32(1)) * fx.Int32(8)
+                scale = scale.shrui(scale_shift) & fx.Int32(0x00FF00FF)
+            out.append(scale)
         return out
 
     # B-weight + B-scale: global->register, streamed per K-tile (not LDS-staged).
@@ -615,10 +630,13 @@ def gemm2_body_v2(
             g2_scale_blk=g2_scale_blk,
             g2_epi_lanes=g2_epi_lanes,
             enable_bias=enable_bias,
+            output_n_base=output_n_base,
+            output_width=output_width,
+            reduce_store=reduce_store,
             **kw,
         )
 
-    g2_interleave = const_expr(g2_kstatic and g2_bf16_lds)
+    g2_interleave = const_expr(g2_kstatic and g2_bf16_lds and output_width is None)
     epi_thunks = [] if const_expr(g2_interleave) else None
     if const_expr(g2_interleave):
         _epilog(c_frags, emit_thunks=epi_thunks)
@@ -848,6 +866,9 @@ def atomic_bf16_epilog(
     emit_thunks=None,
     lds_ready=False,
     enable_bias=False,
+    output_n_base=0,
+    output_width=None,
+    reduce_store=None,
 ):
     if SBM is None:
         SBM = BM
@@ -877,7 +898,13 @@ def atomic_bf16_epilog(
     tx_i32 = fx.Int32(gpu.thread_id("x"))
     m_lane = tx_i32 // EPI_LANES
     n_lane = tx_i32 % EPI_LANES
-    store_vec = 2
+    if reduce_store is not None and (
+        not use_reduce or route_out_fp8 or enable_bias or g2_defer_weight
+    ):
+        raise ValueError("custom BF16 stores require unweighted reduce output")
+    output_width = N_OUT if const_expr(output_width is None) else fx.Int32(output_width)
+    output_n_base = fx.Int32(output_n_base)
+    store_vec = 8 if reduce_store is not None else 2
     store_group_n = EPI_LANES * store_vec
     col_start = n_lane * store_vec
     wave_n = BN // 4
@@ -990,14 +1017,14 @@ def atomic_bf16_epilog(
             # reduce out_row can reach tokens*topk (large-M) so compute the element base in i64 (atomic i32 path byte-identical).
             out_row = fx.Int64(token_id * fx.Int32(topk) + (packed[mr] >> fx.Int32(24)))
             if const_expr(route_out_fp8):
-                row_pitch = N_OUT + _udiv(N_OUT, fx.Int32(g2_scale_blk))
+                row_pitch = output_width + _udiv(output_width, fx.Int32(g2_scale_blk))
                 if const_expr(g2_out_pitch_align > 0):
                     al = fx.Int32(g2_out_pitch_align)
                     row_pitch = ((row_pitch + al - fx.Int32(1)) // al) * al
                 row_base_addr = out_row * fx.Int64(row_pitch)
             else:
-                row_base_addr = out_row * fx.Int64(N_OUT) + fx.Int64(
-                    n_block_idx * BN + col_start
+                row_base_addr = out_row * fx.Int64(output_width) + fx.Int64(
+                    n_block_idx * BN + col_start - output_n_base
                 )
         else:
             out_row = token_id
@@ -1010,7 +1037,8 @@ def atomic_bf16_epilog(
                 col_lane8 = rg * route_group_n + n_lane * fx.Int32(route_vec)
 
                 def store_route_group(col_lane8, rg=rg):
-                    col_g0 = n_block_idx * BN + col_lane8
+                    global_col = n_block_idx * BN + col_lane8
+                    output_col = global_col - output_n_base
                     bvals = []
                     vals = []
                     for q in range_constexpr(route_vec):
@@ -1018,7 +1046,7 @@ def atomic_bf16_epilog(
                         if const_expr(bf16_src):
                             bval = lds_base_bf16[idx_q]
                             if const_expr(enable_bias):
-                                bias_val = load_bias(col_g0 + q)
+                                bias_val = load_bias(global_col + q)
                                 if const_expr(not defer_w):
                                     bias_val = bias_val * weight[mr]
                                 bval = (fx.Float32(bval) + bias_val).to(BFloat16)
@@ -1026,7 +1054,7 @@ def atomic_bf16_epilog(
                         elif const_expr(g2_bf16_lds):
                             val = fx.Float32(lds_base_bf16[idx_q])
                             if const_expr(enable_bias):
-                                bias_val = load_bias(col_g0 + q)
+                                bias_val = load_bias(global_col + q)
                                 if const_expr(not defer_w):
                                     bias_val = bias_val * weight[mr]
                                 val = val + bias_val
@@ -1034,12 +1062,12 @@ def atomic_bf16_epilog(
                         elif const_expr(defer_w):
                             val = fx.Float32(lds_base_fptr[idx_q])
                             if const_expr(enable_bias):
-                                val = val + load_bias(col_g0 + q)
+                                val = val + load_bias(global_col + q)
                             vals.append(val)
                         else:
                             val = fx.Float32(lds_base_fptr[idx_q])
                             if const_expr(enable_bias):
-                                val = val + load_bias(col_g0 + q)
+                                val = val + load_bias(global_col + q)
                             vals.append(val * weight[mr])
                     if const_expr(bf16_src):
                         msk = Vec.filled([2], 0x7FFF, Int16)
@@ -1101,10 +1129,10 @@ def atomic_bf16_epilog(
                                     h,
                                 )
                         words.append(w)
-                    emit_stores(col_g0, words, e8m0)
+                    emit_stores(output_col, words, e8m0)
 
-                def emit_stores(col_g0, words, e8m0, rg=rg):
-                    row_val_off = row_base_addr + fx.Int64(col_g0)
+                def emit_stores(output_col, words, e8m0, rg=rg):
+                    row_val_off = row_base_addr + fx.Int64(output_col)
                     packed_frag = fx.make_rmem_tensor(1, Int32)
                     for d in range_constexpr(len(words)):
                         packed_frag.store(Vec(words[d]).bitcast(Int32))
@@ -1115,8 +1143,8 @@ def atomic_bf16_epilog(
                         )
                     scale_off = (
                         row_base_addr
-                        + fx.Int64(N_OUT)
-                        + fx.Int64(_udiv(col_g0, fx.Int32(g2_scale_blk)))
+                        + fx.Int64(output_width)
+                        + fx.Int64(_udiv(output_col, fx.Int32(g2_scale_blk)))
                     )
                     scale_frag = fx.make_rmem_tensor(1, Int8)
                     scale_frag.store(Vec.from_elements([e8m0.to(Int8)], Int8))
@@ -1128,6 +1156,38 @@ def atomic_bf16_epilog(
                         store_route_group(col_lane8)
 
                 store_route_group_if_valid(col_lane8)
+        elif const_expr(reduce_store is not None):
+            for s in range_constexpr(BN // store_group_n):
+                idx0 = row_in_block * BN + col_start + s * store_group_n
+                if const_expr(g2_bf16_lds):
+                    pk = Vec(
+                        lds_vec_load(
+                            lds_acc_base,
+                            idx0 * 2,
+                            Vec.make_type(store_vec, BFloat16),
+                            BFloat16,
+                            align=16,
+                        )
+                    )
+                else:
+                    values = Vec(
+                        lds_vec_load(
+                            lds_acc_base,
+                            idx0 * 4,
+                            Vec.make_type(store_vec, Float32),
+                            Float32,
+                            align=16,
+                        )
+                    )
+                    pk = Vec.from_elements(
+                        [
+                            fx.Float32(values[i]) * weight[mr]
+                            for i in range_constexpr(8)
+                        ],
+                        Float32,
+                    ).to(BFloat16)
+                out_off = row_base_addr + fx.Int64(s * store_group_n)
+                reduce_store(arg_out, out_off, pk)
         else:
             for s in range_constexpr(BN // store_group_n):
                 # adjacent ee=0,1 contiguous -> one 2-wide load.
@@ -1188,10 +1248,14 @@ def atomic_bf16_epilog(
 
     for mr in range_constexpr(M_REPS):
         token_id = packed[mr] & fx.Int32(0x00FFFFFF)
+        route_slot = packed[mr] >> fx.Int32(24)
 
         @flyc.jit
-        def store_if_valid(token_id, mr):
-            if token_id < i32_M:
+        def store_if_valid(token_id, route_slot, mr):
+            valid = token_id < i32_M
+            if const_expr(use_reduce):
+                valid = valid & (route_slot < fx.Int32(topk))
+            if valid:
                 store_one_mr(mr)
 
-        store_if_valid(token_id, mr)
+        store_if_valid(token_id, route_slot, mr)

--- a/aiter/ops/flydsl/kernels/mxmoe_gemm_v2.py
+++ b/aiter/ops/flydsl/kernels/mxmoe_gemm_v2.py
@@ -256,7 +256,7 @@ def gemm2_body_v2(
     g2_epi_lanes=None,
     g2_apre=False,
     enable_bias=False,
-    reduce_store=None,
+    reduce_store_cache_modifier=None,
     resolved_input_rows=(),
     output_n_base=0,
     output_width=None,
@@ -632,7 +632,7 @@ def gemm2_body_v2(
             enable_bias=enable_bias,
             output_n_base=output_n_base,
             output_width=output_width,
-            reduce_store=reduce_store,
+            reduce_store_cache_modifier=reduce_store_cache_modifier,
             **kw,
         )
 
@@ -868,7 +868,7 @@ def atomic_bf16_epilog(
     enable_bias=False,
     output_n_base=0,
     output_width=None,
-    reduce_store=None,
+    reduce_store_cache_modifier=None,
 ):
     if SBM is None:
         SBM = BM
@@ -898,13 +898,13 @@ def atomic_bf16_epilog(
     tx_i32 = fx.Int32(gpu.thread_id("x"))
     m_lane = tx_i32 // EPI_LANES
     n_lane = tx_i32 % EPI_LANES
-    if reduce_store is not None and (
+    if reduce_store_cache_modifier is not None and (
         not use_reduce or route_out_fp8 or enable_bias or g2_defer_weight
     ):
-        raise ValueError("custom BF16 stores require unweighted reduce output")
+        raise ValueError("custom BF16 store policies require unweighted reduce output")
     output_width = N_OUT if const_expr(output_width is None) else fx.Int32(output_width)
     output_n_base = fx.Int32(output_n_base)
-    store_vec = 8 if reduce_store is not None else 2
+    store_vec = 8 if reduce_store_cache_modifier is not None else 2
     store_group_n = EPI_LANES * store_vec
     col_start = n_lane * store_vec
     wave_n = BN // 4
@@ -926,6 +926,13 @@ def atomic_bf16_epilog(
     load_i32 = fx.make_copy_atom(fx.rocdl.BufferCopy32b(), Int32)
     load_f32 = fx.make_copy_atom(fx.rocdl.BufferCopy32b(), Float32)
     atomic_bf16x2 = fx.make_copy_atom(fx.rocdl.BufferAtomicPkAdd(BFloat16), BFloat16)
+    reduce_bf16x8 = (
+        fx.make_copy_atom(
+            fx.rocdl.BufferCopy128b(reduce_store_cache_modifier), BFloat16
+        )
+        if reduce_store_cache_modifier is not None
+        else None
+    )
     store_i32 = fx.make_copy_atom(fx.rocdl.BufferCopy32b(STORE_CACHE_MODIFIER), Int32)
     store_i8 = fx.make_copy_atom(fx.rocdl.BufferCopy8b(STORE_CACHE_MODIFIER), Int8)
 
@@ -1156,7 +1163,7 @@ def atomic_bf16_epilog(
                         store_route_group(col_lane8)
 
                 store_route_group_if_valid(col_lane8)
-        elif const_expr(reduce_store is not None):
+        elif const_expr(reduce_store_cache_modifier is not None):
             for s in range_constexpr(BN // store_group_n):
                 idx0 = row_in_block * BN + col_start + s * store_group_n
                 if const_expr(g2_bf16_lds):
@@ -1187,7 +1194,9 @@ def atomic_bf16_epilog(
                         Float32,
                     ).to(BFloat16)
                 out_off = row_base_addr + fx.Int64(s * store_group_n)
-                reduce_store(arg_out, out_off, pk)
+                out_frag = fx.make_rmem_tensor(store_vec, BFloat16)
+                out_frag.store(pk)
+                fx.copy(reduce_bf16x8, out_frag, out_bf16[None, out_off])
         else:
             for s in range_constexpr(BN // store_group_n):
                 # adjacent ee=0,1 contiguous -> one 2-wide load.

--- a/op_tests/multigpu_tests/test_comm_fused_moe.py
+++ b/op_tests/multigpu_tests/test_comm_fused_moe.py
@@ -1,0 +1,792 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2026, Advanced Micro Devices, Inc. All rights reserved.
+"""TP8 production correctness smoke test for communication-fused MoE.
+
+Run with:
+    torchrun --standalone --nproc_per_node=8 \
+        op_tests/multigpu_tests/test_comm_fused_moe.py
+
+The test resolves production runners from CSV and covers both the direct
+Stage2 path and the complete AITer MoE runtime.  The latter intentionally
+uses M=3, so it also validates the production M=3 -> M=4 padding path.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+from dataclasses import dataclass
+from types import SimpleNamespace
+
+import torch
+import torch.distributed as dist
+
+from aiter import ActivationType, QuantType, dtypes
+from aiter.dist.parallel_state import (
+    ensure_model_parallel_initialized,
+    get_dcp_group,
+    get_dp_group,
+    get_ep_group,
+    get_pcp_group,
+    get_pp_group,
+    get_tp_group,
+    init_distributed_environment,
+    set_custom_all_reduce,
+)
+from aiter.fused_moe import (
+    fused_moe,
+    get_2stage_cfgs,
+    get_padded_M,
+    moe_sorting,
+    stage2_uses_route_reduce,
+)
+from aiter.jit.utils.chip_info import get_cu_num, get_gfx_runtime
+from aiter.ops.comm_fused_moe_runtime import CommFusedMoeRuntime
+from aiter.ops.flydsl.comm_fused_moe_host import (
+    ShapeKey,
+    create_flydsl_comm_fused_runners,
+    winners_for,
+)
+from aiter.ops.flydsl.kernels.comm_fused_moe.gfx950.a8w4.config import (
+    MegakernelConfig,
+)
+from aiter.ops.quant import (
+    mxfp4_moe_sort_fwd,
+    per_1x32_f4_quant,
+    per_1x32_f8_scale_f8_quant,
+)
+from aiter.ops.shuffle import shuffle_scale_a16w4, shuffle_weight_a16w4
+
+
+@dataclass
+class Stage2Case:
+    topk: int
+    block_m: int
+    inter_states: torch.Tensor
+    w2: torch.Tensor
+    w2_scale: torch.Tensor
+    a2_scale: torch.Tensor
+    sorted_token_ids: torch.Tensor
+    sorted_expert_ids: torch.Tensor
+    sorted_weights: torch.Tensor
+    num_valid_ids: torch.Tensor
+    partial_out: torch.Tensor
+
+
+@dataclass
+class FullMoeCase:
+    hidden_states: torch.Tensor
+    topk_ids: torch.Tensor
+    topk_weights: torch.Tensor
+    w1: torch.Tensor
+    w1_scale: torch.Tensor
+    w2: torch.Tensor
+    w2_scale: torch.Tensor
+
+
+def setup_distributed(expected_world: int):
+    rank = int(os.environ["RANK"])
+    world = int(os.environ["WORLD_SIZE"])
+    local_rank = int(os.environ.get("LOCAL_RANK", rank))
+    if world != expected_world:
+        raise ValueError(
+            f"torchrun world size is {world}, but expected {expected_world}"
+        )
+    torch.cuda.set_device(local_rank)
+    device = torch.device("cuda", local_rank)
+    set_custom_all_reduce(True)
+    init_distributed_environment(
+        world_size=world,
+        rank=rank,
+        local_rank=local_rank,
+        distributed_init_method="env://",
+        backend="nccl",
+    )
+    ensure_model_parallel_initialized(world, 1)
+    group = get_tp_group().device_group
+    dist.all_reduce(torch.zeros(1, dtype=torch.int32, device=device), group=group)
+    torch.cuda.synchronize(device)
+    return rank, world, device, group
+
+
+def barrier(group):
+    torch.cuda.synchronize()
+    dist.barrier(group=group)
+
+
+def cleanup_distributed(rank: int):
+    if rank == 0:
+        print("[STAGE] release distributed communicators", flush=True)
+    for get_group in (
+        get_tp_group,
+        get_pcp_group,
+        get_pp_group,
+        get_dp_group,
+        get_ep_group,
+        get_dcp_group,
+    ):
+        group = get_group()
+        communicator = group.device_communicator
+        if communicator is not None:
+            communicator.destroy()
+            group.device_communicator = None
+        group.mq_broadcaster = None
+    dist.destroy_process_group()
+    if rank == 0:
+        print("[STAGE] distributed teardown complete", flush=True)
+
+
+def make_routes(tokens: int, experts: int, topk: int, device, route: str):
+    token = torch.arange(tokens, dtype=torch.int64, device=device)[:, None]
+    slot = torch.arange(topk, dtype=torch.int64, device=device)[None, :]
+    if route == "uniform":
+        topk_ids = (token * topk + slot) % experts
+    elif route == "skew":
+        topk_ids = 1 + ((token + slot - 1) % (experts - 1))
+        hot_slot = (token % 8) != 7
+        cold_slot = 1 + ((token + topk - 1) % (experts - 1))
+        topk_ids[:, :1] = torch.where(hot_slot, 0, cold_slot)
+    else:
+        raise ValueError(f"unsupported route pattern: {route}")
+    weights = (slot + 1).expand(tokens, -1).to(torch.float32)
+    return (
+        topk_ids.to(torch.int32).contiguous(),
+        (weights / weights.sum(dim=1, keepdim=True)).contiguous(),
+    )
+
+
+def make_stage2_case(
+    args,
+    rank: int,
+    device,
+    *,
+    shared_w2: torch.Tensor | None,
+    shared_w2_scale: torch.Tensor | None,
+    seed_offset: int,
+    accumulate: bool,
+) -> Stage2Case:
+    topk_ids, topk_weights = make_routes(
+        args.tokens, args.experts, args.topk, device, args.route
+    )
+    (
+        sorted_ids,
+        sorted_weights,
+        sorted_expert_ids,
+        num_valid_ids,
+        sorting_out,
+    ) = moe_sorting(
+        topk_ids,
+        topk_weights,
+        args.experts,
+        args.hidden,
+        torch.bfloat16,
+        args.tile_m,
+        accumulate=accumulate,
+    )
+    sorted_ids = sorted_ids.to(torch.int32).contiguous()
+    sorted_weights = sorted_weights.to(torch.float32).contiguous()
+    sorted_expert_ids = sorted_expert_ids.to(torch.int32).contiguous()
+    num_valid_ids = num_valid_ids.to(torch.int32).contiguous()
+    row_capacity = int(sorted_expert_ids.numel()) * args.tile_m
+    if sorted_ids.numel() < row_capacity:
+        sentinel = (args.topk << 24) | args.tokens
+        sorted_ids = torch.nn.functional.pad(
+            sorted_ids, (0, row_capacity - sorted_ids.numel()), value=sentinel
+        ).contiguous()
+        sorted_weights = torch.nn.functional.pad(
+            sorted_weights,
+            (0, row_capacity - sorted_weights.numel()),
+            value=0.0,
+        ).contiguous()
+
+    generator = torch.Generator(device=device).manual_seed(
+        args.seed + rank + seed_offset
+    )
+    activations = torch.randn(
+        (args.tokens, args.topk, args.inter_dim),
+        dtype=torch.bfloat16,
+        device=device,
+        generator=generator,
+    ).mul_(args.inter_dim**-0.25)
+    inter_states, a2_scale_unsorted = per_1x32_f8_scale_f8_quant(
+        activations,
+        quant_dtype=dtypes.fp8,
+        scale_type=dtypes.fp8_e8m0,
+    )
+    del activations
+    inter_states = inter_states.view(args.tokens, args.topk, args.inter_dim)
+    a2_scale = mxfp4_moe_sort_fwd(
+        a2_scale_unsorted.view(args.tokens * args.topk, -1),
+        sorted_ids=sorted_ids,
+        num_valid_ids=num_valid_ids,
+        token_num=args.tokens,
+        cols=args.inter_dim,
+    ).contiguous()
+
+    if (shared_w2 is None) != (shared_w2_scale is None):
+        raise ValueError("shared W2 and scale must be provided together")
+    if shared_w2 is None:
+        w2_bf16 = torch.randn(
+            (args.experts, args.hidden, args.inter_dim),
+            dtype=torch.bfloat16,
+            device=device,
+            generator=generator,
+        ).mul_(args.inter_dim**-0.25)
+        first_quant, first_scale = per_1x32_f4_quant(
+            w2_bf16[0], quant_dtype=dtypes.fp4x2
+        )
+        w2_quant = torch.empty(
+            (args.experts, *first_quant.shape),
+            dtype=first_quant.dtype,
+            device=device,
+        )
+        w2_scale = torch.empty(
+            (args.experts, *first_scale.shape),
+            dtype=first_scale.dtype,
+            device=device,
+        )
+        w2_quant[0].copy_(first_quant)
+        w2_scale[0].copy_(first_scale)
+        for expert in range(1, args.experts):
+            quant, scale = per_1x32_f4_quant(w2_bf16[expert], quant_dtype=dtypes.fp4x2)
+            w2_quant[expert].copy_(quant)
+            w2_scale[expert].copy_(scale)
+        del w2_bf16
+        w2 = shuffle_weight_a16w4(w2_quant, 16, False).contiguous()
+        w2_scale = shuffle_scale_a16w4(
+            w2_scale.view(-1, w2_scale.shape[-1]), args.experts, False
+        ).contiguous()
+        del w2_quant
+    else:
+        w2, w2_scale = shared_w2, shared_w2_scale
+
+    partial_out = (
+        sorting_out
+        if sorting_out.numel()
+        else torch.empty(
+            (args.tokens, args.hidden), dtype=torch.bfloat16, device=device
+        )
+    )
+    return Stage2Case(
+        args.topk,
+        args.tile_m,
+        inter_states,
+        w2,
+        w2_scale,
+        a2_scale,
+        sorted_ids,
+        sorted_expert_ids,
+        sorted_weights,
+        num_valid_ids,
+        partial_out,
+    )
+
+
+def make_full_moe_case(
+    *, rank: int, device, w2: torch.Tensor, w2_scale: torch.Tensor
+) -> FullMoeCase:
+    """Create one complete DSV4 A8W4 case without a full-BF16 W1 allocation."""
+
+    tokens, hidden, inter_dim, experts, topk = 3, 7168, 384, 384, 6
+    generator = torch.Generator(device=device).manual_seed(20260903 + rank)
+    hidden_states = torch.randn(
+        (tokens, hidden),
+        dtype=torch.bfloat16,
+        device=device,
+        generator=generator,
+    ).mul_(hidden**-0.25)
+    topk_ids, topk_weights = make_routes(tokens, experts, topk, device, "skew")
+
+    # Initialize only routed W1 rows to avoid a transient 4+ GiB allocation.
+    first_weight = torch.randn(
+        (inter_dim * 2, hidden),
+        dtype=torch.bfloat16,
+        device=device,
+        generator=generator,
+    ).mul_(hidden**-0.25)
+    first_quant, first_scale = per_1x32_f4_quant(first_weight, quant_dtype=dtypes.fp4x2)
+    # FP4 tensors cannot fill_ or zero_; initialize only the routed experts.
+    w1_quant = torch.empty(
+        (experts, *first_quant.shape), dtype=first_quant.dtype, device=device
+    )
+    w1_scale = torch.empty(
+        (experts, *first_scale.shape), dtype=first_scale.dtype, device=device
+    )
+    routed_experts = {int(expert) for expert in topk_ids.unique().tolist()}
+    if 0 not in routed_experts:
+        raise AssertionError("skew route must include the hot expert")
+    w1_quant[0].copy_(first_quant)
+    w1_scale[0].copy_(first_scale)
+    for expert in sorted(routed_experts - {0}):
+        weight = torch.randn(
+            (inter_dim * 2, hidden),
+            dtype=torch.bfloat16,
+            device=device,
+            generator=generator,
+        ).mul_(hidden**-0.25)
+        quant, scale = per_1x32_f4_quant(weight, quant_dtype=dtypes.fp4x2)
+        w1_quant[expert].copy_(quant)
+        w1_scale[expert].copy_(scale)
+    w1 = shuffle_weight_a16w4(w1_quant, 16, True).contiguous()
+    w1_scale = shuffle_scale_a16w4(
+        w1_scale.view(-1, w1_scale.shape[-1]), experts, True
+    ).contiguous()
+    del w1_quant
+
+    return FullMoeCase(
+        hidden_states=hidden_states,
+        topk_ids=topk_ids,
+        topk_weights=topk_weights,
+        w1=w1,
+        w1_scale=w1_scale,
+        w2=w2,
+        w2_scale=w2_scale,
+    )
+
+
+def resolve_ordinary_stage2(args):
+    metadata = get_2stage_cfgs(
+        get_padded_M(args.tokens),
+        args.hidden,
+        args.inter_dim,
+        args.experts,
+        args.topk,
+        dtypes.bf16,
+        dtypes.fp8,
+        dtypes.fp4x2,
+        QuantType.per_1x32,
+        True,
+        ActivationType.Silu,
+        False,
+        0,
+        0,
+        is_shuffled=True,
+        gate_mode="separated",
+        is_ep=False,
+        has_stage2_bias=False,
+        opus_weights_shuffled=True,
+    )
+    kernel_name = str(
+        getattr(metadata.stage2, "keywords", {}).get("kernelName")
+        or getattr(metadata.stage2, "keywords", {}).get("kernelName2")
+        or ""
+    )
+    return metadata, kernel_name, not stage2_uses_route_reduce(metadata.stage2)
+
+
+def run_ordinary_stage2_allreduce(
+    case, metadata, *, requires_output_zero, shared_partial
+):
+    if requires_output_zero:
+        case.partial_out.zero_()
+    metadata.stage2(
+        case.inter_states,
+        None,
+        case.w2,
+        case.sorted_token_ids,
+        case.sorted_expert_ids,
+        case.num_valid_ids,
+        case.partial_out,
+        case.topk,
+        w2_scale=case.w2_scale.view(dtypes.fp8_e8m0),
+        a2_scale=case.a2_scale,
+        block_m=int(metadata.block_m),
+        sorted_weights=case.sorted_weights,
+    )
+    case.partial_out.add_(shared_partial)
+    return get_tp_group().all_reduce(case.partial_out, ca_fp8_quant=False)
+
+
+def error_stats(actual: torch.Tensor, expected: torch.Tensor, group):
+    diff = actual.float() - expected.float()
+    stats = torch.stack(
+        (
+            diff.abs().max(),
+            diff.norm() / expected.float().norm().clamp_min(1.0e-12),
+        )
+    )
+    dist.all_reduce(stats, op=dist.ReduceOp.MAX, group=group)
+    return float(stats[0].item()), float(stats[1].item())
+
+
+_PRODUCTION_TOKENS = (1, 2, 4, 8, 16)
+_DEFAULT_CASES = (
+    (1, "uniform"),
+    (2, "skew"),
+    (4, "uniform"),
+    (8, "skew"),
+    (16, "uniform"),
+)
+_MAX_ABS = 1.0
+_MAX_REL_L2 = 0.05
+
+
+def _parse_args():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--tokens", type=int, nargs="+")
+    parser.add_argument(
+        "--routes",
+        choices=("uniform", "skew"),
+        nargs="+",
+        default=("uniform", "skew"),
+    )
+    parser.add_argument(
+        "--full",
+        action="store_true",
+        help="Run every production fused bucket with every selected route.",
+    )
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument("--eager-only", action="store_true")
+    mode.add_argument("--graph-only", action="store_true")
+    parser.add_argument("--graph-replays", type=int, default=3)
+    args = parser.parse_args()
+    if args.graph_replays <= 0:
+        parser.error("--graph-replays must be positive")
+    return args
+
+
+def _shape_key() -> ShapeKey:
+    return ShapeKey(
+        get_gfx_runtime(),
+        7168,
+        384,
+        384,
+        6,
+        8,
+        get_cu_num(),
+    )
+
+
+def _case_specs(args, configs):
+    if args.tokens is not None:
+        requested = tuple(args.tokens)
+        missing = sorted(set(requested).difference(configs))
+        if missing:
+            raise AssertionError(
+                "requested tokens do not have a production comm-fused runner: "
+                f"{missing}; available={sorted(configs)}"
+            )
+        return tuple((token, route) for token in requested for route in args.routes)
+    if args.full:
+        return tuple(
+            (token, route) for token in sorted(configs) for route in args.routes
+        )
+    missing = sorted(set(_PRODUCTION_TOKENS).difference(configs))
+    if missing:
+        raise AssertionError(f"production comm-fused rows are missing: {missing}")
+    return _DEFAULT_CASES
+
+
+def _shared_partial(tokens: int, hidden: int, rank: int, device):
+    token_term = (
+        torch.arange(tokens, device=device, dtype=torch.float32)
+        .remainder(7)
+        .mul_(1.0 / 32.0)
+        .view(-1, 1)
+    )
+    column_term = (
+        torch.arange(hidden, device=device, dtype=torch.float32)
+        .remainder(17)
+        .mul_(1.0 / 128.0)
+        .view(1, -1)
+    )
+    return (token_term + column_term + float(rank + 1) / 16.0).to(torch.bfloat16)
+
+
+def _assert_output(name, actual, expected, *, group, rank):
+    if actual.shape != expected.shape or actual.dtype != torch.bfloat16:
+        raise AssertionError(
+            f"{name}: expected BF16 shape {tuple(expected.shape)}, got "
+            f"dtype={actual.dtype} shape={tuple(actual.shape)}"
+        )
+    finite = torch.tensor(
+        int(torch.isfinite(actual).all() and torch.isfinite(expected).all()),
+        device=actual.device,
+        dtype=torch.int32,
+    )
+    dist.all_reduce(finite, op=dist.ReduceOp.MIN, group=group)
+    max_abs, rel_l2 = error_stats(actual, expected, group)
+    if rank == 0:
+        print(
+            f"COMM_FUSED_UT {name} max_abs={max_abs:.6f} rel_l2={rel_l2:.6f}",
+            flush=True,
+        )
+    if not int(finite.item()) or max_abs > _MAX_ABS or rel_l2 > _MAX_REL_L2:
+        raise AssertionError(
+            f"{name}: finite={bool(finite.item())} max_abs={max_abs} "
+            f"rel_l2={rel_l2}"
+        )
+
+
+def _capture_graph(run, group):
+    barrier(group)
+    run()
+    barrier(group)
+    graph = torch.cuda.CUDAGraph()
+    with get_tp_group().graph_capture() as capture, torch.cuda.graph(
+        graph, stream=capture.stream
+    ):
+        run()
+    barrier(group)
+    return graph
+
+
+def _run_full_runtime_case(
+    *,
+    rank,
+    device,
+    group,
+    runners,
+    w2,
+    w2_scale,
+    run_eager,
+    run_graph,
+    graph_replays,
+):
+    """Exercise Stage1 + padding + fused Stage2 through the public runtime."""
+
+    case = make_full_moe_case(
+        rank=rank,
+        device=device,
+        w2=w2,
+        w2_scale=w2_scale,
+    )
+    runtime = CommFusedMoeRuntime(runners=runners)
+    if not runtime.supports(3):
+        raise AssertionError("M=3 must resolve through the production M=4 runner")
+    shared = _shared_partial(3, 7168, rank, device)
+    moe_args = {
+        "hidden_states": case.hidden_states,
+        "w1": case.w1,
+        "w2": case.w2,
+        "topk_weight": case.topk_weights,
+        "topk_ids": case.topk_ids,
+        "activation": ActivationType.Silu,
+        "quant_type": QuantType.per_1x32,
+        "doweight_stage1": False,
+        "w1_scale": case.w1_scale,
+        "w2_scale": case.w2_scale,
+        "hidden_pad": 0,
+        "intermediate_pad": 0,
+        "gate_mode": "interleave",
+    }
+
+    def run_ordinary():
+        partial = fused_moe(**moe_args)
+        partial.add_(shared)
+        return get_tp_group().all_reduce(partial, ca_fp8_quant=False)
+
+    # Match ATOM's before_stage2 call path.
+    def run_fused(stage2_stream=None):
+        return runtime.run(
+            shared_partial=None,
+            before_stage2=lambda: shared,
+            stage2_stream=stage2_stream,
+            **moe_args,
+        )
+
+    ordinary = run_ordinary().clone()
+    label = "runtime_e2e M=3->4 route=skew"
+    if run_eager:
+        fused = run_fused()
+        barrier(group)
+        _assert_output(f"{label} eager", fused, ordinary, group=group, rank=rank)
+        stage2_stream = torch.cuda.Stream(device=device)
+        fused = run_fused(stage2_stream)
+        barrier(group)
+        _assert_output(
+            f"{label} separate_stream", fused, ordinary, group=group, rank=rank
+        )
+    if run_graph:
+        graph = _capture_graph(run_fused, group)
+        for replay in range(graph_replays):
+            graph.replay()
+            barrier(group)
+            _assert_output(
+                f"{label} graph_replay={replay + 1}",
+                runners[4].output[:3],
+                ordinary,
+                group=group,
+                rank=rank,
+            )
+    barrier(group)
+
+
+def _run_case(
+    *,
+    token,
+    route,
+    rank,
+    world,
+    device,
+    group,
+    runners,
+    shared_w2,
+    shared_w2_scale,
+    run_eager,
+    run_graph,
+    graph_replays,
+    seed_offset,
+):
+    case_args = SimpleNamespace(
+        tokens=token,
+        tp_size=world,
+        hidden=7168,
+        inter_dim=384,
+        experts=384,
+        topk=6,
+        tile_m=64,
+        route=route,
+        seed=20260902,
+    )
+    metadata, ordinary_kernel, requires_zero = resolve_ordinary_stage2(case_args)
+    case_args.tile_m = int(metadata.block_m)
+    case = make_stage2_case(
+        case_args,
+        rank,
+        device,
+        shared_w2=shared_w2,
+        shared_w2_scale=shared_w2_scale,
+        seed_offset=seed_offset,
+        accumulate=requires_zero,
+    )
+    shared = _shared_partial(token, case_args.hidden, rank, device)
+    ordinary = run_ordinary_stage2_allreduce(
+        case,
+        metadata,
+        requires_output_zero=requires_zero,
+        shared_partial=shared,
+    ).clone()
+
+    runner = runners[token]
+    config = runner.config
+    if not isinstance(config, MegakernelConfig):
+        raise TypeError(f"M={token} resolved unexpected runner {type(config)!r}")
+    if config.collective != "direct":
+        raise AssertionError(
+            f"M={token} expected direct collective, got {config.collective}"
+        )
+
+    w2_scale = (
+        case.w2_scale.view(dtypes.fp8_e8m0)
+        if case.w2_scale.element_size() == 1
+        else case.w2_scale
+    )
+
+    def run_fused():
+        prepared = runner.prepare_shared_partial(shared)
+        return runner(
+            stage2_args=(
+                case.inter_states,
+                None,
+                case.w2,
+                case.sorted_token_ids,
+                case.sorted_expert_ids,
+                case.num_valid_ids,
+                case.partial_out,
+                case.topk,
+            ),
+            stage2_kwargs={
+                "w2_scale": w2_scale,
+                "a2_scale": case.a2_scale,
+                "block_m": case.block_m,
+                "sorted_weights": case.sorted_weights,
+            },
+            shared_partial=prepared,
+            ordinary_stage2=metadata.stage2,
+        )
+
+    label = f"M={token} route={route} ordinary={ordinary_kernel}"
+    if rank == 0:
+        print(
+            f"COMM_FUSED_UT_DISPATCH {label} config={type(config).__name__} "
+            f"kernel={config}",
+            flush=True,
+        )
+    if run_eager:
+        fused = run_fused()
+        barrier(group)
+        _assert_output(f"{label} eager", fused, ordinary, group=group, rank=rank)
+    if run_graph:
+        fused_graph = _capture_graph(run_fused, group)
+        for replay in range(graph_replays):
+            fused_graph.replay()
+            barrier(group)
+            _assert_output(
+                f"{label} graph_replay={replay + 1}",
+                runner.output,
+                ordinary,
+                group=group,
+                rank=rank,
+            )
+    barrier(group)
+    return case.w2, case.w2_scale
+
+
+def main() -> None:
+    args = _parse_args()
+    rank, world, device, group = setup_distributed(8)
+    previous_fp8_bound = os.environ.get("AITER_BF16_FP8_MOE_BOUND")
+    # Force MXFP8 so small-M does not select the unrelated FP4 fallback.
+    os.environ["AITER_BF16_FP8_MOE_BOUND"] = "0"
+    try:
+        shape = _shape_key()
+        configs = winners_for(shape)
+        if 32 in configs:
+            raise AssertionError(
+                "M=32 fallback row unexpectedly created a fused runner"
+            )
+        specs = _case_specs(args, configs)
+        runners = create_flydsl_comm_fused_runners(
+            tp_group=get_tp_group(),
+            model_dim=shape.model_dim,
+            inter_dim=shape.inter_dim,
+            experts=shape.experts,
+            topk=shape.topk,
+        )
+        shared_w2 = None
+        shared_w2_scale = None
+        for index, (token, route) in enumerate(specs):
+            shared_w2, shared_w2_scale = _run_case(
+                token=token,
+                route=route,
+                rank=rank,
+                world=world,
+                device=device,
+                group=group,
+                runners=runners,
+                shared_w2=shared_w2,
+                shared_w2_scale=shared_w2_scale,
+                run_eager=not args.graph_only,
+                run_graph=not args.eager_only,
+                graph_replays=args.graph_replays,
+                seed_offset=index,
+            )
+        if shared_w2 is None or shared_w2_scale is None:
+            raise AssertionError("Stage2 cases did not initialize shared W2")
+        _run_full_runtime_case(
+            rank=rank,
+            device=device,
+            group=group,
+            runners=runners,
+            w2=shared_w2,
+            w2_scale=shared_w2_scale,
+            run_eager=not args.graph_only,
+            run_graph=not args.eager_only,
+            graph_replays=args.graph_replays,
+        )
+        if rank == 0:
+            print(
+                f"COMM_FUSED_UT_OK stage2_cases={len(specs)} runtime_cases=1",
+                flush=True,
+            )
+    finally:
+        if previous_fp8_bound is None:
+            os.environ.pop("AITER_BF16_FP8_MOE_BOUND", None)
+        else:
+            os.environ["AITER_BF16_FP8_MOE_BOUND"] = previous_fp8_bound
+        cleanup_distributed(rank)
+
+
+if __name__ == "__main__":
+    main()

--- a/op_tests/multigpu_tests/test_comm_fused_moe.py
+++ b/op_tests/multigpu_tests/test_comm_fused_moe.py
@@ -1,26 +1,38 @@
 # SPDX-License-Identifier: MIT
 # Copyright (C) 2026, Advanced Micro Devices, Inc. All rights reserved.
-"""TP8 production correctness smoke test for communication-fused MoE.
+"""TP8 correctness and performance smoke test for communication-fused MoE.
 
 Run with:
     torchrun --standalone --nproc_per_node=8 \
         op_tests/multigpu_tests/test_comm_fused_moe.py
 
-The test resolves production runners from CSV and covers both the direct
-Stage2 path and the complete AITer MoE runtime.  The latter intentionally
-uses M=3, so it also validates the production M=3 -> M=4 padding path.
+The production target is the DeepSeek-V4-Pro TP8 Stage2 shape:
+
+* hidden = 7168
+* local intermediate = 3072 / TP8 = 384
+* routed experts = 384
+* top-k = 6
+
+The test compares both the ordinary and communication-fused paths with an
+independent torch reference built from the unshuffled MXFP8/MXFP4 inputs.  It
+also exercises eager execution, graph replay, the model-facing runtime,
+separate-stream execution, and runtime padding from M=3 to M=4.
 """
 
 from __future__ import annotations
 
 import argparse
+import itertools
 import os
-from dataclasses import dataclass
-from types import SimpleNamespace
+from collections.abc import Callable
+from dataclasses import dataclass, field
 
+import pandas as pd
 import torch
 import torch.distributed as dist
+import torch.nn.functional as F
 
+import aiter
 from aiter import ActivationType, QuantType, dtypes
 from aiter.dist.parallel_state import (
     ensure_model_parallel_initialized,
@@ -39,16 +51,17 @@ from aiter.fused_moe import (
     get_padded_M,
     moe_sorting,
     stage2_uses_route_reduce,
+    torch_moe_stage1,
+    torch_moe_stage2,
 )
 from aiter.jit.utils.chip_info import get_cu_num, get_gfx_runtime
 from aiter.ops.comm_fused_moe_runtime import CommFusedMoeRuntime
 from aiter.ops.flydsl.comm_fused_moe_host import (
     ShapeKey,
+    config_name,
     create_flydsl_comm_fused_runners,
+    is_flydsl_comm_fused_moe_available,
     winners_for,
-)
-from aiter.ops.flydsl.kernels.comm_fused_moe.gfx950.a8w4.config import (
-    MegakernelConfig,
 )
 from aiter.ops.quant import (
     mxfp4_moe_sort_fwd,
@@ -56,16 +69,45 @@ from aiter.ops.quant import (
     per_1x32_f8_scale_f8_quant,
 )
 from aiter.ops.shuffle import shuffle_scale_a16w4, shuffle_weight_a16w4
+from aiter.test_common import benchmark, checkAllclose, run_perftest
+
+SUPPORTED_GFX = ("gfx950",)
+TP_SIZE = 8
+MODEL_DIM = 7168
+INTER_DIM = 384
+EXPERTS = 384
+TOPK = 6
+PRODUCTION_TOKENS = (1, 2, 4, 8, 16)
+ROUTES = ("uniform", "skew")
+MODES = ("eager", "graph")
+
+# Accuracy limits used by the production tuner and host dispatch.
+MAX_ABS = 1.0
+MAX_REL_L2 = 0.05
+MAX_ERR_RATIO = 0.05
+
+# Performance is reported for visibility only; it is not a CI pass/fail gate.
+PERF_WARMUP = 20
+PERF_ITERS = 10
 
 
-@dataclass
+@dataclass(slots=True)
+class Stage2Weights:
+    kernel: torch.Tensor
+    kernel_scale: torch.Tensor
+    reference: torch.Tensor
+    reference_scale: torch.Tensor
+
+
+@dataclass(slots=True)
 class Stage2Case:
-    topk: int
+    tokens: int
     block_m: int
     inter_states: torch.Tensor
-    w2: torch.Tensor
-    w2_scale: torch.Tensor
     a2_scale: torch.Tensor
+    reference_a2_scale: torch.Tensor
+    topk_ids: torch.Tensor
+    topk_weights: torch.Tensor
     sorted_token_ids: torch.Tensor
     sorted_expert_ids: torch.Tensor
     sorted_weights: torch.Tensor
@@ -73,18 +115,61 @@ class Stage2Case:
     partial_out: torch.Tensor
 
 
-@dataclass
+@dataclass(slots=True)
+class Stage2Fixture:
+    case: Stage2Case
+    metadata: object
+    ordinary_kernel: str
+    requires_output_zero: bool
+    shared_partial: torch.Tensor
+    reference: torch.Tensor
+
+
+@dataclass(slots=True)
 class FullMoeCase:
     hidden_states: torch.Tensor
     topk_ids: torch.Tensor
     topk_weights: torch.Tensor
     w1: torch.Tensor
     w1_scale: torch.Tensor
-    w2: torch.Tensor
-    w2_scale: torch.Tensor
+    reference_w1: torch.Tensor
+    reference_w1_scale: torch.Tensor
 
 
-def setup_distributed(expected_world: int):
+@dataclass(slots=True)
+class FullMoeFixture:
+    case: FullMoeCase
+    shared_partial: torch.Tensor
+    reference: torch.Tensor
+    stage2_stream: torch.cuda.Stream
+
+
+@dataclass(slots=True)
+class TestSession:
+    rank: int
+    world: int
+    device: torch.device
+    group: object
+    gfx: str
+    runners: dict
+    weights: Stage2Weights
+    graph_replays: int
+    stage2_fixtures: dict[tuple[int, str], Stage2Fixture] = field(default_factory=dict)
+    full_fixture: FullMoeFixture | None = None
+
+
+# Keep distributed state out of the @benchmark signatures so the summary table
+# contains only real sweep axes (tokens, route, and execution mode).
+_ACTIVE_SESSION: TestSession | None = None
+
+
+def _session() -> TestSession:
+    if _ACTIVE_SESSION is None:
+        raise RuntimeError("comm-fused MoE test session is not initialized")
+    return _ACTIVE_SESSION
+
+
+def _setup_distributed(expected_world: int):
     rank = int(os.environ["RANK"])
     world = int(os.environ["WORLD_SIZE"])
     local_rank = int(os.environ.get("LOCAL_RANK", rank))
@@ -109,14 +194,14 @@ def setup_distributed(expected_world: int):
     return rank, world, device, group
 
 
-def barrier(group):
+def _barrier(group) -> None:
     torch.cuda.synchronize()
     dist.barrier(group=group)
 
 
-def cleanup_distributed(rank: int):
+def _cleanup_distributed(rank: int) -> None:
     if rank == 0:
-        print("[STAGE] release distributed communicators", flush=True)
+        aiter.logger.info("releasing distributed communicators")
     for get_group in (
         get_tp_group,
         get_pcp_group,
@@ -132,19 +217,17 @@ def cleanup_distributed(rank: int):
             group.device_communicator = None
         group.mq_broadcaster = None
     dist.destroy_process_group()
-    if rank == 0:
-        print("[STAGE] distributed teardown complete", flush=True)
 
 
-def make_routes(tokens: int, experts: int, topk: int, device, route: str):
+def _make_routes(tokens: int, route: str, device):
     token = torch.arange(tokens, dtype=torch.int64, device=device)[:, None]
-    slot = torch.arange(topk, dtype=torch.int64, device=device)[None, :]
+    slot = torch.arange(TOPK, dtype=torch.int64, device=device)[None, :]
     if route == "uniform":
-        topk_ids = (token * topk + slot) % experts
+        topk_ids = (token * TOPK + slot) % EXPERTS
     elif route == "skew":
-        topk_ids = 1 + ((token + slot - 1) % (experts - 1))
+        topk_ids = 1 + ((token + slot - 1) % (EXPERTS - 1))
         hot_slot = (token % 8) != 7
-        cold_slot = 1 + ((token + topk - 1) % (experts - 1))
+        cold_slot = 1 + ((token + TOPK - 1) % (EXPERTS - 1))
         topk_ids[:, :1] = torch.where(hot_slot, 0, cold_slot)
     else:
         raise ValueError(f"unsupported route pattern: {route}")
@@ -155,202 +238,48 @@ def make_routes(tokens: int, experts: int, topk: int, device, route: str):
     )
 
 
-def make_stage2_case(
-    args,
-    rank: int,
-    device,
-    *,
-    shared_w2: torch.Tensor | None,
-    shared_w2_scale: torch.Tensor | None,
-    seed_offset: int,
-    accumulate: bool,
-) -> Stage2Case:
-    topk_ids, topk_weights = make_routes(
-        args.tokens, args.experts, args.topk, device, args.route
-    )
-    (
-        sorted_ids,
-        sorted_weights,
-        sorted_expert_ids,
-        num_valid_ids,
-        sorting_out,
-    ) = moe_sorting(
-        topk_ids,
-        topk_weights,
-        args.experts,
-        args.hidden,
-        torch.bfloat16,
-        args.tile_m,
-        accumulate=accumulate,
-    )
-    sorted_ids = sorted_ids.to(torch.int32).contiguous()
-    sorted_weights = sorted_weights.to(torch.float32).contiguous()
-    sorted_expert_ids = sorted_expert_ids.to(torch.int32).contiguous()
-    num_valid_ids = num_valid_ids.to(torch.int32).contiguous()
-    row_capacity = int(sorted_expert_ids.numel()) * args.tile_m
-    if sorted_ids.numel() < row_capacity:
-        sentinel = (args.topk << 24) | args.tokens
-        sorted_ids = torch.nn.functional.pad(
-            sorted_ids, (0, row_capacity - sorted_ids.numel()), value=sentinel
-        ).contiguous()
-        sorted_weights = torch.nn.functional.pad(
-            sorted_weights,
-            (0, row_capacity - sorted_weights.numel()),
-            value=0.0,
-        ).contiguous()
+def _make_stage2_weights(rank: int, device) -> Stage2Weights:
+    """Create one deterministic W2 shared by every token/route case."""
 
-    generator = torch.Generator(device=device).manual_seed(
-        args.seed + rank + seed_offset
-    )
-    activations = torch.randn(
-        (args.tokens, args.topk, args.inter_dim),
-        dtype=torch.bfloat16,
-        device=device,
-        generator=generator,
-    ).mul_(args.inter_dim**-0.25)
-    inter_states, a2_scale_unsorted = per_1x32_f8_scale_f8_quant(
-        activations,
-        quant_dtype=dtypes.fp8,
-        scale_type=dtypes.fp8_e8m0,
-    )
-    del activations
-    inter_states = inter_states.view(args.tokens, args.topk, args.inter_dim)
-    a2_scale = mxfp4_moe_sort_fwd(
-        a2_scale_unsorted.view(args.tokens * args.topk, -1),
-        sorted_ids=sorted_ids,
-        num_valid_ids=num_valid_ids,
-        token_num=args.tokens,
-        cols=args.inter_dim,
-    ).contiguous()
+    generator = torch.Generator(device=device).manual_seed(20260902 + 1000 + rank)
 
-    if (shared_w2 is None) != (shared_w2_scale is None):
-        raise ValueError("shared W2 and scale must be provided together")
-    if shared_w2 is None:
-        w2_bf16 = torch.randn(
-            (args.experts, args.hidden, args.inter_dim),
-            dtype=torch.bfloat16,
-            device=device,
-            generator=generator,
-        ).mul_(args.inter_dim**-0.25)
-        first_quant, first_scale = per_1x32_f4_quant(
-            w2_bf16[0], quant_dtype=dtypes.fp4x2
-        )
-        w2_quant = torch.empty(
-            (args.experts, *first_quant.shape),
-            dtype=first_quant.dtype,
-            device=device,
-        )
-        w2_scale = torch.empty(
-            (args.experts, *first_scale.shape),
-            dtype=first_scale.dtype,
-            device=device,
-        )
-        w2_quant[0].copy_(first_quant)
-        w2_scale[0].copy_(first_scale)
-        for expert in range(1, args.experts):
-            quant, scale = per_1x32_f4_quant(w2_bf16[expert], quant_dtype=dtypes.fp4x2)
-            w2_quant[expert].copy_(quant)
-            w2_scale[expert].copy_(scale)
-        del w2_bf16
-        w2 = shuffle_weight_a16w4(w2_quant, 16, False).contiguous()
-        w2_scale = shuffle_scale_a16w4(
-            w2_scale.view(-1, w2_scale.shape[-1]), args.experts, False
-        ).contiguous()
-        del w2_quant
-    else:
-        w2, w2_scale = shared_w2, shared_w2_scale
-
-    partial_out = (
-        sorting_out
-        if sorting_out.numel()
-        else torch.empty(
-            (args.tokens, args.hidden), dtype=torch.bfloat16, device=device
-        )
-    )
-    return Stage2Case(
-        args.topk,
-        args.tile_m,
-        inter_states,
-        w2,
-        w2_scale,
-        a2_scale,
-        sorted_ids,
-        sorted_expert_ids,
-        sorted_weights,
-        num_valid_ids,
-        partial_out,
-    )
-
-
-def make_full_moe_case(
-    *, rank: int, device, w2: torch.Tensor, w2_scale: torch.Tensor
-) -> FullMoeCase:
-    """Create one complete DSV4 A8W4 case without a full-BF16 W1 allocation."""
-
-    tokens, hidden, inter_dim, experts, topk = 3, 7168, 384, 384, 6
-    generator = torch.Generator(device=device).manual_seed(20260903 + rank)
-    hidden_states = torch.randn(
-        (tokens, hidden),
-        dtype=torch.bfloat16,
-        device=device,
-        generator=generator,
-    ).mul_(hidden**-0.25)
-    topk_ids, topk_weights = make_routes(tokens, experts, topk, device, "skew")
-
-    # Initialize only routed W1 rows to avoid a transient 4+ GiB allocation.
-    first_weight = torch.randn(
-        (inter_dim * 2, hidden),
-        dtype=torch.bfloat16,
-        device=device,
-        generator=generator,
-    ).mul_(hidden**-0.25)
-    first_quant, first_scale = per_1x32_f4_quant(first_weight, quant_dtype=dtypes.fp4x2)
-    # FP4 tensors cannot fill_ or zero_; initialize only the routed experts.
-    w1_quant = torch.empty(
-        (experts, *first_quant.shape), dtype=first_quant.dtype, device=device
-    )
-    w1_scale = torch.empty(
-        (experts, *first_scale.shape), dtype=first_scale.dtype, device=device
-    )
-    routed_experts = {int(expert) for expert in topk_ids.unique().tolist()}
-    if 0 not in routed_experts:
-        raise AssertionError("skew route must include the hot expert")
-    w1_quant[0].copy_(first_quant)
-    w1_scale[0].copy_(first_scale)
-    for expert in sorted(routed_experts - {0}):
+    def quantize_expert():
         weight = torch.randn(
-            (inter_dim * 2, hidden),
+            (MODEL_DIM, INTER_DIM),
             dtype=torch.bfloat16,
             device=device,
             generator=generator,
-        ).mul_(hidden**-0.25)
-        quant, scale = per_1x32_f4_quant(weight, quant_dtype=dtypes.fp4x2)
-        w1_quant[expert].copy_(quant)
-        w1_scale[expert].copy_(scale)
-    w1 = shuffle_weight_a16w4(w1_quant, 16, True).contiguous()
-    w1_scale = shuffle_scale_a16w4(
-        w1_scale.view(-1, w1_scale.shape[-1]), experts, True
-    ).contiguous()
-    del w1_quant
+        ).mul_(INTER_DIM**-0.25)
+        return per_1x32_f4_quant(weight, quant_dtype=dtypes.fp4x2)
 
-    return FullMoeCase(
-        hidden_states=hidden_states,
-        topk_ids=topk_ids,
-        topk_weights=topk_weights,
-        w1=w1,
-        w1_scale=w1_scale,
-        w2=w2,
-        w2_scale=w2_scale,
+    first_quant, first_scale = quantize_expert()
+    reference = torch.empty(
+        (EXPERTS, *first_quant.shape), dtype=first_quant.dtype, device=device
     )
+    reference_scale = torch.empty(
+        (EXPERTS, *first_scale.shape), dtype=first_scale.dtype, device=device
+    )
+    reference[0].copy_(first_quant)
+    reference_scale[0].copy_(first_scale)
+    for expert in range(1, EXPERTS):
+        quant, scale = quantize_expert()
+        reference[expert].copy_(quant)
+        reference_scale[expert].copy_(scale)
+
+    kernel = shuffle_weight_a16w4(reference, 16, False).contiguous()
+    kernel_scale = shuffle_scale_a16w4(
+        reference_scale.view(-1, reference_scale.shape[-1]), EXPERTS, False
+    ).contiguous()
+    return Stage2Weights(kernel, kernel_scale, reference, reference_scale)
 
 
-def resolve_ordinary_stage2(args):
+def _resolve_ordinary_stage2(tokens: int):
     metadata = get_2stage_cfgs(
-        get_padded_M(args.tokens),
-        args.hidden,
-        args.inter_dim,
-        args.experts,
-        args.topk,
+        get_padded_M(tokens),
+        MODEL_DIM,
+        INTER_DIM,
+        EXPERTS,
+        TOPK,
         dtypes.bf16,
         dtypes.fp8,
         dtypes.fp4x2,
@@ -374,110 +303,88 @@ def resolve_ordinary_stage2(args):
     return metadata, kernel_name, not stage2_uses_route_reduce(metadata.stage2)
 
 
-def run_ordinary_stage2_allreduce(
-    case, metadata, *, requires_output_zero, shared_partial
-):
-    if requires_output_zero:
-        case.partial_out.zero_()
-    metadata.stage2(
-        case.inter_states,
-        None,
-        case.w2,
-        case.sorted_token_ids,
-        case.sorted_expert_ids,
-        case.num_valid_ids,
-        case.partial_out,
-        case.topk,
-        w2_scale=case.w2_scale.view(dtypes.fp8_e8m0),
-        a2_scale=case.a2_scale,
-        block_m=int(metadata.block_m),
-        sorted_weights=case.sorted_weights,
+def _make_stage2_case(
+    tokens: int,
+    route: str,
+    block_m: int,
+    requires_output_zero: bool,
+    rank: int,
+    device,
+) -> Stage2Case:
+    topk_ids, topk_weights = _make_routes(tokens, route, device)
+    (
+        sorted_ids,
+        sorted_weights,
+        sorted_expert_ids,
+        num_valid_ids,
+        sorting_out,
+    ) = moe_sorting(
+        topk_ids,
+        topk_weights,
+        EXPERTS,
+        MODEL_DIM,
+        torch.bfloat16,
+        block_m,
+        accumulate=requires_output_zero,
     )
-    case.partial_out.add_(shared_partial)
-    return get_tp_group().all_reduce(case.partial_out, ca_fp8_quant=False)
+    sorted_ids = sorted_ids.to(torch.int32).contiguous()
+    sorted_weights = sorted_weights.to(torch.float32).contiguous()
+    sorted_expert_ids = sorted_expert_ids.to(torch.int32).contiguous()
+    num_valid_ids = num_valid_ids.to(torch.int32).contiguous()
+    row_capacity = int(sorted_expert_ids.numel()) * block_m
+    if sorted_ids.numel() < row_capacity:
+        sentinel = (TOPK << 24) | tokens
+        sorted_ids = F.pad(
+            sorted_ids, (0, row_capacity - sorted_ids.numel()), value=sentinel
+        ).contiguous()
+        sorted_weights = F.pad(
+            sorted_weights,
+            (0, row_capacity - sorted_weights.numel()),
+            value=0.0,
+        ).contiguous()
 
-
-def error_stats(actual: torch.Tensor, expected: torch.Tensor, group):
-    diff = actual.float() - expected.float()
-    stats = torch.stack(
-        (
-            diff.abs().max(),
-            diff.norm() / expected.float().norm().clamp_min(1.0e-12),
-        )
+    seed = 20260902 + 2 * tokens + int(route == "skew") + rank
+    generator = torch.Generator(device=device).manual_seed(seed)
+    activations = torch.randn(
+        (tokens, TOPK, INTER_DIM),
+        dtype=torch.bfloat16,
+        device=device,
+        generator=generator,
+    ).mul_(INTER_DIM**-0.25)
+    inter_states, reference_a2_scale = per_1x32_f8_scale_f8_quant(
+        activations,
+        quant_dtype=dtypes.fp8,
+        scale_type=dtypes.fp8_e8m0,
     )
-    dist.all_reduce(stats, op=dist.ReduceOp.MAX, group=group)
-    return float(stats[0].item()), float(stats[1].item())
-
-
-_PRODUCTION_TOKENS = (1, 2, 4, 8, 16)
-_DEFAULT_CASES = (
-    (1, "uniform"),
-    (2, "skew"),
-    (4, "uniform"),
-    (8, "skew"),
-    (16, "uniform"),
-)
-_MAX_ABS = 1.0
-_MAX_REL_L2 = 0.05
-
-
-def _parse_args():
-    parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--tokens", type=int, nargs="+")
-    parser.add_argument(
-        "--routes",
-        choices=("uniform", "skew"),
-        nargs="+",
-        default=("uniform", "skew"),
+    a2_scale = mxfp4_moe_sort_fwd(
+        reference_a2_scale.view(tokens * TOPK, -1),
+        sorted_ids=sorted_ids,
+        num_valid_ids=num_valid_ids,
+        token_num=tokens,
+        cols=INTER_DIM,
+    ).contiguous()
+    partial_out = (
+        sorting_out
+        if sorting_out.numel()
+        else torch.empty((tokens, MODEL_DIM), dtype=torch.bfloat16, device=device)
     )
-    parser.add_argument(
-        "--full",
-        action="store_true",
-        help="Run every production fused bucket with every selected route.",
-    )
-    mode = parser.add_mutually_exclusive_group()
-    mode.add_argument("--eager-only", action="store_true")
-    mode.add_argument("--graph-only", action="store_true")
-    parser.add_argument("--graph-replays", type=int, default=3)
-    args = parser.parse_args()
-    if args.graph_replays <= 0:
-        parser.error("--graph-replays must be positive")
-    return args
-
-
-def _shape_key() -> ShapeKey:
-    return ShapeKey(
-        get_gfx_runtime(),
-        7168,
-        384,
-        384,
-        6,
-        8,
-        get_cu_num(),
+    return Stage2Case(
+        tokens=tokens,
+        block_m=block_m,
+        inter_states=inter_states.view(tokens, TOPK, INTER_DIM),
+        a2_scale=a2_scale,
+        reference_a2_scale=reference_a2_scale,
+        topk_ids=topk_ids,
+        topk_weights=topk_weights,
+        sorted_token_ids=sorted_ids,
+        sorted_expert_ids=sorted_expert_ids,
+        sorted_weights=sorted_weights,
+        num_valid_ids=num_valid_ids,
+        partial_out=partial_out,
     )
 
 
-def _case_specs(args, configs):
-    if args.tokens is not None:
-        requested = tuple(args.tokens)
-        missing = sorted(set(requested).difference(configs))
-        if missing:
-            raise AssertionError(
-                "requested tokens do not have a production comm-fused runner: "
-                f"{missing}; available={sorted(configs)}"
-            )
-        return tuple((token, route) for token in requested for route in args.routes)
-    if args.full:
-        return tuple(
-            (token, route) for token in sorted(configs) for route in args.routes
-        )
-    missing = sorted(set(_PRODUCTION_TOKENS).difference(configs))
-    if missing:
-        raise AssertionError(f"production comm-fused rows are missing: {missing}")
-    return _DEFAULT_CASES
-
-
-def _shared_partial(tokens: int, hidden: int, rank: int, device):
+def _shared_partial(tokens: int, rank: int, device):
     token_term = (
         torch.arange(tokens, device=device, dtype=torch.float32)
         .remainder(7)
@@ -485,7 +392,7 @@ def _shared_partial(tokens: int, hidden: int, rank: int, device):
         .view(-1, 1)
     )
     column_term = (
-        torch.arange(hidden, device=device, dtype=torch.float32)
+        torch.arange(MODEL_DIM, device=device, dtype=torch.float32)
         .remainder(17)
         .mul_(1.0 / 128.0)
         .view(1, -1)
@@ -493,299 +400,678 @@ def _shared_partial(tokens: int, hidden: int, rank: int, device):
     return (token_term + column_term + float(rank + 1) / 16.0).to(torch.bfloat16)
 
 
-def _assert_output(name, actual, expected, *, group, rank):
+@torch.no_grad()
+def _torch_stage2_partial(
+    inter_states: torch.Tensor,
+    a2_scale: torch.Tensor,
+    topk_ids: torch.Tensor,
+    topk_weights: torch.Tensor,
+    weights: Stage2Weights,
+) -> torch.Tensor:
+    # torch_moe_stage2 only reads w1.shape to infer dimensions. Use the real
+    # packed-MXFP4 shape on a meta tensor, avoiding unused Stage1 storage.
+    w1_shape = torch.empty((EXPERTS, INTER_DIM * 2, MODEL_DIM // 2), device="meta")
+    return torch_moe_stage2(
+        inter_states,
+        w1_shape,
+        weights.reference,
+        topk_weights,
+        topk_ids,
+        dtype=torch.bfloat16,
+        quant_type=QuantType.per_1x32,
+        w2_scale=weights.reference_scale,
+        a2_scale=a2_scale,
+        doweight=True,
+    )
+
+
+@torch.no_grad()
+def _torch_stage2_allreduce(
+    case: Stage2Case,
+    weights: Stage2Weights,
+    shared_partial: torch.Tensor,
+    group,
+) -> torch.Tensor:
+    output = _torch_stage2_partial(
+        case.inter_states,
+        case.reference_a2_scale,
+        case.topk_ids,
+        case.topk_weights,
+        weights,
+    )
+    output.add_(shared_partial)
+    dist.all_reduce(output, group=group)
+    return output
+
+
+def _run_ordinary_stage2(
+    fixture: Stage2Fixture, weights: Stage2Weights
+) -> torch.Tensor:
+    case = fixture.case
+    if fixture.requires_output_zero:
+        case.partial_out.zero_()
+    fixture.metadata.stage2(
+        case.inter_states,
+        None,
+        weights.kernel,
+        case.sorted_token_ids,
+        case.sorted_expert_ids,
+        case.num_valid_ids,
+        case.partial_out,
+        TOPK,
+        w2_scale=weights.kernel_scale.view(dtypes.fp8_e8m0),
+        a2_scale=case.a2_scale,
+        block_m=case.block_m,
+        sorted_weights=case.sorted_weights,
+    )
+    case.partial_out.add_(fixture.shared_partial)
+    return get_tp_group().all_reduce(case.partial_out, ca_fp8_quant=False)
+
+
+def _stage2_fixture(session: TestSession, tokens: int, route: str) -> Stage2Fixture:
+    key = (tokens, route)
+    if key in session.stage2_fixtures:
+        return session.stage2_fixtures[key]
+
+    metadata, kernel_name, requires_zero = _resolve_ordinary_stage2(tokens)
+    case = _make_stage2_case(
+        tokens,
+        route,
+        int(metadata.block_m),
+        requires_zero,
+        session.rank,
+        session.device,
+    )
+    shared = _shared_partial(tokens, session.rank, session.device)
+    reference = _torch_stage2_allreduce(case, session.weights, shared, session.group)
+    fixture = Stage2Fixture(
+        case=case,
+        metadata=metadata,
+        ordinary_kernel=kernel_name,
+        requires_output_zero=requires_zero,
+        shared_partial=shared,
+        reference=reference,
+    )
+    session.stage2_fixtures[key] = fixture
+    return fixture
+
+
+def _make_full_moe_case(rank: int, device) -> FullMoeCase:
+    tokens = 3
+    generator = torch.Generator(device=device).manual_seed(20260903 + rank)
+    hidden_states = torch.randn(
+        (tokens, MODEL_DIM),
+        dtype=torch.bfloat16,
+        device=device,
+        generator=generator,
+    ).mul_(MODEL_DIM**-0.25)
+    topk_ids, topk_weights = _make_routes(tokens, "skew", device)
+
+    # Only routed experts are initialized. Both the production kernel and torch
+    # reference are forbidden from reading any other expert.
+    routed_experts = {int(expert) for expert in topk_ids.unique().tolist()}
+    if 0 not in routed_experts:
+        raise AssertionError("skew route must include the hot expert")
+
+    def quantize_expert():
+        weight = torch.randn(
+            (INTER_DIM * 2, MODEL_DIM),
+            dtype=torch.bfloat16,
+            device=device,
+            generator=generator,
+        ).mul_(MODEL_DIM**-0.25)
+        return per_1x32_f4_quant(weight, quant_dtype=dtypes.fp4x2)
+
+    first_quant, first_scale = quantize_expert()
+    reference_w1 = torch.empty(
+        (EXPERTS, *first_quant.shape), dtype=first_quant.dtype, device=device
+    )
+    reference_w1_scale = torch.empty(
+        (EXPERTS, *first_scale.shape), dtype=first_scale.dtype, device=device
+    )
+    reference_w1[0].copy_(first_quant)
+    reference_w1_scale[0].copy_(first_scale)
+    for expert in sorted(routed_experts - {0}):
+        quant, scale = quantize_expert()
+        reference_w1[expert].copy_(quant)
+        reference_w1_scale[expert].copy_(scale)
+
+    w1 = shuffle_weight_a16w4(reference_w1, 16, True).contiguous()
+    w1_scale = shuffle_scale_a16w4(
+        reference_w1_scale.view(-1, reference_w1_scale.shape[-1]), EXPERTS, True
+    ).contiguous()
+    return FullMoeCase(
+        hidden_states=hidden_states,
+        topk_ids=topk_ids,
+        topk_weights=topk_weights,
+        w1=w1,
+        w1_scale=w1_scale,
+        reference_w1=reference_w1,
+        reference_w1_scale=reference_w1_scale,
+    )
+
+
+@torch.no_grad()
+def _torch_full_moe_allreduce(
+    case: FullMoeCase,
+    weights: Stage2Weights,
+    shared_partial: torch.Tensor,
+    group,
+) -> torch.Tensor:
+    stage1 = torch_moe_stage1(
+        case.hidden_states,
+        case.reference_w1,
+        weights.reference,
+        case.topk_weights,
+        case.topk_ids,
+        dtype=torch.bfloat16,
+        activation=ActivationType.Silu,
+        quant_type=QuantType.per_1x32,
+        w1_scale=case.reference_w1_scale,
+        doweight=False,
+    )
+
+    a2_q, a2_scale = per_1x32_f8_scale_f8_quant(
+        stage1,
+        quant_dtype=dtypes.fp8,
+        scale_type=dtypes.fp8_e8m0,
+    )
+    output = _torch_stage2_partial(
+        a2_q,
+        a2_scale,
+        case.topk_ids,
+        case.topk_weights,
+        weights,
+    )
+    output.add_(shared_partial)
+    dist.all_reduce(output, group=group)
+    return output
+
+
+def _full_moe_fixture(session: TestSession) -> FullMoeFixture:
+    if session.full_fixture is not None:
+        return session.full_fixture
+    case = _make_full_moe_case(session.rank, session.device)
+    shared = _shared_partial(3, session.rank, session.device)
+    reference = _torch_full_moe_allreduce(case, session.weights, shared, session.group)
+    session.full_fixture = FullMoeFixture(
+        case=case,
+        shared_partial=shared,
+        reference=reference,
+        stage2_stream=torch.cuda.Stream(device=session.device),
+    )
+    return session.full_fixture
+
+
+def _accuracy_metrics(
+    actual: torch.Tensor,
+    expected: torch.Tensor,
+    *,
+    session: TestSession,
+    label: str,
+) -> dict[str, float]:
     if actual.shape != expected.shape or actual.dtype != torch.bfloat16:
         raise AssertionError(
-            f"{name}: expected BF16 shape {tuple(expected.shape)}, got "
+            f"{label}: expected BF16 shape {tuple(expected.shape)}, got "
             f"dtype={actual.dtype} shape={tuple(actual.shape)}"
         )
+
+    actual_f32 = actual.to(dtypes.fp32)
+    expected_f32 = expected.to(dtypes.fp32)
+    diff = actual_f32 - expected_f32
     finite = torch.tensor(
-        int(torch.isfinite(actual).all() and torch.isfinite(expected).all()),
-        device=actual.device,
+        int(torch.isfinite(actual_f32).all() and torch.isfinite(expected_f32).all()),
         dtype=torch.int32,
+        device=session.device,
     )
-    dist.all_reduce(finite, op=dist.ReduceOp.MIN, group=group)
-    max_abs, rel_l2 = error_stats(actual, expected, group)
-    if rank == 0:
-        print(
-            f"COMM_FUSED_UT {name} max_abs={max_abs:.6f} rel_l2={rel_l2:.6f}",
-            flush=True,
+    stats = torch.stack(
+        (
+            diff.abs().max(),
+            diff.norm() / expected_f32.norm().clamp_min(1.0e-12),
         )
-    if not int(finite.item()) or max_abs > _MAX_ABS or rel_l2 > _MAX_REL_L2:
+    )
+    dist.all_reduce(finite, op=dist.ReduceOp.MIN, group=session.group)
+    dist.all_reduce(stats, op=dist.ReduceOp.MAX, group=session.group)
+
+    local_err = checkAllclose(
+        expected_f32,
+        actual_f32,
+        rtol=0.05,
+        atol=MAX_ABS,
+        tol_err_ratio=MAX_ERR_RATIO,
+        msg=f"{label}: ",
+        printLog=session.rank == 0,
+    )
+    err = torch.tensor(float(local_err), dtype=torch.float32, device=session.device)
+    dist.all_reduce(err, op=dist.ReduceOp.MAX, group=session.group)
+
+    max_abs, rel_l2, err_ratio = (
+        float(stats[0].item()),
+        float(stats[1].item()),
+        float(err.item()),
+    )
+    if (
+        not int(finite.item())
+        or max_abs > MAX_ABS
+        or rel_l2 > MAX_REL_L2
+        or err_ratio > MAX_ERR_RATIO
+    ):
         raise AssertionError(
-            f"{name}: finite={bool(finite.item())} max_abs={max_abs} "
-            f"rel_l2={rel_l2}"
+            f"{label}: finite={bool(finite.item())} max_abs={max_abs:.6f} "
+            f"rel_l2={rel_l2:.6f} err={err_ratio:.6f}"
         )
+    return {"err": err_ratio, "max_abs": max_abs, "rel_l2": rel_l2}
 
 
-def _capture_graph(run, group):
-    barrier(group)
+def _capture_graph(run: Callable[[], torch.Tensor], group):
+    _barrier(group)
     run()
-    barrier(group)
+    _barrier(group)
     graph = torch.cuda.CUDAGraph()
     with get_tp_group().graph_capture() as capture, torch.cuda.graph(
         graph, stream=capture.stream
     ):
-        run()
-    barrier(group)
-    return graph
+        output = run()
+    _barrier(group)
+    return graph, output
+
+
+def _rank_max(value: float, session: TestSession) -> float:
+    result = torch.tensor(float(value), dtype=torch.float32, device=session.device)
+    dist.all_reduce(result, op=dist.ReduceOp.MAX, group=session.group)
+    return float(result.item())
+
+
+def _measure_candidate(
+    *,
+    name: str,
+    run: Callable[[], torch.Tensor],
+    mode: str,
+    reference: torch.Tensor,
+    session: TestSession,
+) -> tuple[float, dict[str, float]]:
+    if mode == "graph":
+        graph, output = _capture_graph(run, session.group)
+        timed = graph.replay
+    else:
+        graph = None
+        output = None
+        timed = run
+
+    _barrier(session.group)
+    _, local_us = run_perftest(
+        timed,
+        num_iters=PERF_ITERS,
+        num_warmup=PERF_WARMUP,
+        use_cuda_event=True,
+    )
+    _barrier(session.group)
+    latency_us = _rank_max(local_us, session)
+
+    samples = []
+    replays = session.graph_replays if graph is not None else 1
+    for replay in range(replays):
+        if graph is None:
+            actual = run()
+        else:
+            # Never accept the output left by capture or an earlier replay. This
+            # catches missing child-stream launches and partially captured graphs.
+            output.fill_(float("nan"))
+            torch.cuda.synchronize(session.device)
+            graph.replay()
+            actual = output
+        _barrier(session.group)
+        samples.append(
+            _accuracy_metrics(
+                actual,
+                reference,
+                session=session,
+                label=f"{name} {mode} replay={replay + 1}",
+            )
+        )
+
+    return latency_us, {
+        metric: max(sample[metric] for sample in samples)
+        for metric in ("err", "max_abs", "rel_l2")
+    }
+
+
+def _stage2_work(case: Stage2Case, world: int) -> tuple[int, int]:
+    """Return cluster-wide GEMM FLOPs and algorithmic input/output bytes."""
+
+    active_experts = int(torch.unique(case.topk_ids).numel())
+    flops = 2 * case.tokens * TOPK * MODEL_DIM * INTER_DIM * world
+    per_rank_bytes = (
+        case.tokens * TOPK * (INTER_DIM + INTER_DIM // 32)
+        + active_experts * MODEL_DIM * (INTER_DIM // 2 + INTER_DIM // 32)
+        + case.tokens * TOPK * (4 + 4)
+        + case.tokens * MODEL_DIM * (2 + 2)
+    )
+    return flops, per_rank_bytes * world
+
+
+def _full_moe_work(case: FullMoeCase, world: int) -> tuple[int, int]:
+    """Return cluster-wide Stage1+Stage2 FLOPs and algorithmic bytes."""
+
+    tokens = case.hidden_states.shape[0]
+    active_experts = int(torch.unique(case.topk_ids).numel())
+    flops = 6 * tokens * TOPK * MODEL_DIM * INTER_DIM * world
+    per_rank_bytes = (
+        tokens * MODEL_DIM * 2
+        + active_experts
+        * (
+            INTER_DIM * 2 * (MODEL_DIM // 2 + MODEL_DIM // 32)
+            + MODEL_DIM * (INTER_DIM // 2 + INTER_DIM // 32)
+        )
+        + tokens * TOPK * (4 + 4)
+        + tokens * MODEL_DIM * (2 + 2)
+    )
+    return flops, per_rank_bytes * world
+
+
+def _record_candidates(
+    *,
+    candidates: dict[str, Callable[[], torch.Tensor]],
+    mode: str,
+    reference: torch.Tensor,
+    flops: int,
+    nbytes: int,
+    session: TestSession,
+) -> dict[str, float | str]:
+    ret: dict[str, float | str] = {"gfx": session.gfx}
+    for name, run in candidates.items():
+        latency_us, accuracy = _measure_candidate(
+            name=name,
+            run=run,
+            mode=mode,
+            reference=reference,
+            session=session,
+        )
+        ret[f"{name} us"] = latency_us
+        ret[f"{name} TFLOPS"] = flops / latency_us / 1.0e6
+        ret[f"{name} TB/s"] = nbytes / latency_us / 1.0e6
+        ret[f"{name} err"] = accuracy["err"]
+        ret[f"{name} max_abs"] = accuracy["max_abs"]
+        ret[f"{name} rel_l2"] = accuracy["rel_l2"]
+    return ret
+
+
+def _run_stage2_case(
+    session: TestSession, tokens: int, route: str, mode: str
+) -> dict[str, float | str]:
+    fixture = _stage2_fixture(session, tokens, route)
+    runner = session.runners[tokens]
+    if getattr(runner.config, "collective", None) != "direct":
+        raise AssertionError(
+            f"M={tokens} expected direct collective, got {runner.config!r}"
+        )
+
+    def run_ordinary():
+        return _run_ordinary_stage2(fixture, session.weights)
+
+    def run_comm_fused():
+        case = fixture.case
+        prepared = runner.prepare_shared_partial(fixture.shared_partial)
+        return runner(
+            stage2_args=(
+                case.inter_states,
+                None,
+                session.weights.kernel,
+                case.sorted_token_ids,
+                case.sorted_expert_ids,
+                case.num_valid_ids,
+                case.partial_out,
+                TOPK,
+            ),
+            stage2_kwargs={
+                "w2_scale": session.weights.kernel_scale.view(dtypes.fp8_e8m0),
+                "a2_scale": case.a2_scale,
+                "block_m": case.block_m,
+                "sorted_weights": case.sorted_weights,
+            },
+            shared_partial=prepared,
+            ordinary_stage2=fixture.metadata.stage2,
+        )
+
+    flops, nbytes = _stage2_work(fixture.case, session.world)
+    result = _record_candidates(
+        candidates={"ordinary": run_ordinary, "comm_fused": run_comm_fused},
+        mode=mode,
+        reference=fixture.reference,
+        flops=flops,
+        nbytes=nbytes,
+        session=session,
+    )
+    return {
+        "ordinary kernel": fixture.ordinary_kernel,
+        "comm_fused kernel": config_name(runner.config),
+        **result,
+    }
 
 
 def _run_full_runtime_case(
-    *,
-    rank,
-    device,
-    group,
-    runners,
-    w2,
-    w2_scale,
-    run_eager,
-    run_graph,
-    graph_replays,
-):
-    """Exercise Stage1 + padding + fused Stage2 through the public runtime."""
-
-    case = make_full_moe_case(
-        rank=rank,
-        device=device,
-        w2=w2,
-        w2_scale=w2_scale,
-    )
-    runtime = CommFusedMoeRuntime(runners=runners)
-    if not runtime.supports(3):
+    session: TestSession, tokens: int, route: str, mode: str
+) -> dict[str, float | str]:
+    if tokens != 3 or route != "skew":
+        raise ValueError("the runtime-padding case is fixed to M=3, route=skew")
+    fixture = _full_moe_fixture(session)
+    case = fixture.case
+    runtime = CommFusedMoeRuntime(runners=session.runners)
+    if not runtime.supports(tokens):
         raise AssertionError("M=3 must resolve through the production M=4 runner")
-    shared = _shared_partial(3, 7168, rank, device)
+
     moe_args = {
         "hidden_states": case.hidden_states,
         "w1": case.w1,
-        "w2": case.w2,
+        "w2": session.weights.kernel,
         "topk_weight": case.topk_weights,
         "topk_ids": case.topk_ids,
         "activation": ActivationType.Silu,
         "quant_type": QuantType.per_1x32,
         "doweight_stage1": False,
         "w1_scale": case.w1_scale,
-        "w2_scale": case.w2_scale,
+        "w2_scale": session.weights.kernel_scale,
         "hidden_pad": 0,
         "intermediate_pad": 0,
         "gate_mode": "interleave",
     }
 
     def run_ordinary():
-        partial = fused_moe(**moe_args)
-        partial.add_(shared)
-        return get_tp_group().all_reduce(partial, ca_fp8_quant=False)
+        output = fused_moe(**moe_args)
+        output.add_(fixture.shared_partial)
+        return get_tp_group().all_reduce(output, ca_fp8_quant=False)
 
-    # Match ATOM's before_stage2 call path.
-    def run_fused(stage2_stream=None):
+    def run_comm_fused(stage2_stream=None):
         return runtime.run(
             shared_partial=None,
-            before_stage2=lambda: shared,
+            before_stage2=lambda: fixture.shared_partial,
             stage2_stream=stage2_stream,
             **moe_args,
         )
 
-    ordinary = run_ordinary().clone()
-    label = "runtime_e2e M=3->4 route=skew"
-    if run_eager:
-        fused = run_fused()
-        barrier(group)
-        _assert_output(f"{label} eager", fused, ordinary, group=group, rank=rank)
-        stage2_stream = torch.cuda.Stream(device=device)
-        fused = run_fused(stage2_stream)
-        barrier(group)
-        _assert_output(
-            f"{label} separate_stream", fused, ordinary, group=group, rank=rank
+    candidates = {
+        "ordinary": run_ordinary,
+        "comm_fused": run_comm_fused,
+    }
+    if mode == "eager":
+        # A separate stream is a model-facing execution variant, not a graph
+        # candidate; graph capture exercises the default stream choreography.
+        candidates["comm_fused_separate_stream"] = lambda: run_comm_fused(
+            fixture.stage2_stream
         )
-    if run_graph:
-        graph = _capture_graph(run_fused, group)
-        for replay in range(graph_replays):
-            graph.replay()
-            barrier(group)
-            _assert_output(
-                f"{label} graph_replay={replay + 1}",
-                runners[4].output[:3],
-                ordinary,
-                group=group,
-                rank=rank,
-            )
-    barrier(group)
 
-
-def _run_case(
-    *,
-    token,
-    route,
-    rank,
-    world,
-    device,
-    group,
-    runners,
-    shared_w2,
-    shared_w2_scale,
-    run_eager,
-    run_graph,
-    graph_replays,
-    seed_offset,
-):
-    case_args = SimpleNamespace(
-        tokens=token,
-        tp_size=world,
-        hidden=7168,
-        inter_dim=384,
-        experts=384,
-        topk=6,
-        tile_m=64,
-        route=route,
-        seed=20260902,
+    flops, nbytes = _full_moe_work(case, session.world)
+    result = _record_candidates(
+        candidates=candidates,
+        mode=mode,
+        reference=fixture.reference,
+        flops=flops,
+        nbytes=nbytes,
+        session=session,
     )
-    metadata, ordinary_kernel, requires_zero = resolve_ordinary_stage2(case_args)
-    case_args.tile_m = int(metadata.block_m)
-    case = make_stage2_case(
-        case_args,
-        rank,
-        device,
-        shared_w2=shared_w2,
-        shared_w2_scale=shared_w2_scale,
-        seed_offset=seed_offset,
-        accumulate=requires_zero,
+    return {
+        "ordinary kernel": "fused_moe",
+        "comm_fused kernel": config_name(session.runners[4].config),
+        **result,
+    }
+
+
+@benchmark()
+def test_comm_fused_stage2(tokens: int, route: str, mode: str):
+    """Benchmark production Stage2 candidates against a torch reference."""
+
+    return _run_stage2_case(_session(), tokens, route, mode)
+
+
+@benchmark()
+def test_comm_fused_runtime(tokens: int, route: str, mode: str):
+    """Benchmark the model-facing M=3 -> M=4 runtime-padding path."""
+
+    return _run_full_runtime_case(_session(), tokens, route, mode)
+
+
+def _parse_args():
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.RawTextHelpFormatter,
+        description="TP8 communication-fused MoE production validation",
     )
-    shared = _shared_partial(token, case_args.hidden, rank, device)
-    ordinary = run_ordinary_stage2_allreduce(
-        case,
-        metadata,
-        requires_output_zero=requires_zero,
-        shared_partial=shared,
-    ).clone()
-
-    runner = runners[token]
-    config = runner.config
-    if not isinstance(config, MegakernelConfig):
-        raise TypeError(f"M={token} resolved unexpected runner {type(config)!r}")
-    if config.collective != "direct":
-        raise AssertionError(
-            f"M={token} expected direct collective, got {config.collective}"
-        )
-
-    w2_scale = (
-        case.w2_scale.view(dtypes.fp8_e8m0)
-        if case.w2_scale.element_size() == 1
-        else case.w2_scale
+    parser.add_argument(
+        "-m",
+        "--tokens",
+        type=int,
+        nargs="+",
+        default=list(PRODUCTION_TOKENS),
+        help="Production token buckets to test (default: 1 2 4 8 16).",
     )
+    parser.add_argument(
+        "-r",
+        "--routes",
+        choices=ROUTES,
+        nargs="+",
+        default=list(ROUTES),
+        help="Routing distributions to test (default: uniform skew).",
+    )
+    parser.add_argument(
+        "--graph-replays",
+        type=int,
+        default=3,
+        help="Poisoned graph replays checked per candidate (default: 3).",
+    )
+    args = parser.parse_args()
+    if args.graph_replays <= 0:
+        parser.error("--graph-replays must be positive")
+    return args
 
-    def run_fused():
-        prepared = runner.prepare_shared_partial(shared)
-        return runner(
-            stage2_args=(
-                case.inter_states,
-                None,
-                case.w2,
-                case.sorted_token_ids,
-                case.sorted_expert_ids,
-                case.num_valid_ids,
-                case.partial_out,
-                case.topk,
-            ),
-            stage2_kwargs={
-                "w2_scale": w2_scale,
-                "a2_scale": case.a2_scale,
-                "block_m": case.block_m,
-                "sorted_weights": case.sorted_weights,
-            },
-            shared_partial=prepared,
-            ordinary_stage2=metadata.stage2,
-        )
 
-    label = f"M={token} route={route} ordinary={ordinary_kernel}"
-    if rank == 0:
-        print(
-            f"COMM_FUSED_UT_DISPATCH {label} config={type(config).__name__} "
-            f"kernel={config}",
-            flush=True,
+def _runtime_skip_reason() -> str | None:
+    gfx = get_gfx_runtime()
+    if gfx not in SUPPORTED_GFX:
+        return f"requires one of {SUPPORTED_GFX}, got {gfx}"
+    if not is_flydsl_comm_fused_moe_available():
+        return "requires ROCm >= 7.2 and a compatible mori.cco installation"
+    return None
+
+
+def _log_summary(name: str, rows: list[dict]) -> None:
+    if rows:
+        aiter.logger.info(
+            "%s summary (markdown):\n%s",
+            name,
+            pd.DataFrame(rows).to_markdown(index=False),
         )
-    if run_eager:
-        fused = run_fused()
-        barrier(group)
-        _assert_output(f"{label} eager", fused, ordinary, group=group, rank=rank)
-    if run_graph:
-        fused_graph = _capture_graph(run_fused, group)
-        for replay in range(graph_replays):
-            fused_graph.replay()
-            barrier(group)
-            _assert_output(
-                f"{label} graph_replay={replay + 1}",
-                runner.output,
-                ordinary,
-                group=group,
-                rank=rank,
-            )
-    barrier(group)
-    return case.w2, case.w2_scale
 
 
 def main() -> None:
+    global _ACTIVE_SESSION
+
     args = _parse_args()
-    rank, world, device, group = setup_distributed(8)
+    skip_reason = _runtime_skip_reason()
+    if skip_reason is not None:
+        if int(os.environ.get("LOCAL_RANK", "0")) == 0:
+            aiter.logger.warning("comm-fused MoE test skipped: %s", skip_reason)
+        return
+
+    requested_tokens = tuple(dict.fromkeys(args.tokens))
+    requested_routes = tuple(dict.fromkeys(args.routes))
+    invalid_tokens = sorted(set(requested_tokens).difference(PRODUCTION_TOKENS))
+    if invalid_tokens:
+        raise ValueError(
+            f"unsupported production token buckets: {invalid_tokens}; "
+            f"expected a subset of {list(PRODUCTION_TOKENS)}"
+        )
+
+    rank, world, device, group = _setup_distributed(TP_SIZE)
+    if rank != 0:
+        aiter.logger.setLevel("WARNING")
     previous_fp8_bound = os.environ.get("AITER_BF16_FP8_MOE_BOUND")
-    # Force MXFP8 so small-M does not select the unrelated FP4 fallback.
     os.environ["AITER_BF16_FP8_MOE_BOUND"] = "0"
     try:
-        shape = _shape_key()
-        configs = winners_for(shape)
-        if 32 in configs:
-            raise AssertionError(
-                "M=32 fallback row unexpectedly created a fused runner"
-            )
-        specs = _case_specs(args, configs)
-        runners = create_flydsl_comm_fused_runners(
-            tp_group=get_tp_group(),
-            model_dim=shape.model_dim,
-            inter_dim=shape.inter_dim,
-            experts=shape.experts,
-            topk=shape.topk,
+        shape = ShapeKey(
+            get_gfx_runtime(),
+            MODEL_DIM,
+            INTER_DIM,
+            EXPERTS,
+            TOPK,
+            TP_SIZE,
+            get_cu_num(),
         )
-        shared_w2 = None
-        shared_w2_scale = None
-        for index, (token, route) in enumerate(specs):
-            shared_w2, shared_w2_scale = _run_case(
-                token=token,
-                route=route,
-                rank=rank,
-                world=world,
-                device=device,
-                group=group,
-                runners=runners,
-                shared_w2=shared_w2,
-                shared_w2_scale=shared_w2_scale,
-                run_eager=not args.graph_only,
-                run_graph=not args.eager_only,
-                graph_replays=args.graph_replays,
-                seed_offset=index,
+        configs = winners_for(shape)
+        missing = sorted(set(requested_tokens).difference(configs))
+        if missing:
+            raise AssertionError(
+                f"production comm-fused rows are missing: {missing}; "
+                f"available={sorted(configs)}"
             )
-        if shared_w2 is None or shared_w2_scale is None:
-            raise AssertionError("Stage2 cases did not initialize shared W2")
-        _run_full_runtime_case(
+        if 32 in configs:
+            raise AssertionError("M=32 fallback unexpectedly created a fused runner")
+
+        session = TestSession(
             rank=rank,
+            world=world,
             device=device,
             group=group,
-            runners=runners,
-            w2=shared_w2,
-            w2_scale=shared_w2_scale,
-            run_eager=not args.graph_only,
-            run_graph=not args.eager_only,
+            gfx=shape.gfx,
+            runners=create_flydsl_comm_fused_runners(
+                tp_group=get_tp_group(),
+                model_dim=MODEL_DIM,
+                inter_dim=INTER_DIM,
+                experts=EXPERTS,
+                topk=TOPK,
+            ),
+            weights=_make_stage2_weights(rank, device),
             graph_replays=args.graph_replays,
         )
+        _ACTIVE_SESSION = session
+
+        stage2_rows = []
+        for tokens, route, mode in itertools.product(
+            requested_tokens, requested_routes, MODES
+        ):
+            row = test_comm_fused_stage2(tokens, route, mode)
+            if rank == 0:
+                stage2_rows.append(row)
+
+        runtime_rows = []
+        for mode in MODES:
+            row = test_comm_fused_runtime(3, "skew", mode)
+            if rank == 0:
+                runtime_rows.append(row)
+
         if rank == 0:
+            _log_summary("comm-fused MoE Stage2", stage2_rows)
+            _log_summary("comm-fused MoE runtime padding", runtime_rows)
             print(
-                f"COMM_FUSED_UT_OK stage2_cases={len(specs)} runtime_cases=1",
+                f"COMM_FUSED_UT_OK stage2_cases={len(stage2_rows)} "
+                f"runtime_cases={len(runtime_rows)}",
                 flush=True,
             )
     finally:
+        _ACTIVE_SESSION = None
         if previous_fp8_bound is None:
             os.environ.pop("AITER_BF16_FP8_MOE_BOUND", None)
         else:
             os.environ["AITER_BF16_FP8_MOE_BOUND"] = previous_fp8_bound
-        cleanup_distributed(rank)
+        _cleanup_distributed(rank)
 
 
 if __name__ == "__main__":

--- a/op_tests/tuners/tune_comm_fused_moe.py
+++ b/op_tests/tuners/tune_comm_fused_moe.py
@@ -1,0 +1,786 @@
+# SPDX-License-Identifier: MIT
+"""Offline tuner for communication-fused FlyDSL MoE."""
+
+import argparse
+import csv
+import os
+import statistics
+from dataclasses import MISSING, dataclass, fields
+from itertools import product
+from pathlib import Path
+
+import torch
+import torch.distributed as dist
+
+from aiter import ActivationType, QuantType, dtypes
+from aiter.dist.parallel_state import (
+    ensure_model_parallel_initialized,
+    get_dcp_group,
+    get_dp_group,
+    get_ep_group,
+    get_pcp_group,
+    get_pp_group,
+    get_tp_group,
+    init_distributed_environment,
+    set_custom_all_reduce,
+)
+from aiter.fused_moe import (
+    get_2stage_cfgs,
+    get_padded_M,
+    moe_sorting,
+    stage2_uses_route_reduce,
+)
+from aiter.jit.utils.chip_info import get_cu_num, get_gfx_runtime
+from aiter.ops.flydsl.comm_fused_moe_host import (
+    ShapeKey,
+    config_name,
+    create_runner,
+)
+from aiter.ops.flydsl.kernels.comm_fused_moe.gfx950.a8w4.config import (
+    AtomicConfig,
+    MegakernelConfig,
+    PipelineConfig,
+    Shape,
+    WindowConfig,
+)
+from aiter.ops.quant import (
+    mxfp4_moe_sort_fwd,
+    per_1x32_f4_quant,
+    per_1x32_f8_scale_f8_quant,
+)
+from aiter.ops.shuffle import shuffle_scale_a16w4, shuffle_weight_a16w4
+
+
+@dataclass
+class _Stage2Case:
+    inter_states: torch.Tensor
+    w2: torch.Tensor
+    w2_scale: torch.Tensor
+    a2_scale: torch.Tensor
+    sorted_token_ids: torch.Tensor
+    sorted_expert_ids: torch.Tensor
+    sorted_weights: torch.Tensor
+    num_valid_ids: torch.Tensor
+    partial_out: torch.Tensor
+    topk: int
+    block_m: int
+
+
+def _setup_distributed(expected_world: int):
+    rank = int(os.environ["RANK"])
+    world = int(os.environ["WORLD_SIZE"])
+    local_rank = int(os.environ.get("LOCAL_RANK", rank))
+    if world != expected_world:
+        raise ValueError(
+            f"torchrun world size is {world}, but expected {expected_world}"
+        )
+    torch.cuda.set_device(local_rank)
+    device = torch.device("cuda", local_rank)
+    set_custom_all_reduce(True)
+    init_distributed_environment(
+        world_size=world,
+        rank=rank,
+        local_rank=local_rank,
+        distributed_init_method="env://",
+        backend="nccl",
+    )
+    ensure_model_parallel_initialized(world, 1)
+    group = get_tp_group().device_group
+    dist.all_reduce(torch.zeros(1, dtype=torch.int32, device=device), group=group)
+    torch.cuda.synchronize(device)
+    return rank, device, group
+
+
+def _cleanup_distributed():
+    for get_group in (
+        get_tp_group,
+        get_pcp_group,
+        get_pp_group,
+        get_dp_group,
+        get_ep_group,
+        get_dcp_group,
+    ):
+        group = get_group()
+        communicator = group.device_communicator
+        if communicator is not None:
+            communicator.destroy()
+            group.device_communicator = None
+        group.mq_broadcaster = None
+    dist.destroy_process_group()
+
+
+def _make_stage2_case(args, rank: int, device, *, accumulate: bool):
+    token = torch.arange(args.token, dtype=torch.int64, device=device)[:, None]
+    slot = torch.arange(args.topk, dtype=torch.int64, device=device)[None, :]
+    if args.route == "uniform":
+        topk_ids = (token * args.topk + slot) % args.experts
+    else:
+        topk_ids = 1 + ((token + slot - 1) % (args.experts - 1))
+        hot_slot = (token % 8) != 7
+        cold_slot = 1 + ((token + args.topk - 1) % (args.experts - 1))
+        topk_ids[:, :1] = torch.where(hot_slot, 0, cold_slot)
+    weights = (slot + 1).expand(args.token, -1).to(torch.float32)
+    topk_weights = (weights / weights.sum(dim=1, keepdim=True)).contiguous()
+    (
+        sorted_ids,
+        sorted_weights,
+        sorted_expert_ids,
+        num_valid_ids,
+        sorting_out,
+    ) = moe_sorting(
+        topk_ids.to(torch.int32).contiguous(),
+        topk_weights,
+        args.experts,
+        args.model_dim,
+        torch.bfloat16,
+        args.tile_m,
+        accumulate=accumulate,
+    )
+    sorted_ids = sorted_ids.to(torch.int32).contiguous()
+    sorted_weights = sorted_weights.to(torch.float32).contiguous()
+    sorted_expert_ids = sorted_expert_ids.to(torch.int32).contiguous()
+    num_valid_ids = num_valid_ids.to(torch.int32).contiguous()
+    row_capacity = int(sorted_expert_ids.numel()) * args.tile_m
+    if sorted_ids.numel() < row_capacity:
+        sentinel = (args.topk << 24) | args.token
+        sorted_ids = torch.nn.functional.pad(
+            sorted_ids, (0, row_capacity - sorted_ids.numel()), value=sentinel
+        ).contiguous()
+        sorted_weights = torch.nn.functional.pad(
+            sorted_weights,
+            (0, row_capacity - sorted_weights.numel()),
+            value=0.0,
+        ).contiguous()
+
+    generator = torch.Generator(device=device).manual_seed(20260819 + rank)
+    activations = torch.randn(
+        (args.token, args.topk, args.inter_dim),
+        dtype=torch.bfloat16,
+        device=device,
+        generator=generator,
+    ).mul_(args.inter_dim**-0.25)
+    inter_states, a2_scale_unsorted = per_1x32_f8_scale_f8_quant(
+        activations,
+        quant_dtype=dtypes.fp8,
+        scale_type=dtypes.fp8_e8m0,
+    )
+    del activations
+    inter_states = inter_states.view(args.token, args.topk, args.inter_dim)
+    a2_scale = mxfp4_moe_sort_fwd(
+        a2_scale_unsorted.view(args.token * args.topk, -1),
+        sorted_ids=sorted_ids,
+        num_valid_ids=num_valid_ids,
+        token_num=args.token,
+        cols=args.inter_dim,
+    ).contiguous()
+
+    w2_bf16 = torch.randn(
+        (args.experts, args.model_dim, args.inter_dim),
+        dtype=torch.bfloat16,
+        device=device,
+        generator=generator,
+    ).mul_(args.inter_dim**-0.25)
+    first_quant, first_scale = per_1x32_f4_quant(w2_bf16[0], quant_dtype=dtypes.fp4x2)
+    w2_quant = torch.empty(
+        (args.experts, *first_quant.shape), dtype=first_quant.dtype, device=device
+    )
+    w2_scale = torch.empty(
+        (args.experts, *first_scale.shape), dtype=first_scale.dtype, device=device
+    )
+    w2_quant[0].copy_(first_quant)
+    w2_scale[0].copy_(first_scale)
+    for expert in range(1, args.experts):
+        quant, scale = per_1x32_f4_quant(w2_bf16[expert], quant_dtype=dtypes.fp4x2)
+        w2_quant[expert].copy_(quant)
+        w2_scale[expert].copy_(scale)
+    del w2_bf16
+    w2 = shuffle_weight_a16w4(w2_quant, 16, False).contiguous()
+    w2_scale = shuffle_scale_a16w4(
+        w2_scale.view(-1, w2_scale.shape[-1]), args.experts, False
+    ).contiguous()
+    del w2_quant
+    partial_out = (
+        sorting_out
+        if sorting_out.numel()
+        else torch.empty(
+            (args.token, args.model_dim), dtype=torch.bfloat16, device=device
+        )
+    )
+    return _Stage2Case(
+        inter_states,
+        w2,
+        w2_scale,
+        a2_scale,
+        sorted_ids,
+        sorted_expert_ids,
+        sorted_weights,
+        num_valid_ids,
+        partial_out,
+        args.topk,
+        args.tile_m,
+    )
+
+
+def _resolve_ordinary_stage2(args):
+    metadata = get_2stage_cfgs(
+        get_padded_M(args.token),
+        args.model_dim,
+        args.inter_dim,
+        args.experts,
+        args.topk,
+        dtypes.bf16,
+        dtypes.fp8,
+        dtypes.fp4x2,
+        QuantType.per_1x32,
+        True,
+        ActivationType.Silu,
+        False,
+        0,
+        0,
+        is_shuffled=True,
+        gate_mode="separated",
+        is_ep=False,
+        has_stage2_bias=False,
+        opus_weights_shuffled=True,
+    )
+    return metadata, not stage2_uses_route_reduce(metadata.stage2)
+
+
+def _run_ordinary_stage2_allreduce(
+    case, metadata, *, requires_output_zero, shared_partial
+):
+    if requires_output_zero:
+        case.partial_out.zero_()
+    metadata.stage2(
+        case.inter_states,
+        None,
+        case.w2,
+        case.sorted_token_ids,
+        case.sorted_expert_ids,
+        case.num_valid_ids,
+        case.partial_out,
+        case.topk,
+        w2_scale=case.w2_scale.view(dtypes.fp8_e8m0),
+        a2_scale=case.a2_scale,
+        block_m=int(metadata.block_m),
+        sorted_weights=case.sorted_weights,
+    )
+    case.partial_out.add_(shared_partial)
+    return get_tp_group().all_reduce(case.partial_out, ca_fp8_quant=False)
+
+
+_WINNER_KEY_FIELDS = (
+    "gfx",
+    "cu_num",
+    "token",
+    "model_dim",
+    "inter_dim",
+    "expert",
+    "topk",
+    "tp",
+    "act_type",
+    "dtype",
+    "q_dtype_a",
+    "q_dtype_w",
+    "q_type",
+    "use_g1u1",
+    "doweight_stage1",
+)
+CSV_FIELDS = (
+    *_WINNER_KEY_FIELDS,
+    "block_m",
+    "us",
+    "kernelName",
+    "max_abs",
+    "rel_l2",
+)
+
+
+@dataclass(frozen=True, slots=True)
+class TuningResult:
+    config: PipelineConfig
+    latency_us: float
+    max_abs: float
+    rel_l2: float
+    block_m: int | None = None
+
+
+def _graph_latency_us(
+    run,
+    *,
+    tp_group,
+    process_group,
+    device,
+    warmup_replays,
+    rounds,
+    iterations,
+):
+    dist.barrier(group=process_group)
+    graph = torch.cuda.CUDAGraph()
+    with tp_group.graph_capture() as capture, torch.cuda.graph(
+        graph, stream=capture.stream
+    ):
+        run()
+    for _ in range(warmup_replays):
+        graph.replay()
+    torch.cuda.synchronize(device)
+    dist.barrier(group=process_group)
+
+    world = dist.get_world_size(process_group)
+    samples = []
+    for _ in range(rounds):
+        start = torch.cuda.Event(enable_timing=True)
+        end = torch.cuda.Event(enable_timing=True)
+        start.record()
+        for _ in range(iterations):
+            graph.replay()
+        end.record()
+        end.synchronize()
+        local = torch.tensor(
+            [start.elapsed_time(end) * 1000.0 / iterations],
+            dtype=torch.float64,
+            device=device,
+        )
+        ranks = torch.empty(world, dtype=torch.float64, device=device)
+        dist.all_gather_into_tensor(ranks, local, group=process_group)
+        samples.append(float(ranks.max().item()))
+    return statistics.median(samples)
+
+
+def _candidates(config_type, shape, m, axes):
+    config_fields = tuple(
+        field for field in fields(config_type) if field.name not in ("shape", "m")
+    )
+    value_axes = []
+    for field in config_fields:
+        if field.name in axes:
+            value_axes.append(axes[field.name])
+        elif field.default is not MISSING:
+            value_axes.append((field.default,))
+        elif field.default_factory is not MISSING:
+            value_axes.append((field.default_factory(),))
+        else:
+            raise KeyError(field.name)
+    for values in product(*value_axes):
+        yield config_type(
+            shape=shape,
+            m=m,
+            **{field.name: value for field, value in zip(config_fields, values)},
+        )
+
+
+def benchmark(
+    *,
+    tp_group,
+    process_group,
+    config: PipelineConfig,
+    stage2_args: tuple,
+    stage2_kwargs: dict,
+    ordinary_stage2=None,
+    shared_partial: torch.Tensor,
+    reference: torch.Tensor,
+    warmup_replays: int = 100,
+    rounds: int = 3,
+    iterations: int = 20,
+) -> TuningResult:
+    """Measure one complete Stage2 + shared + TP communication candidate."""
+
+    runner = create_runner(tp_group, config)
+    candidate_shared = shared_partial.clone()
+    prepare_shared_partial = getattr(runner, "prepare_shared_partial", None)
+    if prepare_shared_partial is not None:
+        candidate_shared = prepare_shared_partial(candidate_shared)
+
+    def run():
+        return runner(
+            stage2_args=stage2_args,
+            stage2_kwargs=stage2_kwargs,
+            shared_partial=candidate_shared,
+            ordinary_stage2=ordinary_stage2,
+        )
+
+    reference_f32 = reference.float()
+    diff = run().float() - reference_f32
+    error = torch.stack(
+        (
+            diff.abs().max(),
+            diff.norm() / reference_f32.norm().clamp_min(1.0e-12),
+        )
+    )
+    dist.all_reduce(error, op=dist.ReduceOp.MAX, group=process_group)
+
+    return TuningResult(
+        config,
+        _graph_latency_us(
+            run,
+            tp_group=tp_group,
+            process_group=process_group,
+            device=shared_partial.device,
+            warmup_replays=warmup_replays,
+            rounds=rounds,
+            iterations=iterations,
+        ),
+        float(error[0].item()),
+        float(error[1].item()),
+        int(stage2_kwargs["block_m"]),
+    )
+
+
+_CONFIG_TYPES = {
+    "atomic": AtomicConfig,
+    "mega": MegakernelConfig,
+    "window": WindowConfig,
+}
+
+
+def _parse_axis(field, raw_values: str):
+    if not raw_values.strip():
+        raise ValueError(f"empty axis for {field.name}")
+
+    def parse(raw):
+        if field.type is bool:
+            normalized = raw.strip().lower()
+            if normalized in ("1", "true", "yes", "on"):
+                return True
+            if normalized in ("0", "false", "no", "off"):
+                return False
+            raise ValueError(f"invalid boolean {raw!r} for {field.name}")
+        if field.type is str:
+            return raw
+        return int(raw)
+
+    values = tuple(parse(raw) for raw in raw_values.split(","))
+    return values
+
+
+def candidate_configs(
+    current,
+    family: str,
+    axis_specs: tuple[str, ...],
+    *,
+    shape: Shape | None = None,
+    m: int | None = None,
+):
+    if current is None and family == "current":
+        raise ValueError("family='current' requires a production config")
+    config_type = type(current) if family == "current" else _CONFIG_TYPES[family]
+    config_fields = {
+        field.name: field
+        for field in fields(config_type)
+        if field.name not in ("shape", "m")
+    }
+    axes = {}
+    if current is not None and type(current) is config_type:
+        axes = {name: (getattr(current, name),) for name in config_fields}
+    for spec in axis_specs:
+        name, separator, raw_values = spec.partition("=")
+        if not separator or name not in config_fields:
+            valid = ", ".join(sorted(config_fields))
+            raise ValueError(f"invalid --axis {spec!r}; valid fields: {valid}")
+        axes[name] = _parse_axis(config_fields[name], raw_values)
+    if current is not None:
+        shape = current.shape
+        m = current.m
+    if shape is None or m is None:
+        raise ValueError("shape and m are required without a production config")
+    candidates = list(_candidates(config_type, shape, m, axes))
+    return tuple(dict.fromkeys(candidates))
+
+
+def select_winner(
+    results,
+    *,
+    max_abs: float = 1.0,
+    max_rel_l2: float = 0.05,
+    ordinary_us: float | None = None,
+) -> TuningResult | None:
+    valid = tuple(
+        result
+        for result in results
+        if result.max_abs <= max_abs and result.rel_l2 <= max_rel_l2
+    )
+    if not valid:
+        return None
+    winner = min(valid, key=lambda result: result.latency_us)
+    if ordinary_us is not None and winner.latency_us >= ordinary_us:
+        return None
+    return winner
+
+
+def _winner_key(shape: ShapeKey, token: int) -> dict:
+    return {
+        "gfx": shape.gfx,
+        "cu_num": shape.cu_num if shape.cu_num is not None else get_cu_num(),
+        "token": token,
+        "model_dim": shape.model_dim,
+        "inter_dim": shape.inter_dim,
+        "expert": shape.experts,
+        "topk": shape.topk,
+        "act_type": shape.act_type,
+        "dtype": shape.dtype,
+        "q_dtype_a": shape.q_dtype_a,
+        "q_dtype_w": shape.q_dtype_w,
+        "q_type": shape.q_type,
+        "use_g1u1": shape.use_g1u1,
+        "doweight_stage1": shape.doweight_stage1,
+        "tp": shape.tp,
+    }
+
+
+def winner_row(shape: ShapeKey, result: TuningResult) -> dict:
+    config = result.config
+    block_m = getattr(config, "sort_block_m", result.block_m)
+    if block_m is None:
+        raise ValueError("block_m is required for an atomic pipeline winner")
+    if result.block_m is not None and int(result.block_m) != int(block_m):
+        raise ValueError(
+            f"tuned block_m={result.block_m} does not match "
+            f"kernel sort_block_m={block_m}"
+        )
+    row = {
+        **_winner_key(shape, config.m),
+        "block_m": block_m,
+        "us": result.latency_us,
+        "kernelName": config_name(config),
+        "max_abs": result.max_abs,
+        "rel_l2": result.rel_l2,
+    }
+    return {field: row.get(field, "") for field in CSV_FIELDS}
+
+
+def fallback_row(shape: ShapeKey, token: int, block_m: int) -> dict:
+    row = {
+        **_winner_key(shape, token),
+        "block_m": block_m,
+        "kernelName": "fallback",
+    }
+    return {field: row.get(field, "") for field in CSV_FIELDS}
+
+
+def write_winner(path, row: dict) -> None:
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    rows = []
+    if path.exists():
+        with path.open(newline="") as file:
+            rows = list(csv.DictReader(file))
+    key = tuple(str(row[field]) for field in _WINNER_KEY_FIELDS)
+    rows = [
+        old
+        for old in rows
+        if tuple(str(old[field]) for field in _WINNER_KEY_FIELDS) != key
+    ]
+    rows.append({field: row.get(field, "") for field in CSV_FIELDS})
+    with path.open("w", newline="") as file:
+        writer = csv.DictWriter(file, fieldnames=CSV_FIELDS)
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def _parse_args():
+    parser = argparse.ArgumentParser(
+        description="Tune one complete FlyDSL GEMM2 + TP communication shape."
+    )
+    parser.add_argument("--token", type=int, required=True)
+    parser.add_argument("--model-dim", type=int, default=7168)
+    parser.add_argument("--inter-dim", type=int, default=384)
+    parser.add_argument("--experts", type=int, default=384)
+    parser.add_argument("--topk", type=int, default=6)
+    parser.add_argument("--tp", type=int, default=8)
+    parser.add_argument("--route", choices=("uniform", "skew"), default="uniform")
+    parser.add_argument(
+        "--family",
+        choices=("current", *_CONFIG_TYPES),
+        default="current",
+        help="Candidate family; current starts from the production winner.",
+    )
+    parser.add_argument(
+        "--axis",
+        action="append",
+        default=[],
+        metavar="FIELD=V1,V2",
+        help="Override one config field with a comma-separated search axis.",
+    )
+    parser.add_argument("--rounds", type=int, default=3)
+    parser.add_argument("--iterations", type=int, default=20)
+    parser.add_argument(
+        "--warmup",
+        type=int,
+        default=100,
+        help="Graph replays used to warm each candidate before timing.",
+    )
+    parser.add_argument("--max-abs", type=float, default=1.0)
+    parser.add_argument("--max-rel-l2", type=float, default=0.05)
+    parser.add_argument(
+        "--ordinary-only",
+        action="store_true",
+        help="Measure the ordinary Stage2 + TP AllReduce baseline and exit.",
+    )
+    parser.add_argument("--profile-output", type=Path)
+    parser.add_argument("--winner-output", type=Path)
+    return parser.parse_args()
+
+
+def main():
+    args = _parse_args()
+    rank, device, group = _setup_distributed(args.tp)
+    try:
+        metadata, requires_zero = _resolve_ordinary_stage2(args)
+        args.tile_m = int(metadata.block_m)
+        case = _make_stage2_case(args, rank, device, accumulate=requires_zero)
+        shared = (
+            torch.arange(args.token, device=device, dtype=torch.float32)
+            .remainder(7)
+            .mul_(1.0 / 32.0)
+            .view(-1, 1)
+            + torch.arange(args.model_dim, device=device, dtype=torch.float32)
+            .remainder(17)
+            .mul_(1.0 / 128.0)
+            .view(1, -1)
+            + float(rank + 1) / 16.0
+        ).to(torch.bfloat16)
+        reference = _run_ordinary_stage2_allreduce(
+            case,
+            metadata,
+            requires_output_zero=requires_zero,
+            shared_partial=shared,
+        ).clone()
+
+        def run_ordinary():
+            return _run_ordinary_stage2_allreduce(
+                case,
+                metadata,
+                requires_output_zero=requires_zero,
+                shared_partial=shared,
+            )
+
+        ordinary_us = _graph_latency_us(
+            run_ordinary,
+            tp_group=get_tp_group(),
+            process_group=group,
+            device=device,
+            warmup_replays=args.warmup,
+            rounds=args.rounds,
+            iterations=args.iterations,
+        )
+        if rank == 0:
+            print(
+                f"COMM_FUSED_TUNE_ORDINARY us={ordinary_us:.4f}",
+                flush=True,
+            )
+        if args.ordinary_only:
+            return
+        shape = ShapeKey(
+            get_gfx_runtime(),
+            args.model_dim,
+            args.inter_dim,
+            args.experts,
+            args.topk,
+            args.tp,
+            get_cu_num(),
+        )
+        from aiter.ops.flydsl.comm_fused_moe_host import winners_for
+
+        current = winners_for(shape).get(args.token)
+        if current is None and args.family == "current":
+            raise KeyError(
+                f"no production comm_fused config for M={args.token}; "
+                "select an explicit --family"
+            )
+        candidates = candidate_configs(
+            current,
+            args.family,
+            tuple(args.axis),
+            shape=shape.kernel_shape(),
+            m=args.token,
+        )
+        if rank == 0:
+            print(
+                f"COMM_FUSED_TUNE_START M={args.token} route={args.route} "
+                f"family={args.family} candidates={len(candidates)}",
+                flush=True,
+            )
+        stage2_args = (
+            case.inter_states,
+            None,
+            case.w2,
+            case.sorted_token_ids,
+            case.sorted_expert_ids,
+            case.num_valid_ids,
+            case.partial_out,
+            case.topk,
+        )
+        stage2_kwargs = {
+            "w2_scale": case.w2_scale.view(dtypes.fp8_e8m0),
+            "a2_scale": case.a2_scale,
+            "block_m": case.block_m,
+            "sorted_weights": case.sorted_weights,
+        }
+        results = []
+        for index, config in enumerate(candidates, 1):
+            result = benchmark(
+                tp_group=get_tp_group(),
+                process_group=group,
+                config=config,
+                stage2_args=stage2_args,
+                stage2_kwargs=stage2_kwargs,
+                ordinary_stage2=metadata.stage2,
+                shared_partial=shared,
+                reference=reference,
+                warmup_replays=args.warmup,
+                rounds=args.rounds,
+                iterations=args.iterations,
+            )
+            results.append(result)
+            if rank == 0:
+                print(
+                    f"COMM_FUSED_TUNE_RESULT {index}/{len(candidates)} "
+                    f"us={result.latency_us:.4f} "
+                    f"max_abs={result.max_abs:.6f} "
+                    f"rel_l2={result.rel_l2:.6f} "
+                    f"kernel={config_name(config)}",
+                    flush=True,
+                )
+        winner = select_winner(
+            results,
+            max_abs=args.max_abs,
+            max_rel_l2=args.max_rel_l2,
+            ordinary_us=ordinary_us,
+        )
+        if rank == 0:
+            if args.profile_output is not None:
+                args.profile_output.parent.mkdir(parents=True, exist_ok=True)
+                with args.profile_output.open("w", newline="") as file:
+                    writer = csv.DictWriter(file, fieldnames=CSV_FIELDS)
+                    writer.writeheader()
+                    writer.writerows(winner_row(shape, result) for result in results)
+            if winner is None:
+                if args.winner_output is not None:
+                    write_winner(
+                        args.winner_output,
+                        fallback_row(shape, args.token, int(metadata.block_m)),
+                    )
+                print(
+                    f"COMM_FUSED_TUNE_WINNER ordinary_us={ordinary_us:.4f} "
+                    "kernel=ordinary",
+                    flush=True,
+                )
+            else:
+                winner_data = winner_row(shape, winner)
+                if args.winner_output is not None:
+                    write_winner(args.winner_output, winner_data)
+                print(
+                    f"COMM_FUSED_TUNE_WINNER us={winner.latency_us:.4f} "
+                    f"ordinary_us={ordinary_us:.4f} "
+                    f"speedup={ordinary_us / winner.latency_us:.4f}x "
+                    f"max_abs={winner.max_abs:.6f} "
+                    f"rel_l2={winner.rel_l2:.6f} "
+                    f"kernel={winner_data['kernelName']}",
+                    flush=True,
+                )
+    finally:
+        _cleanup_distributed()
+
+
+if __name__ == "__main__":
+    main()

--- a/op_tests/tuners/tune_comm_fused_moe.py
+++ b/op_tests/tuners/tune_comm_fused_moe.py
@@ -152,7 +152,7 @@ def _make_stage2_case(args, rank: int, device, *, accumulate: bool):
             value=0.0,
         ).contiguous()
 
-    generator = torch.Generator(device=device).manual_seed(20260819 + rank)
+    generator = torch.Generator(device=device).manual_seed(args.seed + rank)
     activations = torch.randn(
         (args.token, args.topk, args.inter_dim),
         dtype=torch.bfloat16,
@@ -386,21 +386,24 @@ def benchmark(
     """Measure one complete Stage2 + shared + TP communication candidate."""
 
     runner = create_runner(tp_group, config)
+    runner.output.fill_(float("nan"))
     candidate_shared = shared_partial.clone()
     prepare_shared_partial = getattr(runner, "prepare_shared_partial", None)
-    if prepare_shared_partial is not None:
-        candidate_shared = prepare_shared_partial(candidate_shared)
 
     def run():
+        current_shared = candidate_shared
+        if prepare_shared_partial is not None:
+            current_shared = prepare_shared_partial(current_shared)
         return runner(
             stage2_args=stage2_args,
             stage2_kwargs=stage2_kwargs,
-            shared_partial=candidate_shared,
+            shared_partial=current_shared,
             ordinary_stage2=ordinary_stage2,
         )
 
     reference_f32 = reference.float()
-    diff = run().float() - reference_f32
+    output = run()
+    diff = output.float() - reference_f32
     error = torch.stack(
         (
             diff.abs().max(),
@@ -409,17 +412,28 @@ def benchmark(
     )
     dist.all_reduce(error, op=dist.ReduceOp.MAX, group=process_group)
 
+    latency_us = _graph_latency_us(
+        run,
+        tp_group=tp_group,
+        process_group=process_group,
+        device=shared_partial.device,
+        warmup_replays=warmup_replays,
+        rounds=rounds,
+        iterations=iterations,
+    )
+    graph_diff = output.float() - reference_f32
+    graph_error = torch.stack(
+        (
+            graph_diff.abs().max(),
+            graph_diff.norm() / reference_f32.norm().clamp_min(1.0e-12),
+        )
+    )
+    dist.all_reduce(graph_error, op=dist.ReduceOp.MAX, group=process_group)
+    error = torch.maximum(error, graph_error)
+
     return TuningResult(
         config,
-        _graph_latency_us(
-            run,
-            tp_group=tp_group,
-            process_group=process_group,
-            device=shared_partial.device,
-            warmup_replays=warmup_replays,
-            rounds=rounds,
-            iterations=iterations,
-        ),
+        latency_us,
         float(error[0].item()),
         float(error[1].item()),
         int(stage2_kwargs["block_m"]),
@@ -588,6 +602,7 @@ def _parse_args():
     parser.add_argument("--topk", type=int, default=6)
     parser.add_argument("--tp", type=int, default=8)
     parser.add_argument("--route", choices=("uniform", "skew"), default="uniform")
+    parser.add_argument("--seed", type=int, default=20260819)
     parser.add_argument(
         "--family",
         choices=("current", *_CONFIG_TYPES),


### PR DESCRIPTION
## Motivation

Communication-fused MoE currently executes the Stage2 GEMM and TP reduction as
separate operations. For decode-sized batches, kernel launches, intermediate
workspace traffic, and cross-rank synchronization account for a significant
part of the end-to-end latency.

This PR adds a config-driven FlyDSL communication-fused Stage2 path for gfx950
A8W4 MXFP4 MoE workloads. The initial production target is DeepSeek-V4 TP8
decode. Unsupported shapes and token buckets continue to use the existing
ordinary Stage2 + TP AllReduce path.

## Performance

### Single-operator latency

Representative TP8 graph measurements collected during development are shown
below. Each value is the median of three rounds using the maximum latency across
all eight ranks. The fused path includes GEMM2 and the TP collective; the
ordinary path includes Stage2 followed by TP AllReduce.

| M | Routing | Ordinary (us) | Comm-fused (us) | Latency reduction |
|---:|---|---:|---:|---:|
| 1 | uniform | 22.187 | 15.549 | 29.92% |
| 1 | skew | 22.195 | 15.380 | 30.71% |
| 2 | uniform | 24.050 | 15.679 | 34.81% |
| 2 | skew | 23.248 | 15.505 | 33.31% |
| 4 | uniform | 25.173 | 18.147 | 27.91% |
| 4 | skew | 28.175 | 25.742 | 8.64% |
| 8 | uniform | 30.214 | 25.939 | 14.15% |
| 8 | skew | 21.864 | 17.116 | 21.72% |
| 16 | uniform | 42.309 | 37.232 | 12.00% |
| 16 | skew | 25.671 | 23.215 | 9.57% |

The production table enables the direct comm-fused megakernel only for
`M = 1, 2, 4, 8, 16`. Larger buckets remain explicit ordinary fallbacks unless
a fused candidate has been separately validated and selected.

### End-to-end model performance

The end-to-end comparison used DeepSeek-V4-Pro with TP8/EP1, FULL CUDA graph,
ISL=8192, OSL=1024, random-range-ratio=0.8, and concurrency
`1, 2, 4, 8, 16`. Each arm started the model once and ran all five concurrency
levels. Results use three adjacent `A/B` pairs in the fixed order
`A1 -> B1 -> A2 -> B2 -> A3 -> B3`, where A enables comm-fused MoE and B sets
`AITER_DISABLE_COMM_FUSED_MOE=1`. The reported improvements are the median of
the three paired improvements.

| Concurrency | Fused total tok/s | Ordinary total tok/s | Throughput improvement | Fused median TPOT | Ordinary median TPOT | TPOT improvement |
|---:|---:|---:|---:|---:|---:|---:|
| 1 | 605.215 | 579.768 | +4.123% | 14.576 ms | 15.188 ms | +4.089% |
| 2 | 1193.275 | 1162.718 | +2.628% | 14.345 ms | 14.744 ms | +2.629% |
| 4 | 2231.085 | 2108.697 | +5.857% | 15.454 ms | 16.360 ms | +5.582% |
| 8 | 4079.240 | 3888.174 | +4.427% | 16.862 ms | 17.591 ms | +4.183% |
| 16 | 6661.362 | 6536.340 | +1.782% | 20.863 ms | 21.249 ms | +1.653% |

All five concurrency levels improved both TPOT and total-token throughput. The
observed paired-median TPOT improvement is 1.65% to 5.58%, while total-token
throughput improves by 1.78% to 5.86%.

## Technical Details

- Add gfx950 A8W4 comm-fused MoE kernels under
  `aiter/ops/flydsl/kernels/comm_fused_moe/gfx950/a8w4/`.
  - Compose the MXMoE GEMM2 tile emitter into one persistent direct megakernel.
  - Keep the collective, completion-ticket, epoch, and graph synchronization
    protocol inside the comm-fused shell.
  - Retain Atomic and Window implementations for continued tuning without
    selecting them in the current production CSV.
  - Support TP2/TP4 direct-kernel shapes in addition to the TP8 production path.

- Add AITER runtime and config dispatch.
  - `CommFusedMoeRuntime` reuses the existing routing and Stage1 implementation,
    then replaces Stage2 + TP AllReduce with a prepared fused runner.
  - Synchronize the caller and Stage2 streams when a distinct Stage2 stream is
    supplied.
  - Select implementations by GPU, CU count, shape, TP degree, and token bucket.
  - Load model-specific rows from
    `configs/model_configs/*tuned_comm_fused_moe*.csv`.
  - Use explicit `fallback` rows for buckets without a validated fused winner.

- Add dynamic MXFP8 TP partials.
  - FP8 partial payloads carry runtime E8M0 scales; the final output remains
    BF16.
  - A compile-time row resolver lets the MXMoE producer read the existing
    comm-fused Stage2 input layout without an extra reorder kernel or workspace.
  - JIT identities include the collective and layout ABI to prevent reuse of an
    incompatible cached code object.

- Add peer-VMM workspace handling.
  - Symmetric workspaces are aligned to 2 MiB to avoid the ROCm 7.2.4
    small-allocation peer-VMM performance cliff.
  - Reuse the existing cross-device monotonic i64 wait primitive.
  - Synchronize ranks after peer-window registration before launching kernels
    that dereference peer mappings.

## Correctness and Accuracy

The current source was validated on gfx950 TP8 with ROCm 7.2.4 using the full
production matrix:

- `M = 1, 2, 4, 8, 16`;
- uniform and skew routing;
- eager execution and three CUDA graph replays;
- runtime padding from M=3 to the M=4 bucket;
- a distinct Stage2 CUDA stream in eager execution.

All cases were finite and passed the error thresholds. Direct-path relative L2
error ranged from `0.013351` to `0.014934`; the complete M=3 to M=4 runtime path
reported `rel_l2=0.021019`.

Full GSM8K regression used 3-shot evaluation over all 1,319 examples with TP8,
FULL CUDA graph, concurrency 8, and the production small-M comm-fused path:

| Metric | Comm-fused | Ordinary | Difference |
|---|---:|---:|---:|
| strict match | 1258/1319 (95.3753%) | 1253/1319 (94.9962%) | +5 examples |
| flexible extract | 1257/1319 (95.2995%) | 1252/1319 (94.9204%) | +5 examples |

The difference is smaller than the single-run statistical uncertainty; the
result is treated as evidence of no observed accuracy regression, not as an
accuracy improvement claim. Both arms completed all requests without NaNs,
rank failures, or invalid server responses.

## Test Plan and Results

- Static validation:
  - Black: passed.
  - Ruff: passed.
  - `git diff --check`: passed.

- TP8 production correctness:

  ```bash
  torchrun --standalone --nproc_per_node=8 \
    op_tests/multigpu_tests/test_comm_fused_moe.py \
    --full \
    --graph-replays 3
  ```

  Result: all 10 production route cases plus runtime padding, distinct-stream
  execution, and graph replay passed.

- Additional retained-kernel validation:
  - Atomic M=2048: `321.584 us` ordinary versus `265.063 us` fused, with
    `max_abs=0.75` and `rel_l2=0.02998`.
  - Window M=4096 compiled and passed correctness, but was slower in the latest
    short run and therefore remains outside the production CSV.

## Submission Checklist

- [ ] Add the `multigpu` PR label so the gfx950 8-GPU CI job executes the full
  comm-fused MoE test.
- [ ] Look over the contributing guidelines at
  https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
