### PR TITLE
[Triton/Gluon] Fix AMDGCN codegen abort in fp8_mqa_logits past ~32K context

### DIFF
--- a/aiter/ops/triton/attention/fp8_mqa_logits.py
+++ b/aiter/ops/triton/attention/fp8_mqa_logits.py
@@ -194,6 +194,12 @@ def fp8_mqa_logits(
             matrix_instr_nonkdim=matrix_instr_nonkdim,
         )
     else:
+        # Buffer ops use a 32-bit byte offset (2 GiB resource descriptor cap).
+        # Fall back to plain global load/store when a tensor exceeds that.
+        BUFFER_LIMIT_BYTES = 2 * 1024 * 1024 * 1024
+        use_buffer_load = KV.numel() * KV.element_size() < BUFFER_LIMIT_BYTES
+        use_buffer_store = logits.numel() * logits.element_size() < BUFFER_LIMIT_BYTES
+
         num_buffers = 2
         USE_FOLDED_REDUCTION = FOLDED_REDUCTED_SUPPORT and num_heads > 16
         if arch == "gfx950":
@@ -203,7 +209,12 @@ def fp8_mqa_logits(
             num_chains = 4 if USE_FOLDED_REDUCTION else 0
             num_warps = 2 if num_heads <= 32 else 1
             block_kv = 64 if num_heads <= 32 else 32
-            block_m = 2 if (num_heads <= 32 and seq_len > 4096) else 1
+            # BLOCK_M=2 with the non-buffer store path aborts the AMDGCN backend
+            # at JIT time (Sequence.h:275 "Begin must be less or equal to End").
+            # Only reachable once logits pass 2 GiB, i.e. context past ~32K.
+            block_m = (
+                2 if (num_heads <= 32 and seq_len > 4096 and use_buffer_store) else 1
+            )
             mfma_nonk_dim = 32 if (head_size <= 64 or num_heads == 32) else 16
             other = {
                 "USE_PADDED_SHARED_LAYOUT": ASYNC_COPY_SUPPORTS_DISTRIBUTED,
@@ -220,11 +231,6 @@ def fp8_mqa_logits(
             block_m = 1
             other = {"LOOP_VARIANT": loop_variant}
 
-        # Buffer ops use a 32-bit byte offset (2 GiB resource descriptor cap).
-        # Fall back to plain global load/store when a tensor exceeds that.
-        BUFFER_LIMIT_BYTES = 2 * 1024 * 1024 * 1024
-        use_buffer_load = KV.numel() * KV.element_size() < BUFFER_LIMIT_BYTES
-        use_buffer_store = logits.numel() * logits.element_size() < BUFFER_LIMIT_BYTES
         _gluon_fp8_mqa_logits_kernel[((seq_len + block_m - 1) // block_m,)](
             Q_ptr=Q,
             KV_ptr=KV,

--- a/op_tests/triton_tests/attention/test_fp8_mqa_logits.py
+++ b/op_tests/triton_tests/attention/test_fp8_mqa_logits.py
@@ -95,6 +95,10 @@ def generate_cp_test_data(seq_len, seq_len_kv):
         (128, 1024),
         (1024, 1024),
         (1024, 1560),
+        # Exactly 2 GiB of logits, which is where the gfx950 kernel pairs
+        # BLOCK_M=2 with a non-buffer store -- the combination that used to abort
+        # the AMDGCN backend at JIT time. Nothing above it comes close.
+        (8192, 65536),
     ],
 )
 @pytest.mark.parametrize("num_heads", [32, 64])
@@ -110,6 +114,16 @@ def test_fp8_mqa_logits(
     disable_cp: bool,
     clean_logits: bool,
 ) -> None:
+    # The 2 GiB shape is here for one configuration only: BLOCK_M=2 needs
+    # num_heads <= 32, and the shape costs 2 GiB of logits plus a reference,
+    # which is not worth paying sixteen times over.
+    big = s_q * s_k * 4 >= 2 * 1024**3
+    if big:
+        if (num_heads, head_dim, disable_cp, clean_logits) != (32, 128, True, True):
+            pytest.skip("large shape is checked once")
+        if torch.cuda.mem_get_info()[0] < 8 * 1024**3:
+            pytest.skip("needs ~8 GiB free")
+
     torch.manual_seed(0)
     q = torch.randn(s_q, num_heads, head_dim, device="cuda", dtype=torch.bfloat16)
     kv = torch.randn(s_k, head_dim, device="cuda", dtype=torch.bfloat16)
@@ -126,10 +140,6 @@ def test_fp8_mqa_logits(
     q_fp8 = q.to(e4m3_type)
     kv_fp8, scales = per_custom_dims_cast_to_fp8(kv, (0,), False)
 
-    ref_logits, _ref_cost = ref_fp8_mqa_logits(
-        q=q, kv=kv, weights=weights, cu_seqlen_ks=ks, cu_seqlen_ke=ke
-    )
-
     logits = fp8_mqa_logits(q_fp8, kv_fp8, scales, weights, ks, ke, clean_logits)
 
     # If clean_logits is not set, clean the rest for testing
@@ -140,56 +150,25 @@ def test_fp8_mqa_logits(
             tmp[i, ks[i] : ke[i]] = logits[i, : ke[i] - ks[i]]
         logits = tmp
 
-    ref_neginf_mask = ref_logits == float("-inf")
-    neginf_mask = logits == float("-inf")
-    assert torch.equal(neginf_mask, ref_neginf_mask)
-    ref_logits = ref_logits.masked_fill(ref_neginf_mask, 0)
-    logits = logits.masked_fill(neginf_mask, 0)
-    diff = calc_diff(logits, ref_logits)
-    if ref_neginf_mask.all():
-        return  # nothing left to compare
-    assert diff < 1e-3, f"{diff=}"
-
-
-# Both shapes land on exactly 2 GiB of logits, which is where the gfx950 kernel
-# pairs BLOCK_M=2 with a non-buffer store and used to abort the AMDGCN backend at
-# JIT time. Nothing above reaches it: every shape there is <= 1024 queries or far
-# under 2 GiB.
-@pytest.mark.parametrize("s_q, s_k", [(8192, 65536), (16384, 32768)])
-@torch.inference_mode()
-def test_fp8_mqa_logits_long_context(s_q: int, s_k: int) -> None:
-    num_heads, head_dim = 32, 128
-    logits_bytes = s_q * s_k * 4
-    if torch.cuda.mem_get_info()[0] < logits_bytes + 2 * 1024**3:
-        pytest.skip(f"needs ~{(logits_bytes + 2 * 1024**3) / 1024**3:.0f} GiB free")
-
-    torch.manual_seed(0)
-    q = torch.randn(s_q, num_heads, head_dim, device="cuda", dtype=torch.bfloat16)
-    kv = torch.randn(s_k, head_dim, device="cuda", dtype=torch.bfloat16)
-    kv_fp8, scales = per_custom_dims_cast_to_fp8(kv, (0,), False)
-    kv = (kv_fp8.to(torch.float32) * scales.reshape(-1, 1)).to(torch.bfloat16)
-    weights = torch.randn(s_q, num_heads, device="cuda", dtype=torch.float32)
-    # Every row attends to all of kv, so clean_logits=False leaves nothing
-    # undefined and the whole output is comparable.
-    ks = torch.zeros(s_q, dtype=torch.int, device="cuda")
-    ke = torch.full((s_q,), s_k, dtype=torch.int, device="cuda")
-
-    q_fp8 = q.to(e4m3_type)
-    kv_fp8, scales = per_custom_dims_cast_to_fp8(kv, (0,), False)
-
-    logits = fp8_mqa_logits(q_fp8, kv_fp8, scales, weights, ks, ke, clean_logits=False)
-    assert logits.shape == (s_q, s_k)
-
-    # A full reference needs num_heads x s_q x s_k floats, so compare row windows
-    # instead. Rows are independent, and both ends cover a paired block and the
-    # trailing one.
-    for rows in (slice(0, 32), slice(s_q - 32, s_q)):
-        ref_logits, _ = ref_fp8_mqa_logits(
+    # The reference holds num_heads x s_q x s_k floats, 64 GiB at the largest
+    # shape, so check row windows there instead of the whole tensor. Rows are
+    # independent, and the two ends cover a paired block and the trailing one.
+    windows = [slice(0, 32), slice(s_q - 32, s_q)] if big else [slice(0, s_q)]
+    for rows in windows:
+        ref_logits, _ref_cost = ref_fp8_mqa_logits(
             q=q[rows],
             kv=kv,
             weights=weights[rows],
             cu_seqlen_ks=ks[rows],
             cu_seqlen_ke=ke[rows],
         )
-        diff = calc_diff(logits[rows], ref_logits)
-        assert diff < 1e-3, f"{s_q=} {s_k=} {rows=} {diff=}"
+        ref_neginf_mask = ref_logits == float("-inf")
+        neginf_mask = logits[rows] == float("-inf")
+        assert torch.equal(neginf_mask, ref_neginf_mask)
+        if ref_neginf_mask.all():
+            continue  # nothing left to compare
+        diff = calc_diff(
+            logits[rows].masked_fill(neginf_mask, 0),
+            ref_logits.masked_fill(ref_neginf_mask, 0),
+        )
+        assert diff < 1e-3, f"{diff=}"

--- a/op_tests/triton_tests/attention/test_fp8_mqa_logits.py
+++ b/op_tests/triton_tests/attention/test_fp8_mqa_logits.py
@@ -149,3 +149,47 @@ def test_fp8_mqa_logits(
     if ref_neginf_mask.all():
         return  # nothing left to compare
     assert diff < 1e-3, f"{diff=}"
+
+
+# Both shapes land on exactly 2 GiB of logits, which is where the gfx950 kernel
+# pairs BLOCK_M=2 with a non-buffer store and used to abort the AMDGCN backend at
+# JIT time. Nothing above reaches it: every shape there is <= 1024 queries or far
+# under 2 GiB.
+@pytest.mark.parametrize("s_q, s_k", [(8192, 65536), (16384, 32768)])
+@torch.inference_mode()
+def test_fp8_mqa_logits_long_context(s_q: int, s_k: int) -> None:
+    num_heads, head_dim = 32, 128
+    logits_bytes = s_q * s_k * 4
+    if torch.cuda.mem_get_info()[0] < logits_bytes + 2 * 1024**3:
+        pytest.skip(f"needs ~{(logits_bytes + 2 * 1024**3) / 1024**3:.0f} GiB free")
+
+    torch.manual_seed(0)
+    q = torch.randn(s_q, num_heads, head_dim, device="cuda", dtype=torch.bfloat16)
+    kv = torch.randn(s_k, head_dim, device="cuda", dtype=torch.bfloat16)
+    kv_fp8, scales = per_custom_dims_cast_to_fp8(kv, (0,), False)
+    kv = (kv_fp8.to(torch.float32) * scales.reshape(-1, 1)).to(torch.bfloat16)
+    weights = torch.randn(s_q, num_heads, device="cuda", dtype=torch.float32)
+    # Every row attends to all of kv, so clean_logits=False leaves nothing
+    # undefined and the whole output is comparable.
+    ks = torch.zeros(s_q, dtype=torch.int, device="cuda")
+    ke = torch.full((s_q,), s_k, dtype=torch.int, device="cuda")
+
+    q_fp8 = q.to(e4m3_type)
+    kv_fp8, scales = per_custom_dims_cast_to_fp8(kv, (0,), False)
+
+    logits = fp8_mqa_logits(q_fp8, kv_fp8, scales, weights, ks, ke, clean_logits=False)
+    assert logits.shape == (s_q, s_k)
+
+    # A full reference needs num_heads x s_q x s_k floats, so compare row windows
+    # instead. Rows are independent, and both ends cover a paired block and the
+    # trailing one.
+    for rows in (slice(0, 32), slice(s_q - 32, s_q)):
+        ref_logits, _ = ref_fp8_mqa_logits(
+            q=q[rows],
+            kv=kv,
+            weights=weights[rows],
+            cu_seqlen_ks=ks[rows],
+            cu_seqlen_ke=ke[rows],
+        )
+        diff = calc_diff(logits[rows], ref_logits)
+        assert diff < 1e-3, f"{s_q=} {s_k=} {rows=} {diff=}"


### PR DESCRIPTION
## Summary

On gfx950, `fp8_mqa_logits` aborts inside the AMDGCN backend at JIT-compile time
once the context passes roughly 32K tokens. It is a `Fatal Python error: Aborted`,
so the process dies rather than raising — an inference server hosting a DSA/NSA
model (GLM-5.2, DeepSeek-V3.2-style indexers) goes down with no recoverable error.

```
python3: /__w/triton/triton/llvm-project/llvm/include/llvm/ADT/Sequence.h:275:
llvm::iota_range<unsigned int>::iota_range(T, T, bool) [T = unsigned int]:
Assertion `Begin <= End && "Begin must be less or equal to End."' failed.

Current thread (most recent call first):
  File "triton/backends/amd/compiler.py", line 544 in make_amdgcn
  File "triton/compiler/compiler.py", line 327 in compile
  File "aiter/ops/triton/attention/fp8_mqa_logits.py", line 228 in fp8_mqa_logits
```

## Root cause

Two independent constexprs in the Gluon launch path combine into a shape the
AMDGCN backend cannot codegen:

- `block_m = 2 if (num_heads <= 32 and seq_len > 4096) else 1` — 2 for any
  prefill chunk over 4096 tokens on a ≤32-head indexer.
- `use_buffer_store = logits.numel() * logits.element_size() < 2 GiB` — False
  once the fp32 `[seq_len, seq_len_kv]` logits buffer clears the 32-bit byte
  offset of a buffer resource descriptor.

`BLOCK_M == 2` **and** `USE_BUFFER_STORE == False` together abort the compile.
Either one alone is fine.

The pair had never been compiled before because nothing reaches it until the
logits buffer passes 2 GiB, i.e. `seq_len * seq_len_kv >= 2^29`. With a
16384-token prefill chunk that is a KV length of 32768 — every context past
~32K tokens, and nothing below it.

Measured on MI355X / gfx950, ROCm 7.2.4, torch 2.11.0+rocm7.2, Triton
`3.7.0+amd.rocm7.2.0.git89002410`, `num_heads=32`, `head_dim=128`:

| seq_len | seq_len_kv | logits | BLOCK_M | USE_BUFFER_STORE | result |
|--------:|-----------:|-------:|:-------:|:----------------:|:-------|
| 16384 | 16384 | 1.00 GiB | 2 | True (auto) | ok |
| 16384 | 32768 | 2.00 GiB | 2 | False (auto) | **abort** |
| 16384 | 2048 | 0.12 GiB | 2 | False (forced) | **abort** |
| 4096 | 131072 | 2.00 GiB | 1 | False (auto) | ok |
| 8192 | 65536 | 2.00 GiB | 2 | False (auto) | **abort** |
| 16384 | 32768 | 2.00 GiB | 2 | True (forced) | ok |

Rows 3 and 4 isolate it: the abort tracks the constexpr pair, not the tensor size,
and neither flag triggers it alone.

## Fix

Hoist the buffer-limit computation above the arch dispatch and gate `block_m` on
it, so the non-buffer store path always walks one query row per program:

```python
block_m = 2 if (num_heads <= 32 and seq_len > 4096 and use_buffer_store) else 1
```

`BLOCK_M=1` is the same kernel without the row pairing, and it is already what
every shorter context uses. This is a workaround at the aiter level — the
underlying codegen bug in the `BLOCK_M=2` + `gl.store` combination is still there
and worth fixing separately in the compiler.

**Scoped to one Triton build.** Everything here was measured on
`3.7.0+amd.rocm7.2.0.git89002410`; no other version was tried, so I cannot say
whether an earlier or later backend codegens the pair. The fix does not depend on
the answer — it only removes a configuration that no shape reached before ~32K
context — but the abort itself may not reproduce elsewhere.

## Correctness

Same inputs through the buffer-store and non-buffer-store paths:

```
buffer-store vs non-buffer-store: max|diff| = 0.000e+00     (bit-identical)
vs torch reference:  buffer = 1.479e-04   non-buffer = 1.479e-04
```

## Performance

No shape that worked before changes behaviour: `use_buffer_store` is still True
there, so `block_m` is still 2 and the emitted kernel is unchanged. The fix only
takes effect where `BLOCK_M=2` could not be compiled at all.

Kernel time, median of 20, MI355X:

| shape | BLOCK_M=2 | BLOCK_M=1 | selected after fix |
|:------|----------:|----------:|:------------------:|
| 8192 × 8192 | 0.456 ms | 0.458 ms | 2 (unchanged) |
| 16384 × 16384 | 1.491 ms | 1.617 ms | 2 (unchanged) |
| 16384 × 32768 | **abort** | 3.27 ms | 1 (fix applies) |

For reference, giving up the row pairing costs 8.4% at 16384 × 16384 — but the
fix never applies at a shape where the pairing was available.

End to end, SGLang v0.5.17 + GLM-5.2-MXFP4, TP4 on MI355X, 45K-token prompt,
prefix cache disabled, median of 4:

| configuration | TTFT | LLVM aborts |
|:--------------|-----:|------------:|
| stock, `--chunked-prefill-size 16384` (default) | **crash**, HTTP 500 | 4 |
| stock, `--chunked-prefill-size 4096` (workaround) | 4.31 s | 0 |
| **this fix**, `--chunked-prefill-size 16384` | **3.91 s** | 0 |

Shrinking the prefill chunk to 4096 also avoids the abort (it forces
`BLOCK_M=1`), but costs 9.3% TTFT because every GEMM and MoE stage loses 4× of
its M dimension. The fix keeps the default chunk size.

## Test

`(8192, 65536)` added to the existing `test_fp8_mqa_logits` parametrization in
`op_tests/triton_tests/attention/test_fp8_mqa_logits.py` — exactly 2 GiB of
logits, the smallest shape that reaches the combination. The list previously
topped out at 1024 queries and far under 2 GiB, which is why this shipped.

Two things the shape needs that the rest of the list does not, both guarded in
the body rather than in a separate test:

- It runs for one configuration (`num_heads=32, head_dim=128`) instead of all
  sixteen. `BLOCK_M=2` needs `num_heads <= 32`, so half the cross product cannot
  reach the bug at all, and each case costs 2 GiB plus a reference.
- The reference is checked on 32-row windows at each end of the query range
  rather than the whole tensor — `ref_fp8_mqa_logits` materializes
  `num_heads × s_q × s_k` floats, which is 64 GiB here. Rows are independent, so
  the two windows cover both a paired block and the trailing one. Smaller shapes
  still compare in full; the window list is just `[slice(0, s_q)]` for them.

It also skips below 8 GiB free VRAM.

- Before the fix: aborts the pytest process (fatal, not a test failure).
- After: `145 passed, 15 skipped in 16.83s` — one new case, the 144 pre-existing
  ones unchanged, and the 15 skips are the guarded-out configurations.
