### PR TITLE
[HIP] [Feature] Radix-select top-k for wide ungrouped MoE routers

### DIFF
--- a/csrc/kernels/topk_softmax_kernels_group.cu
+++ b/csrc/kernels/topk_softmax_kernels_group.cu
@@ -280,6 +280,98 @@ __inline__ __device__ void warpReduceMax(float& val_o, int& idx)
     //         }
 }
 
+// ---------------------------------------------------------------------------
+// Helpers for grouped_topk_radix_kernel.
+
+struct radix_topk_traits
+{
+    // Bits per radix pass, buckets per pass, and passes to resolve a full float
+    // key. Four 8-bit digits cover the key; two passes suffice on real routing
+    // data.
+    static constexpr int Bits   = 8;
+    static constexpr int Bins   = 1 << Bits;
+    static constexpr int Passes = 32 / Bits;
+    // Vector registers of scores each lane holds. This fixes the register
+    // footprint at Slots * vec_size values per lane for every instantiation,
+    // and caps the expert count the kernel can serve at
+    // Slots * WARP_SIZE * vec_size (1024 for the vec4 path, which is what wide
+    // routers like Kimi-K3 use).
+    static constexpr int Slots = 4;
+};
+
+// Order-preserving map float -> uint32, so integer compares reproduce float
+// compares. Positive floats keep their order once the sign bit is set;
+// negative floats need a full bit flip.
+__device__ __forceinline__ unsigned int radix_mono_key(float f)
+{
+    unsigned int b = __builtin_bit_cast(unsigned int, f);
+    return (b & 0x80000000u) ? ~b : (b | 0x80000000u);
+}
+
+// Set bits strictly below this lane. mbcnt is the native wave prefix popcount.
+__device__ __forceinline__ int radix_ballot_rank(unsigned long long m)
+{
+    return static_cast<int>(__builtin_amdgcn_mbcnt_hi(
+        static_cast<unsigned int>(m >> 32),
+        __builtin_amdgcn_mbcnt_lo(static_cast<unsigned int>(m), 0u)));
+}
+
+template <int CTRL, int ROW_MASK, int BANK_MASK, typename T>
+__device__ __forceinline__ T radix_dpp_fetch(T x)
+{
+    // old = 0, so lanes disabled by the masks and lanes whose source lane is
+    // out of range contribute nothing to the accumulation.
+    return __builtin_bit_cast(T,
+                              __builtin_amdgcn_update_dpp(0,
+                                                          __builtin_bit_cast(int, x),
+                                                          CTRL,
+                                                          ROW_MASK,
+                                                          BANK_MASK,
+                                                          false));
+}
+
+// Inclusive add scan across the wave, kept in the VALU. Hillis-Steele via
+// row_shr inside each row of 16 lanes, then row_bcast to carry across rows.
+// This is the hot alternative to a __shfl_up chain, which lowers to
+// ds_bpermute and pays LDS latency on every step.
+template <typename T>
+__device__ __forceinline__ T radix_wave_scan_add(T x)
+{
+#if defined(__GFX9__)
+    x += radix_dpp_fetch<0x111, 0xf, 0xf>(x); // row_shr:1
+    x += radix_dpp_fetch<0x112, 0xf, 0xf>(x); // row_shr:2
+    x += radix_dpp_fetch<0x114, 0xf, 0xf>(x); // row_shr:4
+    x += radix_dpp_fetch<0x118, 0xf, 0xf>(x); // row_shr:8
+    x += radix_dpp_fetch<0x142, 0xa, 0xf>(x); // row_bcast:15 -> rows 1,3
+    if constexpr(WARP_SIZE > 32)
+        x += radix_dpp_fetch<0x143, 0xc, 0xf>(x); // row_bcast:31 -> rows 2,3
+    return x;
+#else
+    // GFX10+ dropped the row_bcast DPP modes this scan carries rows with
+    // ("broadcasts are not supported on GFX10+"), the same reason
+    // wave_reduce() in hip_reduce.h guards them. The radix path only dispatches
+    // on wave64 (see radix_topk_applicable below), so non-GFX9 targets just
+    // need something that compiles and stays correct if it ever runs; speed
+    // there is irrelevant.
+    const int lane = static_cast<int>(__lane_id());
+    for(int off = 1; off < WARP_SIZE; off <<= 1)
+    {
+        T up = __shfl_up(x, off, WARP_SIZE);
+        if(lane >= off)
+            x += up;
+    }
+    return x;
+#endif
+}
+
+template <typename T>
+__device__ __forceinline__ T radix_wave_total_add(T x)
+{
+    return __builtin_bit_cast(
+        T,
+        __builtin_amdgcn_readlane(__builtin_bit_cast(int, radix_wave_scan_add(x)), WARP_SIZE - 1));
+}
+
 __device__ void blockReduceMax(float& val, int& idx)
 {
     __shared__ float shared_vals[32];
@@ -604,6 +696,251 @@ grouped_topk_kernel(DTYPE_I* __restrict__ gating_output,         // [num_tokens,
         topk_weights[token_idx * stride_tk + k] = topk_value * sum;
         topk_ids[token_idx * stride_tk + k]     = topk_indice;
     }
+}
+
+// ---------------------------------------------------------------------------
+// Radix-select top-k for wide, ungrouped routers (e.g. Kimi-K3: 896 experts,
+// one expert group, top-16).
+//
+// grouped_topk_kernel above selects by running `topk` rounds of scan-all-scores
+// / wave arg-max / write -INF back to LDS. The rounds are strictly serial and
+// each pays LDS round trips plus a reduction ending in two readlanes, so its
+// cost is topk * ceil(num_experts / (WARP_SIZE * vec_size)) units of exposed
+// latency with nothing to hide them behind: the block is a single wave.
+//
+// That product is 8 for the shape the kernel was tuned for (256 experts, 8
+// groups, top-8, one vector per lane) but 64 for Kimi-K3, and the measured
+// kernel body on MI355X tracks it almost exactly: 0.93 us versus 8.57 us at
+// M=1. The kernel is latency-bound rather than bandwidth-bound -- its time is
+// flat from M=1 to M=1024, i.e. 1024x the tokens for the same duration.
+//
+// This kernel keeps every score in registers and never spills them to LDS. It
+// finds the exact topk-th largest score by radix select over the
+// order-preserving uint32 image of the score: at most four passes over 8-bit
+// digits, exiting as soon as the boundary bucket is exactly consumed, which on
+// real routing data happens after two. Cost is therefore independent of topk;
+// measured at 896 experts, going from top-4 to top-32 moves this kernel from
+// 4.7 to 5.0 us while grouped_topk_kernel goes from 4.4 to 18.7 us.
+//
+// Requirements, all enforced by the caller:
+//   * NUM_GRP == 1 -- grouped routers keep using grouped_topk_kernel, whose
+//     group reduction wants the scores in LDS
+//   * !isSoftmax -- the softmax path normalises over the whole row first
+//   * num_experts <= radix_topk_traits::Slots * WARP_SIZE * vec_size
+//
+// Selected experts are emitted in ascending expert order instead of descending
+// score order. The op does not fix that order: op_tests compares after sorting
+// by id, "this is useful when we don't care about the absolute position of the
+// val/idx".
+template <typename DTYPE_I, typename f32vec, bool need_renorm, bool isBiased>
+__global__ void
+grouped_topk_radix_kernel(DTYPE_I* __restrict__ gating_output,         // [num_tokens, hidden_size]
+                          const DTYPE_I* __restrict__ correction_bias, // [num_expert]
+                          float* __restrict__ topk_weights,            // [num_tokens, topk]
+                          int* __restrict__ topk_ids,                  // [num_tokens, topk]
+                          const size_t stride_gating,
+                          const size_t stride_tk,
+                          const int num_experts,
+                          const int topk,
+                          const int num_tokens,
+                          const float routed_scaling_factor)
+{
+    using cktype_i                = typename aiter::hip2opus<DTYPE_I>::type;
+    static constexpr int vec_size = opus::vector_traits<f32vec>::size();
+    using vec_i                   = opus::vector_t<cktype_i, vec_size>;
+
+    static constexpr int BITS          = radix_topk_traits::Bits;
+    static constexpr int BINS          = radix_topk_traits::Bins;
+    static constexpr int PASSES        = radix_topk_traits::Passes;
+    static constexpr int SLOTS         = radix_topk_traits::Slots;
+    static constexpr int BINS_PER_LANE = BINS / WARP_SIZE;
+
+    extern __shared__ char shared_mem[];
+    unsigned int* bins = reinterpret_cast<unsigned int*>(shared_mem);
+
+    const int token_idx = blockIdx.x;
+    const int lane      = threadIdx.x;
+    const int num_vec   = num_experts / vec_size;
+
+    // Issued ahead of the loads so the stores retire underneath HBM latency.
+#pragma unroll
+    for(int p = 0; p < PASSES; ++p)
+#pragma unroll
+        for(int i = 0; i < BINS_PER_LANE; ++i)
+            bins[p * BINS + lane * BINS_PER_LANE + i] = 0u;
+
+    unsigned int key[SLOTS][vec_size];
+    float weight[SLOTS][vec_size];
+    bool live[SLOTS];
+
+    // ---- one pass over the logits, straight into registers ----
+    {
+        auto const* input_ptr = gating_output + token_idx * stride_gating;
+#pragma unroll
+        for(int s = 0; s < SLOTS; ++s)
+        {
+            const int v = s * WARP_SIZE + lane;
+            live[s]     = v < num_vec;
+            if(!live[s])
+                continue;
+            vec_i raw = reinterpret_cast<vec_i const*>(input_ptr)[v];
+            vec_i bias;
+            if constexpr(isBiased)
+                bias = reinterpret_cast<vec_i const*>(correction_bias)[v];
+#pragma unroll
+            for(int j = 0; j < vec_size; ++j)
+            {
+                // Same instruction sequence as grouped_topk_kernel's phase 1,
+                // so the scores are bit-identical.
+                const float sig =
+                    __builtin_amdgcn_rcpf(1.0f + exp2f(-C_LOG2E * static_cast<float>(raw[j])));
+                // The routing weight is the pre-bias sigmoid; the bias only
+                // steers selection.
+                weight[s][j] = sig;
+                key[s][j]    = radix_mono_key(
+                    isBiased ? sig + static_cast<float>(bias[j]) : sig);
+            }
+        }
+    }
+    __syncthreads();
+
+    // ---- radix select for the exact topk-th largest key ----
+    // Invariant: `thresh` holds the resolved high bits of the topk-th largest
+    // key, `hi_mask` marks which bits are resolved, and `need` counts how many
+    // values matching `thresh` on those bits still have to be taken. `cnt` is
+    // the population of the bucket that `thresh` last landed in.
+    unsigned int thresh  = 0u;
+    unsigned int hi_mask = 0u;
+    int need             = topk;
+    int cnt              = 0;
+
+#pragma unroll
+    for(int p = 0; p < PASSES; ++p)
+    {
+        const int shift       = 32 - BITS * (p + 1);
+        unsigned int* my_bins = bins + p * BINS;
+
+#pragma unroll
+        for(int s = 0; s < SLOTS; ++s)
+        {
+            if(!live[s])
+                continue;
+#pragma unroll
+            for(int j = 0; j < vec_size; ++j)
+                if((key[s][j] & hi_mask) == thresh)
+                    atomicAdd(&my_bins[(key[s][j] >> shift) & (BINS - 1)], 1u);
+        }
+        __syncthreads();
+
+        // Lane l owns the buckets at reversed positions [l*B, l*B+B), that is
+        // buckets counted down from the top, so one prefix sum over lanes gives
+        // the population of every bucket above lane l's block.
+        int mine[BINS_PER_LANE];
+        int block_sum = 0;
+#pragma unroll
+        for(int i = 0; i < BINS_PER_LANE; ++i)
+        {
+            mine[i] = static_cast<int>(my_bins[(BINS - 1) - (lane * BINS_PER_LANE + i)]);
+            block_sum += mine[i];
+        }
+        int acc = radix_wave_scan_add(block_sum) - block_sum;
+
+        // Bucket index in the top byte, remaining need and bucket population
+        // below it, so the answer costs one readlane instead of three
+        // shuffles. The lane select comes from a ballot and is wave-uniform.
+        bool found       = false;
+        unsigned int hit = 0u;
+#pragma unroll
+        for(int i = 0; i < BINS_PER_LANE; ++i)
+        {
+            const int before = acc;
+            acc += mine[i];
+            if(!found && before < need && need <= acc)
+            {
+                found = true;
+                hit   = (static_cast<unsigned int>((BINS - 1) - (lane * BINS_PER_LANE + i))
+                       << 24) |
+                      (static_cast<unsigned int>(need - before) << 12) |
+                      static_cast<unsigned int>(mine[i]);
+            }
+        }
+
+        const unsigned int packed = static_cast<unsigned int>(
+            __builtin_amdgcn_readlane(static_cast<int>(hit), __ffsll(__ballot(found)) - 1));
+        need = static_cast<int>((packed >> 12) & 0xFFFu);
+        cnt  = static_cast<int>(packed & 0xFFFu);
+
+        hi_mask |= (0xFFFFFFFFu << shift);
+        thresh |= ((packed >> 24) & 0xFFu) << shift;
+
+        // Boundary bucket exactly consumed: no finer digit can change the set.
+        if(need == cnt)
+            break;
+    }
+
+    // ---- emit ----
+    // When the boundary bucket was exactly consumed -- the early-exit condition,
+    // and what real routing data always hits -- `key >= thresh` already names
+    // exactly topk experts, so one ballot per element is enough. Otherwise the
+    // strictly-greater experts are emitted first and the ties fill what is left,
+    // clamped by rank so exactly topk slots are written.
+    const bool exact = (need == cnt);
+    int slot[SLOTS][vec_size];
+    bool sel[SLOTS][vec_size];
+    int base   = 0;
+    float psum = 0.0f;
+
+#pragma unroll
+    for(int s = 0; s < SLOTS; ++s)
+#pragma unroll
+        for(int j = 0; j < vec_size; ++j)
+        {
+            const unsigned int k       = key[s][j] & hi_mask;
+            const bool hit             = live[s] && (exact ? (k >= thresh) : (k > thresh));
+            const unsigned long long m = __ballot(hit);
+            sel[s][j]                  = hit;
+            slot[s][j]                 = base + radix_ballot_rank(m);
+            base += __popcll(m);
+            if(hit)
+                psum += weight[s][j];
+        }
+
+    if(!exact)
+    {
+#pragma unroll
+        for(int s = 0; s < SLOTS; ++s)
+#pragma unroll
+            for(int j = 0; j < vec_size; ++j)
+            {
+                const bool tie             = live[s] && ((key[s][j] & hi_mask) == thresh);
+                const unsigned long long m = __ballot(tie);
+                const int r                = radix_ballot_rank(m);
+                if(tie && r < need)
+                {
+                    sel[s][j]  = true;
+                    slot[s][j] = base + r;
+                    psum += weight[s][j];
+                }
+                const int taken = min(static_cast<int>(__popcll(m)), need);
+                base += taken;
+                need -= taken;
+            }
+    }
+
+    const float scale =
+        need_renorm ? routed_scaling_factor / radix_wave_total_add(psum) : routed_scaling_factor;
+
+    float* w_out = topk_weights + token_idx * stride_tk;
+    int* i_out   = topk_ids + token_idx * stride_tk;
+#pragma unroll
+    for(int s = 0; s < SLOTS; ++s)
+#pragma unroll
+        for(int j = 0; j < vec_size; ++j)
+            if(sel[s][j])
+            {
+                i_out[slot[s][j]] = (s * WARP_SIZE + lane) * vec_size + j;
+                w_out[slot[s][j]] = weight[s][j] * scale;
+            }
 }
 
 template <typename DTYPE_I,
