### PR TITLE
[CI] Skip MegaMoE v2 multi-GPU tests

### DIFF
--- a/.github/scripts/aiter_test.sh
+++ b/.github/scripts/aiter_test.sh
@@ -35,10 +35,12 @@ else
 fi
 
 skip_tests=(
+    "op_tests/multigpu_tests/bench_mega_moe_v2.py"
     "op_tests/multigpu_tests/test_dispatch_combine.py"
     "op_tests/multigpu_tests/test_communication.py"
     "op_tests/multigpu_tests/test_mori_all2all.py"
     "op_tests/multigpu_tests/test_fused_ar_rms.py"
+    "op_tests/multigpu_tests/test_mega_moe_v2.py"
     "op_tests/multigpu_tests/triton_test/test_reduce_scatter_all_gather.py"
     "op_tests/multigpu_tests/triton_test/test_fused_rs_rmsnorm_quant_ag.py"
 )
@@ -82,30 +84,6 @@ for file in "${sharded_files[@]}"; do
     # batch gate so they exercise the persistent kernel at every batch size.
     test_cmd=(timeout 60m python3 "$file")
     case "$file" in
-        op_tests/multigpu_tests/bench_mega_moe_v2.py)
-            {
-                echo "Running MegaMoEV2 versus Mori EP performance guards on 8 GPUs"
-            } | tee -a latest_test.log
-            test_cmd=(
-                env MORI_SOCKET_IFNAME=lo MORI_SHMEM_HEAP_SIZE=40G
-                timeout 60m
-                bash -c '
-                    set -euo pipefail
-                    bench=$1
-                    for spec in \
-                        "512 uniform 0.6" \
-                        "512 rank-mixed-skew 1.0" \
-                        "8192 uniform 0.6" \
-                        "8192 rank-mixed-skew 1.0"; do
-                        read -r tokens route bias <<< "$spec"
-                        torchrun --standalone --nproc_per_node=8 "$bench" \
-                            --tokens "$tokens" --mtpr 8192 --route "$route" \
-                            --hot-bias "$bias" --iters 20 --perf-guard
-                    done
-                '
-                _ "$file"
-            )
-            ;;
         op_tests/multigpu_tests/test_mega_moe_gfx1250.py)
             {
                 echo "Running gfx1250 MegaMoE fused-scatter accuracy on 8 GPUs when supported"
@@ -126,21 +104,6 @@ for file in "${sharded_files[@]}"; do
                         --combine scatter_fused --layers 2 --acc_verify 1
                 '
                 _ "$file"
-            )
-            ;;
-        op_tests/multigpu_tests/test_mega_moe_v2.py)
-            {
-                echo "Running MegaMoEV2 v4_pro fixed-slot and compact coverage on 8 GPUs"
-            } | tee -a latest_test.log
-            test_cmd=(
-                env MORI_SHMEM_HEAP_SIZE=40G
-                timeout 60m
-                torchrun --standalone --nproc_per_node=8 "$file"
-                --network v4_pro
-                --bs-list 128,512
-                --iters 10
-                --accuracy-max-bs 512
-                --rtol 0.10
             )
             ;;
         op_tests/test_mla_persistent.py|op_tests/test_mla_persistent_round_robin.py)

--- a/.github/workflows/aiter-test.yaml
+++ b/.github/workflows/aiter-test.yaml
@@ -1004,15 +1004,11 @@ jobs:
           bash -lc "
             set -euo pipefail
             pip uninstall -y amd-aiter aiter || true
-            apt-get update
-            DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends libgrpc++1.51t64
             pip install -r requirements.txt
             pip install --upgrade pandas pyzmq einops numpy==1.26.2
             pip install --upgrade 'pybind11>=3.0.1'
             pip install --upgrade 'ninja>=1.11.1'
             pip install tabulate
-            pip install 'amd-mori==1.2.2'
-            python3 -c 'import mori, mori.shmem'
             pip install '${AITER_WHEEL_PATH}'
             pip show amd-aiter
           "


### PR DESCRIPTION
Summary:
- skip bench_mega_moe_v2.py and test_mega_moe_v2.py in the multi-GPU CI sweep
- remove the MegaMoE/Mori-specific multi-GPU install dependencies added for those tests
- delete the now-unreachable special command branches for the skipped tests

Root cause:
- recent main runs time out in Multi-GPU Tests after test_mega_moe_v2.py starts torchrun and stops making progress
- bench_mega_moe_v2.py also fails early because Mori JIT cannot find infiniband/verbs.h
- keeping both tests in the required 8-GPU sweep blocks main recovery and holds the scarce 8-GPU runner until timeout

Validation:
- git diff --check
- bash -n .github/scripts/aiter_test.sh