### PR TITLE
[HIP] fix(topk): correct lambda arity in ob::radix_kernel / last_filter_kernel

### DIFF
--- a/csrc/kernels/topk_per_row_kernels.cu
+++ b/csrc/kernels/topk_per_row_kernels.cu
@@ -1140,7 +1140,7 @@ __device__ void filter_and_histogram(T const* in_buf,
 
     if(pass == 0)
     {
-        auto f = [select_min, start_bit, mask](T value, IdxT, int&, int&, bool) {
+        auto f = [select_min, start_bit, mask](T value, IdxT) {
             int bucket = calc_bucket<T, BitsPerPass>(value, start_bit, mask, select_min);
             atomicAdd(histogram_smem + bucket, static_cast<IdxT>(1));
         };
@@ -1169,7 +1169,7 @@ __device__ void filter_and_histogram(T const* in_buf,
                   kth_value_bits,
                   p_filter_cnt,
                   p_out_cnt,
-                  early_stop](T value, IdxT i, int&, int&, bool) {
+                  early_stop](T value, IdxT i) {
             const auto previous_bits = (twiddle_in(value, select_min) >> previous_start_bit)
                                        << previous_start_bit;
             if(previous_bits == kth_value_bits)
@@ -1698,7 +1698,7 @@ __global__ void last_filter_kernel(T const* in,
               in_idx_buf,
               out,
               out_idx,
-              rowStart](T value, IdxT i, int&, int&, bool) {
+              rowStart](T value, IdxT i) {
         const auto bits = (twiddle_in(value, select_min) >> start_bit) << start_bit;
         if(bits < kth_value_bits)
         {
@@ -2602,6 +2602,17 @@ inline void dispatch_topk_oneblock(void* buf, size_t& buf_size, T const* in, Idx
 }
 
 } } // namespace aiter::ob
+
+// Compile-time regression guard. standalone_stable_radix_topk_ has no callers,
+// so its templates are only type-checked if something instantiates them; without
+// this the body silently rots (it had drifted out of sync with vectorized_process
+// and no longer compiled). Instantiate one specialization so the build breaks
+// instead.
+namespace aiter { namespace ob {
+template void standalone_stable_radix_topk_<float, int, 11, 1024, false, Phase::Prefill>(
+    void*, size_t&, float const*, int const*, int, int64_t, int*, int*, int,
+    float*, int*, bool, bool, unsigned, hipStream_t, bool, int);
+} }
 
 // Top-level dispatcher: selects mb or ob path based on batch size and hardware.
 // TOPK_FORCE_PATH=mul/one  -- force a specific path


### PR DESCRIPTION
## Problem

`ob::standalone_stable_radix_topk_` does not compile. It has no callers, so its
templates are never instantiated, never type-checked, and the body has drifted
out of sync with `vectorized_process`.

Reproduce with an explicit instantiation:

```cpp
namespace aiter { namespace ob {
template void standalone_stable_radix_topk_<float, int, 11, 1024, false, Phase::Prefill>(
    void*, size_t&, float const*, int const*, int, int64_t, int*, int*, int,
    float*, int*, bool, bool, unsigned, hipStream_t, bool, int);
} }
```

```
error: no matching function for call to object of type '(lambda at ...)'
note: candidate function not viable: requires 5 arguments, but 2 were provided
```

## Cause

Three lambdas declare five parameters:

```cpp
auto f = [select_min, start_bit, mask](T value, IdxT, int&, int&, bool) { ... };
```

`vectorized_process`, their only caller, invokes them with two:

```cpp
f(wide0.array[j], real_i + j);
```

The trailing three are unnamed and unused — the lambdas capture everything they
need. Both copies of `vectorized_process` (`mb::`, `ob::`) use the two-argument
form, as does the live `ob::radix_topk_one_block_kernel` lambda.

## Change

Three lines: drop the unused parameters. No live path is affected.

Plus one explicit instantiation, which serves as the regression test — an
uninstantiated template is never checked, which is how this rotted. There is no
precedent for it in the repo; the fix stands without it if you would rather not
carry the symbol.

## Verification

`hipcc -c --offload-arch=gfx950 -std=c++17` at `e9e1278b1`, upstream headers:

| build | result |
|---|---|
| patched | 0 errors |
| patched, one lambda reverted to five parameters | 8 errors |

