### PR TITLE
[HIP] [JIT] fp8_paged_mqa_logits: hand-written gfx950 decode indexer kernel

### DIFF
--- a/aiter/jit/optCompilerConfig.json
+++ b/aiter/jit/optCompilerConfig.json
@@ -1872,5 +1872,16 @@
         "extra_include": [],
         "verbose": "False",
         "blob_gen_cmd": "''"
+    },
+    "module_fp8_paged_mqa_logits": {
+        "srcs": [
+            "f'{AITER_CSRC_DIR}/pybind/fp8_paged_mqa_logits_pybind.cu'",
+            "f'{AITER_CSRC_DIR}/kernels/fp8_paged_mqa_logits.cu'"
+        ],
+        "flags_extra_cc": [],
+        "flags_extra_hip": ["'-fno-honor-nans'"],
+        "extra_ldflags": "None",
+        "extra_include": [],
+        "verbose": "False"
     }
 }

--- a/aiter/ops/fp8_paged_mqa_logits.py
+++ b/aiter/ops/fp8_paged_mqa_logits.py
@@ -1,0 +1,76 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+"""Hand-written HIP decode-phase FP8 paged MQA indexer logits kernel for gfx950.
+
+The paged half of the DeepSeek-V3.2 / GLM-5 sparse-attention lightning indexer:
+
+    logits[m, n] = sum_h relu(Q[m,h,:] . K[n,:]) * w[m,h] * kv_scale[n]
+
+K and its per-token dequant scale are co-packed in a paged cache and gathered
+through a block table. Drop-in for ``deepgemm_fp8_paged_mqa_logits``, so the two
+can be A/B'd on identical inputs.
+
+Fixed at n_heads=32, head_dim=128 -- the shipped GLM-5-FP8 indexer shape.
+``is_supported()`` gates on that, so a caller that also has to serve other shapes
+can route them to the Triton kernel rather than trip a TORCH_CHECK.
+"""
+
+from torch import Tensor
+
+from ..jit.core import compile_ops
+from ..jit.utils.chip_info import get_gfx
+
+MD_NAME = "module_fp8_paged_mqa_logits"
+
+SUPPORTED_GFX = ("gfx950",)
+NUM_HEADS = 32
+HEAD_DIM = 128
+# KVBlockSize folds into the kernel as a compile-time constant, and each value is
+# tied to one cache layout -- the pairing production uses.
+SUPPORTED_KV_BLOCK_SIZES = (1, 64)
+
+
+def is_supported(num_heads: int, head_dim: int, kv_block_size: int = 1) -> bool:
+    """True when this kernel can run this shape/layout on this device."""
+    return (
+        get_gfx() in SUPPORTED_GFX
+        and num_heads == NUM_HEADS
+        and head_dim == HEAD_DIM
+        and kv_block_size in SUPPORTED_KV_BLOCK_SIZES
+    )
+
+
+@compile_ops(MD_NAME, fc_name="fp8_paged_mqa_logits")
+def fp8_paged_mqa_logits(
+    q_fp8: Tensor,
+    kv_cache_fp8: Tensor,
+    weights: Tensor,
+    context_lens: Tensor,
+    block_tables: Tensor,
+    max_model_len: int,
+    ChunkK: int = 0,
+    SplitKV: int = 0,
+    num_warps: int = 0,
+    TotalCuCount: int = 256,
+    RowsPerBlock: int = 0,
+    out: Tensor | None = None,
+) -> Tensor:
+    """Decode indexer logits over a paged KV cache.
+
+    q_fp8        [batch, next_n, 32, 128] fp8
+    kv_cache_fp8 [num_blocks, block_size, 1, index_dim] -- block_size*128 fp8 K
+                 bytes followed by block_size f32 dequant scales, so
+                 index_dim == 132 for the fp8 layout.
+                 block_size must be 1 or 64, and the two take different layouts,
+                 exactly as in production: block_size=1 takes the plain cache,
+                 block_size=64 takes the `shuffle_weight(layout=(16, 16))`
+                 preshuffled one.
+    weights      [batch*next_n, 32] f32   context_lens [batch] i32
+    block_tables [batch, max_blocks_per_seq] i32
+
+    The zero-valued tunables (ChunkK, SplitKV, num_warps, RowsPerBlock) mean "use
+    the host heuristic". Writes into `out` when given (and returns it), otherwise
+    allocates [batch*next_n, max_model_len] f32. Only the causal window
+    p <= context_lens[b] - next_n + n is written; the -inf outside it is the
+    caller's, exactly as for `deepgemm_fp8_paged_mqa_logits`.
+    """

--- a/csrc/include/fp8_paged_mqa_logits.h
+++ b/csrc/include/fp8_paged_mqa_logits.h
@@ -1,0 +1,45 @@
+#pragma once
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+//
+// Hand-written HIP decode-phase FP8 paged MQA indexer logits kernel for gfx950.
+//
+// The paged half of the DeepSeek-V3.2 / GLM-5 sparse-attention lightning indexer:
+//
+//   logits[m, n] = sum_h relu(Q[m,h,:] . K[n,:]) * w[m,h] * kv_scale[n]
+//
+// K and its per-token dequant scale are co-packed in a paged cache and gathered
+// through a block table. Same tensor contract as
+// `deepgemm_fp8_paged_mqa_logits`, so it drops into the same call site.
+//
+// Fixed at n_heads=32, head_dim=128 -- the shipped GLM-5-FP8 indexer shape.
+
+// aiter builds csrc without hipify, so the ATen CUDA headers (which pull in
+// cuda_runtime_api.h) are unavailable -- use the HIP-flavoured ones, as the rest
+// of csrc does.
+#include <ATen/hip/HIPContext.h>
+#include <ATen/hip/impl/HIPGuardImplMasqueradingAsCUDA.h>
+#include <c10/util/Optional.h>
+#include <torch/all.h>
+#include <torch/extension.h>
+#include <cstdlib>
+#include <type_traits>
+
+// Writes into `out` when given (and returns it), otherwise allocates
+// [batch*next_n, max_model_len] f32. Only the causal window
+// p <= context_lens[b] - next_n + n is written; the -inf outside it is the
+// caller's, exactly as for deepgemm_fp8_paged_mqa_logits.
+torch::Tensor
+fp8_paged_mqa_logits(torch::Tensor q_fp8,        // [batch, next_n, 32, 128] fp8
+                     torch::Tensor kv_cache_fp8, // [blocks, bsz, 1, index_dim];
+                                                 // bsz=1 plain, bsz=64 preshuffled
+                     torch::Tensor weights,      // [batch*next_n, 32] f32
+                     torch::Tensor context_lens, // [batch]             i32
+                     torch::Tensor block_tables, // [batch, max_blocks] i32
+                     int64_t max_model_len,
+                     int64_t ChunkK,
+                     int64_t SplitKV,
+                     int64_t num_warps,
+                     int64_t TotalCuCount,
+                     int64_t RowsPerBlock,
+                     std::optional<torch::Tensor> out);

--- a/csrc/include/rocm_ops.hpp
+++ b/csrc/include/rocm_ops.hpp
@@ -2780,3 +2780,19 @@ namespace py = pybind11;
           py::arg("final_lse"),              \
           py::arg("q_scale"),                \
           py::arg("kv_scale"));
+
+#define FP8_PAGED_MQA_LOGITS_PYBIND                    \
+    m.def("fp8_paged_mqa_logits",                      \
+          &fp8_paged_mqa_logits,                       \
+          py::arg("q_fp8"),                            \
+          py::arg("kv_cache_fp8"),                     \
+          py::arg("weights"),                          \
+          py::arg("context_lens"),                     \
+          py::arg("block_tables"),                     \
+          py::arg("max_model_len"),                    \
+          py::arg("ChunkK")       = 0,                 \
+          py::arg("SplitKV")      = 0,                 \
+          py::arg("num_warps")    = 0,                 \
+          py::arg("TotalCuCount") = 256,               \
+          py::arg("RowsPerBlock") = 0,                 \
+          py::arg("out")          = std::nullopt);

