### PR TITLE
[Triton/Attention] Clamp unified_attention 3D config to the LDS budget on gfx1201

### DIFF
--- a/aiter/ops/triton/attention/unified_attention.py
+++ b/aiter/ops/triton/attention/unified_attention.py
@@ -34,6 +34,7 @@ except:  # noqa: E722
     _reduce_segments_gluon = None
 
 from aiter.ops.triton._triton_kernels.flash_attn_triton_amd.utils import get_arch
+from aiter.ops.flydsl.utils import get_shared_memory_per_block
 from aiter.ops.triton.utils._triton import arch_info
 from aiter.ops.triton.utils.types import e4m3_dtype
 
@@ -156,6 +157,29 @@ def select_2d_config(
     }
 
 
+def _unified_3d_lds_footprint(
+    tile_size: int,
+    head_size_padded: int,
+    kv_elem_bytes: int,
+    q_elem_bytes: int,
+    block_m: int,
+    num_stages: int,
+) -> int:
+    """Shared memory (LDS) requested by kernel_unified_attention_3d on the gfx1201 stack.
+
+    The gfx1201 Triton stack honors the requested pipeline depth and double-buffers
+    both the K and V tiles: ``2 (K, V) * tile * head * kv_elem_bytes * num_stages``,
+    plus the Q tile (``block_m * head * q_elem_bytes``). At TILE_SIZE=64 / head_size=128 /
+    bf16 KV that is 65792-73728 B, over the 64 KB limit (issue #4329, downstream
+    vllm-project/vllm#48723). The formula reproduces all three reported footprints
+    exactly (measured via ``triton.compile(...).metadata.shared``).
+    """
+    return (
+        2 * tile_size * head_size_padded * kv_elem_bytes * num_stages
+        + block_m * head_size_padded * q_elem_bytes
+    )
+
+
 def select_3d_config(
     head_size,
     block_size,
@@ -167,6 +191,7 @@ def select_3d_config(
     shuffled_kv_cache: bool = False,
     NUM_BLOCKS_GATHER_PER_TILE: int = 1,
     SLIDING_WINDOW: int | None = None,
+    block_m: int = 16,
 ):
     arch = get_arch()
     reduce_num_warps = 2
@@ -290,6 +315,54 @@ def select_3d_config(
     # with bitwise-identical output. Mirrors the waves_per_eu=8 gfx1151 tuning above.
     if DEVICE_ARCH == "gfx1151":
         attn_warps = 8
+
+    # gfx1201: clamp the 3D config to the device LDS budget. This stack's Triton honors
+    # the requested pipeline depth, so the shared request can exceed 64 KB (e.g.
+    # TILE_SIZE=64 / head_size=128 / bf16 KV), which Triton rejects at kernel launch
+    # (issue #4329, downstream vllm-project/vllm#48723). Other archs are untouched:
+    # gfx1250 has 320 KB of LDS, and the gfx1151 stack resolves the same request to
+    # 33024 B (measured), so clamping there would change working configs.
+    if DEVICE_ARCH == "gfx1201":
+        head_size_padded = triton.next_power_of_2(head_size)
+        kv_elem_bytes = 1 if kv_cache_dtype in (e4m3_dtype, torch.uint8) else 2
+        q_elem_bytes = 1 if q_dtype == e4m3_dtype else 2
+        lds_budget = get_shared_memory_per_block(fallback_gfx=DEVICE_ARCH)
+        lds_footprint = _unified_3d_lds_footprint(
+            TILE_SIZE, head_size_padded, kv_elem_bytes, q_elem_bytes, block_m, attn_stages
+        )
+        if lds_footprint > lds_budget:
+            # Drop a pipeline stage first: it halves the K/V term and keeps the tiling
+            # (TILE_SIZE) that the segment and gather sizing above depends on.
+            if attn_stages > 1:
+                attn_stages = 1
+                lds_footprint = _unified_3d_lds_footprint(
+                    TILE_SIZE, head_size_padded, kv_elem_bytes, q_elem_bytes, block_m, attn_stages
+                )
+            # Shrink TILE_SIZE only where the tiling is not coupled to the KV block
+            # layout: shuffled cache loads one block per tile, and gather mode derives
+            # NUM_BLOCKS_GATHER_PER_TILE from TILE_SIZE.
+            if (
+                lds_footprint > lds_budget
+                and not shuffled_kv_cache
+                and NUM_BLOCKS_GATHER_PER_TILE == 1
+            ):
+                while lds_footprint > lds_budget and TILE_SIZE > 16:
+                    TILE_SIZE = TILE_SIZE // 2
+                    lds_footprint = _unified_3d_lds_footprint(
+                        TILE_SIZE,
+                        head_size_padded,
+                        kv_elem_bytes,
+                        q_elem_bytes,
+                        block_m,
+                        attn_stages,
+                    )
+            if lds_footprint > lds_budget:
+                raise ValueError(
+                    f"unified_attention 3D config does not fit the {lds_budget} B LDS budget: "
+                    f"TILE_SIZE={TILE_SIZE} head_size={head_size} kv_dtype={kv_cache_dtype} "
+                    f"q_dtype={q_dtype} block_m={block_m} num_stages={attn_stages} "
+                    f"requires {lds_footprint} B (issue #4329)"
+                )
 
     attn_config = {
         "TILE_SIZE": TILE_SIZE,
@@ -560,6 +633,7 @@ def unified_attention(
             shuffled_kv_cache,
             NUM_BLOCKS_GATHER_PER_TILE,
             SLIDING_WINDOW,
+            BLOCK_M,
         )
         NUM_SEGMENTS = attn_config["NUM_SEGMENTS_PER_SEQ"]
         if NUM_SEGMENTS > 1:

--- a/op_tests/triton_tests/attention/test_unified_attention_lds_budget.py
+++ b/op_tests/triton_tests/attention/test_unified_attention_lds_budget.py
@@ -1,0 +1,96 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+"""Regression tests for the gfx1201 LDS-budget clamp in select_3d_config (issue #4329).
+
+The 3D split-KV kernel's shared-memory request on the gfx1201 Triton stack is
+``2 (K, V) * TILE_SIZE * head_size_padded * kv_elem_bytes * num_stages + Q tile``.
+At TILE_SIZE=64 / head_size=128 / bf16 KV the shipped config requests
+65792-73728 B, over the 64 KB limit, so Triton aborts at kernel launch
+(downstream: vllm-project/vllm#48723, `vllm serve` startup failure).
+"""
+
+import pytest
+import torch
+
+try:
+    from aiter.ops.triton.attention.unified_attention import (
+        DEVICE_ARCH,
+        _unified_3d_lds_footprint,
+        select_3d_config,
+    )
+    from aiter.ops.triton.utils.types import e4m3_dtype
+except Exception:  # CPU-only host or triton unavailable
+    pytest.skip("unified_attention module not importable on this host", allow_module_level=True)
+
+BUDGET_64KB = 65536
+
+# (tile_size, head_padded, kv_elem_bytes, q_elem_bytes, block_m, num_stages, expected bytes)
+# The three footprints reported in issue #4329 / vllm#48723, measured via
+# triton.compile(...).metadata.shared.
+REPORTED_OVERFLOW_CONFIGS = [
+    (64, 128, 2, 2, 1, 2, 65792),
+    (64, 128, 2, 2, 16, 2, 69632),
+    (64, 128, 2, 2, 32, 2, 73728),
+]
+
+
+def test_footprint_reproduces_reported_overflows():
+    for tile, head, kvb, qb, bm, stages, expected in REPORTED_OVERFLOW_CONFIGS:
+        got = _unified_3d_lds_footprint(tile, head, kvb, qb, bm, stages)
+        assert got == expected, f"footprint model drift: {got} != {expected}"
+        assert got > BUDGET_64KB
+
+
+def _select_3d(head_size, block_size, q_dtype, kv_dtype, block_m):
+    return select_3d_config(
+        head_size,
+        block_size,
+        max_seqlen_k=16384,
+        target_num_prgms=160,
+        num_2d_prgms=40,
+        q_dtype=q_dtype,
+        kv_cache_dtype=kv_dtype,
+        shuffled_kv_cache=False,
+        NUM_BLOCKS_GATHER_PER_TILE=1,
+        SLIDING_WINDOW=None,
+        block_m=block_m,
+    )
+
+
+@pytest.mark.skipif(DEVICE_ARCH != "gfx1201", reason="clamp is scoped to gfx1201")
+def test_select_3d_config_clamps_overflow_configs_on_gfx1201():
+    # The vllm#48723 shape: head_size=128, bf16 KV, block_size 64 (TILE_SIZE 64),
+    # long context so the 3D path is selected.
+    for block_m in (1, 16, 32):
+        attn_config, _ = _select_3d(128, 64, torch.bfloat16, torch.bfloat16, block_m)
+        footprint = _unified_3d_lds_footprint(
+            attn_config["TILE_SIZE"],
+            128,
+            2,
+            2,
+            block_m,
+            attn_config["num_stages"],
+        )
+        assert footprint <= BUDGET_64KB, (
+            f"3D config over the 64 KB LDS budget: {footprint} B "
+            f"(TILE_SIZE={attn_config['TILE_SIZE']}, num_stages={attn_config['num_stages']})"
+        )
+
+
+@pytest.mark.skipif(DEVICE_ARCH != "gfx1201", reason="guard against over-clamping on gfx1201")
+def test_select_3d_config_keeps_fitting_configs_untouched_on_gfx1201():
+    # FP8 KV halves the K/V pipeline: the full double-buffered config fits, so the
+    # clamp must not touch it (over-clamping would regress throughput).
+    attn_config, _ = _select_3d(128, 64, torch.bfloat16, e4m3_dtype, 16)
+    assert attn_config["num_stages"] == 2
+    assert attn_config["TILE_SIZE"] == 64
+
+
+@pytest.mark.skipif(DEVICE_ARCH != "gfx1151", reason="gfx1151 keeps its working config")
+def test_select_3d_config_unchanged_on_gfx1151():
+    # The gfx1151 stack resolves the same request to 33024 B (measured in #4329),
+    # so the clamp is deliberately not applied there; this guards that scoping.
+    attn_config, _ = _select_3d(128, 64, torch.bfloat16, torch.bfloat16, 16)
+    assert attn_config["num_stages"] == 2
+    assert attn_config["TILE_SIZE"] == 64


### PR DESCRIPTION
Fixes #4329.

## Summary

`select_3d_config` chooses the 3D split-KV tiling without any check that the resulting shared-memory (LDS) request fits the target device. On gfx1201 (Radeon AI PRO R9700), the Triton stack honors the requested pipeline depth and double-buffers **both** the K and V tiles, so the shipped config (TILE_SIZE=64, head_size=128, bf16 KV) requests 65792-73728 B, over the 64 KB limit, and Triton aborts at kernel launch:

```
triton.runtime.errors.OutOfResources: out of resource: shared memory
    Required: 65792, Hardware limit: 65536
```

Downstream this is a hard `vllm serve` startup failure for head_size=128 models on the AITER unified-attention backend (vllm-project/vllm#48723).

## Fix

A budget check in `select_3d_config`, scoped to gfx1201:

- The shared request is modeled as `2 (K, V) * TILE_SIZE * head_size_padded * kv_elem_bytes * num_stages + block_m * head_size_padded * q_elem_bytes`. The formula reproduces all three reported footprints (65792 / 69632 / 73728 B, measured via `triton.compile(...).metadata.shared`) exactly.
- When the budget is exceeded: drop the pipeline depth 2 -> 1 first (halves the K/V term and keeps the tiling the segment/gather sizing depends on), then shrink TILE_SIZE 64 -> 32 -> 16 where the tiling is not coupled to the KV block layout (shuffled cache / gather mode). If still infeasible, raise a clear `ValueError` instead of letting Triton reject the config at launch.
- The device budget comes from the existing `get_shared_memory_per_block` helper (live query with a per-gfx fallback).

## Why scoped to gfx1201

- **gfx1250** has 320 KB of LDS; the config never overflows there.
- **gfx1151** (Strix Halo): the issue's measurements show the same request resolves to 33024 B on that stack, i.e. it fits today. Clamping there would change a working config. Notably, the stage-1 result of this clamp is exactly that 33024 B footprint. If a future stack change pushes gfx1151 over the same cliff, widening the scope is a one-line change.
- **CDNA** is untouched — no behavior change for any shipping CDNA config.

## Notes

- Makes the vllm-side stopgap (vllm-project/vllm#49264) unnecessary for gfx1201.
- Related unmerged candidates: #4385 (aiter, different shape), vllm-project/vllm#49264 (downstream stopgap).
- No kernel changes; pure config selection. The only cost is stages 2 -> 1 for configs that previously failed to launch at all.

## Test

New `op_tests/triton_tests/attention/test_unified_attention_lds_budget.py`:

- footprint model reproduces the three reported byte counts (runs on any arch)
- gfx1201: overflow configs are clamped inside the budget; a fitting fp8-KV config is left untouched (no over-clamping)
- gfx1151: config unchanged (scope guard)

Verified on gfx1201 (R9700): 3 passed, 1 skipped (gfx1151 guard); with the clamp disabled the regression test fails with `assert 65792 <= 65536`.
