### PR TITLE
[Triton/Gluon] Fix PR#4562 and PR#4470 for GPT-OSS-120b on gfx1250

### DIFF
--- a/aiter/ops/triton/_gluon_kernels/gfx1250/moe/moe_op_gemm_a8w4.py
+++ b/aiter/ops/triton/_gluon_kernels/gfx1250/moe/moe_op_gemm_a8w4.py
@@ -1709,7 +1709,9 @@ def get_moe_a8w4_layouts(
         warp_bases = [[0, 1]]
         reg_bases = []
     elif num_warps == 4:
-        warp_bases = [[0, 1], [0, 2]]
+        # This helper only feeds the prefill kernel, which needs a warp basis
+        # along M; distributing all four warps along N produces garbage output.
+        warp_bases = [[0, 1], [1, 0]]
         reg_bases = []
     else:
         warp_bases = (

--- a/aiter/ops/triton/moe/moe_op_gemm_a8w4.py
+++ b/aiter/ops/triton/moe/moe_op_gemm_a8w4.py
@@ -276,6 +276,28 @@ def get_gluon_a8w4_ctas_per_cga(m):
     return [1, num_ctas]
 
 
+def _untuned_config_gluon(n, k, block_m, out_mx_quant):
+    """Shape-derived (block_n, block_k, num_buffers, num_warps, persistent_iters)
+    for shapes with no tuned entry."""
+    num_warps = 4
+    if block_m == 16:
+        # The persistent decode kernel has no MXFP8 emit path (HAS_MX_OUT);
+        # route out_mx_quant to the non-persistent decode kernel.
+        if k <= 768 and not out_mx_quant:
+            return 128, 256, 2, num_warps, 3
+        if n <= 1536:
+            return 128, 512, 3, num_warps, 0
+        if n <= 3072:
+            return 128, 512, 2, num_warps, 0
+        if n <= 4096:
+            return 256, 512, 1, num_warps, 0
+        return 512, 512, 1, num_warps, 0
+    if block_m == 32:
+        block_n = 128 if n <= 1024 else 256
+        return block_n, 512, 3, num_warps, 0
+    return 256, 256, 3, num_warps, 0
+
+
 def get_kernel_config_gluon(m, n, k, routing_data, out_mx_quant=False):
     ctas_per_cga = get_gluon_a8w4_ctas_per_cga(m)
     num_ctas = ctas_per_cga[0] * ctas_per_cga[1]
@@ -287,16 +309,22 @@ def get_kernel_config_gluon(m, n, k, routing_data, out_mx_quant=False):
     bucket = m2bucket(m)
     tuned = _get_a8w4_dispatch(get_arch())
     key = f"bm{block_m}_n{n}_k{k}_{bucket}"
-    if key not in tuned:
-        key = f"bm{block_m}_any"
-    cfg = tuned[key]
-    block_n, block_k, num_buffers, num_warps, persistent_iters = (
-        cfg["block_n"],
-        cfg["block_k"],
-        cfg["num_buffers"],
-        cfg["num_warps"],
-        cfg["persistent_iters"],
-    )
+    if key in tuned:
+        cfg = tuned[key]
+        block_n, block_k, num_buffers, num_warps, persistent_iters = (
+            cfg["block_n"],
+            cfg["block_k"],
+            cfg["num_buffers"],
+            cfg["num_warps"],
+            cfg["persistent_iters"],
+        )
+    else:
+        # The generic bm*_any entries are not a safe stand-in for an untuned
+        # shape: they force BLOCK_K=256, which yields wrong results for
+        # block_m <= 32. Fall back to the shape-derived configuration instead.
+        block_n, block_k, num_buffers, num_warps, persistent_iters = (
+            _untuned_config_gluon(n, k, block_m, out_mx_quant)
+        )
 
     num_buffers = min(num_buffers, triton.cdiv(k, block_k))
     block_m *= ctas_per_cga[0]


### PR DESCRIPTION
## Problem
On gfx1250, the Gluon MoE a8w4 path returns garbage for GPT-OSS-120B
(MXFP4 W4A8). GSM8K via SGLang, 200 questions: accuracy 0.010, invalid 0.990.
## Root cause
Two independent regressions:
1. **#4562** hoisted the per-kernel WMMA/shared layouts into
   `get_moe_a8w4_layouts()`. Its `num_warps == 4` branch spreads all warps
   along N (`[[0, 1], [0, 2]]`), but this helper only feeds
   `_moe_gemm_a8w4_prefill`, which previously hardcoded `[[0, 1], [1, 0]]`.
   Dropping the M basis corrupts the output. The 8-warp prefill branch kept
   its M basis, so this looks like an oversight.
2. **#4470** replaced the shape-derived Gluon config with a tuned lookup that
   falls back to `bm{block_m}_any`. Those generic entries force
   `BLOCK_K=256`, while the previous logic used `BLOCK_K=512` for
   `block_m <= 32`. GPT-OSS shapes (N=5760/2880, K=2880) have no tuned entry,
   so both GEMMs land on the fallback.
## Fix
1. Restore `[[0, 1], [1, 0]]` for `num_warps == 4`.
2. For untuned shapes, fall back to the shape-derived config instead of
   `bm*_any`. Shapes with a tuned entry are unaffected.
## Validation
gfx1250, GPT-OSS-120B MXFP4 W4A8, SGLang GSM8K, 200 questions @ parallel 1319:
| Build | Accuracy | Invalid |
| --- | --- | --- |
| before | 0.010 | 0.990 |
| fix 1 only | 0.725 | 0.060 |
| fix 1 + 2 | **0.865** | **0.005** |
| revert #4470 + #4562 + #4892 + #4836 | 0.860 | 0.005 |

This matches a full revert of both regressions and their dependents, while
keeping the a4w4 Triton backend that #4836 added.

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
