### PR TITLE
[Triton/Gluon] [gfx1250] Integrate GEMM UTs into combined microbench

### DIFF
--- a/op_tests/bench_gfx1250_combo.py
+++ b/op_tests/bench_gfx1250_combo.py
@@ -1,0 +1,619 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+"""Combined gfx1250 asm-kernel perf bench.
+
+Imports the top-level @benchmark sweep fns from the aiter op_tests (which the
+aiter-op-test skill keeps importable for exactly this kind of combination
+testing) and runs each over its own shape axes.
+
+Output discipline: this script prints ONLY the per-op summary tables. All the
+underlying noise (per-config "calling ..." logs, JIT build output, aiter import
+banners, pandas/torch/ROCTracer warnings, including C-level fd writes) is
+silenced via os-level fd redirection while the kernels run; the markdown tables
+are then printed to real stdout.
+
+Run from the aiter repo root so `op_tests/` siblings import cleanly:
+
+    cd /app/aiter
+    python op_tests/bench_gfx1250_combo.py            # all ops, curated defaults
+    python op_tests/bench_gfx1250_combo.py --ops mha  # just one op
+    python op_tests/bench_gfx1250_combo.py --ops moe  # just FlyDSL MoE
+    python op_tests/bench_gfx1250_combo.py --ops gemm  # just gemm_a4w4 (16384^3)
+    python op_tests/bench_gfx1250_combo.py --ops mla_v4  # asm vs Triton MLA v4 compare
+
+gfx1250's bundled CK does not compile, so the asm JIT modules must be built with
+ENABLE_CK=0. The script sets it (before importing aiter) so a plain run just
+works; an explicit env override still wins.
+"""
+
+import os
+
+# Must be set BEFORE `import aiter` so the JIT build picks it up. setdefault =>
+# an explicitly-exported ENABLE_CK from the caller is respected.
+os.environ.setdefault("ENABLE_CK", "0")
+
+# FlyDSL MoE env vars — must be set before importing aiter / moe test module.
+os.environ.setdefault("AITER_USE_GROUPED_GEMM", "1")
+os.environ.setdefault("AITER_GROUPED_DEBUG", "0")
+os.environ.setdefault("FLYDSL_DUMP_IR", "1")
+os.environ.setdefault("AITER_LOG_MORE", "1")
+os.environ.setdefault("AITER_MOE_EXPERT_BALANCE", "true")
+os.environ.setdefault("AITER_FLYDSL_MOE_EXPERT_SCHEDULING_MODE", "1")
+os.environ.setdefault("AITER_FORCE_GFX1250", "1")
+
+import argparse
+import contextlib
+import itertools
+import sys
+import warnings
+
+warnings.filterwarnings("ignore")
+
+
+@contextlib.contextmanager
+def _silence():
+    """Discard everything written to stdout/stderr — including native (C/C++)
+    fd writes (ROCTracer, hipcc, aiter logger) — for the duration of the block.
+    Redirects at the OS fd level so it catches more than sys.stdout swapping."""
+    devnull = os.open(os.devnull, os.O_WRONLY)
+    # Flush any buffered Python-level output to the REAL fds BEFORE redirecting.
+    # stdout is block-buffered when piped/redirected, so an earlier _print_table()
+    # can still be sitting in the buffer; without this flush it would drain to
+    # devnull once fd 1 is redirected here and the printed table would be lost.
+    sys.stdout.flush()
+    sys.stderr.flush()
+    old1, old2 = os.dup(1), os.dup(2)
+    try:
+        os.dup2(devnull, 1)
+        os.dup2(devnull, 2)
+        yield
+    finally:
+        # Flush again BEFORE restoring so anything printed inside the block goes
+        # to devnull (not the real stdout after we restore it).
+        sys.stdout.flush()
+        sys.stderr.flush()
+        os.dup2(old1, 1)
+        os.dup2(old2, 2)
+        os.close(devnull)
+        os.close(old1)
+        os.close(old2)
+
+
+# Import aiter + the op-test modules quietly (import-time banners suppressed).
+with _silence():
+    import pandas as pd
+    import test_f4gemm as gemm_mod
+    import test_flydsl_grouped_gemm_gfx1250 as moe_mod
+    import test_fmha_fwd_with_sink_asm as mha_mod  # has __main__ guard
+    import test_mla_v4_kargpreld as mla_v4_kargpreld_mod
+    import torch
+    from triton_tests.attention import test_mla_v4_triton as mla_v4_triton_mod
+
+    import aiter
+    from aiter import dtypes
+    from aiter.jit.utils.chip_info import get_gfx
+    from aiter.test_common import run_perftest
+
+SUPPORTED_GFX = ["gfx1250"]
+
+
+def _int_quad(s):
+    """Parse 'a,b,c,d' -> (int, int, int, int) — MLA v4 kargpreld shape tuples."""
+    a, b, c, d = s.split(",")
+    return int(a), int(b), int(c), int(d)
+
+
+def _tflops(flop, us):
+    """TFLOPS from a FLOP count and microseconds (None-safe)."""
+    return round(flop / us / 1e6, 2) if us else None
+
+
+def _bw(nbytes, us):
+    """Bandwidth (TB/s) from a byte count and microseconds (None-safe).
+    bytes / (us*1e-6) / 1e12 == bytes / us / 1e6."""
+    return round(nbytes / us / 1e6, 3) if us else None
+
+
+# bytes-per-VALUE for the MoE quant formats (dims below are logical value counts,
+# so fp4 must be 0.5 B/value, not the 1 B/element of the packed fp4x2 dtype).
+#   a4w4 : fp4 act (0.5) x fp4 weight (0.5)
+#   a8w4 : fp8 act (1.0) x fp4 weight (0.5)   (mxfp8 x mxfp4)
+# The bf16 stage output is 2 B/value. (act_bpe, weight_bpe) per data_format.
+_MOE_BPE = {"a4w4": (0.5, 0.5), "a8w4": (1.0, 0.5)}
+_OUT_BPE = 2  # bf16 stage outputs
+
+
+def _moe_stage_flops(token, topk, model_dim, inter_dim, use_g1u1=True):
+    """Per-stage FLOP counts for the fused 2-stage MoE (matches gemm_moe_tune.py):
+        stage1 GEMM: [token, model_dim] x [E, n, model_dim] -> token*n*model_dim*topk*2
+                     n = inter_dim*2 (g1u1 gate+up) or inter_dim
+        stage2 GEMM: [token, topk, inter_dim] x [E, model_dim, inter_dim]
+                     -> topk*token*model_dim*inter_dim*2
+    Returns (flop1, flop2)."""
+    n = inter_dim * 2 if use_g1u1 else inter_dim
+    flop1 = token * n * model_dim * topk * 2
+    flop2 = topk * token * model_dim * inter_dim * 2
+    return flop1, flop2
+
+
+# per_1x32 microscale: every 32 quantized values share one e8m0 (1B) scale, so
+# each quantized value carries an extra 1/32 B of scale traffic, on top of its
+# own bpe. Applies to BOTH activations and weights (fp4 => bpe 0.5 => 17/16;
+# fp8 => bpe 1.0 => 33/32). Output stays bf16 and is not microscaled.
+# (gemm_moe_tune.py's stage1/stage2 omit scale entirely; we include it.)
+_SCALE_PER_VALUE = 1 / 32
+
+
+def _moe_stage_bytes(
+    token, topk, model_dim, inter_dim, experts, aq_bpe, wq_bpe, use_g1u1=True
+):
+    """Per-stage MoE traffic (bytes), including per_1x32 e8m0 scale on every
+    quantized operand (act + weight). The stage1 output / stage2 input is the
+    expanded [token*topk, n] / [token*topk, inter] intermediate, so both carry
+    topk; the stage1 input act is read once per token (reused across its topk
+    experts):
+        stage1: act[token,model_dim]@aq + out[token,topk,n]@bf16 + w1[E,n,model_dim]@wq
+        stage2: act[token,topk,inter_dim]@aq + out[token,model_dim]@bf16
+                + w2[E,model_dim,inter_dim]@wq
+        n = inter_dim*2 (g1u1) or inter_dim.
+    Returns (bytes1, bytes2)."""
+    n = inter_dim * 2 if use_g1u1 else inter_dim
+    bo = _OUT_BPE
+    aq = aq_bpe + _SCALE_PER_VALUE  # quantized act: data + e8m0 scale per value
+    wq = wq_bpe + _SCALE_PER_VALUE  # quantized weight: data + e8m0 scale per value
+    bytes1 = (
+        token * model_dim * aq + token * topk * n * bo + experts * n * model_dim * wq
+    )
+    bytes2 = (
+        token * topk * inter_dim * aq
+        + token * model_dim * bo
+        + experts * model_dim * inter_dim * wq
+    )
+    return bytes1, bytes2
+
+
+# Per-op column whitelists: keep shape identifiers + perf, drop the constant
+# config/correctness columns @benchmark echoes (gfx/dtype/err/cos_diff/...).
+_MHA_KEEP = [
+    "dtype",
+    "head_dim",
+    "hq",
+    "hk",
+    "sq",
+    "sk",
+    "batch",
+    "is_causal",
+    "init",
+    "asm us",
+    "asm TFLOPS",
+    "asm TB/s",
+]
+# Curated (head_dim, seqlen, is_causal) grid — hq=64, hk=8(d64)/4(d128), batch=1.
+_MHA_SHAPES = [
+    (64, 32768, True),
+    (128, 16384, True),
+    (64, 32768, False),
+    (128, 16384, False),
+]
+_MOE_KEEP = [
+    "data_format",
+    "act",
+    "token",
+    "model_dim",
+    "inter_dim",
+    "E",
+    "topk",
+    "pass",
+    "gemm1_us",
+    "gemm1 TFLOPS",
+    "gemm1 TB/s",
+    "gemm2_us",
+    "gemm2 TFLOPS",
+    "gemm2 TB/s",
+    "total us",
+    "total TFLOPS",
+    "total TB/s",
+]
+# Fixed kernel-bench config (mirrors test_flydsl_grouped_gemm_gfx1250.py --scenario kernel).
+_MOE_DATA_FORMATS = ["a4w4", "a8w4"]
+_MOE_CONFIG = {
+    "experts": 96,
+    "tokens": 512,
+    "topk": 6,
+    "model_dim": 7168,
+    "inter_dim": 3072,
+    "activation": "silu",  # ActivationType.Silu
+    "use_bias": False,
+}
+_GEMM_KEEP = [
+    "intype",
+    "M",
+    "N",
+    "K",
+    "apre",
+    "outtype",
+    "data_init",
+    "scale_init",
+    "asm us",
+    "asm TFLOPS",
+    "asm TB/s",
+]
+# gemm_a4w4 throughput square only (no FUNC_SHAPES / other M,N,K sweeps).
+_GEMM_A4W4_SHAPE = (16384, 16384, 16384)
+
+# Curated (gqa_ratio, batch, kv_seq_lens, num_kv_splits) grid for MLA v4 nm
+# kernarg-preload perf (mirrors op_tests/test_mla_v4_kargpreld.py sweep subset).
+_MLA_V4_KARGPRELD_SHAPES = [
+    (64, 64, 256, 1),
+    (64, 64, 256, 2),
+    (64, 64, 256, 4),
+    (64, 64, 512, 1),
+    (64, 64, 512, 2),
+    (64, 64, 512, 4),
+    (64, 64, 1024, 1),
+    (64, 64, 1024, 2),
+    (64, 64, 1024, 4),
+    (128, 64, 256, 1),
+    (128, 64, 256, 2),
+    (128, 64, 256, 4),
+    (128, 64, 512, 1),
+    (128, 64, 512, 2),
+    (128, 64, 512, 4),
+    (128, 64, 1024, 1),
+    (128, 64, 1024, 2),
+    (128, 64, 1024, 4),
+]
+_MLA_V4_COMPARE_KEEP = [
+    "dtype",
+    "gqa_ratio",
+    "batch",
+    "kv_seq_lens",
+    "num_kv_splits",
+    "asm_s1",
+    "triton_s1",
+    "s1 triton/asm",
+    "asm_s2",
+    "triton_s2",
+    "s2 triton/asm",
+    "asm_tot",
+    "triton_tot",
+    "tot triton/asm",
+]
+
+
+def _print_table(name, rows, keep=None):
+    df = pd.DataFrame([r for r in rows if r is not None])
+    if not df.empty:
+        # Drop columns that are entirely empty, then whitelist/order via `keep`.
+        # The @benchmark decorator dumps every call arg as a column, which makes
+        # the tables wide; `keep` trims to shape ids + perf. ALWAYS surface any
+        # err_msg / *err column so failures never get silently hidden.
+        df = df.replace("", pd.NA).dropna(axis=1, how="all")
+        if keep is not None:
+            cols = [c for c in keep if c in df.columns]
+            cols += [c for c in df.columns if "err_msg" in c and c not in cols]
+            df = df[cols]
+    print(f"\n===== {name} =====")
+    print(df.to_markdown(index=False))
+
+
+# --- per-op runners: sweep axes silently, then print one table ---
+
+
+def run_mha(args):
+    # perf-only fn (no torch ref): sq==sk, hq=64, hk=8(d64)/4(d128), batch=1.
+    rows = []
+    with _silence():
+        for init in args.mha_init:
+            for head_dim, seqlen, causal in _MHA_SHAPES:
+                hk = 8 if head_dim == 64 else 4
+                rows.append(
+                    mha_mod.test_fmha_fwd_with_sink_asm_perf(
+                        head_dim, 64, hk, seqlen, seqlen, 1, causal, init
+                    )
+                )
+    for row in rows:
+        if row is not None:
+            row["dtype"] = "bf16"
+    _print_table("mha (bf16)", rows, keep=_MHA_KEEP)
+
+
+def run_moe(args):
+    cfg = _MOE_CONFIG
+    tokens = cfg["tokens"]
+    activation = moe_mod.ActivationType.Silu
+    rows = []
+    for fmt in _MOE_DATA_FORMATS:
+        moe_mod.set_data_format(fmt)
+        with _silence():
+            metrics = moe_mod.run_moe(
+                fmt,
+                experts=cfg["experts"],
+                tokens=tokens,
+                topk=cfg["topk"],
+                model_dim=cfg["model_dim"],
+                inter_dim=cfg["inter_dim"],
+                activation=activation,
+                use_bias=cfg["use_bias"],
+                kernel_bench=True,
+                check_aot_cache=False,
+                raise_on_fail=False,
+            )
+        # stage1 n = inter_dim*2 (gate+up for silu/swiglu GUGU layout).
+        aq_bpe, wq_bpe = _MOE_BPE.get(fmt, (1, 1))
+        flop1, flop2 = _moe_stage_flops(
+            tokens,
+            cfg["topk"],
+            cfg["model_dim"],
+            cfg["inter_dim"],
+            use_g1u1=True,
+        )
+        bytes1, bytes2 = _moe_stage_bytes(
+            tokens,
+            cfg["topk"],
+            cfg["model_dim"],
+            cfg["inter_dim"],
+            cfg["experts"],
+            aq_bpe,
+            wq_bpe,
+            use_g1u1=True,
+        )
+        us1, us2 = metrics.get("gemm1_us"), metrics.get("gemm2_us")
+        total_us = (us1 or 0) + (us2 or 0) if (us1 or us2) else None
+        bw1, bw2, bwt = (
+            _bw(bytes1, us1),
+            _bw(bytes2, us2),
+            _bw(bytes1 + bytes2, total_us),
+        )
+        rows.append(
+            {
+                "data_format": fmt,
+                "act": cfg["activation"],
+                "token": tokens,
+                "model_dim": cfg["model_dim"],
+                "inter_dim": cfg["inter_dim"],
+                "E": cfg["experts"],
+                "topk": cfg["topk"],
+                "pass": metrics["passed"],
+                "gemm1_us": us1,
+                "gemm1 TFLOPS": _tflops(flop1, us1),
+                "gemm1 TB/s": bw1,
+                "gemm2_us": us2,
+                "gemm2 TFLOPS": _tflops(flop2, us2),
+                "gemm2 TB/s": bw2,
+                "total us": round(total_us, 2) if total_us else None,
+                "total TFLOPS": _tflops(flop1 + flop2, total_us),
+                "total TB/s": bwt,
+            }
+        )
+    _print_table("flydsl_grouped_gemm (kernel, silu)", rows, keep=_MOE_KEEP)
+
+
+def run_gemm(args):
+    # op_tests/test_f4gemm.py perf-mode intype/outtype/init sweep at one shape only.
+    M, N, K = _GEMM_A4W4_SHAPE
+    rows = []
+    init_pairs = [("constant", "constant"), ("uniform", "auto")]
+    with _silence():
+        for (di, si), intype, apre, outtype in itertools.product(
+            init_pairs,
+            ["mxfp4", "nvfp4"],
+            [1],
+            ["bf16", "fp8"],
+        ):
+            rows.append(gemm_mod.test_gemm(intype, M, N, K, apre, outtype, di, si))
+    _print_table("gemm_a4w4", rows, keep=_GEMM_KEEP)
+
+
+def _perf_ratio(num, den):
+    """triton/asm speed ratio as '1.03x'; 'nanx' when undefined."""
+    if num is None or den is None or den == 0:
+        return "nanx"
+    return f"{num / den:.2f}x"
+
+
+def _bench_mla_v4_asm_staged(gqa, batch, ctx, split_kv, num_iters, num_warmup):
+    """Asm kernel (s1) + merge (s2) + total; lives in combo bench only."""
+    mod = mla_v4_kargpreld_mod
+    q_seq = 1
+    assert (gqa, q_seq) in mod._SHIPPED_TILE_VARIANTS
+    if split_kv > 1:
+        min_split = ctx // split_kv
+        assert (
+            min_split >= 16
+        ), f"smallest KV split = floor({ctx}/{split_kv}) = {min_split} < 16"
+
+    device = "cuda"
+    inputs = mod._build_bf16_inputs(
+        batch=batch,
+        kv_seq_lens=ctx,
+        q_seq_logical=q_seq,
+        seed=mod._SEED,
+        gqa_ratio=gqa,
+        attn_sink=True,
+    )
+    sm_scale = 1.0 / (mod._QUANT_D**0.5)
+    q_packed, q_rope = mod._native_to_2buff_for_asm(inputs["q_bf16"])
+    kv_packed, kv_rope = mod._native_to_2buff_for_asm(inputs["kv_bf16"])
+
+    total_q = inputs["q_bf16"].size(0)
+    num_seqs = inputs["qo_indptr"].size(0) - 1
+    num_heads = mod.NUM_KV_HEADS * gqa
+    output_buf = torch.empty(
+        (total_q, gqa, mod.V_HEAD_DIM), dtype=dtypes.bf16, device=device
+    )
+    split_indptr = torch.tensor(
+        [i * split_kv for i in range(num_seqs + 1)],
+        dtype=torch.int32,
+        device=device,
+    )
+    logits_buf = torch.empty(
+        (total_q, split_kv, num_heads, mod.V_HEAD_DIM),
+        dtype=torch.float32,
+        device=device,
+    )
+    lse_buf = torch.empty(
+        (total_q, split_kv, num_heads, 1), dtype=torch.float32, device=device
+    )
+    valid_split_count = torch.empty((num_seqs,), dtype=torch.int32, device=device)
+
+    common_kwargs = {
+        "q": q_packed,
+        "qrope": q_rope.contiguous(),
+        "kv_buffer": kv_packed,
+        "kvrope": kv_rope.contiguous(),
+        "output": output_buf,
+        "qo_indptr": inputs["qo_indptr"],
+        "kv_indptr": inputs["kv_indptr"],
+        "kv_page_indices": inputs["kv_page_indices"],
+        "kv_last_page_lens": inputs["kv_last_page_lens"],
+        "split_indptr": split_indptr,
+        "max_seqlen_q": inputs["max_seqlen_q"],
+        "sink": inputs["sink"],
+        "sm_scale": sm_scale,
+        "num_kv_splits": split_kv,
+        "logits": logits_buf,
+        "attn_lse": lse_buf,
+    }
+    perf = {"num_iters": num_iters, "num_warmup": num_warmup, "num_rotate_args": 1}
+
+    _, us_k = run_perftest(
+        aiter.mla_decode_v4_asm,
+        q_packed,
+        q_rope.contiguous(),
+        kv_packed,
+        kv_rope.contiguous(),
+        inputs["qo_indptr"],
+        inputs["kv_indptr"],
+        inputs["kv_page_indices"],
+        split_indptr,
+        inputs["sink"],
+        inputs["max_seqlen_q"],
+        sm_scale,
+        0,
+        split_kv,
+        logits_buf,
+        lse_buf,
+        output_buf,
+        valid_split_count,
+        int(split_kv > 1),
+        inputs["kv_last_page_lens"],
+        **perf,
+    )
+    _, us_tot = run_perftest(
+        aiter.mla.mla_decode_fwd_v4_nm,
+        out_16_nosplit=0,
+        **common_kwargs,
+        **perf,
+    )
+    asm_s2 = max(0.0, us_tot - us_k) if split_kv > 1 else 0.0
+    return {
+        "asm_s1": round(us_k, 2),
+        "asm_s2": round(asm_s2, 2),
+        "asm_tot": round(us_tot, 2),
+    }
+
+
+def run_mla_v4(args):
+    # Side-by-side asm (kargpreld) vs Triton sparse decode on the same shape grid.
+    iters = args.mla_v4_kargpreld_iters
+    warmup = args.mla_v4_kargpreld_warmup
+    mla_v4_triton_mod._PERF["num_iters"] = iters
+    mla_v4_triton_mod._PERF["num_warmup"] = warmup
+    shapes = args.mla_v4_kargpreld_shapes or _MLA_V4_KARGPRELD_SHAPES
+    rows = []
+    with _silence():
+        for gqa, batch, ctx, split_kv in shapes:
+            row = {
+                "gqa_ratio": gqa,
+                "batch": batch,
+                "kv_seq_lens": ctx,
+                "num_kv_splits": split_kv,
+            }
+            try:
+                asm = _bench_mla_v4_asm_staged(gqa, batch, ctx, split_kv, iters, warmup)
+                tri = mla_v4_triton_mod.test_mla_v4_triton_staged(
+                    gqa_ratio=gqa,
+                    batch=batch,
+                    kv_seq_lens=ctx,
+                    num_kv_splits=split_kv,
+                )
+                row.update(asm)
+                row.update(tri)
+                row["s1 triton/asm"] = _perf_ratio(row["triton_s1"], row["asm_s1"])
+                row["s2 triton/asm"] = _perf_ratio(row["triton_s2"], row["asm_s2"])
+                row["tot triton/asm"] = _perf_ratio(row["triton_tot"], row["asm_tot"])
+            except (RuntimeError, AssertionError, ValueError) as exc:
+                msg = str(exc).splitlines()[0] if str(exc) else type(exc).__name__
+                row["err_msg"] = msg
+            rows.append(row)
+    for row in rows:
+        row["dtype"] = "bf16"
+    _print_table("mla_v4 (bf16, asm vs triton)", rows, keep=_MLA_V4_COMPARE_KEEP)
+
+
+OPS = {
+    "mha": run_mha,
+    "moe": run_moe,
+    "gemm": run_gemm,
+    "mla_v4": run_mla_v4,
+}
+
+
+def main():
+    if get_gfx() not in SUPPORTED_GFX:
+        print(
+            f"combo bench targets {SUPPORTED_GFX} only; current {get_gfx()} — skipping"
+        )
+        return
+
+    p = argparse.ArgumentParser(
+        formatter_class=argparse.RawTextHelpFormatter,
+        description="combined gfx1250 asm-kernel perf bench (prints only summaries)",
+    )
+    p.add_argument(
+        "--ops",
+        nargs="*",
+        choices=list(OPS),
+        default=list(OPS),
+        help="which ops to bench (default: all)",
+    )
+    # mha (SWA fwd asm) — fixed 4-shape grid; init sweep only
+    p.add_argument(
+        "--mha-init",
+        type=str,
+        nargs="*",
+        default=["randn", "const0.25"],
+        choices=["randn", "const0.25"],
+    )
+    # flydsl moe — fixed kernel-bench config (see _MOE_CONFIG)
+    # mla_v4 (v4 nm kernarg-preload decode) axes
+    p.add_argument(
+        "--mla-v4-kargpreld-shapes",
+        type=_int_quad,
+        nargs="*",
+        default=None,
+        metavar="GQA,BATCH,CTX,SPLIT",
+        help="Override curated shape grid as gqa,batch,ctx,split tuples "
+        "(default: built-in 18-row grid)",
+    )
+    p.add_argument(
+        "--mla-v4-kargpreld-iters",
+        type=int,
+        default=50,
+        help="mla_v4_kargpreld timed iterations (default: 50)",
+    )
+    p.add_argument(
+        "--mla-v4-kargpreld-warmup",
+        type=int,
+        default=2,
+        help="mla_v4_kargpreld warmup iterations (default: 2)",
+    )
+    args = p.parse_args()
+
+    for name in args.ops:
+        OPS[name](args)
+
+
+if __name__ == "__main__":
+    main()

