### PR TITLE
[Triton/Gluon] Tune MoE GEMM A8W8 blockscale

### DIFF
--- a/aiter/ops/triton/moe/moe_op_gemm_a8w8_blockscale.py
+++ b/aiter/ops/triton/moe/moe_op_gemm_a8w8_blockscale.py
@@ -80,7 +80,7 @@ def get_kernel_config(m, n, k, routing_data):
     if block_m == 16:
         block_n = 256
         block_k = 128
-        num_warps = 4
+        num_warps = 8
 
         grid_m = routing_data.n_blocks(m, block_m)
         grid_n = triton.cdiv(n, block_n)


### PR DESCRIPTION
## Motivation

In `moe_gemm_a8w8_blockscale`'s wrapper file, The `block_m == 16` branch of `get_kernel_config()` launches with `num_warps=4`. For the default `BLOCK_N=256`, that bucket loads a 128×256 W tile per K-step (`BLOCK_K=128`), i.e. 32,768 W elements. Because this is an 8-bit matmul, that is 32 KiB of W data per K-step. The kernel does this via `WPtrs` + `tl.load(WPtrs)` inside the K loop, and this bucket is bandwidth-bound, so it needs waves to hide load latency.

On gfx950, the `block_m=16` bucket is **+26.5%** slower than Triton 3.4 on the DeepSeek-R1 layer-2 shape. The kernel config is identical between the two versions (`num_stages=2`, so the regression is compiler-side: the constant originated before Triton enabling async direct-to-LDS by default on gfx950 (`third_party/amd/backend/compiler.py:33`), which changed how the loop is pipelined. `num_warps=8` recovers it.


## Technical Details

```python
 if block_m == 16:
     block_n = 256
     block_k = 128
-    num_warps = 4
+    num_warps = 8
```

One line in `aiter/ops/triton/moe/moe_op_gemm_a8w8_blockscale.py`. No logic change. Only shapes with `block_m == 16` are affected; every other shape already used `num_warps=8`.

## Test Plan

We run these benchmark numbers and sweeps with `rocprofv3 --kernel-trace`, per-dispatch end-start, first and last 10% dropped, mean of the middle 80%. 250 iterations -> 200 kept, 5 reps, median.

Shapes from `model_benchmarking_tool/model_shapes.json` (`moe_op_gemm_a8w8_blockscale`): 
- DeepSeek-R1 `E=256, Dim1=7168, Dim2=4096,
TopK=8`
 
and 
- Kimi-K2 `E=384, Dim1=7168, Dim2=4096,
TopK=8`

each as the two MoE layers across an M sweep. All 8 shapes measured, not only the regressing one, since the branch fires for any `block_m == 16`.

## Test Result
Updated table: 

| KERNEL | SHAPE | golden_runs_us (5 reps) | tot_runs_us (5 reps) | golden_us | tot_us | delta_us | delta_% | threshold_us | status |
|---|---|---|---|---|---|---|---|---|---|
| _moe_gemm_a8w8_blockscale | E384 K2048 N7168 topk8 M1024 | 1112.1;1112.1;1111.7;1112.0;1111.9 | 1048.3;1048.5;1048.3;1048.3;1048.4 | 1112.03 | 1048.32 | -63.70 | -5.73% | 1118.09 | improvement |
| _moe_gemm_a8w8_blockscale | E256 K2048 N7168 topk8 M1024 | 997.4;997.5;997.3;997.9;997.3 | 968.3;968.6;968.0;968.6;968.5 | 997.42 | 968.46 | -28.96 | -2.90% | 1002.91 | improvement |
| _moe_gemm_a8w8_blockscale | E256 K2048 N7168 topk8 M4096 | 1484.2;1483.6;1485.0;1482.9;1485.2 | 1463.5;1462.8;1463.4;1463.1;1462.7 | 1484.15 | 1463.09 | -21.06 | -1.42% | 1492.07 | improvement |
| _moe_gemm_a8w8_blockscale | E256 K2048 N7168 topk8 M128 | 591.0;590.9;591.0;590.1;591.2 | 589.0;588.8;589.3;588.9;589.1 | 590.98 | 589.05 | -1.93 | -0.33% | 594.43 | ok |
| _moe_gemm_a8w8_blockscale | E256 K7168 N4096 topk8 M128 | golden cannot compile | 1081.4;1081.4;1081.9;1079.5;1079.8 | - | 1081.40 | - | - | - | no baseline |
| _moe_gemm_a8w8_blockscale | E256 K7168 N4096 topk8 M1024 | golden cannot compile | 1574.2;1573.1;1573.2;1572.8;1573.3 | - | 1573.16 | - | - | - | no baseline |
| _moe_gemm_a8w8_blockscale | E256 K7168 N4096 topk8 M4096 | golden cannot compile | 2635.5;2645.2;2647.0;2645.7;2646.8 | - | 2645.74 | - | - | - | no baseline |
| _moe_gemm_a8w8_blockscale | E384 K7168 N4096 topk8 M1024 | golden cannot compile | 1711.3;1715.3;1715.8;1715.2;1716.9 | - | 1715.28 | - | - | - | no baseline |

**No regressions. 3 improvements, 1 ok.**

The regressing shape `E256 K2048 N7168 topk8 M128` goes from **+15.99%** before this change to **-0.33%** after, so regression is closed.

The four "no baseline" rows are Triton 3.4 aborting in `TritonAMDGPUCanonicalizePointers`. They run correctly on 3.8. Pre-existing, not caused by this change.

- Correctness: 
`768 passed in 69.81s (0:01:09)`

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
