### PR TITLE
[Triton/Gluon] [Perf] Optimize live-window unified-attention decode

### DIFF
--- a/aiter/ops/triton/_gluon_kernels/gfx1250/attention/unified_attention_3d.py
+++ b/aiter/ops/triton/_gluon_kernels/gfx1250/attention/unified_attention_3d.py
@@ -722,7 +722,7 @@ class AttentionProgram:
         query_offset_1_pv,
         query_mask_0_pv,
         query_mask_1_pv,
-        segm_idx,
+        segment_tile_start,
         tiles_per_segment,
         stride_k_cache_0,
         stride_k_cache_1,
@@ -903,8 +903,8 @@ class AttentionProgram:
 
         # Calculate tile range
         num_tiles = (max_seq_prefix_len + cfg.TILE_SIZE - 1) // cfg.TILE_SIZE
-        tile_start = segm_idx * tiles_per_segment
-        tile_end = min((segm_idx + 1) * tiles_per_segment, num_tiles)
+        tile_start = segment_tile_start
+        tile_end = min(segment_tile_start + tiles_per_segment, num_tiles)
         if cfg.SLIDING_WINDOW > 0:
             qpos_lo = q_block_local_idx * cfg.BLOCK_Q
             qpos_hi = gl.minimum(
@@ -913,8 +913,10 @@ class AttentionProgram:
             )
             first_allowed_key = context_len + qpos_lo - cfg.SLIDING_WINDOW + 1
             last_allowed_key = context_len + qpos_hi