--- a/op_tests/bench_gfx1250_combo.py
+++ b/op_tests/bench_gfx1250_combo.py
@@ -18,7 +18,11 @@ Run from the aiter repo root so `op_tests/` siblings import cleanly:
     python op_tests/bench_gfx1250_combo.py            # all ops, curated defaults
     python op_tests/bench_gfx1250_combo.py --ops mha  # just one op
     python op_tests/bench_gfx1250_combo.py --ops moe  # just FlyDSL MoE
-    python op_tests/bench_gfx1250_combo.py --ops gemm  # just gemm_a4w4 (16384^3)
+    python op_tests/bench_gfx1250_combo.py --ops gemm  # just F4GEMM perf
+    python op_tests/bench_gfx1250_combo.py --ops f8gemm  # just F8GEMM perf
+    python op_tests/bench_gfx1250_combo.py --ops gemm --gemm-mode func  # F4GEMM UT
+    python op_tests/bench_gfx1250_combo.py --ops f8gemm --gemm-mode func  # F8GEMM UT
+    python op_tests/bench_gfx1250_combo.py --ops gemm f8gemm --gemm-mode func  # all GEMM UTs
     python op_tests/bench_gfx1250_combo.py --ops mla_v4  # asm vs Triton MLA v4 compare
 
 gfx1250's bundled CK does not compile, so the asm JIT modules must be built with