--- a/csrc/kernels/fp8_paged_mqa_logits.cu
+++ b/csrc/kernels/fp8_paged_mqa_logits.cu
@@ -1,0 +1,388 @@
+// SPDX-License-Identifier: MIT
+// Decode-phase FP8 paged MQA indexer logits kernel, gfx950.
+#include "fp8_paged_mqa_logits.h"
+
+// ============================================================================
+// fp8_paged_mqa_logits — decode-phase indexer kernel (GLM-5-FP8), CDNA4 / gfx950
+//
+// K is streamed from the paged cache straight to registers: 32 heads x 32 tokens
+// per V_MFMA_SCALE_F32_32X32X64_F8F6F4 tile, no LDS staging on the K path.
+//
+// Tunable parameters:
+//   NUM_WARPS       — template: warps per block (occupancy)
+//   CHUNK_K         — template: context positions per chunk; the unit SplitKV
+//                     hands to a block, so it sets the grid.y granularity
+//   KV_BLOCK_SIZE   — template: paged block size. 1 reads the plain co-packed
+//                     cache, 64 the shuffle_weight((16,16)) preshuffled one
+//   ROWS_PER_BLOCK  — template: next_n rows sharing one K stream
+//   SplitKV         — runtime:  parallelism over context length (grid size)
+// ============================================================================
+
+using fp8 = __hip_fp8_storage_t;
+
+constexpr int WARP_SIZE  = 64;
+constexpr int NUM_HEADS  = 32;
+constexpr int HEAD_SIZE  = 128;
+
+#define CDIV(a, b) ((a) + (b) - 1) / b
+// ============================================================================
+// Two epilogue choices that are worth spelling out, both measured against the
+// straightforward version (48 v_mul + 48 v_max + 48 fma + 3 ds_bpermute per tile
+// at NW8/CK64/KB64/R3):
+//   (a) hoist the per-token scale OUT of the relu/weight loop. kv_scale >= 0 (it is
+//       a quantisation scale), so relu(c*s)*w == s*relu(c)*w — this also matches the
+//       torch reference exactly (it applies the scale after the head reduction).
+//       Kills 16 v_mul per row per tile (48 at R=3), leaving one v_mul per row.
+//   (b) replace __shfl_down(x,32) (→ ds_bpermute_b32, LDS round-trip + lgkmcnt wait,
+//       ~11% of stalls per the ATT trace) with V_PERMLANE32_SWAP_B32, a pure-VALU
+//       cross-row swap. Semantics (probed on HW): `v_permlane32_swap_b32 a, b`
+//       swaps a.row1 (lanes 32-63) with b.row0 (lanes 0-31), so after the swap
+//       b.row0 holds a's old lanes 32-63 — exactly the shfl_down(32) operand.
+//       Emitted as inline asm: the clang builtin mis-models its second output
+//       (both results map to the same VGPR).
+// ============================================================================
+namespace mqa_paged {
+
+using f8x16 = __attribute__((__vector_size__(16))) fp8;
+using f8x32 = __attribute__((__vector_size__(32))) fp8;
+
+// lanes 0-31 receive x[lane+32]; lanes 32-63 get garbage (unused).
+// `v_permlane32_swap_b32 a, b` → a = (a.row0, b.row0), b = (a.row1, b.row1), so b's
+// low half ends up holding a's old high half — the shfl_down(32) operand, in VALU.
+// The `s_nop 1` is mandatory: a VALU write of the source needs 2 wait states before
+// a permlane-swap read of it (this matches the nops LLVM emits around the builtin).
+// Without it the swap reads stale data and the logits come out wrong. The builtin
+// itself is unusable here — clang lowers both of its results to the same VGPR.
+// relu(x). Compiled with -fno-honor-nans (set for this module in
+// aiter/jit/optCompilerConfig.json) this is a single
+// `v_max_f32 x, 0, x`. Without that flag LLVM must assume x may be a signalling NaN
+// and emits an IEEE canonicalize `v_max_f32 x, x, x` first — two VALU per value, and
+// this loop runs NACC of them per row per tile, ~27% of all VALU in the kernel.
+// Inline asm would also give one instruction but is NOT safe here: the hazard
+// recognizer does not treat inline asm as a reader of the MFMA destination, so the
+// mandatory post-MFMA s_nops disappear and the accumulator is read before it lands.
+__device__ __forceinline__ float relu_fast(float x) { return fmaxf(x, 0.0f); }
+
+__device__ __forceinline__ float swap32_hi(float x) {
+    float hi;
+    asm("s_nop 1\n\tv_permlane32_swap_b32 %0, %1" : "+v"(x), "=&v"(hi));
+    return hi;
+}
+
+template <int NUM_WARPS, int CHUNK_K, int KV_BLOCK_SIZE, int ROWS_PER_BLOCK>
+__global__ __launch_bounds__(NUM_WARPS * WARP_SIZE)
+void fp8_paged_mqa_logits_kernel(
+    const fp8*   __restrict__ Q_ptr,
+    const fp8*   __restrict__ kv_cache_ptr,
+    const float* __restrict__ weights_ptr,
+    const int*   __restrict__ context_lens,
+    const int*   __restrict__ block_tables,
+    float*       __restrict__ logits_ptr,
+    int batch_size, int next_n,
+    int max_blocks_per_seq, int max_model_len, int index_dim,
+    int SplitKV
+){
+    constexpr int TILE_N = 32;                 // tokens per tile
+    constexpr int NACC   = 16;                 // C accumulator floats/lane
+    using VecOutMFMA = __attribute__((__vector_size__(NACC * sizeof(float)))) float;
+    constexpr bool PRESHUFFLE = (KV_BLOCK_SIZE > 1);
+    constexpr int UNIT_SCALE = 0x7f;
+
+    const int pid_batch    = blockIdx.x;
+    const int pid_split_kv = blockIdx.y;
+    const int row_start    = blockIdx.z * ROWS_PER_BLOCK;
+    if (pid_batch >= batch_size || row_start >= next_n) return;
+
+    const int ctx_len      = context_lens[pid_batch];
+    const int ctx_chunks   = CDIV(ctx_len, CHUNK_K);
+    const int split_chunks = CDIV(ctx_chunks, SplitKV);
+    const int split_start  = pid_split_kv * split_chunks * CHUNK_K;
+    const int split_end    = min(ctx_len, split_start + split_chunks * CHUNK_K);
+    if (split_start >= ctx_len) return;
+
+    const int l    = threadIdx.x % WARP_SIZE;
+    const int warpId = threadIdx.x / WARP_SIZE;
+    const int rw    = l / 16;
+    const int col   = l % 16;
+    const int nA    = col + 16 * (rw & 1);     // input M/N index (0..31)
+    const int dhalf = rw / 2;                  // 0 or 1
+    const int jtok  = l % 32;                  // output token index
+    const int hset  = l / 32;                  // output head-set (0/1)
+
+    f8x32 q_reg[ROWS_PER_BLOCK][2];            // [row][MFMA# (dims 0-63 / 64-127)]
+    float w_reg[ROWS_PER_BLOCK][NACC];         // weights for this lane's 16 output heads
+
+    const int  q_row0 = pid_batch * next_n + row_start;
+    const int* bt     = block_tables + (int64_t)pid_batch * max_blocks_per_seq;
+
+    auto pack = [&](f8x16 lo, f8x16 hi) -> f8x32 {
+        f8x32 v; *reinterpret_cast<f8x16*>(&v) = lo; *(reinterpret_cast<f8x16*>(&v) + 1) = hi; return v;
+    };
+    // 16 contiguous fp8 of K at (token, 16-dim run d_hi) given resolved block blk.
+    auto kv16 = [&](int blk, int token, int d_hi) -> f8x16 {
+        const int off = token % KV_BLOCK_SIZE;
+        const int64_t base = (int64_t)blk * (KV_BLOCK_SIZE * index_dim);
+        int64_t a;
+        if constexpr (PRESHUFFLE)
+            a = base + (int64_t)d_hi * 256 + (off & 15) * 16
+              + ((off & (KV_BLOCK_SIZE - 1)) >> 4) * 16 * HEAD_SIZE;
+        else
+            a = base + (int64_t)off * HEAD_SIZE + d_hi * 16;
+        return *reinterpret_cast<const f8x16*>(kv_cache_ptr + a);
+    };
+    auto scale_addr = [&](int blk, int token) -> int64_t {
+        const int off = token % KV_BLOCK_SIZE;
+        return (int64_t)blk * (KV_BLOCK_SIZE * index_dim)
+             + (int64_t)KV_BLOCK_SIZE * HEAD_SIZE + (int64_t)off * 4;
+    };
+    auto load_blk = [&](int tt) -> int {
+        if constexpr (KV_BLOCK_SIZE == 1) {
+            const int tok = split_start + tt * TILE_N + nA;
+            return (tok < ctx_len) ? bt[tok] : -1;
+        } else {
+            const int tb = split_start + tt * TILE_N;
+            return (tb < ctx_len) ? bt[tb / KV_BLOCK_SIZE] : -1;
+        }
+    };
+
+    // ---- Q → registers; W → registers (16 output heads for this lane) ----
+    #pragma unroll
+    for (int r = 0; r < ROWS_PER_BLOCK; ++r) {
+        if (row_start + r >= next_n) break;
+        const int head = nA;                                     // input M index
+        const int qb = (q_row0 + r) * NUM_HEADS * HEAD_SIZE + head * HEAD_SIZE;
+        q_reg[r][0] = pack(*reinterpret_cast<const f8x16*>(&Q_ptr[qb + dhalf * 16]),
+                           *reinterpret_cast<const f8x16*>(&Q_ptr[qb + (2 + dhalf) * 16]));
+        q_reg[r][1] = pack(*reinterpret_cast<const f8x16*>(&Q_ptr[qb + (4 + dhalf) * 16]),
+                           *reinterpret_cast<const f8x16*>(&Q_ptr[qb + (6 + dhalf) * 16]));
+        #pragma unroll
+        for (int v = 0; v < NACC; ++v) {
+            const int i = 8 * (v / 4) + 4 * hset + (v % 4);      // output head for this vgpr
+            w_reg[r][v] = weights_ptr[(q_row0 + r) * NUM_HEADS + i];
+        }
+    }
+
+    const int num_tiles = CDIV(split_end - split_start, TILE_N);
+    int blk_cur = load_blk(warpId);
+    for (int t = warpId; t < num_tiles; t += NUM_WARPS) {
+        const int blk_next = load_blk(t + NUM_WARPS);
+        const int token_base = split_start + t * TILE_N;
+        const int token      = token_base + nA;
+
+        f8x32 vB0, vB1;
+        if (blk_cur >= 0 && token < ctx_len) {
+            vB0 = pack(kv16(blk_cur, token, dhalf), kv16(blk_cur, token, 2 + dhalf));
+            vB1 = pack(kv16(blk_cur, token, 4 + dhalf), kv16(blk_cur, token, 6 + dhalf));
+        } else { vB0 = f8x32{}; vB1 = f8x32{}; }
+
+        const int stoken = token_base + jtok;
+        int blk_s = blk_cur;
+        if constexpr (KV_BLOCK_SIZE == 1) blk_s = (stoken < ctx_len) ? bt[stoken] : -1;
+        const float kv_scale = (stoken < ctx_len && blk_s >= 0)
+            ? *reinterpret_cast<const float*>(kv_cache_ptr + scale_addr(blk_s, stoken)) : 0.0f;
+        blk_cur = blk_next;
+
+        #pragma unroll
+        for (int r = 0; r < ROWS_PER_BLOCK; ++r) {
+            if (row_start + r >= next_n) break;
+            VecOutMFMA vC = {};
+            vC = __builtin_amdgcn_mfma_scale_f32_32x32x64_f8f6f4(
+                q_reg[r][0], vB0, vC, 0, 0, 0, UNIT_SCALE, 0, UNIT_SCALE);
+            vC = __builtin_amdgcn_mfma_scale_f32_32x32x64_f8f6f4(
+                q_reg[r][1], vB1, vC, 0, 0, 0, UNIT_SCALE, 0, UNIT_SCALE);
+
+            // Scale hoisted out of the relu: kv_scale >= 0 (it is a quantisation
+            // scale) so relu(c*s)*w == s*relu(c)*w, which is also exactly what the
+            // torch reference computes. Saves NACC v_mul per row per tile.
+            float partial = 0.0f;
+            #pragma unroll
+            for (int v = 0; v < NACC; ++v)
+                partial += relu_fast(vC[v]) * w_reg[r][v];
+            // lanes l and l+32 hold the same token, hence the same kv_scale, so the
+            // scale applies once, after the head reduction.
+            partial = (partial + swap32_hi(partial)) * kv_scale;
+
+            if (l < 32) {
+                const int abs_pos = token_base + jtok;
+                const int causal_limit = ctx_len - next_n + row_start + r;
+                if (abs_pos < ctx_len && abs_pos <= causal_limit && abs_pos < max_model_len)
+                    logits_ptr[(int64_t)(q_row0 + r) * max_model_len + abs_pos] = partial;
+            }
+        }
+    }
+}
+
+}  // namespace mqa_paged
+// ============================================================================
+// Host dispatch
+// ============================================================================
+static void dispatch_fp8_paged_mqa_logits(
+    const fp8* d_q, const fp8* d_kv, const float* d_w,
+    const int* d_ctx, const int* d_bt, float* d_out,
+    int batch_size, int next_n,
+    int max_blocks_per_seq, int max_model_len, int index_dim,
+    int ChunkK, int SplitKV, int num_warps, int kv_block_size,
+    int rows_per_block, hipStream_t stream
+) {
+    // grid = dim3(batch, SplitKV, num_groups). Each block owns ROWS_PER_BLOCK
+    // (=R) consecutive next_n rows; num_groups = ceil(next_n / R).
+    const int num_groups = CDIV(next_n, rows_per_block);
+
+    const dim3 grid = dim3(batch_size, SplitKV, num_groups);
+
+    #define LAUNCH(NW, CK, KB, R)                                                       \
+        mqa_paged::fp8_paged_mqa_logits_kernel<NW, CK, KB, R>                          \
+            <<<grid, NW * WARP_SIZE, 0, stream>>>(                                       \
+                d_q, d_kv, d_w, d_ctx, d_bt, d_out,                                      \
+                batch_size, next_n, max_blocks_per_seq, max_model_len, index_dim, SplitKV);
+
+    // R folds in as a compile-time constant so q_reg/w_reg stay in registers.
+    #define LAUNCH_NN(NW, CK, KB)                                                       \
+        switch (rows_per_block) {                                                       \
+            case 1: { LAUNCH(NW, CK, KB, 1) break; }                                    \
+            case 2: { LAUNCH(NW, CK, KB, 2) break; }                                    \
+            case 3: { LAUNCH(NW, CK, KB, 3) break; }                                    \
+            case 4: { LAUNCH(NW, CK, KB, 4) break; }                                    \
+            case 6: { LAUNCH(NW, CK, KB, 6) break; }                                    \
+            case 8: { LAUNCH(NW, CK, KB, 8) break; }                                    \
+            default:                                                                    \
+                throw std::runtime_error("Unsupported rows_per_block="                  \
+                    + std::to_string(rows_per_block) + ". Supported: 1,2,3,4,6,8");     \
+        }
+
+    // block_size folds into the kernel as a compile-time constant so the
+    // token->slot div/mod become shifts/ands; {1, 64} match the indexer's
+    // ROCm-supported KV block sizes.
+    #define LAUNCH_KB(NW, CK)                                                           \
+        switch (kv_block_size) {                                                        \
+            case 1:  { LAUNCH_NN(NW, CK, 1)  break; }                                   \
+            case 64: { LAUNCH_NN(NW, CK, 64) break; }                                   \
+            default:                                                                    \
+                throw std::runtime_error("Unsupported kv_block_size="                   \
+                    + std::to_string(kv_block_size) + ". Supported: 1, 64");            \
+        }
+
+    #define LAUNCH_NW(NW)                                                               \
+        switch (ChunkK) {                                                               \
+            case 64:  { LAUNCH_KB(NW, 64)  break; }                                     \
+            case 128: { LAUNCH_KB(NW, 128) break; }                                     \
+            case 256: { LAUNCH_KB(NW, 256) break; }                                     \
+            default:                                                                    \
+                throw std::runtime_error("Unsupported ChunkK=" + std::to_string(ChunkK) \
+                    + ". Supported: 64, 128, 256");                                     \
+        }
+
+    switch (num_warps) {
+        case 2: { LAUNCH_NW(2) break; }
+        case 4: { LAUNCH_NW(4) break; }
+        case 8: { LAUNCH_NW(8) break; }
+        default:
+            throw std::runtime_error("Unsupported num_warps=" + std::to_string(num_warps)
+                + ". Supported: 2, 4, 8");
+    }
+    #undef LAUNCH_NW
+    #undef LAUNCH_KB
+    #undef LAUNCH_NN
+    #undef LAUNCH
+}
+
+// ============================================================================
+// Torch-facing entry point
+// ============================================================================
+torch::Tensor fp8_paged_mqa_logits(
+    torch::Tensor q_fp8,            // [batch, next_n, 32, 128]
+    torch::Tensor kv_cache_fp8,     // [num_blocks, block_size, 1, index_dim]
+    torch::Tensor weights,          // [batch*next_n, 32]
+    torch::Tensor context_lens,     // [batch]
+    torch::Tensor block_tables,     // [batch, max_blocks_per_seq]
+    int64_t max_model_len,
+    int64_t ChunkK,
+    int64_t SplitKV,
+    int64_t num_warps,
+    int64_t TotalCuCount,
+    int64_t RowsPerBlock,
+    std::optional<torch::Tensor> out
+) {
+    const int batch_size         = q_fp8.size(0);
+    const int next_n             = q_fp8.size(1);
+    const int n_heads            = q_fp8.size(2);
+    const int head_dim           = q_fp8.size(3);
+    const int kv_block_size      = kv_cache_fp8.size(1);
+    const int index_dim          = kv_cache_fp8.size(3);
+    const int max_blocks_per_seq = block_tables.size(1);
+    const int total_cu_i         = static_cast<int>(TotalCuCount);
+
+    TORCH_CHECK(n_heads == NUM_HEADS && head_dim == HEAD_SIZE,
+                "Only n_heads=32, head_dim=128 supported");
+    TORCH_CHECK(kv_cache_fp8.is_contiguous(),
+                "kv_cache_fp8 must be contiguous for paged MQA logits");
+
+    // ---- autotune ChunkK, num_warps, R, SplitKV ----
+    // From the gfx950 reliable (cache-busting) sweep, the best config tracks the
+    // total K footprint tot = batch*ctx_len (redundancy vs occupancy trade):
+    //   tot <  32K  → R=1  (tiny: maximise occupancy, K-redundancy is ~free/L2)
+    //   tot < 158K  → R=2  (mid: occupancy still dominates)
+    //   else        → R=3  (bandwidth-bound: minimise redundant K reads; plenty
+    //                       of work for occupancy). R>=4/6 never wins (q_reg
+    //                       register pressure kills waves — occupancy is the only
+    //                       HBM-latency hider; prefetch/large-R both hurt).
+    //   CHUNK_K = 128 for long ctx (more splittable tiles) or R=1; else 256.
+    //   num_warps = 8 except the tiny R=1 case (4).
+    const int mml_i = static_cast<int>(max_model_len);
+    const int64_t tot = (int64_t)batch_size * mml_i;
+
+    int chunk_k_i      = static_cast<int>(ChunkK);
+    int num_warps_i    = static_cast<int>(num_warps);
+    int rows_per_block = static_cast<int>(RowsPerBlock);
+    int split_kv_i     = static_cast<int>(SplitKV);
+
+    // Fitted against a 35-shape tuning sweep.
+    // num_warps=4 is the broad optimum, with 8 only in a mid band; large total
+    // footprints want the small chunk.
+    if (rows_per_block <= 0) rows_per_block = (tot < 90000) ? 1 : (tot < 280000 ? 2 : 3);
+    if (rows_per_block > next_n) rows_per_block = next_n;
+    if (num_warps_i <= 0) num_warps_i = (tot >= 80000 && tot < 280000) ? 8 : 4;
+    if (chunk_k_i   <= 0)
+        chunk_k_i = (mml_i >= 50000) ? (tot >= 400000 ? 64 : 128)
+                                     : (tot < 280000 ? 256 : 64);
+
+    if (split_kv_i <= 0) {
+        const int ctx_chunks_ub = std::max(1, (mml_i + chunk_k_i - 1) / chunk_k_i);
+        const int num_groups = (next_n + rows_per_block - 1) / rows_per_block;
+        const int units = std::max(1, batch_size * num_groups);
+        const int target_blocks = total_cu_i * 2;   // ~2 blocks/CU (tail + latency)
+        split_kv_i = std::max(1, std::min(ctx_chunks_ub,
+            (target_blocks + units - 1) / units));
+    }
+
+    // The kernel writes only the causal window, so the -inf outside it is the
+    // caller's -- same contract as deepgemm_fp8_paged_mqa_logits. When no buffer is
+    // handed in, allocate one; those positions are then simply undefined.
+    torch::Tensor out_logits =
+        out.has_value() ? out.value()
+                        : torch::empty({batch_size * next_n,
+                                        static_cast<int64_t>(max_model_len)},
+                                       torch::dtype(torch::kFloat32).device(q_fp8.device()));
+    TORCH_CHECK(out_logits.scalar_type() == torch::kFloat32 &&
+                    out_logits.is_contiguous() &&
+                    out_logits.size(0) == batch_size * next_n &&
+                    out_logits.size(1) == max_model_len,
+                "out must be a contiguous f32 [batch*next_n, max_model_len] tensor");
+
+    const at::hip::OptionalHIPGuardMasqueradingAsCUDA guard(device_of(out_logits));
+    const hipStream_t stream = at::hip::getCurrentHIPStreamMasqueradingAsCUDA();
+
+    dispatch_fp8_paged_mqa_logits(
+        static_cast<fp8*>(q_fp8.data_ptr()),
+        static_cast<fp8*>(kv_cache_fp8.data_ptr()),
+        static_cast<float*>(weights.data_ptr()),
+        static_cast<int*>(context_lens.data_ptr()),
+        static_cast<int*>(block_tables.data_ptr()),
+        out_logits.data_ptr<float>(),
+        batch_size, next_n, max_blocks_per_seq,
+        static_cast<int>(max_model_len), index_dim,
+        chunk_k_i, split_kv_i,
+        num_warps_i, kv_block_size, rows_per_block, stream);
+
+    return out_logits;
+}

