### PR TITLE
[gfx1250] fused_moe: require GUGU gu_interleave layout

### DIFF
--- a/aiter/fused_moe.py
+++ b/aiter/fused_moe.py
@@ -756,6 +756,12 @@ def _fused_moe_impl(
     ], f"Invalid MoE weight: {w1.shape=} {w2.shape=}"
     isG1U1 = inter_dim != w1.shape[1]
     isShuffled = getattr(w1, "is_shuffled", False) or getattr(w2, "is_shuffled", False)
+    # gfx1250: GUGU row-interleave, not 16-row block shuffle.
+    if get_gfx() == "gfx1250" and isG1U1 and gate_mode != GateMode.INTERLEAVE:
+        raise ValueError(
+            "gfx1250 fused_moe requires gu_interleave weight layout "
+            f"(gate_mode={GateMode.INTERLEAVE.value!r}), got {gate_mode.value!r}"
+        )
 
     global_E = E
     if expert_mask is not None:


### PR DESCRIPTION
## Summary
- gfx1250 grouped GEMM only consumes GUGU (gate/up row-interleaved) `w1`, not 16-row block shuffle.
- `fused_moe` now raises if G1U1 callers on gfx1250 pass a `gate_mode` other than `interleave`.

## Test plan
- [x] On gfx1250, run grouped GEMM UT with `gate_mode=interleave` (should still pass accuracy).
- [x] On gfx1250, call `fused_moe` with G1U1 + `gate_mode=separated` and confirm it raises `ValueError`.
- [x] Non-gfx1250 paths unchanged.


Made with [Cursor](https://cursor.com)