@@ -86,6 +90,7 @@ with _silence():
     import test_flydsl_grouped_gemm_gfx1250 as moe_mod
     import test_fmha_fwd_with_sink_asm as mha_mod  # has __main__ guard
     import test_mla_v4_kargpreld as mla_v4_kargpreld_mod
+    import test_mxfp8fp4gemm as f8gemm_mod
     import torch
     from triton_tests.attention import test_mla_v4_triton as mla_v4_triton_mod
 
@@ -234,11 +239,14 @@ _GEMM_KEEP = [
     "outtype",
     "data_init",
     "scale_init",
+    "knl_name",
     "asm us",
     "asm TFLOPS",
     "asm TB/s",
+    "asm err",
+    "asm result",
 ]
-# gemm_a4w4 throughput square only (no FUNC_SHAPES / other M,N,K sweeps).
+# gemm_a4w4 throughput square. Functional shapes come from test_f4gemm.py.
 _GEMM_A4W4_SHAPE = (16384, 16384, 16384)
 
 # Curated (gqa_ratio, batch, kv_seq_lens, num_kv_splits) grid for MLA v4 nm
@@ -390,19 +398,76 @@ def run_moe(args):
 
 
 def run_gemm(args):
-    # op_tests/test_f4gemm.py perf-mode intype/outtype/init sweep at one shape only.
-    M, N, K = _GEMM_A4W4_SHAPE
+    # Mirror test_f4gemm.py's mode-aware execution: functional mode exercises
+    # its correctness shape set and both A layouts; perf/profile keep the single
+    # throughput square and preshuffled A path.
+    is_func = args.gemm_mode == "func"
+    shapes = gemm_mod.FUNC_SHAPES if is_func else [_GEMM_A4W4_SHAPE]
+    init_pairs = (
+        [("uniform", "auto")]
+        if is_func
+        else [("constant", "constant"), ("uniform", "auto")]
+    )
+    apre_list = [1, 0] if is_func else [1]
     rows = []