--- a/csrc/pybind/fp8_paged_mqa_logits_pybind.cu
+++ b/csrc/pybind/fp8_paged_mqa_logits_pybind.cu
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+#include "fp8_paged_mqa_logits.h"
+#include "rocm_ops.hpp"
+
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) { FP8_PAGED_MQA_LOGITS_PYBIND; }

--- a/op_tests/test_fp8_paged_mqa_logits.py
+++ b/op_tests/test_fp8_paged_mqa_logits.py
@@ -1,0 +1,398 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+"""Correctness + perf sweep for the decode FP8 paged MQA indexer logits kernels.
+
+Candidates are the production Triton/Gluon kernel
+(`deepgemm_fp8_paged_mqa_logits`) and the hand-written HIP one
+(`aiter.ops.fp8_paged_mqa_logits`), graded against the same fp32 torch reference
+on identical inputs.
+
+The HIP kernel only covers nh=32/hd=128 on gfx950 and KVBlockSize in {1, 64}, so
+it is added per case rather than unconditionally; its cells stay NaN elsewhere.
+"""
+
+import argparse
+import itertools
+import random
+
+import pandas as pd
+import torch
+
+import aiter
+from aiter import dtypes
+from aiter.jit.utils.chip_info import get_gfx
+from aiter.ops.triton.attention.pa_mqa_logits import deepgemm_fp8_paged_mqa_logits
+from aiter.ops.triton.utils.types import get_fp8_e4m3_dtype
+from aiter.test_common import benchmark, checkAllclose, run_perftest
+
+torch.set_default_device("cuda")
+
+SUPPORTED_GFX = ["gfx950"]
+
+# What the production Triton host uses for this op.
+REF_CHUNK_K = 256
+REF_WAVE_PER_EU = 2
+
+try:
+    from aiter.ops.fp8_paged_mqa_logits import fp8_paged_mqa_logits as hip_paged_logits
+    from aiter.ops.fp8_paged_mqa_logits import is_supported as hip_supported
+except ImportError:
+    hip_paged_logits = None
+
+    def hip_supported(num_heads, head_dim, kv_block_size=1):
+        return False
+
+
+def calc_diff(x, y):
+    x, y = x.double(), y.double()
+    return 1 - 2 * (x * y).sum() / (x * x + y * y).sum()
+
+
+def kv_cache_cast_to_fp8(x, fp8_dtype):
+    """Co-pack a bf16 KV cache into the fp8+scale byte layout: per block-row,
+    block_size*head_dim fp8 bytes then block_size f32 scales, no padding.
+    """
+    num_blocks, block_size, num_heads, head_dim = x.shape
+    assert num_heads == 1
+    x_amax = x.abs().float().amax(dim=3, keepdim=True).clamp(1e-4)
+    sf = x_amax / 240.0
+    x_scaled = (x * (1.0 / sf)).to(fp8_dtype)
+    x_fp8 = torch.empty(
+        (num_blocks, block_size * (head_dim + 4)), device=x.device, dtype=torch.uint8
+    )
+    x_fp8[:, : block_size * head_dim] = x_scaled.view(
+        num_blocks, block_size * head_dim
+    ).view(dtype=torch.uint8)
+    x_fp8[:, block_size * head_dim : block_size * head_dim + 4 * block_size] = sf.view(
+        num_blocks, block_size
+    ).view(dtype=torch.uint8)
+    return x_fp8.view(num_blocks, block_size, num_heads, head_dim + 4)
+
+
+def preshuffle_kv_data(kv_cache_fp8, head_dim):
+    """Apply ``shuffle_weight(layout=(16,16))`` to the per-block fp8 key bytes,
+    leaving the co-packed f32 scale tail alone -- the production Preshuffle
+    layout. Only the kernel gets this copy; the reference reads the unshuffled
+    cache, since it is layout-agnostic.
+    """
+    from aiter.ops.shuffle import shuffle_weight
+
+    num_blocks, block_size, one, index_dim = kv_cache_fp8.shape
+    assert block_size % 16 == 0, "preshuffle requires KVBlockSize % 16 == 0"
+    flat = kv_cache_fp8.reshape(num_blocks, block_size * index_dim).clone()
+    data = (
+        flat[:, : block_size * head_dim]
+        .contiguous()
+        .view(num_blocks, block_size, head_dim)
+    )
+    flat[:, : block_size * head_dim] = shuffle_weight(data, layout=(16, 16)).reshape(
+        num_blocks, block_size * head_dim
+    )
+    return flat.view(num_blocks, block_size, one, index_dim)
+
+
+def run_torch(
+    q,
+    kv_cache_fp8,
+    weights,
+    context_lens,
+    block_tables,
+    max_model_len,
+    fp8_dtype,
+    block_size,
+):
+    """Reference only: a torch port of vLLM's ``fp8_paged_mqa_logits_torch``.
+    Not timed, not in the table.
+
+    Dequantizes per sequence rather than up front. Materializing the whole cache
+    in fp32 costs total_ctx * head_dim * 4 twice over (keys and keys*scales),
+    which is several GiB at the long-context shapes; this way the fp32 peak is one
+    sequence's worth.
+    """
+    batch_size, next_n, _heads, dim = q.size()
+    num_blocks = kv_cache_fp8.shape[0]
+    index_dim = kv_cache_fp8.shape[-1]
+    flat = kv_cache_fp8.reshape(num_blocks, block_size * index_dim)
+    keys_u8 = flat[:, : block_size * dim].contiguous().view(num_blocks, block_size, dim)
+    scales = (
+        flat[:, block_size * dim : block_size * dim + 4 * block_size]
+        .contiguous()
+        .view(dtypes.fp32)
+        .view(num_blocks, block_size)
+    )
+    qf = q.float()
+    logits = torch.full(
+        [batch_size * next_n, max_model_len],
+        float("-inf"),
+        device=q.device,
+        dtype=dtypes.fp32,
+    )
+    for i in range(batch_size):
+        context_len = int(context_lens[i].item())
+        if context_len == 0:
+            continue
+        pos = torch.arange(context_len, device=q.device)
+        blk = block_tables[i, pos // block_size]
+        tok = pos % block_size
+        kx = keys_u8[blk, tok].view(fp8_dtype).float() * scales[blk, tok][:, None]
+        s = torch.relu(torch.einsum("nhd,pd->nhp", qf[i], kx))
+        wl = weights[i * next_n : (i + 1) * next_n, :]
+        s = torch.einsum("nhp,nh->np", s, wl)
+        causal = context_len - next_n + torch.arange(next_n, device=q.device)
+        s = s.masked_fill(pos[None, :] > causal[:, None], float("-inf"))
+        logits[i * next_n : (i + 1) * next_n, :context_len] = s
+        del kx, s
+    return logits
+
+
+def _build_inputs(
+    batch_size,
+    next_n,
+    heads,
+    head_dim,
+    avg_kv_length,
+    block_size,
+    var_ratio=0.0,
+    seed=0,
+):
+    torch.manual_seed(seed)
+    random.seed(seed)
+    fp8_dtype = get_fp8_e4m3_dtype()
+
+    max_model_len = 2 * avg_kv_length
+    if var_ratio == 0.0:
+        context_lens = torch.full(
+            (batch_size,), avg_kv_length, device="cuda", dtype=torch.int32
+        )
+    else:
+        # Ragged: sequences of different lengths in one batch, which is the normal
+        # serving case. It gives every sequence a different tail tile and a
+        # different causal boundary, so a kernel that derives its bounds from one
+        # sequence -- or from max_model_len -- is caught.
+        lo = max(1, int((1 - var_ratio) * avg_kv_length))
+        hi = int((1 + var_ratio) * avg_kv_length) + 1
+        context_lens = torch.randint(lo, hi, (batch_size,)).cuda().to(torch.int32)
+    context_lens = context_lens.clamp(min=next_n)
+
+    blocks_per_seq = (context_lens.to(torch.int64) + block_size - 1) // block_size
+    max_block_len = int(blocks_per_seq.max().item())
+    num_blocks = int(blocks_per_seq.sum().item())
+
+    q = torch.randn((batch_size, next_n, heads, head_dim), dtype=dtypes.bf16)
+    kv_cache = torch.randn((num_blocks, block_size, 1, head_dim), dtype=dtypes.bf16)
+    weights = torch.randn((batch_size * next_n, heads), dtype=dtypes.fp32)
+
+    # A shuffled block pool, so a kernel that ignores the block table and walks the
+    # cache linearly is caught rather than accidentally right.
+    pool = list(range(num_blocks))
+    random.shuffle(pool)
+    pool_t = torch.tensor(pool, device="cuda", dtype=torch.int32)
+    col = torch.arange(max_block_len, device="cuda", dtype=torch.int64)
+    starts = torch.cumsum(blocks_per_seq, 0) - blocks_per_seq
+    block_tables = torch.where(
+        col[None, :] < blocks_per_seq[:, None],
+        pool_t[(starts[:, None] + col[None, :]) % num_blocks],
+        torch.zeros((), device="cuda", dtype=torch.int32),
+    ).to(torch.int32)
+
+    return (
+        q,
+        q.to(fp8_dtype),
+        kv_cache_cast_to_fp8(kv_cache, fp8_dtype),
+        weights,
+        context_lens,
+        block_tables,
+        max_model_len,
+        fp8_dtype,
+    )
+
+
+@benchmark()
+def test_fp8_paged_mqa_logits(
+    batch_size, next_n, heads, head_dim, avg_kv_length, block_size, var_ratio
+):
+    (
+        q,
+        q_fp8,
+        kv_cache_fp8,
+        weights,
+        context_lens,
+        block_tables,
+        max_model_len,
+        fp8_dtype,
+    ) = _build_inputs(
+        batch_size,
+        next_n,
+        heads,
+        head_dim,
+        avg_kv_length,
+        block_size,
+        var_ratio=var_ratio,
+    )
+
+    ref = run_torch(
+        q,
+        kv_cache_fp8,
+        weights,
+        context_lens,
+        block_tables,
+        max_model_len,
+        fp8_dtype,
+        block_size,
+    )
+    ref_mask = ref == float("-inf")
+
+    rows = batch_size * next_n
+    # Preshuffle is the production pairing: KVBlockSize=1 plain, >1 shuffled. The
+    # reference stays on the plain cache either way.
+    preshuffle = block_size > 1
+    kv_kernel = (
+        preshuffle_kv_data(kv_cache_fp8, head_dim) if preshuffle else kv_cache_fp8
+    )
+
+    # Both kernels write only the causal window and leave the -inf outside it to the
+    # caller, and the Triton launcher writes in place rather than returning, so each
+    # candidate owns a pre-filled buffer that is graded after the run. Filling once
+    # is enough: every repeat writes the same window.
+    outs = {
+        name: torch.full((rows, max_model_len), float("-inf"), dtype=dtypes.fp32)
+        for name in ("triton", "hip")
+    }
+
+    candidates = {
+        "triton": lambda: deepgemm_fp8_paged_mqa_logits(
+            q_fp8,
+            kv_kernel,
+            weights,
+            outs["triton"],
+            context_lens,
+            block_tables,
+            max_model_len,
+            ChunkK=REF_CHUNK_K,
+            Preshuffle=preshuffle,
+            KVBlockSize=block_size,
+            WavePerEU=REF_WAVE_PER_EU,
+        ),
+    }
+    # gfx950-only, nh=32/hd=128-only, KVBlockSize in {1, 64}; NaN cells elsewhere
+    # rather than a wrong row.
+    if hip_paged_logits is not None and hip_supported(heads, head_dim, block_size):
+        candidates["hip"] = lambda: hip_paged_logits(
+            q_fp8,
+            kv_kernel,
+            weights,
+            context_lens,
+            block_tables,
+            max_model_len,
+            out=outs["hip"],
+        )
+
+    total_ctx = int(context_lens.sum().item())
+    flops = 2 * heads * head_dim * next_n * total_ctx
+    nbytes = (
+        rows * heads * head_dim * q_fp8.element_size()  # Q
+        + total_ctx * (head_dim + 4)  # K bytes + co-packed f32 scales
+        + rows * heads * 4  # weights
+        + rows * max_model_len * 4  # output
+    )
+
+    ret = {"gfx": get_gfx()}
+    for name, fn in candidates.items():
+        _, us = run_perftest(fn)
+        out = outs[name]
+        out_mask = out == float("-inf")
+        assert torch.equal(out_mask, ref_mask), (
+            f"{name}: -inf mask mismatch, "
+            f"{int((out_mask != ref_mask).sum())} of {ref.numel()} positions"
+        )
+        err = checkAllclose(
+            ref.masked_fill(ref_mask, 0).to(dtypes.fp32),
+            out.masked_fill(out_mask, 0).to(dtypes.fp32),
+            rtol=1e-2,
+            atol=5.0,
+            msg=f"{name}: fp8_paged_mqa_logits",
+            printLog=False,
+        )
+        diff = calc_diff(out.masked_fill(out_mask, 0), ref.masked_fill(ref_mask, 0))
+        assert diff < 1e-3, f"{name}: calc_diff={diff.item():.3e}"
+
+        ret[f"{name} us"] = us
+        ret[f"{name} TFLOPS"] = flops / us / 1e6
+        ret[f"{name} TB/s"] = nbytes / us / 1e6
+        ret[f"{name} err"] = err
+    return ret
+
+
+def main():
+    if get_gfx() not in SUPPORTED_GFX:
+        aiter.logger.warning(
+            "fp8_paged_mqa_logits unsupported on %s; skipping", get_gfx()
+        )
+        return
+
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.RawTextHelpFormatter,
+        description="config input of test",
+    )
+    parser.add_argument("-b", "--batch", type=int, nargs="*", default=[1, 4, 16, 64])
+    # next_n drives ROWS_PER_BLOCK, which the host clamps to next_n; 4 and 6 are what
+    # reach the R=3 instantiation that MTP decode actually runs on.
+    parser.add_argument("--next-n", type=int, nargs="*", default=[1, 2, 4, 6])
+    parser.add_argument("--heads", type=int, nargs="*", default=[32, 64])
+    parser.add_argument("--head-dim", type=int, nargs="*", default=[128])
+    parser.add_argument(
+        "--kv-len",
+        type=int,
+        nargs="*",
+        default=[1024, 8192, 32768, 131072],
+        help="average context length per sequence",
+    )
+    parser.add_argument("--kv-block-size", type=int, nargs="*", default=[1, 64])
+    parser.add_argument(
+        "--var-ratio",
+        type=float,
+        nargs="*",
+        default=[0.0, 0.3],
+        help="context-length spread within a batch: 0 is uniform, 0.3 draws each\n"
+        "sequence from +/-30%% of --kv-len (the normal serving case)",
+    )
+    args = parser.parse_args()
+
+    df = []
+    skipped = []
+    for b, nn, h, hd, kv, kvb, vr in itertools.product(
+        args.batch,
+        args.next_n,
+        args.heads,
+        args.head_dim,
+        args.kv_len,
+        args.kv_block_size,
+        args.var_ratio,
+    ):
+        try:
+            df.append(test_fp8_paged_mqa_logits(b, nn, h, hd, kv, kvb, vr))
+        except torch.OutOfMemoryError:
+            # The long-context corner needs several GiB for the cache plus one
+            # output buffer per candidate. Record what was dropped rather than
+            # letting a short table read as full coverage.
+            skipped.append((b, nn, h, hd, kv, kvb, vr))
+            torch.cuda.empty_cache()
+    df = pd.DataFrame(df)
+    aiter.logger.info(
+        "fp8_paged_mqa_logits summary (markdown):\n%s", df.to_markdown(index=False)
+    )
+    if skipped:
+        aiter.logger.warning(
+            "fp8_paged_mqa_logits: %d of %d cases skipped, out of memory:\n%s",
+            len(skipped),
+            len(skipped) + len(df),
+            "\n".join(
+                f"  batch={b} next_n={nn} heads={h} head_dim={hd} kv_len={kv} "
+                f"kv_block_size={kvb} var_ratio={vr}"
+                for b, nn, h, hd, kv, kvb, vr in skipped
+            ),
+        )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
> **Validation status:** PR kernel commit `81a860a7f2`, rebased onto `ROCm/aiter@9aa8a6b9`.
> The original op-level measurements are retained below. The supplied GLM-5.2-MXFP4 E2E and accuracy report is now included under **GLM-5.2-MXFP4 E2E and accuracy (2026-09-08 update)**, using vLLM `8a728663c` and AITER `0.1.19` plus this PR's files.

