### PR TITLE
[FlyDSL] [ROCm] Keep untuned SiLU A4W4 on native CK

### DIFF
--- a/aiter/fused_moe.py
+++ b/aiter/fused_moe.py
@@ -2745,8 +2745,9 @@ def get_2stage_cfgs(
             0,
             False,
         )
-    # Debug: AITER_FLYDSL_FORCE=1 is for debug use.
-    _flydsl_force = os.environ.get("AITER_FLYDSL_FORCE", "1") == "1"
+    # Keep untuned SiLU A4W4 on native CK. Other supported MX formats and the
+    # activations that explicitly select FlyDSL retain their existing routes.
+    _is_a4w4 = q_dtype_a == dtypes.fp4x2 and q_dtype_w == dtypes.fp4x2
     # a16w4-SiTUv2 (bf16 A x mxfp4 W) -> ported 2-stage path; SiTUv2 gate distinguishes gpt-oss (Swiglu -> cktile).
     _is_a16w4_situv2 = (
         dtype in [dtypes.bf16, dtypes.fp16]
@@ -2763,8 +2764,7 @@ def get_2stage_cfgs(
         dtype in [dtypes.bf16, dtypes.fp16]
         and q_type == QuantType.per_1x32
         and (
-            activation in (ActivationType.Swiglu, ActivationType.Situv2)
-            or _flydsl_force
+            activation in (ActivationType.Swiglu, ActivationType.Situv2) or not _is_a4w4
         )
         and (
             q_dtype_a in (dtypes.fp4x2, dtypes.fp8)

--- a/op_tests/test_flydsl_moe_dispatch.py
+++ b/op_tests/test_flydsl_moe_dispatch.py
@@ -1,0 +1,96 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+"""Regression tests for untuned MX MoE dispatch policy."""
+
+from __future__ import annotations
+
+import pytest
+
+import aiter.fused_moe as fm
+from aiter import ActivationType, QuantType, dtypes
+
+
+@pytest.fixture(autouse=True)
+def _clear_dispatch_cache():
+    fm.get_2stage_cfgs.cache_clear()
+    yield
+    fm.get_2stage_cfgs.cache_clear()
+
+
+def _mock_dispatch(monkeypatch, q_dtype_a, q_dtype_w, activation):
+    monkeypatch.setattr(fm, "get_cu_num", lambda: 256)
+    monkeypatch.setattr(fm, "get_gfx", lambda: "gfx950")
+    monkeypatch.setattr(fm, "get_gfx_runtime", lambda: "gfx950")
+    monkeypatch.setattr(fm, "is_flydsl_available", lambda: True)
+    monkeypatch.setattr(fm, "cfg_2stages", ({}, {}))
+
+    return fm.get_2stage_cfgs(
+        64,
+        2560,
+        768,
+        64,
+        10,
+        dtypes.bf16,
+        q_dtype_a,
+        q_dtype_w,
+        QuantType.per_1x32,
+        True,
+        activation,
+        False,
+        0,
+        128,
+        is_shuffled=True,
+        is_ep=True,
+    )
+
+
+def test_silu_a4w4_uses_native_ck(monkeypatch):
+    metadata = _mock_dispatch(
+        monkeypatch,
+        dtypes.fp4x2,
+        dtypes.fp4x2,
+        ActivationType.Silu,
+    )
+
+    assert metadata.stage1.func is fm.ck_moe_stage1
+
+
+@pytest.mark.parametrize(
+    "q_dtype_w",
+    [
+        pytest.param(dtypes.fp4x2, id="a8w4"),
+        pytest.param(dtypes.fp8, id="a8w8"),
+    ],
+)
+def test_silu_a8w_flydsl_remains_default(monkeypatch, q_dtype_w):
+    metadata = _mock_dispatch(
+        monkeypatch,
+        dtypes.fp8,
+        q_dtype_w,
+        ActivationType.Silu,
+    )
+
+    assert metadata.stage1.func is fm._flydsl_stage1_wrapper
+
+
+@pytest.mark.parametrize(
+    "activation",
+    [
+        pytest.param(ActivationType.Swiglu, id="swiglu"),
+        pytest.param(ActivationType.Situv2, id="situv2"),
+    ],
+)
+def test_explicit_a4w4_flydsl_activations_remain_enabled(monkeypatch, activation):
+    metadata = _mock_dispatch(
+        monkeypatch,
+        dtypes.fp4x2,
+        dtypes.fp4x2,
+        activation,
+    )
+
+    assert metadata.stage1.func is fm._flydsl_stage1_wrapper
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Summary

- Keep untuned SiLU A4W4 on native CK deterministically.
- Preserve the existing FlyDSL routing for SiLU A8W4/A8W8 and explicit Swiglu/SiTUv2 activations.
- Remove the local debug-only `AITER_FLYDSL_FORCE` override from production dispatch.
- Add top-level executable dispatch regressions so the routing policy is included in standard AITER test discovery.

## Root cause and scope

`AITER_FLYDSL_FORCE` was documented as a debug force flag, but its fallback value was `"1"`. An unset variable therefore forced eligible untuned SiLU A4W4 workloads onto the experimental FlyDSL path instead of native CK.

The routing policy is now deterministic and based only on activation and quantization metadata:

| Workload | Untuned fallback |
| --- | --- |
| SiLU A4W4 | Native CK |
| SiLU A8W4/A8W8 | FlyDSL |
| A4W4 with explicit Swiglu/SiTUv2 activation | FlyDSL |

Tuned configurations continue to return before this fallback selector. There are no model-name, GPU-architecture, or shape-specific branches in the production change.

## Regression coverage

`op_tests/test_flydsl_moe_dispatch.py` covers five cases:

- SiLU A4W4 selects native CK.
- SiLU A8W4 and A8W8 retain FlyDSL.
- A4W4 Swiglu and SiTUv2 retain their explicit FlyDSL routes.

The file is top-level and has an executable pytest entry point, so both pytest collection and AITER standard-test execution run the assertions.

## Current-head validation

```text
black --check aiter/fused_moe.py op_tests/test_flydsl_moe_dispatch.py
All files would be left unchanged

ruff==0.16.0 check aiter/fused_moe.py op_tests/test_flydsl_moe_dispatch.py
All checks passed

python3 -m py_compile aiter/fused_moe.py op_tests/test_flydsl_moe_dispatch.py
git diff --check origin/main...HEAD
```

The branch is rebased onto current `ROCm/aiter:main`. ROCm runtime results are provided by the PR CI triggered for this head.

## Prior end-to-end validation of the unchanged default route

Before removal of the debug override, commit `bca656892cbf272d542a93bbfa0db85d512e7007` was validated on 8x AMD Instinct MI350X (`gfx950`) with tensor/expert parallel size 8 and `FULL_AND_PIECEWISE` graph mode. The environment override was absent, so this exercised the same SiLU A4W4 native-CK route retained by the current change.

| Metric | Result |
| --- | ---: |
| Questions | 1,319 / 1,319 |
| Correct | 1,268 |
| Accuracy | 96.1334% |
| Errors / invalid parses | 0 / 0 |
| Finish reasons | 1,316 stop / 3 length |
| Rate | 7.6993 q/s |

Postflight evidence showed native `module_moe_ck2stages_fp4x2_fp4x2...` loaded on all eight ranks, no A4W4 FlyDSL fallback, no fatal server or GPU errors, and full GPU release after validation.

Full-result artifact SHA256: `77d950c0048fde79b79f139df5a941c91fb58d7a4a21c87094a3792b4f384646`

Current PR head: `8dac031f0a07cb54a6a6de4ff439b627e4553554`

## AI assistance

OpenAI Codex assisted with implementation and validation. I reviewed every changed line and the validation evidence and can defend the change end to end.