@@ -1124,7 +1461,11 @@ grouped_topk_opt_sort_kernel(DTYPE_I* __restrict__ gating_output, // [num_tokens
 #define LAUNCHER4(VEC_F, NUM_GRP, need_renorm)                                                     \
     if constexpr(isBiased)                                                                         \
     {                                                                                              \
-        if(use_opt_sort)                                                                           \
+        if(use_radix)                                                                              \
+        {                                                                                          \
+            LAUNCHER_biased_grouped_topk_radix_kernel(VEC_F, NUM_GRP, need_renorm)                 \
+        }                                                                                          \
+        else if(use_opt_sort)                                                                      \
         {                                                                                          \
             LAUNCHER_biased_grouped_topk_opt_sort_kernel(VEC_F, NUM_GRP, need_renorm, true, false) \
         }                                                                                          \
@@ -1139,10 +1480,64 @@ grouped_topk_opt_sort_kernel(DTYPE_I* __restrict__ gating_output, // [num_tokens
         {                                                                                          \
             LAUNCHER_grouped_topk_kernel(VEC_F, NUM_GRP, need_renorm, false, true)                 \
         }                                                                                          \
+        else if(use_radix)                                                                         \
+        {                                                                                          \
+            LAUNCHER_grouped_topk_radix_kernel(VEC_F, NUM_GRP, need_renorm)                        \
+        }                                                                                          \
         else                                                                                       \
         {                                                                                          \
             LAUNCHER_grouped_topk_kernel(VEC_F, NUM_GRP, need_renorm, false, false)                \
         }                                                                                          \
+    }
+
+// use_radix already requires num_expert_group == 1 at runtime, so the guard here
+// only keeps the other NUM_GRP instantiations from being emitted.
+#define LAUNCHER_biased_grouped_topk_radix_kernel(VEC_F, NUM_GRP, need_renorm)                    \
+    if constexpr(NUM_GRP == 1)                                                                    \
+    {                                                                                             \
+        VLLM_DISPATCH_FLOATING_TYPES_rmTorch(                                                     \
+            gating_output.dtype(), "biased_grouped_topk_radix_kernel", [&] {                       \
+                hipLaunchKernelGGL(                                                               \
+                    (aiter::grouped_topk_radix_kernel<scalar_t, VEC_F, need_renorm, true>),        \
+                    dim3(grid),                                                                   \
+                    dim3(block),                                                                  \
+                    shared_mem_size,                                                              \
+                    stream,                                                                       \
+                    reinterpret_cast<scalar_t*>(gating_output.data_ptr()),                         \
+                    reinterpret_cast<scalar_t*>(correction_bias.data_ptr()),                      \
+                    reinterpret_cast<float*>(topk_weights.data_ptr()),                             \
+                    reinterpret_cast<int*>(topk_ids.data_ptr()),                                   \
+                    stride_gating,                                                                \
+                    stride_tk,                                                                    \
+                    num_experts,                                                                  \
+                    topk,                                                                         \
+                    num_tokens,                                                                   \
+                    routed_scaling_factor);                                                       \
+            });                                                                                   \
+    }
+
+#define LAUNCHER_grouped_topk_radix_kernel(VEC_F, NUM_GRP, need_renorm)                           \
+    if constexpr(NUM_GRP == 1)                                                                    \
+    {                                                                                             \
+        VLLM_DISPATCH_FLOATING_TYPES_rmTorch(                                                     \
+            gating_output.dtype(), "grouped_topk_radix_kernel", [&] {                              \
+                hipLaunchKernelGGL(                                                               \
+                    (aiter::grouped_topk_radix_kernel<scalar_t, VEC_F, need_renorm, false>),       \
+                    dim3(grid),                                                                   \
+                    dim3(block),                                                                  \
+                    shared_mem_size,                                                              \
+                    stream,                                                                       \
+                    reinterpret_cast<scalar_t*>(gating_output.data_ptr()),                         \
+                    nullptr,                                                                      \
+                    reinterpret_cast<float*>(topk_weights.data_ptr()),                             \
+                    reinterpret_cast<int*>(topk_ids.data_ptr()),                                   \
+                    stride_gating,                                                                \
+                    stride_tk,                                                                    \
+                    num_experts,                                                                  \
+                    topk,                                                                         \
+                    num_tokens,                                                                   \
+                    routed_scaling_factor);                                                       \
+            });                                                                                   \
     }
 
 #define LAUNCHER_biased_grouped_topk_kernel(VEC_F, NUM_GRP, need_renorm, isBiased, isSoftmax)      \
@@ -1216,6 +1611,49 @@ grouped_topk_opt_sort_kernel(DTYPE_I* __restrict__ gating_output, // [num_tokens
                                routed_scaling_factor);                            \
         });
 