## Motivation

The DeepSeek-V3.2 / GLM-5 "lightning indexer" produces the sparse-attention
selection logits. For each query row `m` and KV position `n`:

```
logits[m, n] = sum_h relu(<Q[m, h, :], K[n, :]>) * kv_scale[n] * weights[m, h]
```

In the decode path K and its per-token dequant scale are co-packed in a paged
cache and gathered through a block table. This PR adds a hand-written HIP kernel
for that path on **gfx950 (CDNA4)**, alongside the existing Triton/Gluon
`deepgemm_fp8_paged_mqa_logits`. The prefill half is #5046.

The decode indexer streams the entire K cache for a handful of FLOPs per token,
so it is squarely memory-bound and the grid carries a `next_n` axis -- every one
of a batch's MTP rows re-reads the same K. That redundancy, and the cost of
routing K through LDS, is what this kernel targets.

## Technical Details

**New op: `aiter/ops/fp8_paged_mqa_logits.py`**

`fp8_paged_mqa_logits` uses the same tensor interface as `deepgemm_fp8_paged_mqa_logits` -- same
tensors (`q_fp8`, `kv_cache_fp8`, `weights`, `context_lens`, `block_tables`,
`max_model_len`), same contract that only the causal window
`p <= context_lens[b] - next_n + n` is written and the `-inf` outside it is the
caller's. Key design points:

