### PR TITLE
[HIP] [BugFix] Fix BF16 FMHA extreme negative logits

### DIFF
--- a/csrc/include/fmha_fwd_hd128_bf16_opus_kernel.hpp
+++ b/csrc/include/fmha_fwd_hd128_bf16_opus_kernel.hpp
@@ -321,7 +321,8 @@ template<typename T, typename V>
 __device__ inline typename T::D_ACC attn_row_max(const V& v_s) {
     using D_ACC = typename T::D_ACC;
     constexpr opus::index_t s_len = opus::vector_traits<V>::size();
-    D_ACC row_max = -1e30f;
+    // Keep fully masked tiles finite without clipping any finite fp32 score.
+    D_ACC row_max = opus::numeric_limits<D_ACC>::lowest();
     opus::static_for<s_len>([&](auto i) {
         row_max = max(row_max, v_s[i.value]);
     });

--- a/csrc/include/fmha_fwd_hd192_v128_bf16_opus_kernel.hpp
+++ b/csrc/include/fmha_fwd_hd192_v128_bf16_opus_kernel.hpp
@@ -71,7 +71,8 @@ template<typename T, typename V>
 __device__ inline typename T::D_ACC attn_row_max(const V& v_s) {
     using D_ACC = typename T::D_ACC;
     constexpr opus::index_t s_len = opus::vector_traits<V>::size();
-    D_ACC row_max = -1e30f;
+    // Keep fully masked tiles finite without clipping any finite fp32 score.
+    D_ACC row_max = opus::numeric_limits<D_ACC>::lowest();
     opus::static_for<s_len>([&](auto i) { row_max = max(row_max, v_s[i.value]); });
     opus::vector_t<opus::u32_t, 2> res = __builtin_amdgcn_permlane32_swap(
         std::bit_cast<opus::u32_t>(row_max), std::bit_cast<opus::u32_t>(row_max), false, true);

--- a/csrc/kernels/mha_native/fused/pipeline.hpp
+++ b/csrc/kernels/mha_native/fused/pipeline.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include <cfloat>
 #include <hip/hip_runtime.h>
 #include "runner/params.hpp"
 #include "op_lds.hpp"
@@ -341,9 +342,9 @@ __device__ __forceinline__ void fmha_fwd_d64_device(const FmhaFwdParams& params,
             q_regs[kstep] = v4i{0, 0, 0, 0};
     }
 
-    // Finite rmax seed below any realizable raw score, so a real score always wins
-    // the running max; -inf would make a fully-masked row NaN instead of O=0/LSE=-inf.
-    float rmax = -1e30f;
+    // The lowest finite fp32 value lets every finite score participate while
+    // avoiding (-inf) - (-inf) when a tile is fully masked.
+    float rmax = -FLT_MAX;
     float rsum = 0.0f;
 
     // kv_offset = absolute key row of the current tile's first key.

--- a/op_tests/test_mha_extreme_logits.py
+++ b/op_tests/test_mha_extreme_logits.py
@@ -1,0 +1,72 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2026, Advanced Micro Devices, Inc. All rights reserved.
+
+import pytest
+import torch
+
+from aiter import dtypes
+from aiter.jit.utils.chip_info import get_gfx
+from aiter.ops.mha import fmha_fwd_bf16_opus_fwd, mha_fwd_native_splitkv
+
+# The old -1e30 maximum seed clips this finite BF16 dot product.
+_TARGET_LOGIT = -(2.0**101)
+
+
+def _extreme_inputs(head_dim_qk, head_dim_v):
+    seqlen = 64
+    shape_qk = (1, seqlen, 1, head_dim_qk)
+    q = torch.ones(shape_qk, dtype=dtypes.bf16, device="cuda")
+    k = torch.full(
+        shape_qk,
+        _TARGET_LOGIT / head_dim_qk,
+        dtype=dtypes.bf16,
+        device="cuda",
+    )
+    v = torch.ones((1, seqlen, 1, head_dim_v), dtype=dtypes.bf16, device="cuda")
+    return q, k, v
+
+
+def _assert_unit_output(out):
+    # Softmax weights sum to one, so constant V must pass through exactly.
+    torch.testing.assert_close(out, torch.ones_like(out), rtol=0, atol=0)
+
+
+def test_mha_native_extreme_negative_logits():
+    if get_gfx() != "gfx942":
+        pytest.skip("native D64 regression runs on gfx942")
+
+    q, k, v = _extreme_inputs(64, 64)
+    out, lse = mha_fwd_native_splitkv(
+        q,
+        k,
+        v,
+        out=None,
+        softmax_scale=64**-0.5,
+        causal=False,
+        return_lse=True,
+        num_splits=1,
+    )
+
+    _assert_unit_output(out)
+    assert torch.isfinite(lse).all()
+
+
+@pytest.mark.parametrize("head_dim_qk", [128, 192])
+def test_fmha_opus_extreme_negative_logits(head_dim_qk):
+    if get_gfx() != "gfx950":
+        pytest.skip("OPUS regression requires gfx950")
+
+    q, k, v = _extreme_inputs(head_dim_qk, 128)
+    out = fmha_fwd_bf16_opus_fwd(
+        q,
+        k,
+        v,
+        softmax_scale=head_dim_qk**-0.5,
+        causal=False,
+    )
+
+    _assert_unit_output(out)
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Summary

* Replace the `-1e30f` softmax maximum seed in native D64 and OPUS D128 and D192/V128 with the lowest finite FP32 value.
* Add a focused BF16 regression where every QK score is below `-1e30` and constant values make the exact expected output one.

The lowest finite FP32 value allows every finite score to become the maximum. It also keeps fully masked tiles from evaluating `(-inf) - (-inf)`, so this does not add guards or arithmetic to the hot loop.

This PR fixes the source kernels only. FMHA v3 uses precompiled code objects and still needs a separate fix. Therefore this PR references, but does not close, #5086.

## Validation

On AMD Instinct MI300X, gfx942, using an isolated ROCm 7.2.3 container:

```text
main: 4096 / 4096 output elements are 0 instead of 1
fixed: 1 passed, 2 skipped
```

The two skipped cases exercise OPUS D128 and D192/V128 and require gfx950.

Formatting checks:

```text
black 26.3.0: passed
ruff 0.16.0: passed
git diff --check: passed
```

Refs #5086
