### PR TITLE
[Triton/Gluon] Tune MoE GEMM A8W8

### DIFF
--- a/aiter/ops/triton/moe/moe_op_gemm_a8w8.py
+++ b/aiter/ops/triton/moe/moe_op_gemm_a8w8.py
@@ -67,7 +67,7 @@ def allocate_output(
     return matmul_output, final_output
 
 
-def get_kernel_config(m, n, k, routing_data):
+def get_kernel_config(m, n, k, routing_data, swizzle_mx_scale=None):
     block_m = routing_data.block_m
     group_m = 4
     num_xcds = 8
@@ -94,9 +94,19 @@ def get_kernel_config(m, n, k, routing_data):
         block_n = 256
         block_k = 256
         num_warps = 8
+        if swizzle_mx_scale is None:
+            # switch to block_k=128 as 256 exceeds LDS budget
+            block_k = 128
+            if block_m >= 128:
+                block_n = 128
+            elif block_m == 64:
+                num_warps = 4
     num_stages = pick_gemm_num_stages(
         arch, block_m, block_n, block_k, 8, 8, use_async_padding=True
     )
+    if swizzle_mx_scale is None and block_m == 64 and block_k == 128 and block_n == 256:
+        # Override the heuristic to use num_stages=1 for preserving occupancy
+        num_stages = 1
 
     ret = {
         "block_m": block_m,
@@ -177,7 +187,7 @@ def moe_gemm_a8w8(
     if unpadded_K and block_m == 16:
         K = unpadded_K
     # compute optimization flags
-    config = get_kernel_config(M, N, K, routing_data)
+    config = get_kernel_config(M, N, K, routing_data, swizzle_mx_scale)
     if apply_swiglu and config["split_k"] > 1:
         apply_swiglu_matmul = False
         reduction_n_matmul = 1


### PR DESCRIPTION
## Motivation

While comparing Triton 3.8 changes against Triton 3.4 on gfx950, `moe_gemm_a8w8` had 3 regressing shapes:
- `E128 K4096 N3072 topk8 M4096`
- `E128 K4096 N3072 topk8 M1024`
- `E128 K1536 N4096 topk8 M1024`

The tiles no longer fit. The `block_m != 16` branch of `get_kernel_config()` has asked for `block_n=256, block_k=256`, and that was fine until Triton 3.8 enabled async copy (direct-to-LDS) by default on gfx950. Async copy needs a padded shared-memory layout, which pushes this tile to 166-221 KB against a 163,840 B budget. It doesn't fit, so `pick_gemm_num_stages()` quietly falls back to a single pipeline stage. 

Halving `block_k` gets the tile back under budget. Which `block_n` / `num_warps` / `num_stages` to pair with it depends on `block_m`, so this is a small gate change rather than constants. All three regressions are now clean.

## Technical Details
14 insertions, 2 deletions:

```python
-def get_kernel_config(m, n, k, routing_data):
+def get_kernel_config(m, n, k, routing_data, swizzle_mx_scale=None): # changed on 2 other lines outside of this block
     ...
     else:
         block_n = 256
         block_k = 256
         num_warps = 8
+        if swizzle_mx_scale is None:
+            block_k = 128
+            if block_m >= 128:
+                block_n = 128
+            elif block_m == 64:
+                num_warps = 4
```

On the same non-mx condition, `num_stages` is changed to 1 for the `block_m == 64` tile since it measured faster. Clean A/B with everything else held equal (block_k=128, block_n=256, num_warps=8): 0.998x vs 1.242x on one block_m=64 shape and 0.974x vs 1.367x on the other. The extra stage costs more occupancy than it buys in latency hiding.

The mx path derives `MX_SCALE_BLOCK_K = block_k // MX_PACK_DIVISOR` (32) and then reshapes by `MX_SCALE_BLOCK_K // 8`; at `block_k=128` that is `4 // 8 == 0`, a zero-sized dim, and the kernel fails to compile with `ValueError: Shape element 1 must be a power of 2`. Hence the `swizzle_mx_scale is None` guard and the new parameter, passed from the single call site.

The best `(block_n, num_warps, num_stages)` varies with `block_m`, so a single constant does not work - `bk128+nw4` is best at `block_m=64` but the worst option at 128, and worse than the old tile at 32.

## Test Plan

`rocprofv3 --kernel-trace`, per-dispatch End-Start, first and last 10% dropped, mean of the middle 80%. 250 iters -> 200 kept, 5 reps, median.

Shapes from `model_benchmarking_tool/model_shapes.json` (`moe_op_gemm_a8w8`):
- Llama4 Maverick `E=128, Dim1=5120, Dim2=16384, TopK=1` 

and 
- Qwen3-235B `E=128, Dim1=4096, Dim2=3072, TopK=8` 

as both MoE layers across an M sweep. All 8 shapes measured, including the 4 outside the changed branch, to confirm they are unaffected.

## Test Result

| KERNEL | SHAPE | branch | golden_runs_us (5 reps) | tot_runs_us (5 reps) | golden_us | tot_us | delta_us | delta_% | threshold_us | status |
|---|---|---|---|---|---|---|---|---|---|---|
| _moe_gemm_a8w8 | E128 K4096 N3072 topk8 M128 | untouched | 425.9;425.4;425.7;425.4;425.5 | 388.5;388.6;388.8;389.0;388.8 | 425.50 | 388.82 | -36.68 | -8.62% | 428.13 | improvement |
| _moe_gemm_a8w8 | E128 K8192 N5120 topk1 M1024 | untouched | 1507.8;1508.6;1508.8;1507.2;1508.0 | 1428.6;1426.7;1428.9;1428.7;1427.3 | 1508.01 | 1428.65 | -79.36 | -5.26% | 1516.05 | improvement |
| _moe_gemm_a8w8 | E128 K4096 N3072 topk8 M4096 | **changed** | 706.2;705.1;705.4;705.3;705.5 | 673.6;673.2;673.4;673.6;672.9 | 705.41 | 673.42 | -31.98 | -4.53% | 709.43 | improvement |
| _moe_gemm_a8w8 | E128 K4096 N3072 topk8 M1024 | **changed** | 371.3;372.1;371.6;371.9;372.2 | 363.0;363.0;362.6;362.5;362.5 | 371.92 | 362.63 | -9.29 | -2.50% | 374.28 | improvement |
| _moe_gemm_a8w8 | E128 K1536 N4096 topk8 M1024 | **changed** | 214.4;213.9;214.0;214.0;215.1 | 213.7;213.4;213.7;213.6;213.6 | 213.99 | 213.63 | -0.36 | -0.17% | 215.56 | ok |
| _moe_gemm_a8w8 | E128 K5120 N16384 topk1 M4096 | **changed** | golden cannot compile | 2180.6;2182.2;2184.0;2180.2;2178.5 | - | 2180.57 | - | - | - | no baseline |
| _moe_gemm_a8w8 | E128 K5120 N16384 topk1 M128 | untouched | golden cannot compile | 1599.8;1600.0;1598.4;1599.3;1599.3 | - | 1599.34 | - | - | - | no baseline |
| _moe_gemm_a8w8 | E128 K5120 N16384 topk1 M1024 | untouched | golden cannot compile | 2864.4;2861.8;2865.7;2866.9;2867.6 | - | 2865.71 | - | - | - | no baseline |

**No remaining outstanding regressions.**

Of the 4 shapes in the changed `block_m != 16` branch, 3 had a golden baseline and all 3 were regressions; they are now -4.53%, -2.50% and -0.17%. The 4th (`E128 K5120 N16384 topk1 M4096`) has no baseline and is unchanged in verdict.

The other 4 rows are in the untouched `block_m == 16` branch. They are measured to prove this patch does not disturb them - their -8.62% / -5.26% figures are pre-existing Triton 3.8 wins and are not attributable to this change.

The three `no baseline` rows are Triton 3.4 aborting while processing the MLIR module (`moe_op_gemm_a8w8.py:198`, SIGABRT); they run correctly on 3.8. Pre-existing and unrelated to this change.

### Register pressure

`Scratch_Size` is 0 on every shape with both the old and new tile - no spilling. VGPR count drops on the larger tiles (100 -> 52 at `block_m=128`, 56 -> 40 at 32) for better occupancy and is flat-to-slightly-up at 64 (80 -> 84, 76 -> 76). This allows runtime to excel golden and better optimization

**Correctness:**
- `test_moe_gemm_a8w8.py`: 576 passed, 0 failed

int: `black --check` and `ruff check` clean

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