- **No LDS on the K path.** K is read from the paged cache straight to registers
  and contracted 32 heads x 32 tokens per `mfma_scale_f32_32x32x64_f8f6f4` tile.
- **`ROWS_PER_BLOCK` rows share one K stream.** R consecutive `next_n` rows are
  handled by one block, so the cache is read once per R rows instead of once per
  row; grid is `(batch, SplitKV, ceil(next_n / R))`. R trades that redundancy
  against occupancy, so the host picks it -- along with `ChunkK`, `num_warps` and
  `SplitKV` -- from the total KV footprint `batch * max_model_len`. Each is
  overridable.
- **kv-scale hoist.** `kv_scale >= 0` and ReLU is positive-homogeneous, so the
  scale is hoisted out of the head sum and applied once per KV column. This also
  matches the order the torch reference applies it in.
- **`v_permlane32_swap_b32` head reduce**, instead of `__shfl_down(x, 32)` which
  lowers to `ds_bpermute_b32` -- an LDS round-trip plus an `lgkmcnt` wait.
- **`KVBlockSize` is a compile-time constant**, instantiated for 1 and 64. Each is
  tied to one cache layout, the pairing production already uses: 1 reads the plain
  co-packed cache, 64 the `shuffle_weight(layout=(16,16))` preshuffled one.
