### PR TITLE
[HIP] [ROCm] Widen the AR+RMSNorm reduce-scatter producer

### DIFF
--- a/csrc/include/custom_all_reduce.cuh
+++ b/csrc/include/custom_all_reduce.cuh
@@ -24,6 +24,7 @@
 #include <iostream>
 #include <limits>
 #include <map>
+#include <cstdlib>
 #include <string>
 #include <type_traits>
 #include <unordered_map>
@@ -1329,6 +1330,186 @@ __global__ void __launch_bounds__(512, 1) reduce_scatter_cross_device_store(
     // output at per-rank volumes above ~1.2 MB (verified via
     // sglang/benchmark/kernels/all_reduce/repro_ar_rmsnorm_corruption.py).
     end_sync<ngpus, false>(sg, self_sg, rank);
+}
+
+// ---------------------------------------------------------------------------
+// Wide variant of the reduce-scatter producer (AITER_AR_RS_WIDE=1).
+//
+// The kernel above maps threads to peers rather than to data: each group of
+// THREAD_NUM/ngpus threads is bound to one peer via warp_id, so a thread issues
+// exactly one cross-device load and then waits on __syncthreads() while only
+// warp_id==0 performs the ngpus-way add. Two consequences:
+//
+//   * a block retires only THREAD_NUM/ngpus packs per trip, i.e. 1/ngpus of the
+//     threads' worth of work;
+//   * there is never more than one cross-device load in flight per thread, and
+//     the two __syncthreads() per iteration stop the next trip's loads from
+//     being issued early, so the remote latency is fully exposed.
+//
+// This variant gives every thread its own pack and lets it issue all ngpus
+// remote loads back to back before consuming any of them, which is what the
+// one-shot kernel (allreduce_fusion_kernel_1stage) already does. The reduction
+// happens in registers, so both __syncthreads() and the LDS staging disappear.
+// Traffic is byte-for-byte identical to the kernel above; only the number of
+// outstanding requests per thread changes.
+//
+// Addressing, the tmp-buffer layout and the end_sync ordering are unchanged, so
+// stage 2 (local_device_load_rmsnorm*) cannot tell the two apart.
+template <typename T, int ngpus>
+__global__ void __launch_bounds__(THREAD_NUM, 1) reduce_scatter_cross_device_store_wide(
+    RankData* _dp,
+    RankSignals sg,
+    Signal* self_sg,
+    int rank,
+    int m,
+    int hidden_dim,
+    int input_hidden_dim)
+{
+    constexpr int pack_size = 16 / sizeof(T);
+    using P                 = typename opus::vector_t<T, pack_size>;
+    using A                 = typename opus::vector_t<opus::fp32_t, pack_size>;
+
+    const P* ptrs[ngpus];
+    P* tmps[ngpus];
+#pragma unroll
+    for(int i = 0; i < ngpus; ++i)
+    {
+        ptrs[i] = (const P*)_dp->ptrs[i];
+        tmps[i] = get_tmp_buf<P>(sg.signals[i]);
+    }
+    start_sync<ngpus>(sg, self_sg, rank);
+
+    const int valid_pack_count = hidden_dim / pack_size;
+    const int input_pack_count = input_hidden_dim / pack_size;
+    const int part             = m * valid_pack_count / ngpus;
+    const int tid              = blockIdx.x * blockDim.x + threadIdx.x;
+    const int stride           = gridDim.x * blockDim.x;
+
+    for(int idx = tid; idx < part; idx += stride)
+    {
+        const int flat_idx  = rank * part + idx;
+        const int row       = flat_idx / valid_pack_count;
+        const int col       = flat_idx % valid_pack_count;
+        const int input_idx = row * input_pack_count + col;
+
+        // Issue every peer's load before touching any of them. Keeping the
+        // reads in a separate unrolled loop is what lets the ngpus round trips
+        // overlap; folding them into the accumulate loop below reintroduces the
+        // serialisation this variant exists to remove.
+        P in[ngpus];
+#pragma unroll
+        for(int i = 0; i < ngpus; ++i)
+        {
+            in[i] = ptrs[i][input_idx];
+        }
+
+        A acc;
+        {
+            const T* v = reinterpret_cast<const T*>(&in[0]);
+#pragma unroll
+            for(int j = 0; j < pack_size; ++j)
+            {
+                acc[j] = upcast_s(v[j]);
+            }
+        }
+#pragma unroll
+        for(int i = 1; i < ngpus; ++i)
+        {
+            const T* v = reinterpret_cast<const T*>(&in[i]);
+#pragma unroll
+            for(int j = 0; j < pack_size; ++j)
+            {
+                acc[j] += upcast_s(v[j]);
+            }
+        }
+
+        P rslt;
+#pragma unroll
+        for(int j = 0; j < pack_size; ++j)
+        {
+            rslt[j] = downcast_s<T>(acc[j]);
+        }
+
+        // Same broadcast as above, but all ngpus stores are issued by the same
+        // thread instead of one per warp group.
+#pragma unroll
+        for(int i = 0; i < ngpus; ++i)
+        {
+            tmps[i][flat_idx] = rslt;
+        }
+    }
+    // Same requirement as the non-wide kernel: RELEASE/ACQUIRE, not RELAXED.
+    // See the NOTE on reduce_scatter_cross_device_store.
+    end_sync<ngpus, false>(sg, self_sg, rank);
+}
+
+// Opt-in until it has run through the multi-GPU op tests on every world size.
+inline bool ar_rs_wide_enabled()
+{
+    static const bool enabled = []() {
+        const char* v = std::getenv("AITER_AR_RS_WIDE");
+        return v != nullptr && std::atoi(v) != 0;
+    }();
+    return enabled;
+}
+
+// Diagnostic: force the grid to sweep block count and separate "latency-bound"
+// (time falls as blocks rise) from "bandwidth-bound" (flat). Applies to the
+// wide kernel only.
+inline int ar_rs_wide_forced_blocks()
+{
+    static const int blocks = []() {
+        const char* v = std::getenv("AITER_AR_RS_WIDE_BLOCKS");
+        return v == nullptr ? 0 : std::atoi(v);
+    }();
+    return blocks;
+}
+
+// Single entry point for the producer so the two variants cannot drift apart at
+// the four call sites. The grids differ because the work per block differs: the
+// original retires THREAD_NUM/ngpus packs per trip, the wide one THREAD_NUM.
+//
+// baseline_grid_elems is the element count each call site already used to size
+// the stock kernel's grid. It has to be passed in rather than recomputed here:
+// dispatchFusedAllReduceRMSNorm sizes from m*hidden_dim while
+// allreduce_mhc_post_split_launcher sizes from m*input_hidden_dim, and those
+// differ whenever the input is padded. Recomputing would silently change the
+// grid of the path this variant is supposed to be measured against.
+template <typename T, int NGPUS>
+inline void launch_reduce_scatter_cross_device_store(RankData* _dp,
+                                                     RankSignals sg,
+                                                     Signal* self_sg,
+                                                     int rank,
+                                                     int m,
+                                                     int hidden_dim,
+                                                     int input_hidden_dim,
+                                                     int baseline_grid_elems,
+                                                     hipStream_t stream)
+{
+    dim3 block(THREAD_NUM);
+    if(ar_rs_wide_enabled())
+    {
+        constexpr int pack_size = 16 / sizeof(T);
+        const int part          = (m * (hidden_dim / pack_size)) / NGPUS;
+        int blocks              = (part + THREAD_NUM - 1) / THREAD_NUM;
+        if(const int forced = ar_rs_wide_forced_blocks(); forced > 0)
+        {
+            blocks = forced;
+        }
+        // kMaxBlocks is a hard bound, not a tuning choice: start_sync/end_sync
+        // index Signal::start/end/_flag by blockIdx.x and those arrays are
+        // sized [kMaxBlocks].
+        dim3 grid(std::max(1, std::min(blocks, kMaxBlocks)));
+        reduce_scatter_cross_device_store_wide<T, NGPUS>
+            <<<grid, block, 0, stream>>>(_dp, sg, self_sg, rank, m, hidden_dim, input_hidden_dim);
+    }
+    else
+    {
+        const int block_num = ((baseline_grid_elems / NGPUS) + THREAD_NUM - 1) / THREAD_NUM;
+        dim3 grid(std::max(1, std::min(block_num, kMaxBlocks)));
+        reduce_scatter_cross_device_store<T, NGPUS>
+            <<<grid, block, 0, stream>>>(_dp, sg, self_sg, rank, m, hidden_dim, input_hidden_dim);
+    }
 }
 
 template <int reduce_range>