-    init_pairs = [("constant", "constant"), ("uniform", "auto")]
     with _silence():
-        for (di, si), intype, apre, outtype in itertools.product(
+        for (di, si), intype, apre, outtype, (M, N, K) in itertools.product(
             init_pairs,
             ["mxfp4", "nvfp4"],
-            [1],
+            apre_list,
             ["bf16", "fp8"],
+            shapes,
         ):
-            rows.append(gemm_mod.test_gemm(intype, M, N, K, apre, outtype, di, si))
-    _print_table("gemm_a4w4", rows, keep=_GEMM_KEEP)
+            rows.append(
+                gemm_mod.test_gemm(
+                    intype,
+                    M,
+                    N,
+                    K,
+                    apre,
+                    outtype,
+                    di,
+                    si,
+                    mode=args.gemm_mode,
+                )
+            )
+    _print_table(f"gemm_a4w4 ({args.gemm_mode})", rows, keep=_GEMM_KEEP)
+
+
+def run_f8gemm(args):
+    # Mirror PR #4748's F8GEMM UT execution. Functional mode sweeps both input
+    # formats and both A layouts over the reference functional shape set.
+    is_func = args.gemm_mode == "func"
+    init_pairs = (
+        [("uniform", "auto")]
+        if is_func
+        else [("constant", "constant"), ("uniform", "auto")]
+    )
+    apre_list = [1, 0] if is_func else [1]
+    rows = []
+    with _silence():
+        for (di, si), intype, apre in itertools.product(
+            init_pairs, ["a8w8", "a8w4"], apre_list
+        ):
+            shapes = (
+                f8gemm_mod.FUNC_SHAPES
+                if is_func
+                else f8gemm_mod.PERF_SHAPES[intype]
+            )
+            for M, N, K in shapes:
+                rows.append(
+                    f8gemm_mod.test_gemm(
+                        intype,
+                        M,
+                        N,
+                        K,
+                        apre,
+                        data_init=di,
+                        scale_init=si,
+                        mode=args.gemm_mode,
+                    )
+                )
+    _print_table(f"mxfp8fp4gemm ({args.gemm_mode})", rows, keep=_GEMM_KEEP)
 
 
 def _perf_ratio(num, den):
@@ -556,6 +621,7 @@ OPS = {
     "mha": run_mha,
     "moe": run_moe,
     "gemm": run_gemm,
+    "f8gemm": run_f8gemm,
     "mla_v4": run_mla_v4,
 }
 
@@ -585,6 +651,12 @@ def main():
         nargs="*",
         default=["randn", "const0.25"],
         choices=["randn", "const0.25"],
+    )
+    p.add_argument(
+        "--gemm-mode",
+        choices=["func", "perf", "profile"],
+        default="perf",
+        help="F4/F8 GEMM execution mode: func=UT, perf=benchmark, profile=trace",
     )
     # flydsl moe — fixed kernel-bench config (see _MOE_CONFIG)
     # mla_v4 (v4 nm kernarg-preload decode) axes

