### PR TITLE
[HIP] [DCP] Enable fused indexer QK preparation

### DIFF
--- a/aiter/ops/cache.py
+++ b/aiter/ops/cache.py
@@ -139,6 +139,9 @@ def indexer_qk_rope_quant_and_cache(
     weights_scale: float,
     preshuffle: bool = False,
     is_neox: bool = True,
+    # False (default): slot<0 rows skip the whole fused op.
+    # True (DCP): compute Q/weights for every row; only valid slots write K cache.
+    compute_all_q_rope: bool = False,
 ) -> None: ...
 
 

--- a/csrc/include/cache.h
+++ b/csrc/include/cache.h
@@ -106,7 +106,10 @@ void indexer_qk_rope_quant_and_cache(
     const std::string& scale_fmt,
     double weights_scale,
     bool preshuffle = false,
-    bool is_neox = true);
+    bool is_neox = true,
+    // false: slot<0 skips Q and K; true (DCP): compute Q for every row and
+    // guard only the owner-specific K-cache write.
+    bool compute_all_q_rope = false);
 
 void cp_gather_indexer_k_quant_cache(
     const aiter_tensor_t& kv_cache,     // [num_blocks, block_size, cache_stride]

--- a/csrc/include/rocm_ops.hpp
+++ b/csrc/include/rocm_ops.hpp
@@ -483,7 +483,8 @@ namespace py = pybind11;
           py::arg("scale_fmt"),                                                     \
           py::arg("weights_scale"),                                                 \
           py::arg("preshuffle") = false,                                            \
-          py::arg("is_neox") = true);                                               \
+          py::arg("is_neox") = true,                                                \
+          py::arg("compute_all_q_rope") = false);                                   \
     m.def("cp_gather_indexer_k_quant_cache",                                        \
           &aiter::cp_gather_indexer_k_quant_cache,                                  \
           py::arg("kv_cache"),                                                      \

--- a/csrc/kernels/cache_kernels.cu
+++ b/csrc/kernels/cache_kernels.cu
@@ -1439,7 +1439,9 @@ __global__ void indexer_qk_rope_quant_and_cache_kernel(
     const float weights_scale,
     const bool use_ue8m0,
     const bool preshuffle,
-    const bool is_neox)
+    const bool is_neox,
+    const int max_position,
+    const bool compute_all_q_rope)
 {
     static_assert(HEAD_DIM == 128, "Indexer fused qk cache currently supports head_dim=128");
     static_assert(ROPE_DIM == 64, "Indexer fused qk cache currently supports rope_dim=64");
@@ -1451,10 +1453,10 @@ __global__ void indexer_qk_rope_quant_and_cache_kernel(
         return;
 
     const int64_t slot_idx = slot_mapping[token_idx];
-    if(slot_idx < 0)
+    if(!compute_all_q_rope && slot_idx < 0)
         return;
-
-    const int64_t pos = positions[token_idx];
+    int64_t pos = positions[token_idx];
+    pos = pos < 0 ? 0 : (pos >= max_position ? max_position - 1 : pos);
     const scalar_t* cos_ptr = cos_cache + pos * cos_stride0;
     const scalar_t* sin_ptr = sin_cache + pos * sin_stride0;
 
@@ -1490,13 +1492,11 @@ __global__ void indexer_qk_rope_quant_and_cache_kernel(
         // Match the separate RoPE path, which materializes q_pe before FP8 quant.
         q_val = static_cast<float>(static_cast<scalar_t>(q_val));
     }
-
     auto max_func = [](float a, float b) { return fmaxf(a, b); };
     float q_amax = fabsf(q_val);
     q_amax = block_reduce<float, decltype(max_func), HEAD_DIM, true>(q_amax, max_func);
 
     const float q_fp8_max = static_cast<float>(opus::finfo<cache_t>::max());
-    // Match unfused per_token_group_quant_fp8: reciprocal-multiply + UE8M0.
     const float q_inv_fp8_max = 1.0f / q_fp8_max;
     float q_scale             = fmaxf(q_amax, 1e-10f) * q_inv_fp8_max;
     if(use_ue8m0)
@@ -1514,7 +1514,7 @@ __global__ void indexer_qk_rope_quant_and_cache_kernel(
             w * q_scale * weights_scale;
     }
 
-    if(head_idx != 0)
+    if(head_idx != 0 || slot_idx < 0)
         return;
 
     __shared__ float normed[HEAD_DIM];
@@ -3559,7 +3559,9 @@ void reshape_and_cache_flash(
                                      weights_scale,                                               \
                                      use_ue8m0,                                                   \
                                      do_preshuffle,                                               \
-                                     is_neox);
+                                     is_neox,                                                      \
+                                     max_position,                                                \
+                                     compute_all_q_rope);
 
 #define CALL_CP_GATHER_INDEXER_K_QUANT_CACHE(BLOCK_Y_SIZE)          \
     aiter::cp_gather_indexer_k_quant_cache_kernel<8, BLOCK_Y_SIZE>  \
@@ -4057,7 +4059,8 @@ void indexer_qk_rope_quant_and_cache(
     const std::string& scale_fmt,
     double weights_scale,
     bool preshuffle,
-    bool is_neox)
+    bool is_neox,
+    bool compute_all_q_rope)
 {
     int num_tokens       = std::min(k.size(0), slot_mapping.size(0));
     int head_dim         = k.size(1);
@@ -4065,6 +4068,7 @@ void indexer_qk_rope_quant_and_cache(
     int rope_dim         = cos_cache.size(-1) * 2;
     int cache_block_size = kv_cache.size(1);
     int cache_stride     = kv_cache.size(2);
+    int max_position     = cos_cache.size(0);
     bool use_ue8m0       = scale_fmt == "ue8m0";
     bool do_preshuffle   = preshuffle;
 
@@ -4102,6 +4106,7 @@ void indexer_qk_rope_quant_and_cache(
     AITER_CHECK(cos_cache.size(0) == sin_cache.size(0) &&
                     cos_cache.size(1) == sin_cache.size(1),
                 "cos_cache and sin_cache shapes must match");
+    AITER_CHECK(max_position > 0, "cos_cache and sin_cache must not be empty");
     AITER_CHECK(cos_cache.stride(1) == 1 && sin_cache.stride(1) == 1,
                 "cos_cache and sin_cache last dimension must be contiguous");
     AITER_CHECK(head_dim == 128, "indexer fused qk cache only supports head_dim=128");

--- a/csrc/kernels/cache_kernels.cu
+++ b/csrc/kernels/cache_kernels.cu
@@ -1456,7 +1456,8 @@ __global__ void indexer_qk_rope_quant_and_cache_kernel(
     if(!compute_all_q_rope && slot_idx < 0)
         return;
     int64_t pos = positions[token_idx];
-    pos = pos < 0 ? 0 : (pos >= max_position ? max_position - 1 : pos);
+    if(slot_idx < 0)
+        pos = pos < 0 ? 0 : (pos >= max_position ? max_position - 1 : pos);
     const scalar_t* cos_ptr = cos_cache + pos * cos_stride0;
     const scalar_t* sin_ptr = sin_cache + pos * sin_stride0;
 
@@ -4094,6 +4095,8 @@ void indexer_qk_rope_quant_and_cache(
     AITER_CHECK(cos_cache.dim() == 2, "cos_cache must be [max_position, rope_dim / 2]");
     AITER_CHECK(sin_cache.dim() == 2, "sin_cache must be [max_position, rope_dim / 2]");
     AITER_CHECK(q.size(0) >= num_tokens, "q must cover all indexed tokens");
+    AITER_CHECK(!compute_all_q_rope || q.size(0) == num_tokens,
+                "compute_all_q_rope requires q to have exactly num_tokens rows");
     AITER_CHECK(q.size(2) == head_dim, "q head_dim must match k head_dim");
     AITER_CHECK(positions.size(0) >= num_tokens, "positions must cover all indexed tokens");
     AITER_CHECK(q_out.size(0) >= num_tokens && q_out.size(1) == n_heads &&

--- a/op_tests/test_indexer_qk_rope_quant_and_cache.py
+++ b/op_tests/test_indexer_qk_rope_quant_and_cache.py
@@ -1,158 +1,411 @@
 # SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
 
+import argparse
+import itertools
+
+import pandas as pd
 import torch
 
-from aiter import dtypes, indexer_qk_rope_quant_and_cache
+import aiter
+from aiter import dtypes
+from aiter.jit.utils.chip_info import get_gfx
+from aiter.test_common import benchmark, checkAllclose, run_perftest
+
+torch.set_default_device("cuda")
+
+SUPPORTED_GFX = ["gfx942", "gfx950"]
+HEAD_DIM = 128
+ROPE_DIM = 64
+BLOCK_SIZE = 16
+MAX_POSITION = 128
+EPSILON = 1e-6
+WEIGHTS_SCALE = HEAD_DIM**-0.5 * 32**-0.5
 
 
-def _run(
-    q,
-    weights,
-    k,
-    slot_mapping,
-    positions,
-    cos_cache,
-    sin_cache,
-    norm_weight,
-    norm_bias,
-    compute_all_q_rope,
-):
+def _apply_rope(
+    x: torch.Tensor,
+    positions: torch.Tensor,
+    cos_cache: torch.Tensor,
+    sin_cache: torch.Tensor,
+    is_neox: bool,
+) -> torch.Tensor:
+    rope = x[..., :ROPE_DIM].float()
+    tail = x[..., ROPE_DIM:]
+    cos = cos_cache[positions].float()
+    sin = sin_cache[positions].float()
+    while cos.ndim < rope.ndim:
+        cos = cos.unsqueeze(-2)
+        sin = sin.unsqueeze(-2)
+
+    if is_neox:
+        x1, x2 = rope.chunk(2, dim=-1)
+    else:
+        x1, x2 = rope[..., ::2], rope[..., 1::2]
+    y1 = x1 * cos - x2 * sin
+    y2 = x2 * cos + x1 * sin
+    rotated = (
+        torch.cat((y1, y2), dim=-1)
+        if is_neox
+        else torch.stack((y1, y2), dim=-1).flatten(-2)
+    )
+    return torch.cat((rotated.to(x.dtype), tail), dim=-1)
+
+
+def _quantize_ue8m0(
+    x: torch.Tensor, min_amax: float
+) -> tuple[torch.Tensor, torch.Tensor]:
+    fp8_max = torch.finfo(dtypes.fp8).max
+    scale = x.float().abs().amax(dim=-1).clamp(min=min_amax) / fp8_max
+    scale = torch.pow(2.0, torch.ceil(torch.log2(scale)))
+    return (x.float() / scale.unsqueeze(-1)).to(dtypes.fp8), scale
+
+
+def run_torch(
+    q: torch.Tensor,
+    weights: torch.Tensor,
+    k: torch.Tensor,
+    slot_mapping: torch.Tensor,
+    norm_weight: torch.Tensor,
+    norm_bias: torch.Tensor,
+    positions: torch.Tensor,
+    cos_cache: torch.Tensor,
+    sin_cache: torch.Tensor,
+    compute_all_q_rope: bool,
+    is_neox: bool,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    num_tokens = q.shape[0]
+    num_blocks = max(1, (num_tokens + BLOCK_SIZE - 1) // BLOCK_SIZE)
     q_out = torch.zeros_like(q, dtype=dtypes.fp8)
     weights_out = torch.zeros_like(weights, dtype=torch.float32)
-    kv_cache = torch.zeros((1, 16, 132), device=q.device, dtype=dtypes.fp8)
-    extra = (
-        {} if compute_all_q_rope is None else {"compute_all_q_rope": compute_all_q_rope}
+    kv_cache = torch.zeros((num_blocks, BLOCK_SIZE, HEAD_DIM + 4), dtype=dtypes.fp8)
+
+    valid = slot_mapping >= 0
+    active_q = torch.ones_like(valid) if compute_all_q_rope else valid
+    safe_positions = positions.clamp(0, cos_cache.shape[0] - 1)
+
+    q_rope = _apply_rope(q, safe_positions, cos_cache, sin_cache, is_neox)
+    q_quant, q_scale = _quantize_ue8m0(q_rope, 1e-10)
+    q_out[active_q] = q_quant[active_q]
+    weights_out[active_q] = (
+        weights[active_q].float() * q_scale[active_q] * WEIGHTS_SCALE
     )
-    indexer_qk_rope_quant_and_cache(
+
+    if valid.any():
+        k_valid = k[valid].float()
+        mean = k_valid.mean(dim=-1, keepdim=True)
+        centered = k_valid - mean
+        inv_std = torch.rsqrt(centered.square().mean(dim=-1, keepdim=True) + EPSILON)
+        k_norm = (centered * inv_std * norm_weight.float() + norm_bias.float()).to(
+            k.dtype
+        )
+        k_rope = _apply_rope(
+            k_norm,
+            safe_positions[valid],
+            cos_cache,
+            sin_cache,
+            is_neox,
+        )
+        k_quant, k_scale = _quantize_ue8m0(k_rope, 1e-4)
+        valid_slots = slot_mapping[valid]
+        cache_flat = kv_cache.view(num_blocks, -1)
+        for row, slot in enumerate(valid_slots.tolist()):
+            block, offset = divmod(slot, BLOCK_SIZE)
+            data_start = offset * HEAD_DIM
+            cache_flat[block, data_start : data_start + HEAD_DIM] = k_quant[row]
+            scale_start = BLOCK_SIZE * HEAD_DIM + offset * 4
+            cache_flat[block, scale_start : scale_start + 4].view(torch.float32)[0] = (
+                k_scale[row]
+            )
+
+    return q_out, weights_out, kv_cache
+
+
+def _make_aiter_candidate(
+    q: torch.Tensor,
+    weights: torch.Tensor,
+    k: torch.Tensor,
+    slot_mapping: torch.Tensor,
+    norm_weight: torch.Tensor,
+    norm_bias: torch.Tensor,
+    positions: torch.Tensor,
+    cos_cache: torch.Tensor,
+    sin_cache: torch.Tensor,
+    compute_all_q_rope: bool | None,
+    is_neox: bool,
+):
+    num_blocks = max(1, (q.shape[0] + BLOCK_SIZE - 1) // BLOCK_SIZE)
+    q_out = torch.zeros_like(q, dtype=dtypes.fp8)
+    weights_out = torch.zeros_like(weights, dtype=torch.float32)
+    kv_cache = torch.zeros((num_blocks, BLOCK_SIZE, HEAD_DIM + 4), dtype=dtypes.fp8)
+
+    def run():
+        extra = (
+            {}
+            if compute_all_q_rope is None
+            else {"compute_all_q_rope": compute_all_q_rope}
+        )
+        aiter.indexer_qk_rope_quant_and_cache(
+            q,
+            q_out,
+            weights,
+            weights_out,
+            k,
+            kv_cache,
+            slot_mapping,
+            norm_weight,
+            norm_bias,
+            positions,
+            cos_cache,
+            sin_cache,
+            EPSILON,
+            HEAD_DIM,
+            "ue8m0",
+            WEIGHTS_SCALE,
+            preshuffle=False,
+            is_neox=is_neox,
+            **extra,
+        )
+        return q_out, weights_out, kv_cache
+
+    return run
+
+
+def _split_cache(
+    kv_cache: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    cache_flat = kv_cache.view(kv_cache.shape[0], -1)
+    data = cache_flat[:, : BLOCK_SIZE * HEAD_DIM].view(-1, BLOCK_SIZE, HEAD_DIM)
+    scales = (
+        cache_flat[:, BLOCK_SIZE * HEAD_DIM :]
+        .view(torch.float32)
+        .view(kv_cache.shape[0], BLOCK_SIZE)
+    )
+    return data, scales
+
+
+@benchmark()
+def test_indexer_qk_rope_quant_and_cache(
+    num_tokens: int,
+    num_heads: int,
+    dtype: torch.dtype,
+    valid_fraction: float,
+    compute_all_q_rope: bool,
+    is_neox: bool,
+):
+    torch.manual_seed(1)
+    q = torch.randn(num_tokens, num_heads, HEAD_DIM, dtype=dtype)
+    weights = torch.randn(num_tokens, num_heads, dtype=dtype)
+    k = torch.randn(num_tokens, HEAD_DIM, dtype=dtype)
+    norm_weight = torch.randn(HEAD_DIM, dtype=torch.float32)
+    norm_bias = torch.randn(HEAD_DIM, dtype=torch.float32)
+    angles = torch.randn(MAX_POSITION, ROPE_DIM // 2, dtype=torch.float32)
+    cos_cache = angles.cos().to(dtype)
+    sin_cache = angles.sin().to(dtype)
+
+    num_valid = max(1, int(num_tokens * valid_fraction))
+    slot_mapping = torch.arange(num_tokens, dtype=torch.int64)
+    slot_mapping[num_valid:] = -1
+    positions = torch.arange(num_tokens, dtype=torch.int64) % MAX_POSITION
+    # DCP non-owner rows may carry stale positions. The compute-all path must
+    # clamp these rows before applying RoPE; the default path must skip them.
+    if num_valid < num_tokens:
+        stale = torch.tensor([-7, MAX_POSITION, MAX_POSITION + 99], dtype=torch.int64)
+        positions[num_valid:] = stale[
+            torch.arange(num_tokens - num_valid) % stale.numel()
+        ]
+
+    ref = run_torch(
         q,
-        q_out,
         weights,
-        weights_out,
         k,
-        kv_cache,
         slot_mapping,
         norm_weight,
         norm_bias,
         positions,
         cos_cache,
         sin_cache,
-        1e-6,
-        128,
-        "ue8m0",
-        128**-0.5 * 32**-0.5,
-        preshuffle=False,
-        is_neox=True,
-        **extra,
+        compute_all_q_rope,
+        is_neox,
     )
-    torch.cuda.synchronize()
-    return q_out, weights_out, kv_cache
+    candidates = {
+        "hip": _make_aiter_candidate(
+            q,
+            weights,
+            k,
+            slot_mapping,
+            norm_weight,
+            norm_bias,
+            positions,
+            cos_cache,
+            sin_cache,
+            compute_all_q_rope,
+            is_neox,
+        )
+    }
+    if not compute_all_q_rope:
+        # The omitted argument must remain identical to explicit False for
+        # backward compatibility with existing callers.
+        candidates["hip_default"] = _make_aiter_candidate(
+            q,
+            weights,
+            k,
+            slot_mapping,
+            norm_weight,
+            norm_bias,
+            positions,
+            cos_cache,
+            sin_cache,
+            None,
+            is_neox,
+        )
 
-
-def test_indexer_qk_compute_all_q_rope():
-    torch.manual_seed(1)
-    device = "cuda"
-    num_tokens, num_heads, head_dim = 8, 32, 128
-    q = torch.randn(
-        num_tokens, num_heads, head_dim, device=device, dtype=torch.bfloat16
-    )
-    weights = torch.randn(num_tokens, num_heads, device=device, dtype=torch.bfloat16)
-    k = torch.randn(num_tokens, head_dim, device=device, dtype=torch.bfloat16)
-    norm_weight = torch.ones(head_dim, device=device, dtype=torch.float32)
-    norm_bias = torch.zeros(head_dim, device=device, dtype=torch.float32)
-    angles = torch.randn(16, 32, device=device)
-    cos_cache = angles.cos().bfloat16()
-    sin_cache = angles.sin().bfloat16()
-
-    clamped_positions = torch.tensor(
-        [0, 1, 2, 3, 0, 15, 15, 15], device=device, dtype=torch.int64
-    )
-    valid_slots = torch.arange(num_tokens, device=device, dtype=torch.int64)
-    q_ref, weights_ref, _ = _run(
-        q,
-        weights,
-        k,
-        valid_slots,
-        clamped_positions,
-        cos_cache,
-        sin_cache,
-        norm_weight,
-        norm_bias,
-        False,
-    )
-    q_default, weights_default, cache_default = _run(
-        q,
-        weights,
-        k,
-        valid_slots,
-        clamped_positions,
-        cos_cache,
-        sin_cache,
-        norm_weight,
-        norm_bias,
-        None,
-    )
-    q_explicit, weights_explicit, cache_explicit = _run(
-        q,
-        weights,
-        k,
-        valid_slots,
-        clamped_positions,
-        cos_cache,
-        sin_cache,
-        norm_weight,
-        norm_bias,
-        False,
-    )
-    torch.testing.assert_close(q_default.float(), q_explicit.float(), rtol=0, atol=0)
-    torch.testing.assert_close(weights_default, weights_explicit, rtol=0, atol=0)
-    torch.testing.assert_close(
-        cache_default.float(), cache_explicit.float(), rtol=0, atol=0
+    active_q = num_tokens if compute_all_q_rope else num_valid
+    q_ops = active_q * num_heads * (ROPE_DIM * 3 + HEAD_DIM * 2 + 2)
+    k_ops = num_valid * (HEAD_DIM * 6 + ROPE_DIM * 3 + HEAD_DIM)
+    flops = q_ops + k_ops
+    nbytes = (
+        q.numel() * q.element_size()
+        + weights.numel() * weights.element_size()
+        + k.numel() * k.element_size()
+        + ref[0].numel() * ref[0].element_size()
+        + ref[1].numel() * ref[1].element_size()
+        + ref[2].numel() * ref[2].element_size()
     )
 
-    mixed_slots = valid_slots.clone()
-    mixed_slots[4:] = -1
-    stale_positions = torch.tensor(
-        [0, 1, 2, 3, -7, 16, 100, 1000], device=device, dtype=torch.int64
-    )
-    q_all, weights_all, kv_cache = _run(
-        q,
-        weights,
-        k,
-        mixed_slots,
-        stale_positions,
-        cos_cache,
-        sin_cache,
-        norm_weight,
-        norm_bias,
-        True,
-    )
+    ref_cache_data, ref_cache_scales = _split_cache(ref[2])
+    ret = {"gfx": get_gfx()}
+    for name, candidate in candidates.items():
+        (q_out, weights_out, kv_cache), us = run_perftest(candidate)
+        cache_data, cache_scales = _split_cache(kv_cache)
+        errors = [
+            checkAllclose(
+                ref[0].float(),
+                q_out.float(),
+                rtol=0,
+                atol=0,
+                msg=f"{name}: q_out",
+            ),
+            checkAllclose(
+                ref[1],
+                weights_out,
+                rtol=1e-5,
+                atol=1e-7,
+                msg=f"{name}: weights_out",
+            ),
+            checkAllclose(
+                ref_cache_data.float(),
+                cache_data.float(),
+                rtol=0,
+                atol=0,
+                msg=f"{name}: kv_cache data",
+            ),
+            checkAllclose(
+                ref_cache_scales,
+                cache_scales,
+                rtol=1e-6,
+                atol=0,
+                msg=f"{name}: kv_cache scale",
+            ),
+        ]
+        ret[f"{name} us"] = us
+        ret[f"{name} TFLOPS"] = flops / us / 1e6
+        ret[f"{name} TB/s"] = nbytes / us / 1e6
+        ret[f"{name} err"] = max(errors)
+    return ret
 
-    torch.testing.assert_close(q_all.float(), q_ref.float(), rtol=0, atol=0)
-    torch.testing.assert_close(weights_all, weights_ref, rtol=0, atol=0)
 
-    cache_flat = kv_cache.view(-1)
-    k_region = cache_flat[: 16 * head_dim]
-    scale_region = cache_flat[16 * head_dim :]
-    assert torch.count_nonzero(k_region[4 * head_dim :]).item() == 0
-    assert torch.count_nonzero(scale_region[4 * 4 :]).item() == 0
+def main():
+    if get_gfx() not in SUPPORTED_GFX:
+        aiter.logger.warning(
+            "indexer_qk_rope_quant_and_cache unsupported on %s; skipping", get_gfx()
+        )
+        return
 
-    q_default, weights_default, _ = _run(
-        q,
-        weights,
-        k,
-        mixed_slots,
-        stale_positions,
-        cos_cache,
-        sin_cache,
-        norm_weight,
-        norm_bias,
-        False,
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.RawTextHelpFormatter,
+        description="Test fused indexer Q/K RoPE, quantization, and cache writes",
     )
-    torch.testing.assert_close(q_default[:4].float(), q_ref[:4].float(), rtol=0, atol=0)
-    torch.testing.assert_close(weights_default[:4], weights_ref[:4], rtol=0, atol=0)
-    assert torch.count_nonzero(q_default[4:].float()).item() == 0
-    assert torch.count_nonzero(weights_default[4:]).item() == 0
+    parser.add_argument(
+        "-n",
+        "--num_tokens",
+        type=int,
+        nargs="*",
+        default=[8, 32],
+        help="Number of tokens. e.g.: -n 8 32",
+    )
+    parser.add_argument(
+        "--num_heads",
+        type=int,
+        nargs="*",
+        default=[32, 64],
+        help="Number of indexer heads. e.g.: --num_heads 32 64",
+    )
+    parser.add_argument(
+        "-d",
+        "--dtype",
+        type=dtypes.str2Dtype,
+        choices=[dtypes.bf16],
+        nargs="*",
+        default="bf16,",
+        help="Input dtype. e.g.: -d bf16",
+    )
+    parser.add_argument(
+        "--valid_fraction",
+        type=float,
+        nargs="*",
+        default=[0.5],
+        help="Fraction of rows with valid cache slots. e.g.: --valid_fraction 0.5",
+    )
+    parser.add_argument(
+        "--compute_all_q_rope",
+        type=dtypes.str2bool,
+        nargs="*",
+        default=[False, True],
+        help="Compute Q/weights for slot=-1 rows. e.g.: --compute_all_q_rope 0 1",
+    )
+    parser.add_argument(
+        "--is_neox",
+        type=dtypes.str2bool,
+        nargs="*",
+        default=[True, False],
+        help="RoPE layout. e.g.: --is_neox 1 0",
+    )
+    args = parser.parse_args()
+
+    rows = []
+    for (
+        num_tokens,
+        num_heads,
+        dtype,
+        valid_fraction,
+        compute_all_q_rope,
+        is_neox,
+    ) in itertools.product(
+        args.num_tokens,
+        args.num_heads,
+        args.dtype,
+        args.valid_fraction,
+        args.compute_all_q_rope,
+        args.is_neox,
+    ):
+        rows.append(
+            test_indexer_qk_rope_quant_and_cache(
+                num_tokens,
+                num_heads,
+                dtype,
+                valid_fraction,
+                compute_all_q_rope,
+                is_neox,
+            )
+        )
+
+    df = pd.DataFrame(rows)
+    aiter.logger.info(
+        "indexer_qk_rope_quant_and_cache summary (markdown):\n%s",
+        df.to_markdown(index=False),
+    )
 
 
 if __name__ == "__main__":
-    test_indexer_qk_compute_all_q_rope()
+    main()

--- a/op_tests/test_indexer_qk_rope_quant_and_cache.py
+++ b/op_tests/test_indexer_qk_rope_quant_and_cache.py
@@ -21,9 +21,7 @@ def _run(
     weights_out = torch.zeros_like(weights, dtype=torch.float32)
     kv_cache = torch.zeros((1, 16, 132), device=q.device, dtype=dtypes.fp8)
     extra = (
-        {}
-        if compute_all_q_rope is None
-        else {"compute_all_q_rope": compute_all_q_rope}
+        {} if compute_all_q_rope is None else {"compute_all_q_rope": compute_all_q_rope}
     )
     indexer_qk_rope_quant_and_cache(
         q,
@@ -57,9 +55,7 @@ def test_indexer_qk_compute_all_q_rope():
     q = torch.randn(
         num_tokens, num_heads, head_dim, device=device, dtype=torch.bfloat16
     )
-    weights = torch.randn(
-        num_tokens, num_heads, device=device, dtype=torch.bfloat16
-    )
+    weights = torch.randn(num_tokens, num_heads, device=device, dtype=torch.bfloat16)
     k = torch.randn(num_tokens, head_dim, device=device, dtype=torch.bfloat16)
     norm_weight = torch.ones(head_dim, device=device, dtype=torch.float32)
     norm_bias = torch.zeros(head_dim, device=device, dtype=torch.float32)

--- a/op_tests/test_indexer_qk_rope_quant_and_cache.py
+++ b/op_tests/test_indexer_qk_rope_quant_and_cache.py
@@ -1,0 +1,162 @@
+# SPDX-License-Identifier: MIT
+
+import torch
+
+from aiter import dtypes, indexer_qk_rope_quant_and_cache
+
+
+def _run(
+    q,
+    weights,
+    k,
+    slot_mapping,
+    positions,
+    cos_cache,
+    sin_cache,
+    norm_weight,
+    norm_bias,
+    compute_all_q_rope,
+):
+    q_out = torch.zeros_like(q, dtype=dtypes.fp8)
+    weights_out = torch.zeros_like(weights, dtype=torch.float32)
+    kv_cache = torch.zeros((1, 16, 132), device=q.device, dtype=dtypes.fp8)
+    extra = (
+        {}
+        if compute_all_q_rope is None
+        else {"compute_all_q_rope": compute_all_q_rope}
+    )
+    indexer_qk_rope_quant_and_cache(
+        q,
+        q_out,
+        weights,
+        weights_out,
+        k,
+        kv_cache,
+        slot_mapping,
+        norm_weight,
+        norm_bias,
+        positions,
+        cos_cache,
+        sin_cache,
+        1e-6,
+        128,
+        "ue8m0",
+        128**-0.5 * 32**-0.5,
+        preshuffle=False,
+        is_neox=True,
+        **extra,
+    )
+    torch.cuda.synchronize()
+    return q_out, weights_out, kv_cache
+
+
+def test_indexer_qk_compute_all_q_rope():
+    torch.manual_seed(1)
+    device = "cuda"
+    num_tokens, num_heads, head_dim = 8, 32, 128
+    q = torch.randn(
+        num_tokens, num_heads, head_dim, device=device, dtype=torch.bfloat16
+    )
+    weights = torch.randn(
+        num_tokens, num_heads, device=device, dtype=torch.bfloat16
+    )
+    k = torch.randn(num_tokens, head_dim, device=device, dtype=torch.bfloat16)
+    norm_weight = torch.ones(head_dim, device=device, dtype=torch.float32)
+    norm_bias = torch.zeros(head_dim, device=device, dtype=torch.float32)
+    angles = torch.randn(16, 32, device=device)
+    cos_cache = angles.cos().bfloat16()
+    sin_cache = angles.sin().bfloat16()
+
+    clamped_positions = torch.tensor(
+        [0, 1, 2, 3, 0, 15, 15, 15], device=device, dtype=torch.int64
+    )
+    valid_slots = torch.arange(num_tokens, device=device, dtype=torch.int64)
+    q_ref, weights_ref, _ = _run(
+        q,
+        weights,
+        k,
+        valid_slots,
+        clamped_positions,
+        cos_cache,
+        sin_cache,
+        norm_weight,
+        norm_bias,
+        False,
+    )
+    q_default, weights_default, cache_default = _run(
+        q,
+        weights,
+        k,
+        valid_slots,
+        clamped_positions,
+        cos_cache,
+        sin_cache,
+        norm_weight,
+        norm_bias,
+        None,
+    )
+    q_explicit, weights_explicit, cache_explicit = _run(
+        q,
+        weights,
+        k,
+        valid_slots,
+        clamped_positions,
+        cos_cache,
+        sin_cache,
+        norm_weight,
+        norm_bias,
+        False,
+    )
+    torch.testing.assert_close(q_default.float(), q_explicit.float(), rtol=0, atol=0)
+    torch.testing.assert_close(weights_default, weights_explicit, rtol=0, atol=0)
+    torch.testing.assert_close(
+        cache_default.float(), cache_explicit.float(), rtol=0, atol=0
+    )
+
+    mixed_slots = valid_slots.clone()
+    mixed_slots[4:] = -1
+    stale_positions = torch.tensor(
+        [0, 1, 2, 3, -7, 16, 100, 1000], device=device, dtype=torch.int64
+    )
+    q_all, weights_all, kv_cache = _run(
+        q,
+        weights,
+        k,
+        mixed_slots,
+        stale_positions,
+        cos_cache,
+        sin_cache,
+        norm_weight,
+        norm_bias,
+        True,
+    )
+
+    torch.testing.assert_close(q_all.float(), q_ref.float(), rtol=0, atol=0)
+    torch.testing.assert_close(weights_all, weights_ref, rtol=0, atol=0)
+
+    cache_flat = kv_cache.view(-1)
+    k_region = cache_flat[: 16 * head_dim]
+    scale_region = cache_flat[16 * head_dim :]
+    assert torch.count_nonzero(k_region[4 * head_dim :]).item() == 0
+    assert torch.count_nonzero(scale_region[4 * 4 :]).item() == 0
+
+    q_default, weights_default, _ = _run(
+        q,
+        weights,
+        k,
+        mixed_slots,
+        stale_positions,
+        cos_cache,
+        sin_cache,
+        norm_weight,
+        norm_bias,
+        False,
+    )
+    torch.testing.assert_close(q_default[:4].float(), q_ref[:4].float(), rtol=0, atol=0)
+    torch.testing.assert_close(weights_default[:4], weights_ref[:4], rtol=0, atol=0)
+    assert torch.count_nonzero(q_default[4:].float()).item() == 0
+    assert torch.count_nonzero(weights_default[4:]).item() == 0
+
+
+if __name__ == "__main__":
+    test_indexer_qk_compute_all_q_rope()


### PR DESCRIPTION
## Summary
Enable the fused indexer QK preparation kernel for DCP. On non-owner DCP ranks, `slot_mapping` is negative, but those ranks must still produce valid `q_out` and `weights_out` for distributed index scoring. The previous early return skipped the entire kernel and left these outputs uninitialized.

## Changes
- Add an optional `compute_all_q_rope` argument, following the approach used by #4342.
- Compute Q RoPE, FP8 quantization, and `weights_out` on every DCP rank.
- Keep K normalization, quantization, and cache writes restricted to valid owner slots.
- Clamp stale padding positions before indexing the RoPE cache.
- Preserve the existing non-DCP behavior by default.
- Add coverage for mixed valid/invalid slots, stale positions, and the default non-DCP path.

