### PR TITLE
[FlyDSL] [gfx1250] Fix compute-bound GEMM A scale TDM inner oob

### DIFF
--- a/aiter/ops/flydsl/kernels/gemm_a8w8_256x256_gfx1250.py
+++ b/aiter/ops/flydsl/kernels/gemm_a8w8_256x256_gfx1250.py
@@ -276,6 +276,7 @@ def launch_gemm_a8w8_256x256(
                     0,
                     True,
                 )
+            inner_bound = mn_oob if const_expr(owner == 2 and not mx32) else None
             desc = tdm_ops.make_tensor_descriptor_2d(
                 global_ptr=tensor,
                 lds_memref=_view(
@@ -292,6 +293,7 @@ def launch_gemm_a8w8_256x256(
                 workgroup_mask=mask,
                 early_timeout=early,
                 oob_outer_bound=bound,
+                oob_inner_bound=inner_bound,
             )
             step = shape[1]
             if const_expr(not mx32):

--- a/aiter/ops/flydsl/kernels/tdm_ops_gfx1250.py
+++ b/aiter/ops/flydsl/kernels/tdm_ops_gfx1250.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import contextlib
 
+import flydsl.expr as fx
 from flydsl._mlir import ir
 from flydsl._mlir.dialects import arith as std_arith
 from flydsl._mlir.dialects import fly as fly_dialect
@@ -16,6 +17,7 @@ from flydsl._mlir.dialects import vector
 from flydsl.expr.arith import _to_raw as _raw
 from flydsl.expr.meta import dsl_loc_tracing
 from flydsl.expr.rocdl import tdm_ops as _tdm_ops
+from flydsl.expr.typing import Vector as Vec
 from flydsl.expr.typing import as_ir_value
 
 TDMDescriptor2D = _tdm_ops.TDMDescriptor2D
@@ -72,10 +74,43 @@ def _fly_aware_lds_extraction():
         _tdm_ops.memref_dialect = saved
 
 
-def make_tensor_descriptor_2d(*args, **kwargs) -> TDMDescriptor2D:
+_DIM0_LO_SGPR = 1  # GROUP1 sgpr1[31:16] holds tensor_dim0[15:0]
+_DIM0_HI_SGPR = 2  # GROUP1 sgpr2[15:0]  holds tensor_dim0[31:16]
+
+
+def _clamp_inner_extent(desc: TDMDescriptor2D, bound) -> TDMDescriptor2D:
+    """Rewrite a built descriptor's ``tensor_dim0`` to ``max(0, bound)``."""
+    g1 = Vec(desc.dgroup1)
+    b = fx.Int32(bound)
+    dim0 = (b > 0).select(b, fx.Int32(0))
+    packed = (
+        (
+            _DIM0_LO_SGPR,
+            (fx.Int32(g1[_DIM0_LO_SGPR]) & 0xFFFF) | ((dim0 & 0xFFFF) << 16),
+        ),
+        (_DIM0_HI_SGPR, ((fx.Int32(g1[_DIM0_HI_SGPR]) >> 16) << 16) | (dim0 >> 16)),
+    )
+    raw = _raw(desc.dgroup1)
+    for position, value in packed:
+        raw = vector.InsertOp(
+            _raw(value), raw, static_position=[position], dynamic_position=[]
+        ).result
+    return TDMDescriptor2D(dgroup0=desc.dgroup0, dgroup1=raw)
+
+
+def make_tensor_descriptor_2d(*args, oob_inner_bound=None, **kwargs) -> TDMDescriptor2D:
     """``tdm_ops.make_tensor_descriptor_2d`` accepting a Fly ``lds_memref``."""
     with _fly_aware_lds_extraction():
-        return _tdm_ops.make_tensor_descriptor_2d(*args, **kwargs)
+        desc = _tdm_ops.make_tensor_descriptor_2d(*args, **kwargs)
+    if oob_inner_bound is None:
+        return desc
+    assert (
+        kwargs.get("num_warps", 1) == 1
+    ), "oob_inner_bound does not subtract a per-warp inner offset"
+    assert (
+        kwargs.get("global_offset", (0, 0))[1] == 0
+    ), "oob_inner_bound is relative to the descriptor start, so inner_off must be 0"
+    return _clamp_inner_extent(desc, oob_inner_bound)
 
 
 @dsl_loc_tracing


### PR DESCRIPTION
## Motivation

Fix a gfx1250 FlyDSL 256×256 mxfp8_128 compute GEMM GPU memory fault when the last M-tile is ragged: scale-A TDM loads used inner extent `tile_m` instead of the valid `mn_oob` rows, causing OOB global reads.

## Technical Details

Clamp scale-A `tensor_dim0` to `max(0, mn_oob)` for block128 compute kernels via `oob_inner_bound` in `tdm_ops_gfx1250.py`, matching the existing bandwidth-kernel behavior.

## Test Plan

- HIP VMM guard-page repro with ragged `M=400` (fault without fix, pass with fix)
- Ragged-M correctness vs torch reference

## Test Result

Guard-page fault reproduced pre-fix; post-fix launch and ragged-M accuracy pass (`err=0`). Perf unchanged.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.