@@ -3099,23 +3280,20 @@ void allreduce_fusion_kernel_split_per_group_launcher(RankData* _dp,
                                                       bool transpose_scale = false)
 {
     // step 1: reduce-scatter + allgather cross device store (same as per-token)
-    dim3 block(512);
-    int block_num = ((size / NGPUS) + 512 - 1) / 512;
-    dim3 grid(std::min(block_num, 80));
     int m = size / hidden_dim;
     switch(NGPUS)
     {
     case 8:
-        reduce_scatter_cross_device_store<T, 8>
-            <<<grid, block, 0, stream>>>(_dp, sg, self_sg, rank, m, hidden_dim, hidden_dim);
+        launch_reduce_scatter_cross_device_store<T, 8>(
+            _dp, sg, self_sg, rank, m, hidden_dim, hidden_dim, size, stream);
         break;
     case 4:
-        reduce_scatter_cross_device_store<T, 4>
-            <<<grid, block, 0, stream>>>(_dp, sg, self_sg, rank, m, hidden_dim, hidden_dim);
+        launch_reduce_scatter_cross_device_store<T, 4>(
+            _dp, sg, self_sg, rank, m, hidden_dim, hidden_dim, size, stream);
         break;
     case 2:
-        reduce_scatter_cross_device_store<T, 2>
-            <<<grid, block, 0, stream>>>(_dp, sg, self_sg, rank, m, hidden_dim, hidden_dim);
+        launch_reduce_scatter_cross_device_store<T, 2>(
+            _dp, sg, self_sg, rank, m, hidden_dim, hidden_dim, size, stream);
         break;
     default:
         throw std::runtime_error("unsupported NGPUS=" + std::to_string(NGPUS));
@@ -3156,23 +3334,20 @@ void allreduce_fusion_kernel_split_launcher(RankData* _dp,
                                             T* bf16_output = nullptr)
 {
     // step 1, run reduce-scatter + allgather cross device save
-    dim3 block(512);
-    int block_num = ((size / NGPUS) + 512 - 1) / 512;
-    dim3 grid(std::min(block_num, 80));
     int m = size / hidden_dim;
     switch(NGPUS)
     {
     case 8:
-        reduce_scatter_cross_device_store<T, 8>
-            <<<grid, block, 0, stream>>>(_dp, sg, self_sg, rank, m, hidden_dim, hidden_dim);
+        launch_reduce_scatter_cross_device_store<T, 8>(
+            _dp, sg, self_sg, rank, m, hidden_dim, hidden_dim, size, stream);
         break;
     case 4:
-        reduce_scatter_cross_device_store<T, 4>
-            <<<grid, block, 0, stream>>>(_dp, sg, self_sg, rank, m, hidden_dim, hidden_dim);
+        launch_reduce_scatter_cross_device_store<T, 4>(
+            _dp, sg, self_sg, rank, m, hidden_dim, hidden_dim, size, stream);
         break;
     case 2:
-        reduce_scatter_cross_device_store<T, 2>
-            <<<grid, block, 0, stream>>>(_dp, sg, self_sg, rank, m, hidden_dim, hidden_dim);
+        launch_reduce_scatter_cross_device_store<T, 2>(
+            _dp, sg, self_sg, rank, m, hidden_dim, hidden_dim, size, stream);
         break;
     default: throw std::runtime_error("fused allreduce rmsnorm: unsupported NGPUS=" + std::to_string(NGPUS));
     }
@@ -3207,22 +3382,19 @@ void allreduce_mhc_post_split_launcher(RankData* _dp,
                                        hipStream_t stream)
 {
     const int size = m * input_hidden_dim;
-    dim3 block(512);
-    int block_num = ((size / NGPUS) + 512 - 1) / 512;
-    dim3 grid(std::min(block_num, kMaxBlocks));
     switch(NGPUS)
     {
     case 8:
-        reduce_scatter_cross_device_store<T, 8><<<grid, block, 0, stream>>>(
-            _dp, sg, self_sg, rank, m, hidden_size, input_hidden_dim);
+        launch_reduce_scatter_cross_device_store<T, 8>(
+            _dp, sg, self_sg, rank, m, hidden_size, input_hidden_dim, size, stream);
         break;
     case 4:
-        reduce_scatter_cross_device_store<T, 4><<<grid, block, 0, stream>>>(
-            _dp, sg, self_sg, rank, m, hidden_size, input_hidden_dim);
+        launch_reduce_scatter_cross_device_store<T, 4>(
+            _dp, sg, self_sg, rank, m, hidden_size, input_hidden_dim, size, stream);
         break;
     case 2:
-        reduce_scatter_cross_device_store<T, 2><<<grid, block, 0, stream>>>(
-            _dp, sg, self_sg, rank, m, hidden_size, input_hidden_dim);
+        launch_reduce_scatter_cross_device_store<T, 2>(
+            _dp, sg, self_sg, rank, m, hidden_size, input_hidden_dim, size, stream);
         break;
     default:
         throw std::runtime_error("AR+MHC post split epilogue: unsupported NGPUS=" +
@@ -4163,18 +4335,18 @@ void dispatchFusedAllReduceRMSNorm(hipStream_t stream,
     {
     case 8:
         MAYBE_DISPATCH_1S_KERNEL(8);
-        reduce_scatter_cross_device_store<T, 8>
-            <<<grid, block, 0, stream>>>(ptrs, sg_, self_sg_, rank_, m, n, input_hidden_dim);
+        launch_reduce_scatter_cross_device_store<T, 8>(
+            ptrs, sg_, self_sg_, rank_, m, n, input_hidden_dim, size, stream);
         break;
     case 4:
         MAYBE_DISPATCH_1S_KERNEL(4);
-        reduce_scatter_cross_device_store<T, 4>
-            <<<grid, block, 0, stream>>>(ptrs, sg_, self_sg_, rank_, m, n, input_hidden_dim);
+        launch_reduce_scatter_cross_device_store<T, 4>(
+            ptrs, sg_, self_sg_, rank_, m, n, input_hidden_dim, size, stream);
         break;
     case 2:
         MAYBE_DISPATCH_1S_KERNEL(2);
-        reduce_scatter_cross_device_store<T, 2>
-            <<<grid, block, 0, stream>>>(ptrs, sg_, self_sg_, rank_, m, n, input_hidden_dim);
+        launch_reduce_scatter_cross_device_store<T, 2>(
+            ptrs, sg_, self_sg_, rank_, m, n, input_hidden_dim, size, stream);
         break;
     default: throw std::runtime_error("fused allreduce rmsnorm: unsupported world_size=" + std::to_string(world_size_));
     }

--- a/op_tests/multigpu_tests/test_fused_ar_rms.py
+++ b/op_tests/multigpu_tests/test_fused_ar_rms.py
@@ -320,6 +320,11 @@ def test_fused_ar_rmsnorm(
 ):
     os.environ["MASTER_ADDR"] = "127.0.0.1"
     os.environ["MASTER_PORT"] = "49373"
+    # Seeded like the other cases in this file. Two runs that differ only in a
+    # kernel-selection env var then see identical inputs, which makes the
+    # reported error directly comparable between them instead of just being
+    # separately under tolerance.
+    torch.manual_seed(int(os.environ.get("AITER_TEST_SEED", "0")))
     pool = Pool(processes=tp_size)
     ref = torch.zeros(shape, dtype=dtype)
     rets = []


### PR DESCRIPTION
**Branch:** `rs-wide-producer`
**Status:** opt-in, default off. Measured, correct, small.

## Summary

`reduce_scatter_cross_device_store` — stage 1 of the fused all-reduce + RMSNorm
pair — maps threads to peers rather than to data. This PR adds a variant that
maps them to data instead, behind `AITER_AR_RS_WIDE=1`.

The variant is bit-for-bit identical to the kernel it replaces and about **2.7%
faster** at the decode shapes measured. That is below what an end-to-end serving
run can resolve, so it is proposed as a default-off option rather than as a fix
for anything. The measurements are reported in full below, including the ones
that contradict the original hypothesis.

## What this changes

Adds `reduce_scatter_cross_device_store_wide`:

- One pack per thread. All `ngpus` remote loads are issued back to back before
  any of them is consumed.
- Reduction in registers. No LDS staging, no `__syncthreads()`.
- The broadcast store is likewise issued `ngpus`-wide by the same thread.

Addressing, the tmp-buffer layout, and the `end_sync<ngpus, false>`
(RELEASE/ACQUIRE) ordering are unchanged, so stage 2 cannot distinguish the two
variants.

All call sites go through a single `launch_reduce_scatter_cross_device_store`
wrapper so the two variants cannot drift apart. Each call site passes in the
element count it already used to size the stock kernel's grid, rather than
letting the wrapper recompute it: the call sites do not agree on that count
(`dispatchFusedAllReduceRMSNorm` sizes from `m * hidden_dim`,
`allreduce_mhc_post_split_launcher` from `m * input_hidden_dim`), and those
differ whenever the input is padded. With the flag off, the launch is
bit-identical to what it was before this PR.

`kMaxBlocks` remains a hard bound rather than a tuning choice: `start_sync` /
`end_sync` index `Signal::start` / `end` / `_flag` by `blockIdx.x`, and those
arrays are sized `[kMaxBlocks]`.

## The generated code is what was intended

From the gfx950 ISA (`hipcc --cuda-device-only -S`), bf16, `ngpus = 4`:

| | stock | wide |
|---|---|---|
| `group_segment_fixed_size` | 8192 B | **0** |
| VGPR | 32 | 48 (`ngpus = 8`: 78) |
| `s_barrier` | 5 | 3 |
| `ds_write` / `ds_read` | 2 / 5 | **0 / 0** |
| remote loads per trip | 1 | **4, back to back** |

The four loads issue with a single `s_waitcnt` after all of them, so there
really are `ngpus` requests in flight per thread. At `ngpus = 8` the 78 VGPR do
not cost occupancy at 512 threads per block, so the `in[ngpus]` array is not a
problem.

## Measured effect

Producer kernel, from profiler traces of a real decode workload (mean over
ranks, 155 calls per step):

| | flag off | flag on | delta |
|---|---|---|---|
| producer, per call | 13.94 us (median 13.48) | 13.57 us (median 13.08) | **−2.7%** |
| consumer, per call | 4.41 us | 4.49 us | +1.8% |
| collective total, per rank | — | — | −2.1% |

End to end, on a serving benchmark:

| | effect |
|---|---|
| median inter-token latency | **−0.10%** |
| median TPOT | −0.12% |
| output throughput | +0.10% |

That is nothing measurable, and it is the expected result. The producer is
~13.9 us of an 18.1 us collective call, the collective is ~12% of a decode step,
so 2.7% on the producer predicts

```
0.027 x 13.9us x 155 calls / 24.1ms = 0.24%
```

against a single-A/B resolution floor of roughly 0.3%. The optimization is real
at the kernel level and simply too small to resolve end to end.

## The original hypothesis was wrong

This PR was first written on the premise that the kernel is limited by
outstanding cross-device requests: each thread issues one remote load, then
blocks on `__syncthreads()` while only `warp_id == 0` does the add. That
description of the stock kernel is accurate, and the compiler did exactly what
was asked — but the kernel is not limited by it.

`AITER_AR_RS_WIDE_BLOCKS` sweep, TP = 4, producer us/call (median):

| shape | stock | 8 | 16 | 32 | 64 | 80 |
|---|---|---|---|---|---|---|
| (1, 7168) | 6.62 | 7.03 | 6.56 | 8.01 | 7.06 | 8.00 |
| (64, 7168) | 14.25 | 15.13 | 13.83 | 14.03 | 14.27 | 14.58 |
| (256, 7168) | 41.18 | 39.24 | 39.11 | 39.91 | 41.31 | 41.12 |

The curve is flat. Time does not fall as block count rises, which is the
signature of a fabric-bound kernel, not a latency-bound one. Adding outstanding
requests per thread cannot help a kernel that already cannot issue faster than
the link drains, which is consistent with the 2.7% observed.

Decomposing the 18.1 us collective call at the decode shape: ~6.0 us is data
movement, at a per-rank rate close to the fabric ceiling; ~6.8 us is the two
barriers; ~4.3 us is the consumer RMSNorm. The kernel body this PR rewrites is
the part that was already near its limit.

## Enabling

| env | default | effect |
|---|---|---|
| `AITER_AR_RS_WIDE=1` | off | use the wide variant |
| `AITER_AR_RS_WIDE_BLOCKS=N` | 0 (auto) | force the grid; wide variant only |

With `AITER_AR_RS_WIDE` unset the original kernel runs with the original grid.

`AITER_AR_RS_WIDE_BLOCKS` is a diagnostic, not a tuning parameter: sweeping it
separates latency-bound (time falls as block count rises) from fabric-bound
(flat), as above.

Both are read once per process into a function-local static, and the branch is
resolved at graph capture time, so the environment must be set before the
process starts.

## Correctness

Bit-for-bit identical, not merely inside tolerance. Both arms were given the
same seed and their output tensors compared exactly:

| world size | shapes (n = 7168) | tensors compared | result |
|---|---|---|---|
| TP = 2 | m = 1, 8, 64, 256 | 16 | bitwise identical |
| TP = 4 | m = 1, 8, 32, 64, 128, 256 | 48 | bitwise identical |
| TP = 8 | m = 1, 8, 64, 256 | 64 | bitwise identical |

This is the expected result: the wide kernel accumulates the peers in the same
order at the same fp32 precision and writes the same bytes to the same
tmp-buffer offsets, so there is no reordering for the arithmetic to notice.

`op_tests/multigpu_tests/test_fused_ar_rms.py --test fused` (bf16, m = 1..256,
eager, `AITER_AR_1STAGE=0` so every shape takes the two-kernel path) passes with
the flag both off and on, with identical reported error at every shape.
`test_fused_ar_rmsnorm` is now seeded like the other cases in that file, so two
runs differing only in an env var see identical inputs.

## Known, pre-existing, unrelated

The two-kernel path hangs under graph capture in the op-test harness at m >= 64,
where the graph path selects it. This reproduces identically with
`AITER_AR_RS_WIDE=0` and is not introduced by this PR. It does not affect
serving, where the same path runs under a captured graph without trouble.

## Notes on measurement

Recorded because both produced badly wrong numbers before being fixed.

- **Do not run two arms side by side for a kernel measurement.** Both saturate
  the same cross-device fabric; running them concurrently inflated the producer
  from ~14 us to ~29 us on *both* sides. Correctness runs in parallel are fine,
  and so is an end-to-end serving A/B, where both arms are equally loaded.
- **Report the median, not the mean.** The producer opens with a cross-rank
  barrier, so rank skew lands inside the kernel's own duration. Without a
  per-iteration realignment, m = 1 appeared to cost as much as m = 128. Adding a
  barrier per iteration and reporting the median brought repeat runs to within
  0.24 us of each other, against a mean that swung by a factor of 2.4.
- **A/B against a same-configuration A/A run.** The two GPU groups used for the
  two arms differ by 0.16–0.34% on their own, which is larger than the effect
  being measured. Running A/A, A/B and the swapped A/B gives the arm bias and
  the effect separately.