- **`-fno-honor-nans`** for the module, so the ReLU is a single `v_max_f32`.
  Without it LLVM must assume a signalling NaN and emits an IEEE canonicalize
  first -- two VALU per accumulator value, in the hottest loop of the kernel.

The kernel is gfx950-only and fixed at `n_heads=32, head_dim=128` -- the shipped
GLM-5-FP8 indexer shape. `is_supported(num_heads, head_dim, kv_block_size)` gates
on that, so a caller that also serves other shapes can route them to the Triton
kernel rather than trip a `TORCH_CHECK`. This mirrors how
`_should_use_asm_kernel` gates the head_size=128-only ASM paged-attention kernel
in `aiter/ops/attention.py`.

**Files added / changed:**
- `aiter/ops/fp8_paged_mqa_logits.py` -- the op and its support gate
- `csrc/kernels/fp8_paged_mqa_logits.cu` -- kernel and host dispatch
- `csrc/include/fp8_paged_mqa_logits.h`, `csrc/pybind/fp8_paged_mqa_logits_pybind.cu`
- `csrc/include/rocm_ops.hpp`, `aiter/jit/optCompilerConfig.json` -- `module_fp8_paged_mqa_logits`
- `op_tests/test_fp8_paged_mqa_logits.py` -- correctness + perf sweep

