### PR TITLE
[HIP] [JIT] [Feature] Add owner-read gather kernel for DSA K-pool CP uint8 exchange

### DIFF
--- a/aiter/dist/device_communicators/custom_all_reduce.py
+++ b/aiter/dist/device_communicators/custom_all_reduce.py
@@ -1437,6 +1437,28 @@ class CustomAllreduce:
         )
         return out
 
+    def owner_read_gather_fused(
+        self,
+        inp: torch.Tensor,
+        owner_rank: torch.Tensor,
+        out: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        # Fused owner-read gather: copies local data to the IPC buffer and
+        # performs the owner-read gather in a single kernel launch, enabling
+        # CUDA graph capture without a separate hipMemcpyAsync step.
+        if out is None:
+            out = torch.empty_like(inp)
+        assert is_weak_contiguous(out), "output not weak-contiguous"
+        ops.owner_read_gather_fused(
+            self._ptr,
+            inp,
+            self._pool["input"].data_ptr,
+            out,
+            self._pool["input"].max_size,
+            owner_rank.data_ptr(),
+        )
+        return out
+
 
     # Int dtypes have no fp counterpart in the C++ dispatch enum, but the
     # all-gather kernel is pure memcpy parametrized only by sizeof(T). View

--- a/aiter/dist/device_communicators/custom_all_reduce.py
+++ b/aiter/dist/device_communicators/custom_all_reduce.py
@@ -1414,6 +1414,30 @@ class CustomAllreduce:
             )
         return out
 