+namespace {
+// Vector width LAUNCH_KERNEL will select for this expert count.
+inline int radix_vec_width(int num_experts)
+{
+    return (num_experts % 4 == 0) ? 4 : ((num_experts % 4 == 2) ? 2 : 1);
+}
+
+// Whether grouped_topk_radix_kernel should take over from grouped_topk_kernel.
+//
+// grouped_topk_kernel pays topk * ceil(num_experts / (WARP_SIZE * vec_size))
+// serial selection rounds; grouped_topk_radix_kernel pays a roughly fixed two
+// radix passes. So the new kernel wins by more the larger that product is, and
+// the gate only claims the range where it was measured to win on MI355X
+// (gfx950, ungrouped, tokens 1..4096):
+//
+//   topk >= 16  wins everywhere, 1.35x-4.3x  (Kimi-K3 896/top16: 2.06x at one
+//               token, 1.35x at 4096)
+//   topk == 8   wins 1.04x-1.27x up to 512 experts while tokens are few, but
+//               loses ~7% once the GPU saturates (Kimi-K2.5 384/top8 is 1.27x
+//               at one token and 0.93x at 4096), so it is claimed only below
+//               that point
+//   topk <= 4   a wash or a slight loss, never claimed
+inline bool radix_topk_applicable(
+    int num_experts, int topk, int num_expert_group, bool is_softmax, int num_tokens)
+{
+    if(num_expert_group != 1 || is_softmax)
+        return false;
+    if(get_warp_size_func() != 64)
+        return false;
+    if(num_experts > aiter::radix_topk_traits::Slots * 64 * radix_vec_width(num_experts))
+        return false;
+    if(topk >= 16)
+        return true;
+    return topk >= 8 && num_experts <= 512 && num_tokens <= 1024;
+}
+
+constexpr size_t radix_shared_mem_size()
+{
+    return static_cast<size_t>(aiter::radix_topk_traits::Passes) * aiter::radix_topk_traits::Bins *
+           sizeof(unsigned int);
+}
+} // namespace
+
 void biased_grouped_topk(const aiter_tensor_t& gating_output,   // [num_tokens, num_experts]
                          const aiter_tensor_t& correction_bias, // [num_expert]
                          const aiter_tensor_t& topk_weights,    // [num_tokens, topk]
@@ -1243,6 +1681,8 @@ void biased_grouped_topk(const aiter_tensor_t& gating_output,   // [num_tokens, 
     // bool use_opt_sort = false;
     bool use_opt_sort = (topk == 8) && (num_expert_group == 8) && (num_experts == 256) &&
                         (topk_grp == 4) && (isBiased == true) && (get_warp_size_func() == 64);
+    const bool use_radix =
+        radix_topk_applicable(num_experts, topk, num_expert_group, isSoftmax, num_tokens);
 
     dim3 grid(num_tokens);
     dim3 block(get_warp_size_func());
@@ -1258,6 +1698,10 @@ void biased_grouped_topk(const aiter_tensor_t& gating_output,   // [num_tokens, 
                               + (topk > topk_grp ? topk : topk_grp) * sizeof(float) /* sort_v*/
                               //    + 64 / num_expert_group * sizeof(float) /* for sorting */
                              );
+    // The radix kernel keeps scores in registers; its only LDS use is one
+    // bucket histogram per pass.
+    if(use_radix)
+        shared_mem_size = radix_shared_mem_size();
 
     HipDeviceGuard device_guard(gating_output.device_id);
     const hipStream_t stream = aiter::getCurrentHIPStream();
@@ -1291,12 +1735,16 @@ void grouped_topk(const aiter_tensor_t& gating_output, // [num_tokens, num_exper
 
     // TODO: expand usage in the future
     bool use_opt_sort = false;
+    const bool use_radix =
+        radix_topk_applicable(num_experts, topk, num_expert_group, isSoftmax, num_tokens);
 
     dim3 grid(num_tokens);
     dim3 block(get_warp_size_func());
     size_t shared_mem_size = (num_experts * sizeof(float) + (num_expert_group + 1) * sizeof(float) +
                               topk * sizeof(int) + topk * sizeof(float) + 255) &
                              ~255;
+    if(use_radix)
+        shared_mem_size = radix_shared_mem_size();
 
     HipDeviceGuard device_guard(gating_output.device_id);
     const hipStream_t stream = aiter::getCurrentHIPStream();

--- a/op_tests/test_moeTopkSoftmax.py
+++ b/op_tests/test_moeTopkSoftmax.py
@@ -554,6 +554,196 @@ def test_topk_softmax_shared_experts(
     return ret
 
 
+def _assert_topk_contract(
+    logits: torch.Tensor,
+    ids: torch.Tensor,
+    weights: torch.Tensor,
+    *,
+    topk: int,
+    renorm: bool,
+    scale: float,
+    bias: torch.Tensor | None,
+    scoring: str = "sigmoid",
+) -> None:
+    """Op contract, order-insensitive. Passes on stock and on radix.
+
+    The selected set must be a valid top-k of the biased score (ties allowed
+    at the boundary). Each weight belongs to the id sitting beside it.
+    """
+    assert bool((ids >= 0).all()) and bool(
+        (ids < logits.shape[-1]).all()
+    ), "unfilled or out-of-range topk id"
+    ids64 = ids.to(torch.int64)
+    for row in range(min(ids.shape[0], 64)):
+        uniq = torch.unique(ids64[row])
+        assert (
+            uniq.numel() == topk
+        ), f"duplicate ids on row {row}: {ids64[row].tolist()}"
+
+    logits_f = logits.float()
+    if scoring == "softmax":
+        pre = torch.softmax(logits_f, dim=-1)
+    else:
+        pre = torch.sigmoid(logits_f)
+    choice = pre if bias is None else pre + bias.float().unsqueeze(0)
+    kth = torch.topk(choice, topk, dim=-1, sorted=True).values[:, -1]
+    selected = choice.gather(-1, ids64)
+    slack = 2e-3 if logits.dtype != torch.float32 else 2e-6
+    assert bool(
+        (selected + slack >= kth.unsqueeze(-1)).all()
+    ), "selected expert is not a valid top-k by biased score"
+
+    raw = pre.gather(-1, ids64)
+    if renorm:
+        raw = raw / raw.sum(dim=-1, keepdim=True).clamp_min(1e-12)
+    expected = raw * scale
+    werr = (weights.float() - expected).abs().max().item()
+    wtol = 3e-3 if logits.dtype != torch.float32 else 2e-5
+    assert werr < wtol, f"weight/id pairing drifted: max|dw|={werr}"
+
+
+def test_grouped_topk_radix_envelope() -> tuple[int, int]:
+    """Walk both sides of every vector-width expert ceiling.
+
+    vec4: 896 / 1024 / 1028; vec2: 510 / 514 / 898; vec1: 255 / 257 / 897.
+    Crossed with topk 8/16/32, fp32 and bf16, 1/3/64/1024 tokens, renorm on
+    and off, three scaling factors, and both entry points. Describes the op,
+    not this kernel — the same checks pass on stock aiter.
+    """
+    experts = (896, 1024, 1028, 510, 514, 898, 255, 257, 897)
+    topks = (8, 16, 32)
+    dtypes_ = (torch.float32, torch.bfloat16)
+    tokens = (1, 3, 64, 1024)
+    scales = (1.0, 2.5, 2.827)
+    n_ok = n_fail = 0
+    for ne in experts:
+        for topk in topks:
+            if topk > ne:
+                continue
+            for dtype in dtypes_:
+                for m in tokens:
+                    for renorm in (True, False):
+                        for scale in scales:
+                            for biased in (True, False):
+                                torch.manual_seed(
+                                    (ne * 1009 + topk * 17 + m + int(scale * 10))
+                                    % (2**31 - 1)
+                                )
+                                logits = torch.randn((m, ne), dtype=dtype)
+                                bias = (
+                                    torch.randn((ne,), dtype=dtype) if biased else None
+                                )
+                                w = torch.empty((m, topk), dtype=torch.float32)
+                                ids = torch.full((m, topk), -1, dtype=torch.int32)
+                                try:
+                                    if biased:
+                                        aiter.biased_grouped_topk(
+                                            logits, bias, w, ids, 1, 1, renorm, scale
+                                        )
+                                    else:
+                                        aiter.grouped_topk(
+                                            logits,
+                                            w,
+                                            ids,
+                                            1,
+                                            1,
+                                            renorm,
+                                            False,
+                                            scale,
+                                        )
+                                    torch.cuda.synchronize()
+                                    _assert_topk_contract(
+                                        logits,
+                                        ids,
+                                        w,
+                                        topk=topk,
+                                        renorm=renorm,
+                                        scale=scale,
+                                        bias=bias,
+                                    )
+                                    n_ok += 1
+                                except Exception as exc:  # noqa: BLE001
+                                    n_fail += 1
+                                    aiter.logger.info(
+                                        "radix envelope FAIL ne=%s topk=%s "
+                                        "dtype=%s M=%s renorm=%s scale=%s "
+                                        "biased=%s: %s",
+                                        ne,
+                                        topk,
+                                        dtype,
+                                        m,
+                                        renorm,
+                                        scale,
+                                        biased,
+                                        exc,
+                                    )
+    aiter.logger.info(
+        "test_grouped_topk_radix_envelope: %s passed, %s failed", n_ok, n_fail
+    )
+    return n_ok, n_fail
+
+
+def test_grouped_topk_ties() -> tuple[int, int]:
+    """Drive the non-exact radix path with 2 / 3 / 5 distinct logit values."""
+    n_ok = n_fail = 0
+    for n_distinct in (2, 3, 5):
+        for ne, topk in ((896, 16), (510, 8), (255, 16)):
+            for m in (1, 64):
+                for dtype in (torch.float32, torch.bfloat16):
+                    for biased in (True, False):
+                        g = torch.Generator(device="cuda").manual_seed(
+                            1000 + n_distinct * 17 + ne
+                        )
+                        levels = torch.linspace(-3.0, 3.0, n_distinct, device="cuda")
+                        idx = torch.randint(
+                            0, n_distinct, (m, ne), device="cuda", generator=g
+                        )
+                        logits = levels[idx].to(dtype)
+                        bias = (
+                            torch.zeros((ne,), dtype=dtype, device="cuda")
+                            if biased
+                            else None
+                        )
+                        w = torch.empty((m, topk), dtype=torch.float32, device="cuda")
+                        ids = torch.full(
+                            (m, topk), -1, dtype=torch.int32, device="cuda"
+                        )
+                        try:
+                            if biased:
+                                aiter.biased_grouped_topk(
+                                    logits, bias, w, ids, 1, 1, True, 1.0
+                                )
+                            else:
+                                aiter.grouped_topk(
+                                    logits, w, ids, 1, 1, True, False, 1.0
+                                )
+                            torch.cuda.synchronize()
+                            _assert_topk_contract(
+                                logits,
+                                ids,
+                                w,
+                                topk=topk,
+                                renorm=True,
+                                scale=1.0,
+                                bias=bias,
+                            )
+                            n_ok += 1
+                        except Exception as exc:  # noqa: BLE001
+                            n_fail += 1
+                            aiter.logger.info(
+                                "radix ties FAIL n_distinct=%s ne=%s topk=%s "
+                                "M=%s biased=%s: %s",
+                                n_distinct,
+                                ne,
+                                topk,
+                                m,
+                                biased,
+                                exc,
+                            )
+    aiter.logger.info("test_grouped_topk_ties: %s passed, %s failed", n_ok, n_fail)
+    return n_ok, n_fail
+
+
 parser = argparse.ArgumentParser(
     formatter_class=argparse.RawTextHelpFormatter,
     description="config input of test",
@@ -631,8 +821,29 @@ parser.add_argument(
     Raise this to stabilize GPU clocks for latency-bound (small-token) shapes.
     e.g.: -w 50""",
 )
+parser.add_argument(
+    "--radix-tests-only",
+    action="store_true",
+    help="Run the radix contract tests and exit before the benchmark tables.",
+)
 
 args = parser.parse_args()
+
+# Assertion tests first so a contract failure is loud, not buried in a table.
+_envelope_ok, _envelope_fail = test_grouped_topk_radix_envelope()
+_ties_ok, _ties_fail = test_grouped_topk_ties()
+if _envelope_fail or _ties_fail:
+    raise SystemExit(
+        f"grouped_topk radix contract tests failed: "
+        f"envelope {_envelope_fail}, ties {_ties_fail}"
+    )
+if args.radix_tests_only:
+    aiter.logger.info(
+        "radix contract tests passed (%s envelope + %s ties). exiting.",
+        _envelope_ok,
+        _ties_ok,
+    )
+    raise SystemExit(0)
 
 df = []
 for dtype in args.dtype:


### PR DESCRIPTION
grouped_topk_kernel runs `topk` serial rounds of scan / wave arg-max /
write -INF back to LDS, so latency scales as topk * ceil(num_experts /
(WARP_SIZE * vec_size)) -- 8 rounds for the shape it was tuned for (256
experts, 8 groups, top-8) but 64 for a wide ungrouped router such as
Kimi-K3's 896 experts at top-16.

Add grouped_topk_radix_kernel for that regime: scores stay in registers and
the exact topk-th largest is found by radix select over the order-preserving
uint32 image of the score, with DPP for the wave prefix sum and ballot+mbcnt
for slot assignment. Dispatch is gated to the measured win (single expert
group, sigmoid, topk >= 16 plus a narrow top-8 window), leaving 472
unclaimed shapes verified bit-identical to stock. row_bcast DPP was removed
in GFX10, so the wave scan selects it under #if defined(__GFX9__) with a
__shfl_up fallback.

gfx950, 896 experts at top-16: 1.33x - 2.07x per call across 1..163840
tokens; +1.54% output tok/s in a vLLM TP8 serving A/B over twelve alternating
rounds; gsm8k 1319 questions 0.9644 against 0.9636 stock.

## Motivation

`grouped_topk_kernel` selects the top-k experts by running `topk` serial rounds of
scan / wave arg-max / write `-INF` back to LDS. Latency therefore scales as
`topk * ceil(num_experts / (WARP_SIZE * vec_size))`: 8 rounds for the shape the
kernel was tuned for (256 experts, 8 groups, top-8), but 64 rounds for a wide
*ungrouped* router such as Kimi-K3's 896 experts at top-16.

The router sits on the decode critical path, so those extra rounds show up
directly in inter-token latency. This PR adds a kernel for that regime and leaves
everything else on the existing path.

## Technical Details

New `grouped_topk_radix_kernel`. Instead of repeatedly masking the winner in LDS,
scores stay in registers and the exact `topk`-th largest value is found by radix
select over the order-preserving `uint32` bit image of the score. Per pass, a
bucket histogram narrows the candidate range; once the threshold is known, one
ballot plus `mbcnt` assigns output slots so weights stay paired with their ids.
The wave prefix sum uses DPP. LDS use drops to a single bucket histogram per pass,
versus `2 * num_experts` floats for the scan kernel.

`row_bcast` DPP was removed in GFX10, so the wave scan selects it under
`#if defined(__GFX9__)` and falls back to `__shfl_up` elsewhere. The fallback only
needs to compile and stay correct, since the dispatch gate requires wave64.

Dispatch is gated to the measured win, so unclaimed shapes keep bit-identical
behaviour:

```cpp
if(num_expert_group != 1 || is_softmax)          return false;   // grouped reduction wants LDS
if(get_warp_size_func() != 64)                   return false;
if(num_experts > RADIX_SLOTS * 64 * vec_width)   return false;   // register capacity
if(topk >= 16)                                   return true;
return topk >= 8 && num_experts <= 512 && num_tokens <= 1024;
```

The token-count bound on the top-8 branch is deliberate: that shape wins at low
token counts but loses roughly 7% once the GPU saturates, so the gate stops
claiming it there.

| file | change |
| --- | --- |
| `csrc/kernels/topk_softmax_kernels_group.cu` | +440 |
| `op_tests/test_moeTopkSoftmax.py` | +211 |

## Test Plan

All on gfx950 (MI355X).

1. New contract tests in `op_tests/test_moeTopkSoftmax.py`, runnable standalone
   via `python op_tests/test_moeTopkSoftmax.py --radix-tests-only`:
   - envelope: 9 expert counts (896 / 1024 / 1028 / 510 / 514 / 898 / 255 / 257 /
     897, covering the vec4, vec2 and vec1 widths) x topk 8 / 16 / 32 x fp32 /
     bf16 x 1 / 3 / 64 / 1024 tokens, against a torch reference;
   - ties: 2, 3 and 5 distinct logit values, which forces the non-exact radix
     path, for (896, 16), (510, 8) and (255, 16).
2. aiter's existing benchmark suite in the same file, base versus new, across the
   Kimi-K3, Kimi-K2.5 and DeepSeek-R1 router shapes.
3. Bit-identity check for shapes the gate does not claim: same ids, same weights,
   no tolerance.
4. vLLM TP8 serving A/B on Kimi-K3-MXFP4, alternating rounds to cancel drift.
5. gsm8k, 1319 questions.

## Test Result

**Correctness.** 2592 envelope cases and 72 ties cases pass, 0 failures. Verified
over fp32 / bf16 / fp16, token counts 1 to 163840, strided logits, renorm on and
off, routed scaling factors, heavy ties, both the biased and non-biased entry
points, and all three vector widths.

**472 shapes outside the gate are bit-identical to the stock build** — every
expert-group count, both scoring functions, both renorm settings.

**Per call, Kimi-K3 (896 experts, 1 group, top-16):** 1.33x - 2.07x across
1..163840 tokens, with no measured regression at any point.

| tokens | stock | radix | speedup |
| --- | --- | --- | --- |
| 1 | 13.19 us | 7.71 us | 1.71x |
| 1024 | 13.21 us | 9.93 us | 1.33x |
| 16384 | 65.98 us | 39.57 us | 1.67x |
| 163840 | 552.38 us | 334.55 us | 1.65x |

**Neighbouring shapes.** Kimi-K2.5 (384 experts, 1 group, top-8): 1.28x at 1
token, 1.13x at 1024, unchanged from 2048 up where the gate stops claiming it.
DeepSeek-R1 (256 experts, 8 groups): 1.00x - 1.04x, i.e. untouched.

**End to end.** vLLM TP8 serving A/B on Kimi-K3-MXFP4, 12 alternating rounds,
n=6 per arm:

| metric | stock | radix | delta |
| --- | --- | --- | --- |
| output tok/s | 578.50 [576.81, 580.06] | 587.43 [584.52, 589.72] | **+1.54%** |
| TPOT | 27.07 ms | 26.66 ms | -1.55% |
| ITL p50 | 26.43 ms | 26.00 ms | -1.62% |
| e2e mean | 28313 ms | 27882 ms | -1.52% |

The two arms do not overlap on any of the four metrics across all 12 rounds;
stock's best round and radix's worst round are still 4.5 tok/s apart. TTFT is
unchanged (580 - 633 ms both arms), which is what a decode-path router change
should look like.

**Accuracy.** gsm8k, 1319 questions: 0.9644 with this change against 0.9636 on
stock.

**Pre-existing flake, unrelated to this change.** `op_tests` reports an
intermittent tie-ordering mismatch in the 256-expert 8-group family at a
different token count on each run, because that test does not seed its input.
The radix gate cannot reach that family (it requires `num_expert_group == 1`),
and the family is among the 472 shapes verified bit-identical above. Over five
runs of the same command: stock 11 failures, this branch 1.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