## Test Plan

`op_tests/test_fp8_paged_mqa_logits.py` runs Triton and HIP on identical inputs
and grades both against one fp32 torch reference (a port of vLLM's
`fp8_paged_mqa_logits_torch`). Gates are an exact `-inf` mask match plus
`calc_diff < 1e-3` and `checkAllclose`; tolerances are not widened.

The sweep is the cartesian product of `batch in {1,4,16,64}`,
`next_n in {1,2,4,6}`, `heads in {32,64}`, `head_dim=128`,
`kv_len in {1024, 8192, 32768, 131072}`, `KVBlockSize in {1,64}` and
`var_ratio in {0.0, 0.3}` -- 512 cases, 256 of which the HIP kernel supports.
Points worth calling out:

- **`next_n` up to 6.** The host clamps `ROWS_PER_BLOCK` to `next_n`, so a sweep
  stopping at 2 can never reach the R=3 instantiation MTP decode actually runs on.
- **Ragged context** (`var_ratio 0.3` draws each length from +/-30% of `kv_len`).
  A uniform batch gives every sequence the same tail tile and the same causal
  boundary, so a kernel deriving its bounds from one sequence -- or from
  `max_model_len` -- would pass.
- **Shuffled block pool.** Block tables are built from a shuffled pool, so a
  kernel that ignores the table and walks the cache linearly fails rather than
  passing by accident.
- Cases the HIP kernel does not support leave its columns `nan` rather than
  reporting a wrong-but-fast number, and any case dropped for lack of memory is
  logged by name so a short table cannot read as full coverage.

```
python3 op_tests/test_fp8_paged_mqa_logits.py
```

## Test Result

All correctness gates pass on gfx950 across the sweep; per-case `hip err` matches
`triton err` exactly.

Performance on MI355x/gfx950, `heads=32`, `head_dim=128`, ragged context
(`var_ratio=0.3`), `run_perftest` on an otherwise idle GPU -- 72 shapes:

| B | next_n | ctx len | KVBlockSize | Triton µs | HIP µs | speedup |
|---|--------|---------|-------------|-----------|--------|---------|
| 1 | 2 | 32768 | 1 | 15.8 | 5.4 | **2.90x** |
| 1 | 6 | 131072 | 1 | 65.9 | 14.3 | **4.61x** |
| 4 | 2 | 32768 | 1 | 40.5 | 10.2 | **3.99x** |
| 4 | 6 | 131072 | 1 | 312.9 | 40.2 | **7.77x** |
| 16 | 2 | 32768 | 1 | 166.6 | 29.2 | **5.71x** |
| 16 | 6 | 32768 | 1 | 394.8 | 46.9 | **8.43x** |
| 16 | 6 | 131072 | 1 | 1452.5 | 212.7 | **6.83x** |
| 64 | 2 | 131072 | 1 | 1987.8 | 594.0 | **3.35x** |
| 64 | 6 | 131072 | 1 | 5122.1 | 982.8 | **5.21x** |
| 1 | 2 | 32768 | 64 | 3.9 | 4.3 | 0.90x |
| 4 | 6 | 131072 | 64 | 33.5 | 27.6 | 1.21x |
| 16 | 6 | 32768 | 64 | 39.8 | 32.7 | 1.22x |
| 16 | 6 | 131072 | 64 | 171.4 | 141.2 | 1.21x |
| 64 | 6 | 8192 | 64 | 42.2 | 32.5 | 1.30x |
| 64 | 6 | 131072 | 64 | 712.5 | 551.7 | 1.29x |

Summarised over the full 72-shape sweep:

| group | cases | geomean | range | HIP faster |
|---|---|---|---|---|
| `KVBlockSize=1` | 36 | **3.86x** | 2.01x - 8.43x | 36 / 36 |
| `KVBlockSize=64` (preshuffled) | 36 | 1.01x | 0.69x - 1.61x | 18 / 36 |
| all | 72 | 1.97x | 0.69x - 8.43x | 54 / 72 |

The win is concentrated on the **`KVBlockSize=1`** path, where the HIP kernel is
faster on every shape measured and the gap widens with `next_n` (geomean 1.60x at
`next_n=1`, 1.98x at 2, 2.44x at 6) -- which is what the shared-K-stream design
predicts, since R only has rows to amortise over once `next_n > 1`.

On the **preshuffled `KVBlockSize=64`** path the two are at parity overall
(geomean 1.01x): the HIP kernel wins by ~1.2-1.3x at high `next_n` and loses by up
to 0.69x on the small end, where its prologue is not amortised. It is reported
here rather than hidden -- with `is_supported()` in place a caller can pick per
configuration, and the small-`next_n` preshuffled corner is the obvious next
target.

## Related Work

- #4221 targets the same paged decode operator with a FlyDSL implementation, broader architecture coverage, and additional KV layouts.

This PR proposes a structurally different, fixed-shape HIP backend with direct register streaming and shared K reads across MTP rows. A direct head-to-head comparison with #4221 and quantitative roofline utilization remain pending.

## Current Validation

- Rebased onto upstream `main` at `9aa8a6b91f1972952314bd16176a76d392f6b85c` with no overlapping-file conflicts.
- `black==26.3.0 --check`: pass for the added Python op and test.
- `ruff==0.16.0 check`: pass for the added Python op and test.
- `python3 -m py_compile`: pass for the added Python op and test.
- The supplied integration report below includes a reported op-suite run and model E2E/accuracy results on its stated stack. This documentation update did not rerun GPU experiments; direct comparison with #4221 and quantitative roofline analysis remain pending.

AI assistance: OpenAI Codex was used for rebase adaptation, formatting, static checks, overlap research, and PR drafting. The submitter reviewed the resulting commit.


## GLM-5.2-MXFP4 E2E and accuracy (2026-09-08 update)

This supplied experiment report addresses https://github.com/ROCm/aiter/pull/5047#issuecomment-5531485978. All supplied result tables are retained. The interpretations below distinguish observed differences, unverified statistical estimates, and the accuracy coverage still to be identified.

E2E and accuracy for this PR on **GLM-5.2-MXFP4 / MI355X (gfx950) / TP4**, per @nholmber's request.

Reported result: **about 1.02x output throughput at 128k input on the flat KV layout (`block_size=1`) across all five concurrency points**, with TPOT about 1.03-1.07x better. On the preshuffled layout (`block_size=64`), throughput is about 0.6% lower across the five points. At 1k input, the reported differences are small and the call counter shows much less decode-indexer activity. These observations describe this MTP=0 integration run.

### Setup

| | |
|---|---|
| model | `amd/GLM-5.2-MXFP4`, `kv-cache-dtype=fp8_e4m3`, MTP=0 |
| vLLM | built from source at upstream main `8a728663c` (`0.28.1rc1.dev388`) |
| aiter | `amd-aiter 0.1.19` + this PR's files, JIT module `module_fp8_paged_mqa_logits` |
| serve | AMD's GLM-5.2 MXFP4 doc command, `--tensor-parallel-size 4`, `--linear-backend aiter --moe-backend aiter`, `--block-size {1,64}` |
| bench | vLLM `benchmark_serving.py --dataset-name random`, `--random-range-ratio 1.0`, `--ignore-eos`, `--request-rate inf`, `--seed 1234` |

**Integration** — one env-gated branch in `rocm_fp8_paged_mqa_logits()`
(`vllm/v1/attention/ops/rocm_aiter_mla_sparse.py`), where vLLM already calls
`deepgemm_fp8_paged_mqa_logits`. GLM-5.2 is `index_n_heads=32, index_head_dim=128`, so
`is_supported()` holds and the kernel really engages.

One caller-side change is required and worth flagging, because a naive drop-in is **wrong rather
than slow**: this kernel writes only the causal window and leaves the `-inf` outside it to the
caller. vLLM's existing path relies on a trailing `nan_to_num_`, which does not clear stale finite values — with this
kernel, stale finite logits from an earlier decode step survive in the reused workspace and corrupt
top-k selection. We pre-fill `-inf` before the call instead, matching what this PR's own op test does
for both kernels. Cost is symmetric or better: the fill writes 16.9 MB where `nan_to_num_` reads and
writes 33.8 MB.

**Both arms ran concurrently on one node**, one 4-GPU half each, from one container and one aiter
tree. The compared decode paths include the caller-side output initialization described above:

| arm | decode paged indexer logits kernel |
|---|---|
| before | `_gluon_deepgemm_fp8_paged_mqa_logits[_preshuffle]` (the Gluon reference kernel) |
| after | `aiter.ops.fp8_paged_mqa_logits` (this PR) |

