### PR TITLE
[Triton/Gluon] Support caller-defined padding cache slot in fused MLA writer

### DIFF
--- a/aiter/ops/triton/_gluon_kernels/gfx1250/fusions/fused_kv_cache.py
+++ b/aiter/ops/triton/_gluon_kernels/gfx1250/fusions/fused_kv_cache.py
@@ -419,6 +419,7 @@ def _fused_qk_rope_cat_and_cache_mla_kernel(
     OUTPUT_Q_NOPE_ZEROS_AND_Q_PE: gl.constexpr = False,
     HAVE_K_SCALE: gl.constexpr = False,
     UPCAST_OPERAND: gl.constexpr = False,
+    PAD_SLOT_ID: gl.constexpr = -1,
 ):
     # 1-warp (wave32) blocked layouts matching the Triton-generated ttgir.
     L_NOPE: gl.constexpr = gl.BlockedLayout(
@@ -582,7 +583,7 @@ def _fused_qk_rope_cat_and_cache_mla_kernel(
             gl.amd.gfx1250.tdm.async_store(q_out_nope_desc, [0], qn_smem_out)
             gl.amd.gfx1250.tdm.async_store(q_out_pe_desc, [0], qpe_smem_out)
 
-        if is_kv and pid_slot >= 0:
+        if is_kv and pid_slot >= 0 and pid_slot != PAD_SLOT_ID:
             if BLOCK_SIZE > 1:
                 pid_t_slot = pid_slot // BLOCK_SIZE
                 pid_blk = pid_slot % BLOCK_SIZE
@@ -683,7 +684,7 @@ def _fused_qk_rope_cat_and_cache_mla_kernel(
             _issue_tdm_load_1d(k_pe_desc, 0, kpe_smem)
 
             pid_slot = gl.load(slot_mapping_ptr + pid_b).to(gl.int64)
-            if pid_slot >= 0:
+            if pid_slot >= 0 and pid_slot != PAD_SLOT_ID:
                 if BLOCK_SIZE > 1:
                     pid_t_slot = pid_slot // BLOCK_SIZE
                     pid_blk = pid_slot % BLOCK_SIZE

--- a/aiter/ops/triton/_triton_kernels/fusions/fused_kv_cache.py
+++ b/aiter/ops/triton/_triton_kernels/fusions/fused_kv_cache.py
@@ -307,6 +307,7 @@ def _fused_qk_rope_cat_and_cache_mla_kernel(
     OUTPUT_Q_NOPE_ZEROS_AND_Q_PE: tl.constexpr = False,
     HAVE_K_SCALE: tl.constexpr = False,
     UPCAST_OPERAND: tl.constexpr = False,
+    PAD_SLOT_ID: tl.constexpr = -1,
 ):
     pid = tl.program_id(0)
 
@@ -399,7 +400,7 @@ def _fused_qk_rope_cat_and_cache_mla_kernel(
         is_kv = pid_hk < KH
         if is_kv:
             pid_slot = tl.load(slot_mapping_ptr + pid_b).to(tl.int64)
-            if pid_slot >= 0:
+            if pid_slot >= 0 and pid_slot != PAD_SLOT_ID:
                 if BLOCK_SIZE > 1:
                     pid_t_slot = pid_slot // BLOCK_SIZE
                     pid_blk = pid_slot % BLOCK_SIZE
@@ -475,7 +476,7 @@ def _fused_qk_rope_cat_and_cache_mla_kernel(
             pid_b = pid // KH
             pid_hk = pid % KH
             pid_slot = tl.load(slot_mapping_ptr + pid_b).to(tl.int64)
-            if pid_slot >= 0:
+            if pid_slot >= 0 and pid_slot != PAD_SLOT_ID:
                 if BLOCK_SIZE > 1:
                     pid_t_slot = pid_slot // BLOCK_SIZE
                     pid_blk = pid_slot % BLOCK_SIZE

--- a/aiter/ops/triton/fusions/fused_kv_cache.py
+++ b/aiter/ops/triton/fusions/fused_kv_cache.py
@@ -59,6 +59,7 @@ def fused_qk_rope_cat_and_cache_mla_fake_tensor(
     q_out_dtype: torch.dtype = None,
     shuffled_kv_cache: bool = False,
     upcast_operand: bool = False,
+    pad_slot_id: int = -1,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
     b, qh, d_nope = q_nope.shape
     _, _, d_pe = q_pe.shape
@@ -118,6 +119,7 @@ def fused_qk_rope_cat_and_cache_mla(
     q_out_dtype: torch.dtype = None,
     shuffled_kv_cache: bool = False,
     upcast_operand: bool = False,
+    pad_slot_id: int = -1,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
     """
     Perform RoPE on q_pe and k_pe and concat q_nope with q_pe and k_nope with k_pe along the last dimension
@@ -130,6 +132,9 @@ def fused_qk_rope_cat_and_cache_mla(
     - k_pe: Matrix W with shape (B_slot, KH, D2).
     - kv_cache: Matrix W with shape (B_cache, KH, D1 + D2).
     - slot_mapping: Matrix W with shape (B_slot, ).
+    - pad_slot_id: Optional non-negative cache slot reserved for padding. Cache
+      writes to this slot are skipped. The default preserves the existing
+      behavior where all non-negative slots, including slot 0, are writable.
 
     B is the number of decode tokens, B_slot is the number of prefill + decode tokens, B_cache is the max number of tokens of kv_cache
     QH must be multiple of KH
@@ -320,6 +325,7 @@ def fused_qk_rope_cat_and_cache_mla(
         OUTPUT_Q_NOPE_ZEROS_AND_Q_PE=(num_decode_toks_for_zeros > 0),
         HAVE_K_SCALE=(k_scale is not None and apply_scale),
         UPCAST_OPERAND=upcast_operand,
+        PAD_SLOT_ID=pad_slot_id,
         num_warps=1,
     )
 

--- a/op_tests/triton_tests/fusions/test_fused_kv_cache.py
+++ b/op_tests/triton_tests/fusions/test_fused_kv_cache.py
@@ -260,6 +260,82 @@ def test_fused_qk_rope_cat_and_cache_mla(
     torch.testing.assert_close(torch_k_pe_og_dtype, triton_k_pe, atol=1e-1, rtol=1e-1)
 
 
+@pytest.mark.parametrize(
+    "pad_slot_id,padded_token_index",
+    [(-1, 0), (0, 0), (0, 1)],
+    ids=["default-writes-slot-zero", "decode-branch", "prefill-branch"],
+)
+def test_fused_qk_rope_cat_and_cache_mla_pad_slot_id(
+    pad_slot_id: int, padded_token_index: int
+):
+    """A caller-selected padding slot is preserved in both KV-write branches."""
+    dtype = torch.bfloat16
+    num_q_tokens = 1
+    num_kv_tokens = 2
+    num_q_heads = 16
+    num_kv_heads = 1
+    d_nope = 512
+    d_pe = 64
+
+    q_nope = torch.zeros(
+        (num_q_tokens, num_q_heads, d_nope), dtype=dtype, device="cuda"
+    )
+    q_pe = torch.zeros(
+        (num_q_tokens, num_q_heads, d_pe), dtype=dtype, device="cuda"
+    )
+    k_nope = torch.full(
+        (num_kv_tokens, num_kv_heads, d_nope), 2, dtype=dtype, device="cuda"
+    )
+    k_pe = torch.full(
+        (num_kv_tokens, num_kv_heads, d_pe), 3, dtype=dtype, device="cuda"
+    )
+    k_nope[padded_token_index].fill_(torch.nan)
+    k_pe[padded_token_index].fill_(torch.nan)
+
+    sentinel = 17
+    kv_cache = torch.full(
+        (4, num_kv_heads, d_nope + d_pe),
+        sentinel,
+        dtype=dtype,
+        device="cuda",
+    )
+    slot_mapping = torch.tensor([0, 1], dtype=torch.int64, device="cuda")
+    if padded_token_index == 1:
+        slot_mapping = slot_mapping.flip(0)
+    positions = torch.zeros(num_q_tokens, dtype=torch.int64, device="cuda")
+    cos = torch.ones((1, d_pe), dtype=dtype, device="cuda")
+    sin = torch.zeros_like(cos)
+    k_scale = torch.ones((), dtype=torch.float32, device="cuda")
+
+    fused_qk_rope_cat_and_cache_mla(
+        q_nope,
+        q_pe,
+        k_nope,
+        k_pe,
+        kv_cache,
+        slot_mapping,
+        positions,
+        cos,
+        sin,
+        k_scale,
+        is_neox=True,
+        pad_slot_id=pad_slot_id,
+    )
+
+    if pad_slot_id == 0:
+        torch.testing.assert_close(
+            kv_cache[0], torch.full_like(kv_cache[0], sentinel)
+        )
+    else:
+        assert torch.isnan(kv_cache[0]).all()
+
+    valid_token_index = 1 - padded_token_index
+    expected_slot_one = torch.cat(
+        (k_nope[valid_token_index], k_pe[valid_token_index]), dim=-1
+    )
+    torch.testing.assert_close(kv_cache[1], expected_slot_one)
+
+
 @pytest.mark.parametrize("T", [1, 8, 2048])
 @pytest.mark.parametrize("QH_per_KH", [16])
 @pytest.mark.parametrize("KH", [8])


### PR DESCRIPTION
## Summary

Add an optional `pad_slot_id` to `fused_qk_rope_cat_and_cache_mla` so callers can reserve a non-negative cache slot for padding without changing the default AITER behavior.

The argument defaults to `-1`, so slot 0 remains writable for existing callers. When a caller opts in, both the decode/mixed and extra-prefill KV-write branches skip the selected slot. The behavior is implemented consistently in the Triton and gfx1250 Gluon kernels.

## Motivation

Some runtimes reserve a physical KV-cache slot while using padding rows in `slot_mapping`. The generic SGLang MLA writers already protect this invariant in [sgl-project/sglang#36003](https://github.com/sgl-project/sglang/pull/36003), but the fused AITER writer bypasses those writers and can still overwrite the reserved slot.

This change keeps AITER generic: no slot is reserved by default, and callers explicitly select one when needed. Downstream context is tracked in [sgl-project/sglang#36207](https://github.com/sgl-project/sglang/issues/36207).

## Tests

Added focused coverage that verifies:

- default behavior still writes slot 0;
- `pad_slot_id=0` preserves slot 0 in the decode/mixed branch;
- `pad_slot_id=0` preserves slot 0 in the extra-prefill branch;
- ordinary positive slots are still written.

The new value is a compile-time kernel argument, so the default predicate can be constant-folded to the existing behavior.

Local checks: Python compilation, Black, Ruff, and `git diff --check`. GPU execution is left to AITER CI.