-            tile_start = gl.maximum(0, first_allowed_key // cfg.BLOCK_SIZE)
-            tile_end = gl.minimum((last_allowed_key // cfg.BLOCK_SIZE) + 1, num_tiles)
+            first_allowed_tile = gl.maximum(0, first_allowed_key // cfg.TILE_SIZE)
+            last_allowed_tile = (last_allowed_key // cfg.TILE_SIZE) + 1
+            tile_start = gl.maximum(tile_start, first_allowed_tile)
+            tile_end = gl.minimum(tile_end, gl.minimum(last_allowed_tile, num_tiles))
 
         query_pos_qk = gl.convert_layout(
             query_pos_qk, gl.SliceLayout(1, cfg.QK_WMMA_UNPACKED_LAYOUT)
@@ -1835,17 +1837,30 @@ def cdiv_fn(x, y):
 def get_seq_metadata(
     seq_lens_ptr,
     seq_idx,
+    segm_idx,
     TILE_SIZE: gl.constexpr,
     NUM_SEGMENTS_PER_SEQ: gl.constexpr,
+    SLIDING_WINDOW: gl.constexpr,
+    ALL_DECODE: gl.constexpr,
 ):
     # sequence len for this particular sequence
     seq_len = gl.load(seq_lens_ptr + seq_idx)
 
-    # number of segments for this particular sequence
+    # Decode only needs tiles intersecting the live window. Rebase the segment
+    # grid onto its first tile so different segments do not repeat that work.
+    total_seq_tiles = cdiv_fn(seq_len, TILE_SIZE)
     num_segments = NUM_SEGMENTS_PER_SEQ
-    tiles_per_segment = cdiv_fn(seq_len, num_segments * TILE_SIZE)
+    if ALL_DECODE and SLIDING_WINDOW > 0:
+        first_allowed_key = gl.maximum(0, seq_len - SLIDING_WINDOW)
+        first_tile = first_allowed_key // TILE_SIZE
+        live_tiles = total_seq_tiles - first_tile
+        tiles_per_segment = cdiv_fn(live_tiles, num_segments)
+        segment_tile_start = first_tile + segm_idx * tiles_per_segment
+    else:
+        tiles_per_segment = cdiv_fn(seq_len, num_segments * TILE_SIZE)
+        segment_tile_start = segm_idx * tiles_per_segment
 
-    return seq_len, tiles_per_segment
+    return seq_len, tiles_per_segment, segment_tile_start, total_seq_tiles
 
 
 @gluon.jit
@@ -1910,6 +1925,7 @@ unified_attention_gluon_kernel_3d_repr = make_kernel_repr(
         "BLOCK_SIZE",
         "TILE_SIZE",
         "HEAD_SIZE",
+        "SLIDING_WINDOW",
         "NUM_BLOCKS_GATHER_PER_TILE",
         "NUM_SEGMENTS_PER_SEQ",
         "num_warps",
@@ -2053,14 +2069,17 @@ def _unified_attention_gluon_kernel_3d(
         if q_block_local_idx * cfg.BLOCK_Q >= cur_batch_query_len:
             return
 
-    seq_len, tiles_per_segment = get_seq_metadata(
+    seq_len, tiles_per_segment, segment_tile_start, total_seq_tiles = get_seq_metadata(
         seq_lens_ptr,
         seq_idx,
+        segm_idx,
         cfg.TILE_SIZE,
         cfg.NUM_SEGMENTS_PER_SEQ,
+        cfg.SLIDING_WINDOW,
+        cfg.ALL_DECODE,
     )
 
-    if segm_idx * tiles_per_segment * cfg.TILE_SIZE >= seq_len:
+    if segment_tile_start >= total_seq_tiles:
         return
 
     qk_factor: gl.float32 = cfg.QK_SCALE
@@ -2235,7 +2254,7 @@ def _unified_attention_gluon_kernel_3d(
         query_offset_1_pv,
         query_mask_0_pv,
         query_mask_1_pv,
-        segm_idx,  # for 2D, segm_idx = 0
+        segment_tile_start,
         tiles_per_segment,  # for 2D, tiles_per_segment = num_tiles = (max_seq_prefix_len + cfg.BLOCK_SIZE - 1) // cfg.BLOCK_SIZE
         stride_k_cache_0,
         stride_k_cache_1,

--- a/aiter/ops/triton/_gluon_kernels/gfx1250/attention/unified_attention_reduce.py
+++ b/aiter/ops/triton/_gluon_kernels/gfx1250/attention/unified_attention_reduce.py
@@ -30,6 +30,8 @@ def reduce_segments_gluon(
     D: gl.constexpr,
     D_PAD: gl.constexpr,
     TILE_SIZE: gl.constexpr,
+    SLIDING_WINDOW: gl.constexpr,
+    ALL_DECODE: gl.constexpr,
     NUM_WARPS: gl.constexpr,
     IS_FP8_OUT: gl.constexpr,
     FP8_MIN: gl.constexpr,
@@ -39,9 +41,17 @@ def reduce_segments_gluon(
 
     # all-decode: each sequence has exactly one query token, so seq_idx == token
     seq_len = gl.load(seq_lens_ptr + token)
-    tiles_per_segment = (seq_len + S * TILE_SIZE - 1) // (S * TILE_SIZE)
-    denom = tiles_per_segment * TILE_SIZE
-    act_num_segments = (seq_len + denom - 1) // denom
+    # Match the attention kernel's live-tile partition so uninitialized
+    # trailing segment slots remain masked during the reduction.
+    total_seq_tiles = (seq_len + TILE_SIZE - 1) // TILE_SIZE
+    if ALL_DECODE and SLIDING_WINDOW > 0:
+        first_allowed_key = gl.maximum(0, seq_len - SLIDING_WINDOW)
+        first_tile = first_allowed_key // TILE_SIZE
+        active_tiles = total_seq_tiles - first_tile
+    else:
+        active_tiles = total_seq_tiles
+    tiles_per_segment = (active_tiles + S - 1) // S
+    act_num_segments = (active_tiles + tiles_per_segment - 1) // tiles_per_segment
 
     # --- layouts: head axis split across waves, segment axis in-thread ---
     SIZE_H: gl.constexpr = H // NUM_WARPS

--- a/aiter/ops/triton/_triton_kernels/attention/unified_attention.py
+++ b/aiter/ops/triton/_triton_kernels/attention/unified_attention.py
@@ -469,6 +469,7 @@ kernel_unified_attention_3d_repr = make_kernel_repr(
         "BLOCK_SIZE",
         "TILE_SIZE",
         "HEAD_SIZE",
+        "SLIDING_WINDOW",
         "NUM_SEGMENTS_PER_SEQ",
         "num_warps",
         "waves_per_eu",
@@ -571,11 +572,23 @@ def kernel_unified_attention_3d(
     # sequence len for this particular sequence
     seq_len = tl.load(seq_lens_ptr + seq_idx)
 
-    # number of segments for this particular sequence
+    # Number of segments for this sequence. For sliding-window decode, split
+    # only the live KV window. Partitioning the entire sequence still loads old
+    # KV tiles before masking them and leaves empty leading segments for the
+    # reducer.
     num_segments = NUM_SEGMENTS_PER_SEQ
-    tiles_per_segment = cdiv_fn(seq_len, num_segments * TILE_SIZE)
+    total_seq_tiles = cdiv_fn(seq_len, TILE_SIZE)
+    if ALL_DECODE and SLIDING_WINDOW > 0:
+        first_allowed_key = tl.maximum(0, seq_len - SLIDING_WINDOW)
+        first_tile = first_allowed_key // TILE_SIZE
+        live_tiles = total_seq_tiles - first_tile
+        tiles_per_segment = cdiv_fn(live_tiles, num_segments)
+        segment_tile_start = first_tile + segm_idx * tiles_per_segment
+    else:
+        tiles_per_segment = cdiv_fn(seq_len, num_segments * TILE_SIZE)
+        segment_tile_start = segm_idx * tiles_per_segment
 
-    if segm_idx * tiles_per_segment * TILE_SIZE >= seq_len:
+    if segment_tile_start >= total_seq_tiles:
         return
 
     offs_m = tl.arange(0, BLOCK_M)
@@ -686,8 +699,8 @@ def kernel_unified_attention_3d(
 
     # iterate through tiles within current segment
     for j in range(
-        segm_idx * tiles_per_segment,
-        min((segm_idx + 1) * tiles_per_segment, num_tiles),
+        segment_tile_start,
+        min(segment_tile_start + tiles_per_segment, num_tiles),
     ):
         seq_offset = j * TILE_SIZE + offs_t
         if TILE_SIZE == BLOCK_SIZE:
@@ -875,7 +888,9 @@ _reduce_segments_repr = make_kernel_repr(
         "num_query_heads",
         "TILE_SIZE",
         "HEAD_SIZE",
+        "SLIDING_WINDOW",
         "NUM_SEGMENTS_PER_SEQ",
+        "ALL_DECODE",
     ],
 )
 
@@ -900,6 +915,8 @@ def reduce_segments(
     query_start_len_ptr,  # [num_seqs+1]
     BLOCK_Q: tl.constexpr,  # int
     NUM_SEGMENTS_PER_SEQ: tl.constexpr,  # int
+    SLIDING_WINDOW: tl.constexpr = -1,  # int
+    ALL_DECODE: tl.constexpr = False,  # bool
     FP8_MIN: tl.constexpr = float8_info.min,
     FP8_MAX: tl.constexpr = float8_info.max,
 ):
@@ -919,10 +936,18 @@ def reduce_segments(
 
     # number of segments for this particular sequence
     num_segments = NUM_SEGMENTS_PER_SEQ
-    tiles_per_segment = cdiv_fn(seq_len, num_segments * TILE_SIZE)
+    if ALL_DECODE and SLIDING_WINDOW > 0:
+        total_seq_tiles = cdiv_fn(seq_len, TILE_SIZE)
+        first_allowed_key = tl.maximum(0, seq_len - SLIDING_WINDOW)
+        first_tile = first_allowed_key // TILE_SIZE
+        live_tiles = total_seq_tiles - first_tile
+        tiles_per_segment = cdiv_fn(live_tiles, num_segments)
+        act_num_segments = cdiv_fn(live_tiles, tiles_per_segment)
+    else:
+        tiles_per_segment = cdiv_fn(seq_len, num_segments * TILE_SIZE)
+        act_num_segments = cdiv_fn(seq_len, tiles_per_segment * TILE_SIZE)
 
     # create masks for subsequent loads
-    act_num_segments = cdiv_fn(seq_len, tiles_per_segment * TILE_SIZE)
     segm_mask = tl.arange(0, NUM_SEGMENTS_PER_SEQ) < tl.full(
         [NUM_SEGMENTS_PER_SEQ], act_num_segments, dtype=tl.int32
     )

--- a/aiter/ops/triton/attention/unified_attention.py
+++ b/aiter/ops/triton/attention/unified_attention.py
@@ -39,11 +39,18 @@ from aiter.ops.triton.utils.types import e4m3_dtype
 
 # Max NUM_SEGMENTS the gluon reduce holds in-thread; larger split counts fall back to the Triton reduce_segments.
 _GLUON_REDUCE_MAX_SEGMENTS = 8
+_MAX_2D_KV_TOKENS = 512
 
 DEVICE_ARCH = arch_info.get_arch()
 IS_DEVICE_ARCH_GFX12 = DEVICE_ARCH in ("gfx1250",)
 WARP_SIZE = 32 if IS_DEVICE_ARCH_GFX12 else 64
 WAPR_SIZE_LOG2 = int(math.log2(WARP_SIZE))
+
+
+def _active_kv_length(max_seqlen_k, sliding_window):
+    if sliding_window is not None and sliding_window > 0:
+        return min(sliding_window, max_seqlen_k)
+    return max_seqlen_k
 
 
 def is_gfx950_small_head(head_size):
@@ -169,6 +176,9 @@ def select_3d_config(
     SLIDING_WINDOW: int | None = None,
 ):
     arch = get_arch()
+    # Size split-KV launches for the data that can contribute to the result,
+    # rather than for expired tokens outside a sliding window.
+    active_seqlen_k = _active_kv_length(max_seqlen_k, SLIDING_WINDOW)
     reduce_num_warps = 2
     attn_warps = 2
     waves_per_eu = 2
@@ -204,14 +214,11 @@ def select_3d_config(
             # GFX12 fallback
             waves_per_eu = 1
 
-        if SLIDING_WINDOW is not None and SLIDING_WINDOW > 0:
-            num_segments = 1
-        else:
-            occ = waves_per_eu * 4 // attn_warps
-            MAX_SEGMENTS = max(1, math.ceil(max_seqlen_k / TILE_SIZE))
-            num_segments = max(1, target_num_prgms // 4 * occ // max(1, num_2d_prgms))
-            num_segments = min(MAX_SEGMENTS, num_segments)
-            num_segments = triton.next_power_of_2(num_segments)
+        occ = waves_per_eu * 4 // attn_warps
+        MAX_SEGMENTS = max(1, math.ceil(active_seqlen_k / TILE_SIZE))
+        num_segments = max(1, target_num_prgms // 4 * occ // max(1, num_2d_prgms))
+        num_segments = min(MAX_SEGMENTS, num_segments)
+        num_segments = triton.next_power_of_2(num_segments)
 
         # # this section increases the num_warps if the occ is too high
         # total_num_wg = num_2d_prgms * num_segments
@@ -243,7 +250,7 @@ def select_3d_config(
             # same de-vectorization fix as the 2D path
             TILE_SIZE = 64
 
-        MAX_SEGMENTS = min(128, math.ceil(max_seqlen_k / TILE_SIZE))
+        MAX_SEGMENTS = min(128, math.ceil(active_seqlen_k / TILE_SIZE))
         # the >= 8 floor would clamp the smaller splits (4 and 2) back up to 8
         MIN_SEGMENTS = 1 if wide_lds_copy else min(8, MAX_SEGMENTS)
         if head_size >= 512 and not arch.is_rdna:
@@ -314,22 +321,57 @@ def use_2d_kernel(
     head_size,
     sliding_window,
     all_decode,
-    max_seqlen_q,
     max_seqlen_k,
     target_num_prgms,
     num_2d_prgms,
 ):
-    # if IS_DEVICE_ARCH_GFX12, always use 3D if all_decode and 2D otherwise
+    arch = get_arch()
+    active_seqlen_k = _active_kv_length(max_seqlen_k, sliding_window)
+
+    # The live-window 3-D path adds parallelism without scanning expired KV
+    # tiles. Apply the same workload rule as full-context decode, independent
+    # of head size or GPU architecture.
+    if (
+        all_decode
+        and active_seqlen_k > _MAX_2D_KV_TOKENS
+        and num_2d_prgms <= target_num_prgms
+    ):
+        return False
+
+    # Preserve gfx1250's existing choices for non-window decode and for the
+    # short or already-parallel sliding-window cases not handled above.
     if IS_DEVICE_ARCH_GFX12:
         return (sliding_window > 0) or (not all_decode)
 
-    if head_size >= 512 and not get_arch().is_rdna and not all_decode:
+    if head_size >= 512 and not arch.is_rdna and not all_decode:
         return True
 
     return (
         (sliding_window > 0)
-        or (max_seqlen_k <= 512)
+        or (max_seqlen_k <= _MAX_2D_KV_TOKENS)
         or (num_2d_prgms > target_num_prgms)
+    )
+
+
+def is_3d_gluon_available(q_dtype, kv_cache_dtype, shuffled_kv_cache, sliding_window):
+    """Return whether the gfx12 Gluon producer supports this 3-D workload.
+
+    The 2-D/3-D choice remains workload-based. Once 3-D is selected, use the
+    existing gfx12 Gluon producer for shuffled caches and unshuffled FP8
+    live-window decode; the generic Triton FP8 producer is not reliable for the
+    latter on gfx12.
+    """
+    return (
+        IS_DEVICE_ARCH_GFX12
+        and _unified_attention_gluon_kernel_3d is not None
+        and (
+            shuffled_kv_cache
+            or (
+                sliding_window > 0
+                and q_dtype == e4m3_dtype
+                and kv_cache_dtype == e4m3_dtype
+            )
+        )
     )
 
 
@@ -440,7 +482,6 @@ def unified_attention(
         head_size,
         SLIDING_WINDOW,
         ALL_DECODE,
-        max_seqlen_q,
         max_seqlen_k,
         target_num_prgms,
         num_2d_prgms,
@@ -590,7 +631,9 @@ def unified_attention(
             segm_max = out  # dummy ptr
             segm_expsum = out  # dummy ptr
 
-        if IS_DEVICE_ARCH_GFX12 and shuffled_kv_cache:
+        if is_3d_gluon_available(
+            q_dtype, kv_cache_dtype, shuffled_kv_cache, SLIDING_WINDOW
+        ):
             _unified_attention_gluon_kernel_3d[
                 (total_num_q_blocks, num_kv_heads, NUM_SEGMENTS)
             ](
@@ -747,6 +790,8 @@ def unified_attention(
                 D=head_size,
                 D_PAD=head_size_padded,
                 TILE_SIZE=reduce_config["TILE_SIZE"],
+                SLIDING_WINDOW=SLIDING_WINDOW,
+                ALL_DECODE=ALL_DECODE,
                 NUM_WARPS=gluon_num_warps,
                 IS_FP8_OUT=(out.dtype == e4m3_dtype),
                 FP8_MIN=torch.finfo(e4m3_dtype).min,
@@ -771,6 +816,8 @@ def unified_attention(
             HEAD_SIZE_PADDED=head_size_padded,
             query_start_len_ptr=cu_seqlens_q,
             BLOCK_Q=BLOCK_Q,
+            SLIDING_WINDOW=SLIDING_WINDOW,
+            ALL_DECODE=ALL_DECODE,
             **reduce_config,
         )
 

--- a/op_tests/triton_tests/attention/test_unified_attention.py
+++ b/op_tests/triton_tests/attention/test_unified_attention.py
@@ -364,17 +364,25 @@ def ref_paged_attn(
 
 
 @pytest.mark.parametrize(
-    "seq_lens",
+    "seq_lens, sliding_window",
     [
-        [(1, 1328)],
-        [(1, 8192)] * 32,
-        [(1, 523), (1, 37), (1, 2011)],
-        [(1, 1328), (1, 523), (1, 37), (1, 2011), (1, 8192)],
+        pytest.param([(1, 1328)], None, id="single-decode"),
+        pytest.param([(1, 8192)] * 32, None, id="batched-decode"),
+        pytest.param([(1, 523), (1, 37), (1, 2011)], None, id="ragged-decode"),
+        pytest.param(
+            [(1, 1328), (1, 523), (1, 37), (1, 2011), (1, 8192)],
+            None,
+            id="mixed-decode",
+        ),
+        pytest.param(
+            [(1, 8203)] * 32,
+            2053,
+            id="large-sliding-window-off-tile",
+        ),
     ],
 )
 @pytest.mark.parametrize("num_heads", [(64, 8), (8, 1)])
 @pytest.mark.parametrize("head_size", [64])
-@pytest.mark.parametrize("sliding_window", [None])
 @pytest.mark.parametrize(
     "q_dtype, kv_dtype, o_dtype, block_size, use_out_scale",
     [
@@ -407,11 +415,11 @@ def test_triton_unified_attn_3d(
     torch.cuda.empty_cache()
 
     if DEVICE_ARCH not in (
+        "gfx942",
         "gfx950",
         "gfx1250",
     ):
-        # gfx1250 -> Gluon
-        # gfx950 -> Triton
+        # gfx1250 shuffled KV -> Gluon; other covered paths -> Triton.
         pytest.skip(f"skip {DEVICE_ARCH}")
 
     if kv_dtype == torch.uint8:


### PR DESCRIPTION
## Summary

- Partition the 3-D unified-attention decode kernel over the live sliding window instead of the full logical sequence.
- Apply the same live-segment bound in the Triton and gfx1250 Gluon reducers.
- Select 3-D from decode state, active KV length, and available launch parallelism, independent of GPU architecture and head size.
- Cover a large, off-tile sliding window in the existing unified-attention regression suite; no standalone dispatcher-coupled test file is added.
- On gfx1250, use the existing Gluon 3-D producer for the affected unshuffled FP8 live-window path. This backend choice is separate from the architecture-agnostic 2-D/3-D workload selection.

## Motivation

For sliding-window decode, the previous 3-D kernel derived segment boundaries from the full sequence length. It could therefore visit expired KV tiles before masking them and leave leading reduction segments empty when the logical context was much longer than the active window.

This change rebases 3-D segment ranges onto the first tile intersecting the live window and makes each reducer consume only active live-window segments. It changes neither the attention mask nor the stored KV layout.

## Dispatch and platform scope

The 2-D/3-D selector now chooses 3-D only when all of the following are true:

- the batch is decode-only;
- the active KV length exceeds the existing 2-D short-context boundary;
- the 2-D launch does not already exceed the target launch parallelism.

Short windows, prefills, and already-parallel launches retain the previous 2-D route. There is no model name, product name, GPU-architecture gate, or head-size gate in this workload decision.

The existing architecture-specific kernel implementations and low-level launch tuning remain architecture-specific. In particular, gfx1250 already uses its Gluon 3-D producer for shuffled KV. The wrapper now also uses that available producer for unshuffled FP8 live-window 3-D decode, after gfx1250 testing showed non-finite partials in the generic Triton FP8 producer. No ASIC-revision or model-specific condition is introduced.

## Correctness and regression coverage

Current head: `1138500476bcdcc6f1f695e1f36f98b383149ca4`  
Tested base: `d58537b705269f3179c3ba62fa34c108360a0aa2`

Upstream `main` subsequently advanced to `ce788f58feb47c66c23bfde5d39fab8e5db76606` through #5123, which changes only DCP/top-k files. The current PR head merge-simulates cleanly with that commit and has no file overlap with it.

Static checks on all five changed Python files:

```text
black --check                         PASS
ruff 0.16.0 check                     PASS
python -m py_compile                  PASS
git diff --check                      PASS
```

The gfx1250 runs used one physical `gfx1250` A0 GPU on runner
`heliosr-1b114-a06-4-mi45x`, image
`rocm/ufb-private@sha256:7472a35db180b9e0dd3850be862fea30fb7f5ff7663c7b3740dea01b847bae3a`,
and Triton `3.8.0+gite411a7fd.gfx1250a0v5`. The compiler wheel SHA-256 is
`d6f0db98f683b0f289b150ce048aab380203101cb3e233477f60ed65d21f1668`
([build run](https://github.com/andyluo7/aiter-mi45x-ci/actions/runs/33551006583)).
The validation branch is `58baf857564c6ddd24d24d923f8098a4dda71ffb`; all five PR-file blob IDs
match this public head exactly.

Focused gfx1250 A0 producer/reducer diagnostic:

- Run: https://github.com/andyluo7/aiter-mi45x-ci/actions/runs/33569822567
- `2 passed`; preflight and postflight GPU-health checks passed.
- `segm_output`: 524,288/524,288 finite values.
- `segm_max`: 8,192/8,192 finite values.
- `segm_expsum`: 8,192/8,192 finite values.
- Torch, Triton, synchronized Gluon, and normal-wrapper reductions all had a 0.0 mismatch ratio.
- Maximum finite difference was `0.00439453125` for BF16 output and `0.015625` for FP8 output.
- The test fixes scale tensors at 1.0 so an all-zero result cannot pass only because of loose FP8 tolerances.

Complete gfx1250 3-D selection:

- Run: https://github.com/andyluo7/aiter-mi45x-ci/actions/runs/33569985137
- `100 passed, 20 skipped`; the skips are the unsupported unshuffled-NVFP4 cases.
- All 20 supported large off-tile sliding-window configurations passed; four unsupported NVFP4 configurations skipped.
- Preflight/postflight health checks passed and the kernel-fault log was empty.

Complete gfx1250 unified-attention file, compared with the same 2,168-case matrix on the pre-fix candidate:

- Current run: https://github.com/andyluo7/aiter-mi45x-ci/actions/runs/33572592033 -- `1172 passed, 660 skipped, 336 failed`.
- Pre-fix candidate: https://github.com/andyluo7/aiter-mi45x-ci/actions/runs/33564202060 -- `1170 passed, 660 skipped, 338 failed`.
- The selected-node lists are byte-identical (`sha256:634677cf32cfef001e2329a3ea7a6fbe93f1f9a2fc564466e4a7d256cf15f2d9`).
- The current failure set is a strict subset of the pre-fix set: zero new failures and exactly the two unshuffled-FP8 large-window failures removed.
- All 2,168 selected cases reached terminal outcomes. Preflight/postflight health checks passed, the kernel-fault log was empty, and the downloaded artifact hashes match the host-preserved evidence.
- The workflow is red because 336 known failures from the pre-fix candidate remain, not because this change introduced a new failure.

Upstream exact-head CI:

- [Triton Test](https://github.com/ROCm/aiter/actions/runs/33573357062): all eight MI35X shards, all eight MI300X shards, and both aggregate result jobs passed.
- On both MI35X and MI300X, shard 6 executed all 2,168 cases in `test_unified_attention.py`: `1104 passed, 1064 skipped`. All 16 supported large-window configurations passed; the eight skips are unsupported NVFP4 combinations.
- [OPUS Test](https://github.com/ROCm/aiter/actions/runs/33570073257): MI35X and MI300X passed.
- [Checks](https://github.com/ROCm/aiter/actions/runs/33570073056): Black, Ruff, and repository dependency checks passed; the title/label check also passed.
- [Aiter Test](https://github.com/ROCm/aiter/actions/runs/33570073242): both wheel builds, all eight MI35X and eight MI300X standard-test shards, result aggregation, tuned-op bench, and the final AITER gate passed.

The repository's `ci:gfx1250-ffm-triton` workflow accepts only PR heads hosted in `ROCm/aiter`, so it skips this fork-authored PR by policy. The physical gfx1250 exact-head runs above cover that gap.

## Performance

For the listed shapes, the current selector still chooses the same gfx950 3-D path and the measured gfx950 kernel implementation is unchanged; later edits broadened eligibility and fixed the gfx1250 producer route. MI355X runs used 10 warmups and 50 timed iterations; values below are median speedups of live-window 3-D over the existing 2-D route.

| Batch | Logical context / live window | Speedup |
| ---: | ---: | ---: |
| 1 | 2K / 2K | 1.34x |
| 32 | 2K / 2K | 1.38x |
| 1 | 8,203 / 8,203 | 3.93x |
| 32 | 8,203 / 8,203 | 3.98x |
| 1 | 262K / 32K | 14.30x |
| 32 | 262K / 32K | 9.10x |

These are MI355X kernel measurements, not MI300X or gfx1250 performance claims.

## Related work and merge behavior

- #4761 overlaps the two unified-attention source files but targets a separate non-windowed 2-D prefill/decode optimization. Its current head `0a20fb8f9544b7156f27b4fc61a20f41bb4837d4` merge-simulates cleanly.
- #4614 overlaps the wrapper and test file. Its current head `e20141dcc2d87c29c798d0775fb183a4db8bdec6` merge-simulates cleanly, but its eligible gfx950 Gluon dispatch runs before this Triton selector, so landing order and performance ownership should be coordinated rather than treating the effects as cumulative.
- #4676 overlaps only the wrapper and its current head `e59fa7b41e83803c407db274a606023d380462f2` merge-simulates cleanly. Its FlyDSL path requires a full window, so sliding-window calls fall through to this path.
- #3959 changes only `aiter/ops/triton/attention/pa_decode_shuffle.py`; it has no file overlap with this PR.
- #5088 is a broad wrapper/config refactor and does not implement this live-window partition/reduction fix. Its current head `67abf386c25d4641bc0f0286caded832aa8d648a` conflicts mechanically in `aiter/ops/triton/attention/unified_attention.py`; if it lands first, this PR must be rebased into the new backend/config structure.
- #5157's separate 2-D prefill work merge-simulates cleanly. #5158 is also semantically separate 2-D prefill work but currently conflicts in the shared wrapper/kernel files, so its landing order must likewise be coordinated.

## Review feedback addressed

- Removed architecture and head-size conditions from the 2-D/3-D workload decision.
- Folded the large-window coverage into `test_unified_attention.py`.
- Removed the standalone dispatcher test and test file.
- Kept backend-specific routing separate from the workload selector.

## AI assistance

OpenAI Codex assisted with rebase verification, patch cleanup, duplicate-work analysis, test construction, hardware diagnostics, and PR drafting.