The branch **raises rather than silently falling back** when `is_supported()` is false, and a call
counter prints per TP rank, providing evidence that the HIP path was exercised during the instrumented run:

```
before : [PR5047] hip calls=0     triton calls=16000
after  : [PR5047] paged MQA logits: heads=32 head_dim=128 block_size=64 -> HIP kernel (aiter#5047)
         [PR5047] hip calls=16000 triton calls=0
```

`op_tests/test_fp8_paged_mqa_logits.py`: **512 / 512 configurations reported passing**. First JIT build 21.8 s. As described in the original Test Plan, the HIP kernel supports 256 of those configurations; unsupported HIP entries are not counted as HIP coverage.

### 128k in / 1k out, `block_size=1`

| conc | out tok/s before | after | **speedup** | mean TPOT ms before | after | **TPOT ratio** |
|---|---|---|---|---|---|---|
| 4 | 72.2 | 73.6 | **1.019x** | 31.19 | 29.92 | 1.042x |
| 8 | 81.8 | 83.6 | **1.022x** | 71.34 | 66.92 | 1.066x |
| 16 | 90.1 | 92.5 | **1.028x** | 152.71 | 145.83 | 1.047x |
| 32 | 90.5 | 92.9 | **1.026x** | 234.76 | 228.86 | 1.026x |
| 64 | 91.5 | 93.9 | **1.025x** | 235.63 | 229.57 | 1.026x |

The supplied report summarizes these points as mean +2.40%, with a reported 95% CI of [+2.11%, +2.70%]. Every listed point favours this PR on both metrics. The interval calculation and independent repetition count were not included, so this interval should not be read as an established bound on repeat-run variability.

### 128k in / 1k out, `block_size=64` (preshuffled)

| conc | out tok/s before | after | speedup | mean TPOT ms before | after | mean TTFT s before |
|---|---|---|---|---|---|---|
| 4 | 73.0 | 72.2 | 0.989x | 33.43 | 33.62 | 20.5 |
| 8 | 84.2 | 83.8 | 0.995x | 66.67 | 67.00 | 27.8 |
| 16 | 93.7 | 93.3 | 0.996x | 143.02 | 144.32 | 27.2 |
| 32 | 94.7 | 94.3 | 0.996x | 225.13 | 226.60 | 99.9 |
| 64 | 95.6 | 95.1 | 0.994x | 225.84 | 226.40 | 450.7 |

The supplied report summarizes these points as mean -0.59%, with a reported 95% CI of [-0.85%, -0.33%]. All five throughput differences are negative and TPOT moves in the same direction. This is an observed slowdown in this sweep; the available report does not establish its significance against repeat-run variability.

### 1k in / 1k out

| conc | 4 | 8 | 16 | 32 | 64 | 128 | 256 |
|---|---|---|---|---|---|---|---|
| out tok/s before (bs=64) | 277.0 | 456.0 | 857.7 | 1358.7 | 2171.9 | 3354.1 | 4717.7 |
| out tok/s after (bs=64) | 277.5 | 458.8 | 854.9 | 1347.4 | 2183.5 | 3375.1 | 4726.5 |
| speedup (bs=64) | 1.00x | 1.01x | 1.00x | 0.99x | 1.01x | 1.01x | 1.00x |
| speedup (bs=1) | 1.01x | 1.01x | 1.00x | 1.00x | 0.99x | 1.00x | 1.00x |

**This scenario has limited sensitivity to the kernel.** The report attributes this to vLLM short-circuiting the decode indexer when
`max_seq_len <= index_topk` (`sparse_attn_indexer_kpool.py:210,717`); GLM-5.2 ships
`index_topk=2048` and a 1k/1k server caps at 2080 tokens. Our call counter measures **0.19 op calls
per decode step here against >=2.4 at 128k**.

The report gives a spread of **sigma = 0.507%** and a mean difference of **+0.21%** across these 14 short-context points. They provide a descriptive short-context comparison, but are not a strict A/A control because the measured op-call count is nonzero. Their spread does not independently establish a +-1% detection threshold or rule out GPU-half placement effects at 128k.

### Accuracy

Coverage note: the supplied report contains one baseline/HIP accuracy table and does not identify the block size used for these evaluations. Separate model-accuracy coverage for both `block_size=1` and `64` has not yet been established from this report.

Validation gates and expectations from the AMD "GLM-5.2 MXFP4 - vLLM status and validation" deck,
run with the deck's own commands, both arms in parallel on one 4-GPU half each.

| gate | before | after | expected |
|---|---|---|---|
| coherence (17x23) | PASS, 391 | PASS, 391 | coherent, clean `</think>`, 391 |
| GSM8K (1319 q, 5-shot, flexible-extract) | **93.03%** +- 0.70 | **93.48%** +- 0.68 | ~92% |
| GSM8K (strict-match) | 93.10% +- 0.70 | 93.56% +- 0.68 | ~92% |
| GPQA-Diamond (198 q, max_tokens=100k, temp 1.0 / top_p 0.95) | **91.41%** +- 1.99 | **88.89%** +- 2.23 | ~92%+ |
| RULER `niah_single_2` @ 64k (500 samples) | **100%** | **100%** | ~90%+ |
| RULER `niah_single_2` @ 128k (500 samples) | **100%** | **100%** | ~90%+ |

GSM8K differs by 0.45 pp; the report gives a combined standard error of 0.98 pp (z ~ 0.46). GPQA decreases by 2.5 pp — 5 questions out of 198 — with a reported combined standard error of 3.0 pp (z ~ 0.84). The report also records 7 of 198 responses reaching the 100k token budget on each arm. Those approximate error comparisons do not demonstrate equivalence, and both GPQA point estimates are below the stated ~92%+ expectation. The individual response outcomes needed for a paired analysis were not included.

RULER is at the ceiling on both arms at both tested lengths. This supports long-context retrieval on these samples. The caller's `-inf` initialization contract remains important because stale finite logits can alter top-k selection.

### Notes

- **Why `block_size=1` wins and `block_size=64` does not.** This PR's op-level table predicts both
  signs: geomean 3.86x at `KVBlockSize=1` (36/36 shapes) against 1.01x at `KVBlockSize=64` (18/36,
  worst 0.69x). MTP=0 pins `next_n=1`, this kernel's weakest case by construction — the
  `ROWS_PER_BLOCK` design shares one K stream across R consecutive `next_n` rows, and with one row
  there is nothing to amortise. The op table shows the same shape: geomean 1.60x at `next_n=1`
  rising to 2.44x at `next_n=6`.
- **Why E2E and op-level speedups differ.** The op-level measurements cover different batches, contexts and `next_n` values from this MTP=0 serving run. They suggest a mechanism for the flat-layout benefit, but do not quantify the indexer's share of time in this run. In particular, the original report's 0.13% and 2.5% contribution estimates were extrapolations across configurations rather than measurements of the serving run, and are not used to establish an E2E bound here.
- **`--block-size` must be set explicitly.** The serving recipe leaves vLLM's default of 16, which
  `is_supported()` rejects. Set 1 or 64 explicitly to exercise this kernel and use the dispatch counters above to verify the selected path.
- **Nominal vs actual concurrency at 128k.** KV cache holds 3.23M tokens and each request costs
  ~129k, so about 25 fit. Throughput saturates at ~95 tok/s from conc 16 on and TTFT reaches 450 s at
  conc 64 — those points queue rather than running fully in parallel. Identical on both arms, so the
  comparison holds, but the concurrency label is nominal.
- **Prefix caching disabled** (`--no-enable-prefix-caching`), so absolute numbers are not comparable
  to runs that leave it at the default.
- **Sample counts.** 1k/1k used 10 prompts and 2 warmups per concurrency slot; 128k/1k used 3 and 1
  (`block_size=64`) and 2 and 1 (`block_size=1`). The intended comparisons are baseline versus HIP within each block-size/scenario pair; different sample counts limit comparisons across layouts.
- **Not compared against #4221**, the FlyDSL implementation of the same operator. This run was scoped
  to before/after against the Gluon reference. We can add it as a third arm if that would help.
- **Optional future work (not part of the requested comparison)**: MTP > 0, which is where this kernel's design actually pays (every
  number here is `next_n=1`); a `block_size=16` instantiation, since 16 is what most vLLM/ROCm
  deployments run and the kernel currently supports only 1 and 64; and the small-`next_n` preshuffled
  corner, which is where the -0.59% comes from and which this PR already names as the next target.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