--- a/op_tests/triton_tests/attention/test_mla_v4_triton.py
+++ b/op_tests/triton_tests/attention/test_mla_v4_triton.py
@@ -1,0 +1,664 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+# from __future__ import annotations
+
+import pytest
+import torch
+import triton
+
+from aiter.ops.triton.attention.pa_decode_sparse import pa_decode_sparse
+from aiter.ops.triton.utils._triton import arch_info
+from aiter.test_common import benchmark, checkAllclose, run_perftest
+
+# MLA v4 sparse-decode parity: D=512 heads, page_size=1 unified pool.
+_PA_DECODE_SPARSE_D = 512
+_PERF = {"num_iters": 50, "num_warmup": 2}
+
+
+def _sparse_attn_torch(q, kv, attn_sink, topk_idxs, softmax_scale):
+    """Per-batch sparse multi-head attention with sink in the denominator only.
+
+    Shapes:
+        q:           [B, M, H, D]
+        kv:          [B, N, D]
+        attn_sink:   [H]
+        topk_idxs:   [B, M, K] int32, -1 means skip
+    Returns:
+        [B, M, H, D] same dtype as q.
+    """
+    B, M, H, _D = q.shape
+    K = topk_idxs.shape[-1]
+    device = q.device
+    out_dtype = q.dtype
+
+    valid = topk_idxs != -1
+    safe_idxs = topk_idxs.clamp(min=0).long()
+    batch_idx = torch.arange(B, device=device).view(B, 1, 1).expand(B, M, K)
+    kv_gathered = kv[batch_idx, safe_idxs]  # [B, M, K, D]
+    kv_f32 = kv_gathered.float()
+    kv_f32 = torch.where(
+        valid.unsqueeze(-1), kv_f32, torch.zeros((), dtype=kv_f32.dtype, device=device)
+    )
+
+    q_f32 = q.float()
+    scores = torch.einsum("bmhd,bmkd->bmhk", q_f32, kv_f32) * float(softmax_scale)
+    scores = scores.masked_fill(~valid.unsqueeze(2), float("-inf"))
+
+    sink = attn_sink.float().view(1, 1, H, 1).expand(B, M, H, 1)
+    combined = torch.cat([scores, sink], dim=-1)
+    cmax = combined.amax(dim=-1, keepdim=True)
+    cmax = torch.where(
+        cmax == float("-inf"),
+        torch.zeros((), dtype=cmax.dtype, device=device),
+        cmax,
+    )
+    weights = (combined - cmax).exp()
+    denom = weights.sum(dim=-1, keepdim=True)
+    weights = weights / denom.clamp(min=1e-30)
+    weights_kv = weights[..., :K]
+    out = torch.einsum("bmhk,bmkd->bmhd", weights_kv, kv_f32)
+    return out.to(out_dtype)
+
+
+def pa_decode_sparse_reference(
+    q, unified_kv, kv_indices, kv_indptr, attn_sink, softmax_scale
+):
+    """Pure-torch reference that materialises per-token KV via gather."""
+    T = q.size(0)
+    indptr = kv_indptr.to(torch.int64)
+    spans = (indptr[1:] - indptr[:T]).clamp(min=0)
+    k_dim = int(spans.max().item()) if T > 0 else 1
+    if k_dim == 0:
+        k_dim = 1
+    topk_idxs = torch.full((T, k_dim), -1, device=q.device, dtype=torch.int32)
+    for t in range(T):
+        s = int(indptr[t].item())
+        n = int(spans[t].item())
+        if n > 0:
+            topk_idxs[t, :n] = kv_indices[s : s + n].to(torch.int32)
+    return _sparse_attn_torch(
+        q.unsqueeze(0),
+        unified_kv.unsqueeze(0),
+        attn_sink,
+        topk_idxs.unsqueeze(0),
+        softmax_scale,
+    ).squeeze(0)
+
+
+# ---------------------------------------------------------------------------
+# Input builder
+# ---------------------------------------------------------------------------
+
+
+def _make_inputs(
+    T: int,
+    H: int,
+    D: int,
+    kv_len_per_token: int,
+    total_pages: int,
+    dtype=torch.bfloat16,
+    seed: int = 0,
+    include_sentinels: bool = False,
+    variable_len: bool = False,
+):
+    torch.manual_seed(seed)
+    device = torch.device("cuda")
+
+    q = torch.randn(T, H, D, dtype=dtype, device=device) * 0.5
+    unified_kv = torch.randn(total_pages, D, dtype=dtype, device=device) * 0.5
+    attn_sink = torch.randn(H, dtype=torch.float32, device=device) * 0.1
+
+    # Per-token kv_len: fixed or random in [1, kv_len_per_token].
+    if variable_len:
+        kv_lens = torch.randint(
+            low=1,
+            high=kv_len_per_token + 1,
+            size=(T,),
+            device=device,
+            dtype=torch.int64,
+        )
+    else:
+        kv_lens = torch.full((T,), kv_len_per_token, device=device, dtype=torch.int64)
+
+    indptr = torch.zeros(T + 1, device=device, dtype=torch.int64)
+    indptr[1:] = kv_lens.cumsum(0)
+    total_indices = int(indptr[-1].item())
+
+    indices = torch.randint(
+        low=0,
+        high=total_pages,
+        size=(total_indices,),
+        device=device,
+        dtype=torch.int32,
+    )
+    if include_sentinels and total_indices > 0:
+        # Sprinkle a few -1 sentinels.
+        n_sentinel = max(1, total_indices // 16)
+        sentinel_pos = torch.randperm(total_indices, device=device)[:n_sentinel]
+        indices[sentinel_pos] = -1
+
+    indptr = indptr.to(torch.int32)
+    softmax_scale = float(D) ** -0.5
+    return q, unified_kv, indices, indptr, attn_sink, softmax_scale
+
+
+@benchmark()
+def test_mla_v4_triton_staged(gqa_ratio, batch, kv_seq_lens, num_kv_splits):
+    """Perf-only stage split: main kernel (s1) + reduce (s2) + total."""
+    T = batch
+    H = gqa_ratio
+    D = _PA_DECODE_SPARSE_D
+    pages = T * kv_seq_lens
+    q, unified_kv, indices, indptr, sink, scale = _make_inputs(
+        T, H, D, kv_seq_lens, pages, variable_len=False
+    )
+    pa_kwargs = {
+        "has_invalid": False,
+        "kv_splits": num_kv_splits,
+        "num_iters": _PERF["num_iters"],
+        "num_warmup": _PERF["num_warmup"],
+        "num_rotate_args": 1,
+    }
+    _, us_tot = run_perftest(
+        pa_decode_sparse,
+        q,
+        unified_kv,
+        indices,
+        indptr,
+        sink,
+        scale,
+        skip_reduce=False,
+        **pa_kwargs,
+    )
+    if num_kv_splits > 1:
+        _, us_s1 = run_perftest(
+            pa_decode_sparse,
+            q,
+            unified_kv,
+            indices,
+            indptr,
+            sink,
+            scale,
+            skip_reduce=True,
+            **pa_kwargs,
+        )
+        triton_s2 = max(0.0, us_tot - us_s1)
+    else:
+        us_s1 = us_tot
+        triton_s2 = 0.0
+    return {
+        "triton_s1": round(us_s1, 2),
+        "triton_s2": round(triton_s2, 2),
+        "triton_tot": round(us_tot, 2),
+    }
+
+
+@benchmark()
+def test_mla_v4_triton_perf(gqa_ratio, batch, kv_seq_lens, num_kv_splits):
+    """Perf sweep row for combo bench / gfx1250 Triton sparse MLA v4 decode.
+
+    Shape ids mirror ``test_mla_v4_kargpreld.test_mla_v4_nm``:
+      T=batch (q_seq=1), H=gqa_ratio, ctx=kv_seq_lens, kv_splits=num_kv_splits,
+      D=512.
+    """
+    T = batch
+    H = gqa_ratio
+    D = _PA_DECODE_SPARSE_D
+    pages = T * kv_seq_lens
+    q, unified_kv, indices, indptr, sink, scale = _make_inputs(
+        T, H, D, kv_seq_lens, pages, variable_len=False
+    )
+    _, us = run_perftest(
+        pa_decode_sparse,
+        q,
+        unified_kv,
+        indices,
+        indptr,
+        sink,
+        scale,
+        has_invalid=False,
+        kv_splits=num_kv_splits,
+        num_iters=_PERF["num_iters"],
+        num_warmup=_PERF["num_warmup"],
+        num_rotate_args=1,
+    )
+    flops = 4 * T * H * kv_seq_lens * D  # QK^T + P@V
+    bpe = q.element_size()
+    nbytes = (T * H * D + T * kv_seq_lens * D + T * H * D) * bpe
+    return {
+        "us": round(us, 2),
+        "TFLOPS": round(flops / us / 1e6, 2),
+        "TB/s": round(nbytes / us / 1e6, 3),
+    }
+
+
+# ---------------------------------------------------------------------------
+# skip_reduce: the wrapper hands back the pre-reduce split-K partials and the
+# caller is responsible for the log-sum-exp combine + sink fold. This mirrors
+# the _pa_decode_sparse_reduce kernel in pure torch so we can validate the
+# partials against the dense reference.
+# ---------------------------------------------------------------------------
+
+
+def _wrapper_main_kernel_params(T: int, H: int, D: int):
+    """Reproduce the (use_exp2, block_k) the wrapper picks for the main kernel.
+
+    Must stay in sync with ``pa_decode_sparse``'s USE_EXP2 and block_k logic.
+    """
+    use_gluon = arch_info.get_arch() == "gfx1250"
+    use_exp2 = True
+    if use_gluon:
+        if H >= 128:
+            block_h = 128
+        elif H >= 64:
+            if T >= 2048:
+                block_h = 64
+            elif T >= 32:
+                block_h = 32
+            else:
+                block_h = 16
+        elif H >= 32:
+            if T >= 256:
+                block_h = 32
+            else:
+                block_h = 16
+        else:
+            block_h = triton.next_power_of_2(H)
+    else:
+        block_h = triton.next_power_of_2(min(H, 16))
+    if use_gluon:
+        block_k = 16
+        if block_h == 128:
+            block_k = 32
+    else:
+        block_k = 16 if D >= 256 else 32
+    return use_exp2, block_k
+
+
+def _reduce_partials_torch(
+    acc_partial, m_partial, l_partial, attn_sink, kv_indptr, block_k, use_exp2
+):
+    """Pure-torch port of _pa_decode_sparse_reduce.
+
+    Shapes:
+        acc_partial: [T, KV_SPLITS, H_padded, D] fp32
+        m_partial:   [T, KV_SPLITS, H_padded]    fp32
+        l_partial:   [T, KV_SPLITS, H_padded]    fp32
+    Returns [T, H, D] in attn_sink-implied output dtype (bf16/fp16 caller casts).
+    """
+    T, kv_splits, _, D = acc_partial.shape
+    H = attn_sink.shape[0]
+    device = acc_partial.device
+
+    expfn = torch.exp2 if use_exp2 else torch.exp
+    LOG2E = 1.4426950408889634
+    sink_scale = LOG2E if use_exp2 else 1.0
+
+    indptr = kv_indptr.to(torch.int64)
+    kv_lens = (indptr[1 : T + 1] - indptr[:T]).clamp(min=0)
+    seg_ids = torch.arange(kv_splits, device=device)
+    sink = attn_sink.float() * sink_scale  # [H]
+
+    out = torch.empty(T, H, D, dtype=torch.float32, device=device)
+    for t in range(T):
+        n = int(kv_lens[t].item())
+        # Match the kernel's tiles_per_segment / act_num_segments masking so we
+        # ignore the stale (uninitialised) partial-buffer slots that the split
+        # kernel early-returned on.
+        if n <= 0:
+            act_num_segments = 0
+        else:
+            tiles_per_segment = triton.cdiv(n, kv_splits * block_k)
+            act_num_segments = triton.cdiv(n, tiles_per_segment * block_k)
+        seg_mask = seg_ids < act_num_segments  # [KV_SPLITS]
+
+        m_p = m_partial[t, :, :H].clone()  # [KV_SPLITS, H]
+        l_p = l_partial[t, :, :H]
+        a_p = acc_partial[t, :, :H, :]  # [KV_SPLITS, H, D]
+        m_p = torch.where(seg_mask[:, None], m_p, torch.full_like(m_p, float("-inf")))
+
+        m_max = m_p.max(dim=0).values  # [H]
+        is_dead = m_p == float("-inf")  # [KV_SPLITS, H]
+        alpha = torch.where(is_dead, torch.zeros_like(m_p), expfn(m_p - m_max[None, :]))
+        l_comb = torch.where(is_dead, torch.zeros_like(l_p), l_p * alpha).sum(0)  # [H]
+        acc_comb = torch.where(
+            is_dead[:, :, None], torch.zeros_like(a_p), a_p * alpha[:, :, None]
+        ).sum(
+            0
+        )  # [H, D]
+
+        m_final = torch.maximum(m_max, sink)
+        alpha_kv = expfn(m_max - m_final)
+        alpha_sink = expfn(sink - m_final)
+        l_final = l_comb * alpha_kv + alpha_sink
+        acc_final = acc_comb * alpha_kv[:, None]
+        denom = l_final.clamp(min=1e-30)
+        out[t] = torch.where(
+            l_final[:, None] > 0.0,
+            acc_final / denom[:, None],
+            torch.zeros_like(acc_final),
+        )
+    return out
+
+
+@pytest.mark.parametrize("T", [1, 64, 256, 2048])
+@pytest.mark.parametrize("H", [16, 32, 64, 128])
+@pytest.mark.parametrize("D", [512])
+@pytest.mark.parametrize("kv_len", [136, 388, 1024])
+@pytest.mark.parametrize("var_len", [True, False])
+@pytest.mark.parametrize("sentinels", [False])
+@pytest.mark.parametrize("skip_reduce", [False])
+def test_pa_decode_sparse_vs_reference(
+    T, H, D, kv_len, var_len, sentinels, skip_reduce
+):
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA required")
+
+    pages = T * kv_len
+    q, ukv, indices, indptr, sink, scale = _make_inputs(
+        T,
+        H,
+        D,
+        kv_len,
+        pages,
+        include_sentinels=sentinels,
+        variable_len=var_len,
+    )
+
+    ref = pa_decode_sparse_reference(q, ukv, indices, indptr, sink, scale)
+    result = pa_decode_sparse(
+        q,
+        ukv,
+        indices,
+        indptr,
+        sink,
+        scale,
+        has_invalid=sentinels,
+        skip_reduce=skip_reduce,
+    )
+
+    if isinstance(result, tuple):
+        # skip_reduce with the split-K path active (kv_splits > 1): the wrapper
+        # returns raw partials, so do the log-sum-exp combine + sink fold here.
+        acc_partial, m_partial, l_partial = result
+        use_exp2, block_k = _wrapper_main_kernel_params(T, H, D)
+        out = _reduce_partials_torch(
+            acc_partial, m_partial, l_partial, sink, indptr, block_k, use_exp2
+        ).to(q.dtype)
+    else:
+        # kv_splits == 1 (skip_reduce is a no-op) or skip_reduce=False: the
+        # wrapper already returns the final output.
+        out = result
+
+    tol_err_ratio = 0.01
+    assert (
+        checkAllclose(
+            out.to(torch.bfloat16),
+            ref.to(torch.bfloat16),
+            atol=5e-3,
+            rtol=5e-3,
+            tol_err_ratio=tol_err_ratio,
+            msg="pa_decode_sparse output",
+        )
+        <= tol_err_ratio
+    )
+
+
+# ---------------------------------------------------------------------------
+# FP8 KV cache quantization helpers
+# ---------------------------------------------------------------------------
+
+_FP8_GROUP_SIZE = 64
+_FP8_DTYPE = torch.float8_e4m3fnuz
+
+
+def _quantize_kv_fp8(unified_kv, group_size=_FP8_GROUP_SIZE):
+    """Quantize bf16/fp16 unified_kv to (fp8, scales) with 1xGROUP_SIZE block scaling.
+
+    Returns (kv_fp8, kv_scales) where kv_fp8 is float8_e4m3fnuz and
+    kv_scales is [total_pages, D // group_size] fp32.
+    """
+    total_pages, D = unified_kv.shape
+    assert D % group_size == 0
+    num_groups = D // group_size
+    kv_f32 = unified_kv.float().view(total_pages, num_groups, group_size)
+    amax = kv_f32.abs().amax(dim=-1, keepdim=True).clamp(min=1e-12)
+    fp8_max = torch.finfo(_FP8_DTYPE).max
+    scales = (amax / fp8_max).squeeze(-1)  # [total_pages, num_groups]
+    kv_scaled = kv_f32 / amax * fp8_max
+    kv_fp8 = kv_scaled.view(total_pages, D).to(_FP8_DTYPE)
+    return kv_fp8, scales.to(torch.float32)
+
+
+def _dequant_kv_fp8(kv_fp8, kv_scales, group_size=_FP8_GROUP_SIZE):
+    """Dequantize for reference comparison."""
+    total_pages, D = kv_fp8.shape
+    num_groups = D // group_size
+    kv_f32 = kv_fp8.float().view(total_pages, num_groups, group_size)
+    scales_expanded = kv_scales.unsqueeze(-1).expand(
+        total_pages, num_groups, group_size
+    )
+    return (kv_f32 * scales_expanded).view(total_pages, D)
+
+
+@pytest.mark.parametrize("T", [1, 32])
+@pytest.mark.parametrize("H", [16])
+@pytest.mark.parametrize("D", [512])
+@pytest.mark.parametrize("kv_len", [100])
+@pytest.mark.parametrize("var_len", [True, False])
+def test_pa_decode_sparse_fp8_vs_reference(T, H, D, kv_len, var_len):
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA required")
+
+    pages = T * kv_len
+    q, ukv_bf16, indices, indptr, sink, scale = _make_inputs(
+        T,
+        H,
+        D,
+        kv_len,
+        pages,
+        variable_len=var_len,
+    )
+
+    # Quantize KV to fp8 + scales
+    kv_fp8, kv_scales = _quantize_kv_fp8(ukv_bf16)
+
+    # Reference: dequant back to bf16, run the torch reference
+    ukv_deq = _dequant_kv_fp8(kv_fp8, kv_scales).to(q.dtype)
+    ref = pa_decode_sparse_reference(q, ukv_deq, indices, indptr, sink, scale)
+
+    # Triton kernel with fp8 kv + kv_scales
+    out = pa_decode_sparse(
+        q,
+        kv_fp8,
+        indices,
+        indptr,
+        sink,
+        scale,
+        kv_scales=kv_scales,
+        has_invalid=False,
+    )
+
+    tol_err_ratio = 0.01
+    assert (
+        checkAllclose(
+            out.to(torch.bfloat16),
+            ref.to(torch.bfloat16),
+            atol=1e-2,
+            rtol=1e-2,
+            tol_err_ratio=tol_err_ratio,
+            msg="pa_decode_sparse output",
+        )
+        <= tol_err_ratio
+    )
+
+
+def make_packed_cache(num_tokens, D, dtype):
+    device = "cuda"
+    rope = 64  # DSv4 RoPE dim, stored bf16
+    block = 256  # packed cache page size
+    nope = D - rope  # NoPE dim, stored fp8 e4m3 OCP
+    nb = triton.cdiv(num_tokens, block)
+    if dtype == "bf16":
+        cache = (torch.randn(nb, block, D, device=device) * 0.4).to(torch.bfloat16)
+        return cache, cache.reshape(nb * block, D).float()
+
+    # per token: [nope fp8 (1B) | rope bf16 (2B) | 8 UE8M0 scale bytes]
+    data_bytes = nope + rope * 2
+    scale_bytes = 8
+    row_bytes = data_bytes + scale_bytes
+    cache = torch.zeros(nb, block, row_bytes, dtype=torch.uint8, device=device)
+    flat = cache.view(nb, block * row_bytes)
+    data = flat[:, : block * data_bytes].view(nb, block, data_bytes)
+    scales_region = flat[:, block * data_bytes :].view(nb, block, scale_bytes)
+    nope_fp8 = (torch.randn(nb, block, nope, device=device) * 0.4).to(
+        torch.float8_e4m3fn
+    )
+    data[:, :, :nope] = nope_fp8.view(torch.uint8)
+    rope_bf16 = (torch.randn(nb, block, rope, device=device) * 0.4).to(torch.bfloat16)
+    data[:, :, nope:data_bytes] = rope_bf16.view(torch.uint8).view(nb, block, rope * 2)
+    num_groups = nope // 64
+    exps = torch.randint(
+        124, 130, (nb, block, num_groups), device=device, dtype=torch.uint8
+    )
+    scales_region[:, :, :num_groups] = exps
+    scales = torch.exp2(exps.float() - 127.0).repeat_interleave(64, dim=2)
+    kv_deq = torch.cat([nope_fp8.float() * scales, rope_bf16.float()], dim=2)
+    return cache, kv_deq.reshape(nb * block, D)
+
+
+def widen_to_int32_overflow(cache, kv_deq):
+    """Re-lay ``cache`` as a strided view whose span exceeds a 32-bit offset.
+
+    Same nelement() and same contents, but the dim-0 pitch is stretched so the
+    last block sits past 2**31 bytes. Only the blocks themselves are written;
+    the padding between them is left uninitialised, so the pool costs its
+    address space but not the time to fill it.
+    """
+    nb, block, row = cache.shape
+    itemsize = cache.element_size()
+    pitch = triton.cdiv(2**31, max(1, nb - 1) * itemsize)
+    pitch = max(pitch, block * row)
+    # the packed fp8 cache is viewed as bfloat16, which needs an even stride
+    pitch += pitch % 2
+    pool = torch.empty(
+        pitch * (nb - 1) + block * row, dtype=cache.dtype, device=cache.device
+    )
+    view = pool.as_strided((nb, block, row), (pitch, row, 1))
+    view.copy_(cache)
+    assert view.stride(0) * itemsize * (nb - 1) >= 2**31
+    return view, kv_deq
+
+
+def two_loop_reference(
+    q,
+    main_deq,
+    main_idx,
+    main_indptr,
+    extra_deq,
+    extra_idx,
+    extra_indptr,
+    attn_sink,
+    softmax_scale,
+):
+    """Reference for the SWA(main) + top-k(extra) two-loop: concatenate the two
+    dequantized pools, merge the two ragged index sets (extra slots shifted past
+    the main pool), then reuse ``pa_decode_sparse_reference``.
+    """
+    main_pages = main_deq.shape[0]
+    combined = torch.cat([main_deq, extra_deq], dim=0).to(q.dtype)
+    T = main_indptr.numel() - 1
+    mi, mp = main_idx.long(), main_indptr.long()
+    ei, ep = extra_idx.long(), extra_indptr.long()
+    rows, lens = [], []
+    for tok in range(T):
+        row = torch.cat(
+            [mi[mp[tok] : mp[tok + 1]], ei[ep[tok] : ep[tok + 1]] + main_pages]
+        )
+        rows.append(row)
+        lens.append(row.numel())
+    combined_idx = torch.cat(rows).to(torch.int32)
+    combined_indptr = torch.zeros(T + 1, dtype=torch.int32, device=q.device)
+    combined_indptr[1:] = torch.tensor(lens, device=q.device).cumsum(0)
+    return pa_decode_sparse_reference(
+        q, combined, combined_idx, combined_indptr, attn_sink, softmax_scale
+    )
+
+
+@pytest.mark.parametrize("T", [1, 32, 128])
+@pytest.mark.parametrize("H", [16])
+@pytest.mark.parametrize("D", [512])
+@pytest.mark.parametrize("main_len", [128])
+@pytest.mark.parametrize("extra_len", [8, 256])
+@pytest.mark.parametrize("dtype", ["bf16", "fp8"])
+@pytest.mark.parametrize("strided_cache", [False, True])
+def test_pa_decode_sparse_two_loop(T, H, D, main_len, extra_len, dtype, strided_cache):
+    """gfx950 vLLM DSv4 decode path: SWA (main) + top-k (extra) two-loop over
+    packed caches. fp8 (fp8_ds_mla) is the vLLM production format; bf16 is also
+    exercised. Skipped off gfx950 (extra_* is a packed-only gluon path)."""
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA required")
+    if arch_info.get_arch() != "gfx950":
+        pytest.skip("two-loop (extra_*) is a gfx950 packed-cache-only path")
+    if strided_cache:
+        # The pool has to span >2 GiB for the offsets to overflow, so pin the
+        # regression to one shape -- the fp8 production format at the largest T
+        # -- rather than paying it on all 24 combinations.
+        if dtype != "fp8" or T != 128:
+            pytest.skip("strided-cache case is pinned to the fp8 T=128 shape")
+        if torch.cuda.mem_get_info()[0] < 4 * 1024**3:
+            pytest.skip("needs ~3 GiB free for the >2 GiB strided pool")
+
+    device = "cuda"
+    torch.manual_seed(0)
+    q = torch.randn(T, H, D, dtype=torch.bfloat16, device=device) * 0.125
+    attn_sink = torch.randn(H, dtype=torch.float32, device=device) * 0.1
+    softmax_scale = float(D) ** -0.5
+
+    # main = contiguous SWA window per query
+    main_cache, main_deq = make_packed_cache(T * main_len, D, dtype)
+    query_base = (torch.arange(T, device=device) * main_len)[:, None]
+    main_idx = (
+        (query_base + torch.arange(main_len, device=device)).to(torch.int32).reshape(-1)
+    )
+    main_indptr = torch.arange(
+        0, T * main_len + 1, main_len, dtype=torch.int32, device=device
+    )
+    # extra = scattered top-k over a pool
+    extra_pool = T * extra_len
+    extra_cache, extra_deq = make_packed_cache(extra_pool, D, dtype)
+    if strided_cache:
+        extra_cache, extra_deq = widen_to_int32_overflow(extra_cache, extra_deq)
+    extra_idx = torch.randint(
+        0, extra_pool, (T, extra_len), device=device, dtype=torch.int32
+    ).reshape(-1)
+    extra_indptr = torch.arange(
+        0, T * extra_len + 1, extra_len, dtype=torch.int32, device=device
+    )
+
+    ref = two_loop_reference(
+        q,
+        main_deq,
+        main_idx,
+        main_indptr,
+        extra_deq,
+        extra_idx,
+        extra_indptr,
+        attn_sink,
+        softmax_scale,
+    )
+    out = pa_decode_sparse(
+        q,
+        main_cache,
+        main_idx,
+        main_indptr,
+        attn_sink,
+        softmax_scale,
+        extra_cache=extra_cache,
+        extra_indices=extra_idx,
+        extra_indptr=extra_indptr,
+    )
+
+    tol = 1e-2 if dtype == "fp8" else 5e-3
+    torch.testing.assert_close(out, ref, atol=tol, rtol=tol)


### PR DESCRIPTION
## Summary
- add the gfx1250 combined microbenchmark on top of the latest main branch
- add F8GEMM alongside the existing F4GEMM runner
- expose `func`, `perf`, and `profile` GEMM execution modes
- run the PR #4748 functional shape matrices in UT mode, including both A preshuffle paths
- keep correctness error/result columns in the combined report
- document FP4, FP8, and combined GEMM UT commands in the module docstring

## Validation
- `git diff --check`
- `python3 -m py_compile op_tests/bench_gfx1250_combo.py`
- `ruff check op_tests/bench_gfx1250_combo.py`

GPU execution was not run locally because this environment does not provide the gfx1250 Python/runtime dependencies.