### PR TITLE
[FlyDSL] [Bugfix] Use FLYDSL_GPU_ARCH LDS limit so gfx950 8-wave AOT isn't excluded from builds on gfx942

### DIFF
--- a/aiter/ops/flydsl/utils.py
+++ b/aiter/ops/flydsl/utils.py
@@ -4,6 +4,7 @@
 """General utilities shared across all FlyDSL kernel families."""
 
 import importlib.util
+import os
 from functools import cache, lru_cache
 
 import torch
@@ -47,7 +48,15 @@ def _get_shared_memory_per_block_cached(device_index: int, fallback_gfx: str) ->
 
 
 def get_shared_memory_per_block(device=None, fallback_gfx: str = "") -> int:
-    """Return per-block shared memory/LDS limit for the active device."""
+    """Return per-block shared memory/LDS limit for the compile/run target.
+
+    AOT sets FLYDSL_GPU_ARCH to the job's target, which may differ from the
+    live GPU. Prefer that over torch.cuda device properties so a gfx942
+    builder can compile gfx950 kernels that need more than 64 KiB LDS.
+    """
+    aot_arch = os.environ.get("FLYDSL_GPU_ARCH", "").strip()
+    if aot_arch:
+        return addressable_lds_bytes_for_gfx(aot_arch)
     if device is None:
         device = _default_cuda_device_index()
     elif isinstance(device, torch.device):

--- a/op_tests/flydsl_tests/test_flydsl_utils.py
+++ b/op_tests/flydsl_tests/test_flydsl_utils.py
@@ -1,0 +1,45 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+"""CPU unit tests for FlyDSL helpers (no GPU required)."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import torch
+
+_UTILS_PATH = (
+    Path(__file__).resolve().parents[2] / "aiter" / "ops" / "flydsl" / "utils.py"
+)
+
+
+def _load_utils():
+    spec = importlib.util.spec_from_file_location("flydsl_utils_under_test", _UTILS_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_lds_limit_follows_aot_arch_not_live_device(monkeypatch):
+    """LDS budget must come from the arch we compile for, not the GPU we build on.
+
+    A multi-arch wheel (GPU_ARCHS='gfx942;gfx950') compiles gfx950 8-wave tiles
+    even on a gfx942 host. Reading the host's 64 KiB limit rejected tiles that
+    fit gfx950's 160 KiB, aborting FlyDSL AOT before any wheel was written.
+    """
+
+    class Props:
+        shared_memory_per_block = 65536
+        gcnArchName = "gfx942"
+
+    monkeypatch.setenv("FLYDSL_GPU_ARCH", "gfx950")
+    monkeypatch.setattr(torch.cuda, "current_device", lambda: 0)
+    monkeypatch.setattr(torch.cuda, "get_device_properties", lambda i: Props())
+
+    flydsl_utils = _load_utils()
+    flydsl_utils._default_cuda_device_index.cache_clear()
+    flydsl_utils._get_shared_memory_per_block_cached.cache_clear()
+
+    assert flydsl_utils.get_shared_memory_per_block(fallback_gfx="gfx950") == 163840

--- a/op_tests/flydsl_tests/test_flydsl_utils.py
+++ b/op_tests/flydsl_tests/test_flydsl_utils.py
@@ -16,7 +16,9 @@ _UTILS_PATH = (
 
 
 def _load_utils():
-    spec = importlib.util.spec_from_file_location("flydsl_utils_under_test", _UTILS_PATH)
+    spec = importlib.util.spec_from_file_location(
+        "flydsl_utils_under_test", _UTILS_PATH
+    )
     mod = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(mod)
     return mod


### PR DESCRIPTION
## Motivation

A multi-arch aiter wheel (`PREBUILD_KERNELS=1 GPU_ARCHS='gfx942;gfx950'`) should compile gfx950 FlyDSL 8-wave GEMMs even when the builder is gfx942 (MI325). Those tiles need ~128–160 KiB of LDS, which is legal on gfx950 (MI350, 160 KiB) but not on an MI325 builder (64 KiB).

`get_shared_memory_per_block()` ignored `FLYDSL_GPU_ARCH` and used the live GPU's LDS size. On the MI325 box, this rejected 34 gfx950 kernels, FlyDSL AOT aborted (`GEMM: 34 failed`), and no wheel was written. This blocked local multi-arch wheel testing (possibly including WIP in [#5062](https://github.com/ROCm/aiter/pull/5062) for tuning Gemma-4-31B FP8 kernels).

## Technical Details

AOT already sets `FLYDSL_GPU_ARCH` per job (`override_env` in `aiter/aot/flydsl/gemm.py`). Kernel code already reads that var (`buffer_ops.py`). This change makes the LDS helper do the same: if `FLYDSL_GPU_ARCH` is set, return `addressable_lds_bytes_for_gfx(aot_arch)` (gfx950 → 163840). If it is unset, behavior is unchanged (live device, then `fallback_gfx`).

One file changed: `aiter/ops/flydsl/utils.py`. 
New unit test in: `op_tests/flydsl_tests/test_flydsl_utils.py` (loads `utils.py` by path so it does not need `rocminfo` / a GPU).

## Test Plan

- Mock a gfx942 device (`shared_memory_per_block=65536`) with `FLYDSL_GPU_ARCH=gfx950`.
- `pytest op_tests/flydsl_tests/test_flydsl_utils.py`
- On MI325, `PREBUILD_KERNELS=1 GPU_ARCHS='gfx942;gfx950' python setup.py bdist_wheel` and check the FlyDSL GEMM AOT summary.

## Test Result

- Unit test: fails without the fix (`assert 65536 == 163840`); passes with it.
- Wheel AOT on gfx942: **1997 ok / 34 failed** before; **2031 ok / 0 failed** after. (Later HIP/CK module failures on that run were a missing CK submodule, not this change.)

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.