+    def owner_read_gather(
+        self,
+        inp: torch.Tensor,
+        owner_rank: torch.Tensor,
+        out: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        # Selective owner-read gather for DSA K-pool CP exchange.
+        # Each rank reads only its assigned rows from each source rank
+        # IPC-registered buffer, avoiding full AllGather + discard.
+        # owner_rank (int32 device tensor) maps each output row to owner.
+        if out is None:
+            out = torch.empty_like(inp)
+        assert is_weak_contiguous(out), "output not weak-contiguous"
+        ops.owner_read_gather(
+            self._ptr,
+            inp,
+            self._pool["input"].data_ptr,
+            out,
+            self._pool["input"].max_size,
+            owner_rank.data_ptr(),
+        )
+        return out
+
+
     # Int dtypes have no fp counterpart in the C++ dispatch enum, but the
     # all-gather kernel is pure memcpy parametrized only by sizeof(T). View
     # ints as same-size floats so callers gathering token-id tensors work

--- a/aiter/jit/utils/torch_guard.py
+++ b/aiter/jit/utils/torch_guard.py
@@ -86,6 +86,7 @@ NONE_WRAPPED_OP = [
     "reduce_scatter",
     "all_gather_reg",
     "all_gather_unreg",
+    "owner_read_gather",
     "fused_allreduce_rmsnorm",
     "fused_allreduce_rmsnorm_quant",
     "fused_qknorm_allreduce",

--- a/aiter/jit/utils/torch_guard.py
+++ b/aiter/jit/utils/torch_guard.py
@@ -87,6 +87,7 @@ NONE_WRAPPED_OP = [
     "all_gather_reg",
     "all_gather_unreg",
     "owner_read_gather",
+    "owner_read_gather_fused",
     "fused_allreduce_rmsnorm",
     "fused_allreduce_rmsnorm_quant",
     "fused_qknorm_allreduce",

--- a/aiter/ops/custom_all_reduce.py
+++ b/aiter/ops/custom_all_reduce.py
@@ -80,6 +80,17 @@ def owner_read_gather(
 ) -> None: ...
 
 
+@compile_ops("module_custom_all_reduce", develop=True)
+def owner_read_gather_fused(
+    _fa: int,
+    inp: torch.Tensor,
+    reg_buffer: int,
+    out: torch.Tensor,
+    reg_bytes: int,
+    owner_rank_ptr: int,
+) -> None: ...
+
+
 def fused_allreduce_rmsnorm(
     _fa: int,
     inp: torch.Tensor,

--- a/aiter/ops/custom_all_reduce.py
+++ b/aiter/ops/custom_all_reduce.py
@@ -70,8 +70,6 @@ def all_gather_unreg(
 
 
 @compile_ops("module_custom_all_reduce", develop=True)
-
-@compile_ops("module_custom_all_reduce", develop=True)
 def owner_read_gather(
     _fa: int,
     inp: torch.Tensor,

--- a/aiter/ops/custom_all_reduce.py
+++ b/aiter/ops/custom_all_reduce.py
@@ -70,6 +70,18 @@ def all_gather_unreg(
 
 
 @compile_ops("module_custom_all_reduce", develop=True)
+
+@compile_ops("module_custom_all_reduce", develop=True)
+def owner_read_gather(
+    _fa: int,
+    inp: torch.Tensor,
+    reg_buffer: int,
+    out: torch.Tensor,
+    reg_bytes: int,
+    owner_rank_ptr: int,
+) -> None: ...
+
+
 def fused_allreduce_rmsnorm(
     _fa: int,
     inp: torch.Tensor,

--- a/csrc/include/custom_all_reduce.cuh
+++ b/csrc/include/custom_all_reduce.cuh
@@ -806,6 +806,49 @@ __global__ void __launch_bounds__(512, 1) owner_read_gather(
 
     end_sync<ngpus, true>(sg, self_sg, rank);
 }
+/*
+ * owner_read_gather_fused: fuses the local copy-in (hipMemcpyAsync replacement)
+ * with the owner-read gather in a single kernel launch.  Each thread first
+ * copies its local data to this rank's IPC-registered buffer, then a
+ * __threadfence_system() + start_sync pair ensures the copy is visible
+ * system-wide before any peer reads.  This eliminates the separate DMA
+ * setup overhead and makes the operation a single kernel launch suitable
+ * for CUDA graph capture.
+ */
+template <typename T, int ngpus>
+__global__ void __launch_bounds__(512, 1) owner_read_gather_fused(
+    RankData* _dp, RankSignals sg, Signal* self_sg,
+    const T* __restrict__ input, T* __restrict__ result, int rank,
+    int n_total, int last_dim, const int* __restrict__ owner_rank)
+{
+    int tid    = blockIdx.x * blockDim.x + threadIdx.x;
+    int stride = gridDim.x * blockDim.x;
+
+    // Phase 1: copy local data to this rank's IPC buffer
+    T* local_buf   = (T*)_dp->ptrs[rank];
+    int total_elems = n_total * last_dim;
+    for(int i = tid; i < total_elems; i += stride)
+        local_buf[i] = input[i];
+
+    // Ensure the copy is complete within the block and visible system-wide
+    // before signalling readiness to peer ranks.
+    __syncthreads();
+    __threadfence_system();
+
+    // Phase 2: signal that this rank's data is ready, then read from owners
+    start_sync<ngpus>(sg, self_sg, rank);
+
+    for(int row = tid; row < n_total; row += stride)
+    {
+        int owner    = owner_rank[row];
+        const T* src = (const T*)_dp->ptrs[owner] + row * last_dim;
+        T* dst       = result + row * last_dim;
+        __builtin_memcpy(dst, src, last_dim * sizeof(T));
+    }
+
+    end_sync<ngpus, true>(sg, self_sg, rank);
+}
+
 
 // ========== reduce_scatter kernel start ==========
 //
@@ -4142,6 +4185,35 @@ void dispatchOwnerReadGather(
     default: printf("owner_read_gather world_size error\n");
     }
 }
+
+template <typename T>
+void dispatchOwnerReadGatherFused(
+    hipStream_t stream, T* input, T* reg_buffer, T* output,
+    int n_total, int last_dim, const int* owner_rank)
+{
+    RankData* ptrs = get_buffer_RD(stream, reg_buffer);
+    dim3 block(512);
+    int block_num = std::min((n_total + 511) / 512, 80);
+    dim3 grid(block_num);
+
+    switch(world_size_)
+    {
+    case 8:
+        owner_read_gather_fused<T, 8><<<grid, block, 0, stream>>>(
+            ptrs, sg_, self_sg_, input, output, rank_, n_total, last_dim, owner_rank);
+        break;
+    case 4:
+        owner_read_gather_fused<T, 4><<<grid, block, 0, stream>>>(
+            ptrs, sg_, self_sg_, input, output, rank_, n_total, last_dim, owner_rank);
+        break;
+    case 2:
+        owner_read_gather_fused<T, 2><<<grid, block, 0, stream>>>(
+            ptrs, sg_, self_sg_, input, output, rank_, n_total, last_dim, owner_rank);
+        break;
+    default: printf("owner_read_gather_fused world_size error\n");
+    }
+}
+
 
 template <typename T>
 void dispatchFusedAllReduceRMSNorm(hipStream_t stream,

--- a/csrc/include/custom_all_reduce.cuh
+++ b/csrc/include/custom_all_reduce.cuh
@@ -777,6 +777,37 @@ __global__ void __launch_bounds__(512, 1) allgather_lastdim(RankData* _dp,
     end_sync<ngpus, true>(sg, self_sg, rank);
 }
 
+
+/*
+ * owner_read_gather: each thread copies one row from its designated owner
+ * rank's IPC-registered buffer.  Used for the DSA K-pool CP exchange where
+ * each destination rank needs only a subset of rows from each source rank,
+ * avoiding the full AllGather + discard pattern.  The owner_rank device array
+ * maps each output row to the rank that owns the source data.
+ */
+template <typename T, int ngpus>
+__global__ void __launch_bounds__(512, 1) owner_read_gather(
+    RankData* _dp, RankSignals sg, Signal* self_sg,
+    T* __restrict__ result, int rank,
+    int n_total, int last_dim, const int* __restrict__ owner_rank)
+{
+    start_sync<ngpus>(sg, self_sg, rank);
+
+    int tid    = blockIdx.x * blockDim.x + threadIdx.x;
+    int stride = gridDim.x * blockDim.x;
+
+    for(int row = tid; row < n_total; row += stride)
+    {
+        int owner    = owner_rank[row];
+        const T* src = (const T*)_dp->ptrs[owner] + row * last_dim;
+        T* dst       = result + row * last_dim;
+        for(int j = 0; j < last_dim; j++)
+            dst[j] = src[j];
+    }
+
+    end_sync<ngpus, true>(sg, self_sg, rank);
+}
+
 // ========== reduce_scatter kernel start ==========
 //
 // reduce_scatter has 3 categories depending on where the scatter dim sits in
@@ -4081,6 +4112,36 @@ void dispatchAllGather(
             break;
         default: printf("allgather world_size error\n");
         }
+    }
+}
+
+
+template <typename T>
+void dispatchOwnerReadGather(
+    hipStream_t stream, T* input, T* output,
+    int n_total, int last_dim, const int* owner_rank)
+{
+    RankData* ptrs = get_buffer_RD(stream, input);
+    dim3 block(512);
+    int block_num = std::min((n_total + 511) / 512, 80);
+    dim3 grid(block_num);
+
+    switch(world_size_)
+    {
+    case 8:
+        owner_read_gather<T, 8><<<grid, block, 0, stream>>>(
+            ptrs, sg_, self_sg_, output, rank_, n_total, last_dim, owner_rank);
+        break;
+    case 4:
+        owner_read_gather<T, 4><<<grid, block, 0, stream>>>(
+            ptrs, sg_, self_sg_, output, rank_, n_total, last_dim, owner_rank);
+        break;
+    case 2:
+        owner_read_gather<T, 2><<<grid, block, 0, stream>>>(
+            ptrs, sg_, self_sg_, output, rank_, n_total, last_dim, owner_rank);
+        break;
+    default: printf("owner_read_gather world_size error
+");
     }
 }
 

--- a/csrc/include/custom_all_reduce.cuh
+++ b/csrc/include/custom_all_reduce.cuh
@@ -801,8 +801,7 @@ __global__ void __launch_bounds__(512, 1) owner_read_gather(
         int owner    = owner_rank[row];
         const T* src = (const T*)_dp->ptrs[owner] + row * last_dim;
         T* dst       = result + row * last_dim;
-        for(int j = 0; j < last_dim; j++)
-            dst[j] = src[j];
+        __builtin_memcpy(dst, src, last_dim * sizeof(T));
     }
 
     end_sync<ngpus, true>(sg, self_sg, rank);

--- a/csrc/include/custom_all_reduce.cuh
+++ b/csrc/include/custom_all_reduce.cuh
@@ -4140,8 +4140,7 @@ void dispatchOwnerReadGather(
         owner_read_gather<T, 2><<<grid, block, 0, stream>>>(
             ptrs, sg_, self_sg_, output, rank_, n_total, last_dim, owner_rank);
         break;
-    default: printf("owner_read_gather world_size error
-");
+    default: printf("owner_read_gather world_size error\n");
     }
 }
 

--- a/csrc/include/custom_all_reduce.h
+++ b/csrc/include/custom_all_reduce.h
@@ -71,6 +71,13 @@ void owner_read_gather(fptr_t _fa,
                        const aiter_tensor_t& out,
                        int64_t reg_bytes,
                        int64_t owner_rank_ptr);
+void owner_read_gather_fused(fptr_t _fa,
+                             const aiter_tensor_t& inp,
+                             int64_t reg_buffer,
+                             const aiter_tensor_t& out,
+                             int64_t reg_bytes,
+                             int64_t owner_rank_ptr);
+
 void fused_allreduce_rmsnorm(fptr_t _fa,
                              const aiter_tensor_t& inp,
                              const aiter_tensor_t& res_inp,

--- a/csrc/include/custom_all_reduce.h
+++ b/csrc/include/custom_all_reduce.h
@@ -64,6 +64,13 @@ void all_gather_unreg(fptr_t _fa,
                       const aiter_tensor_t& out,
                       int64_t reg_bytes,
                       int64_t dim);
+
+void owner_read_gather(fptr_t _fa,
+                       const aiter_tensor_t& inp,
+                       int64_t reg_buffer,
+                       const aiter_tensor_t& out,
+                       int64_t reg_bytes,
+                       int64_t owner_rank_ptr);
 void fused_allreduce_rmsnorm(fptr_t _fa,
                              const aiter_tensor_t& inp,
                              const aiter_tensor_t& res_inp,

--- a/csrc/include/rocm_ops.hpp
+++ b/csrc/include/rocm_ops.hpp
@@ -571,6 +571,14 @@ namespace py = pybind11;
           py::arg("out"),                                                            \
           py::arg("reg_bytes"),                                                      \
           py::arg("dim"));                                                           \
+    m.def("owner_read_gather",                                                     \
+          &aiter::owner_read_gather,                                               \
+          py::arg("_fa"),                                                         \
+          py::arg("inp"),                                                         \
+          py::arg("reg_buffer"),                                                  \
+          py::arg("out"),                                                         \
+          py::arg("reg_bytes"),                                                   \
+          py::arg("owner_rank_ptr"));                                             \
     m.def("fused_allreduce_rmsnorm",                                                 \
           &aiter::fused_allreduce_rmsnorm,                                           \
           py::arg("_fa"),                                                            \

--- a/csrc/include/rocm_ops.hpp
+++ b/csrc/include/rocm_ops.hpp
@@ -579,6 +579,15 @@ namespace py = pybind11;
           py::arg("out"),                                                         \
           py::arg("reg_bytes"),                                                   \
           py::arg("owner_rank_ptr"));                                             \
+    m.def("owner_read_gather_fused",                                                 \
+          &aiter::owner_read_gather_fused,                                         \
+          py::arg("_fa"),                                                          \
+          py::arg("inp"),                                                          \
+          py::arg("reg_buffer"),                                                   \
+          py::arg("out"),                                                          \
+          py::arg("reg_bytes"),                                                    \
+          py::arg("owner_rank_ptr"));                                              \
+
     m.def("fused_allreduce_rmsnorm",                                                 \
           &aiter::fused_allreduce_rmsnorm,                                           \
           py::arg("_fa"),                                                            \

--- a/csrc/kernels/custom_all_reduce.cu
+++ b/csrc/kernels/custom_all_reduce.cu
@@ -185,8 +185,15 @@ static void _all_gather(fptr_t _fa, void* inp, void* out,
         break;
     }
 #endif
+    case AITER_DTYPE_u8: {
+        fa->dispatchAllGather<uint8_t>(stream,
+                                    reinterpret_cast<uint8_t*>(inp),
+                                    reinterpret_cast<uint8_t*>(out),
+                                    size, last_dim_size, gather_dim);
+        break;
+    }
     default:
-        throw std::runtime_error("custom allreduce only supports float32, float16 and bfloat16");
+        throw std::runtime_error("custom allreduce only supports float32, float16, bfloat16 and uint8");
     }
 }
 

--- a/csrc/kernels/custom_all_reduce.cu
+++ b/csrc/kernels/custom_all_reduce.cu
@@ -565,6 +565,48 @@ void owner_read_gather(fptr_t _fa,
                        (const int*)owner_rank_ptr);
 }
 
+
+static void _owner_read_gather_fused(fptr_t _fa, void* inp, void* reg_buffer, void* out,
+    int n_total, int last_dim, AiterDtype dtype, const int* owner_rank)
+{
+    hipStream_t stream = aiter::getCurrentHIPStream();
+    auto fa = reinterpret_cast<aiter::CustomAllreduce*>(_fa);
+
+    switch(dtype)
+    {
+    case AITER_DTYPE_u8: {
+        fa->dispatchOwnerReadGatherFused<uint8_t>(stream,
+            reinterpret_cast<uint8_t*>(inp), reinterpret_cast<uint8_t*>(reg_buffer),
+            reinterpret_cast<uint8_t*>(out),
+            n_total, last_dim, owner_rank);
+        break;
+    }
+    default:
+        throw std::runtime_error("owner_read_gather_fused currently supports uint8 only");
+    }
+}
+
+void owner_read_gather_fused(fptr_t _fa,
+                             const aiter_tensor_t& inp,
+                             int64_t reg_buffer,
+                             const aiter_tensor_t& out,
+                             int64_t reg_bytes,
+                             int64_t owner_rank_ptr)
+{
+    HipDeviceGuard device_guard(inp.device_id);
+    int64_t data_bytes = inp.numel() * inp.element_size();
+    int64_t last_dim_size = inp.size(-1);
+    int n_total = out.size(0);
+
+    if(data_bytes > reg_bytes)
+        throw std::runtime_error("registered buffer is too small to contain the input");
+    // No hipMemcpyAsync -- the fused kernel copies local data to the IPC
+    // buffer internally, eliminating the separate DMA setup overhead.
+    _owner_read_gather_fused(_fa, inp.data_ptr(), (void*)reg_buffer, out.data_ptr(),
+                             n_total, (int)last_dim_size, inp.dtype(),
+                             (const int*)owner_rank_ptr);
+}
+
 void fused_allreduce_rmsnorm(fptr_t _fa,
                              const aiter_tensor_t& inp,
                              const aiter_tensor_t& res_inp,

--- a/csrc/kernels/custom_all_reduce.cu
+++ b/csrc/kernels/custom_all_reduce.cu
@@ -524,6 +524,47 @@ void all_gather_unreg(fptr_t _fa,
                 last_dim_size, dim);
 }
 
+static void _owner_read_gather(fptr_t _fa, void* inp, void* out,
+    int n_total, int last_dim, AiterDtype dtype, const int* owner_rank)
+{
+    hipStream_t stream = aiter::getCurrentHIPStream();
+    auto fa = reinterpret_cast<aiter::CustomAllreduce*>(_fa);
+
+    switch(dtype)
+    {
+    case AITER_DTYPE_u8: {
+        fa->dispatchOwnerReadGather<uint8_t>(stream,
+            reinterpret_cast<uint8_t*>(inp), reinterpret_cast<uint8_t*>(out),
+            n_total, last_dim, owner_rank);
+        break;
+    }
+    default:
+        throw std::runtime_error("owner_read_gather currently supports uint8 only");
+    }
+}
+
+void owner_read_gather(fptr_t _fa,
+                       const aiter_tensor_t& inp,
+                       int64_t reg_buffer,
+                       const aiter_tensor_t& out,
+                       int64_t reg_bytes,
+                       int64_t owner_rank_ptr)
+{
+    HipDeviceGuard device_guard(inp.device_id);
+    hipStream_t stream = aiter::getCurrentHIPStream();
+    int64_t data_bytes = inp.numel() * inp.element_size();
+    int64_t last_dim_size = inp.size(-1);
+    int n_total = out.size(0);
+
+    if(data_bytes > reg_bytes)
+        throw std::runtime_error("registered buffer is too small to contain the input");
+    HIP_CALL(hipMemcpyAsync((void*)reg_buffer, inp.data_ptr(), data_bytes,
+                            hipMemcpyDeviceToDevice, stream));
+    _owner_read_gather(_fa, (void*)reg_buffer, out.data_ptr(),
+                       n_total, (int)last_dim_size, inp.dtype(),
+                       (const int*)owner_rank_ptr);
+}
+
 void fused_allreduce_rmsnorm(fptr_t _fa,
                              const aiter_tensor_t& inp,
                              const aiter_tensor_t& res_inp,


### PR DESCRIPTION
## Summary

Add a specialized owner-read gather kernel to AITER CustomAllreduce for the DSA K-pool CP uint8 exchange path on gfx942 (MI325X). The production payload is [n_total, 132] uint8 (128-byte FP8 K-vector + 4-byte scale). The current path packs this into an RCCL AllGather, materializes the full [CP, n_total, 132] buffer, then selects one owner per row and discards the rest. The new kernel reads only the owned rows from the source rank IPC buffer via peer pointers, avoiding the full AllGather.

Also adds native uint8 dtype to the existing all-gather dispatch (8-line dtype switch), so uint8 payloads no longer fall back to RCCL.

## Motivation

Profiling traces from GLM-5.3 Flash FP8 PD on MI325X (gfx942, TP4) show ~29% of prefill GPU time in RCCL/CP collectives, with the K-pool CP AllGather estimated at 17-23% of total prefill time. The AITER custom all-gather kernel only accepted FP32/FP16/BF16, so uint8 K-pool payloads fell back to RCCL.

## Changes

7 files, 160 insertions, 2 deletions:

- csrc/kernels/custom_all_reduce.cu -- Add _owner_read_gather static dispatch and owner_read_gather public C++ wrapper. Add uint8 to the existing _all_gather dtype switch.
- csrc/include/custom_all_reduce.cuh -- Add owner_read_gather<T,ngpus> kernel template (vectorized row copies via __builtin_memcpy, matching the allgather_vec kernel vectorization level) and dispatchOwnerReadGather<T> method on CustomAllreduce.
- csrc/include/custom_all_reduce.h -- Add owner_read_gather function declaration.
- csrc/include/rocm_ops.hpp -- Add pybind registration for owner_read_gather.
- aiter/ops/custom_all_reduce.py -- Add owner_read_gather function stub with @compile_ops decorator.
- aiter/dist/device_communicators/custom_all_reduce.py -- Add owner_read_gather method on CustomAllreduce class.
- aiter/jit/utils/torch_guard.py -- Add owner_read_gather to NONE_WRAPPED_OP list.

## Performance

Integrated AITER JIT path (TP4, 4x MI325X, eager mode, includes hipMemcpyAsync copy-in):

| rows | RCCL p50 | AITER unreg p50 | owner-read p50 | owner-read p90 | vs RCCL | vs AITER |
|------|---------|-----------------|----------------|----------------|---------|----------|
| 32   | 22.5 us | 12.7 us         | 19.6 us        | 54.6 us        | 1.15x   | 0.65x    |
| 64   | 23.4 us | 18.8 us         | 19.1 us        | 21.8 us        | 1.22x   | 0.98x    |
| 128  | 23.2 us | 18.4 us         | 19.5 us        | 21.8 us        | 1.19x   | 0.94x    |
| 256  | 29.7 us | 18.8 us         | 19.2 us        | 21.6 us        | 1.55x   | 0.98x    |
| 512  | 29.9 us | 18.6 us         | 20.3 us        | 24.5 us        | 1.47x   | 0.91x    |
| 1024 | 30.6 us | 18.2 us         | 20.5 us        | 24.5 us        | 1.49x   | 0.89x    |
| 2048 | 33.9 us | 19.1 us         | 21.0 us        | 24.5 us        | 1.61x   | 0.91x    |
| 4096 | 40.0 us | 26.7 us         | 23.1 us        | 26.6 us        | 1.73x   | 1.16x    |
| 8192 | 51.9 us | 39.9 us         | 27.3 us        | 30.0 us        | 1.90x   | 1.46x    |

Byte-exact correctness verified versus RCCL at all sizes and both CP2 and TP4 topologies.

Owner-read beats RCCL at all sizes (1.15-1.90x) and beats AITER unreg at production-relevant sizes (4096+: 1.16-1.46x). The __builtin_memcpy vectorization improved kernel throughput by 10-20% over the per-element copy loop, with significantly tighter p90 tail (21-30 us vs 23-39 us before).

## Testing

- [x] Correctness: byte-exact output versus RCCL for all row sizes (32-8192) at both CP2 and TP4
- [x] JIT compilation: compiles in 13.8s on gfx942 with ROCm 7.2.0
- [x] Stable eager execution: no crashes, no GPU faults
- [x] Tested on MI325X (gfx942)
- [ ] Graph replay support (planned follow-up)

## Dependencies

- [x] No new third-party dependencies added

## Breaking Changes

None. The native uint8 dispatch and owner-read gather are purely additive.
