### PR TITLE
[Triton/Gluon] [Bugfix] fwd_decode: only one K-block program stores lse in _splitK_reduce

### DIFF
--- a/aiter/ops/triton/_triton_kernels/flash_attn_triton_amd/fwd_decode.py
+++ b/aiter/ops/triton/_triton_kernels/flash_attn_triton_amd/fwd_decode.py
@@ -800,9 +800,16 @@ def _splitK_reduce(
     tl.store(out_ptr, acc_out, mask=o_mask)
 
     # Store lse
-    l_ptrs = LSE + pid_zhg * stride_lse_zhg_i64 + pid_m
-    lse_val = tl.where(g_sum > 0, (g_m + tl.math.log2(g_sum)) / 1.44269504, g_m)
-    tl.store(l_ptrs, lse_val)
+    # only one K-block program writes lse: its address does not depend on
+    # pid_k (unlike the output store above, which is partitioned by offs_k),
+    # so all pid_k programs would store the same value to the same location
+    # concurrently (an unsynchronized same-value WAW). This is the same
+    # `pid_k == 0` convention the moe and gemm kernels in this repository
+    # already apply to their K-split-redundant work.
+    if pid_k == 0:
+        l_ptrs = LSE + pid_zhg * stride_lse_zhg_i64 + pid_m
+        lse_val = tl.where(g_sum > 0, (g_m + tl.math.log2(g_sum)) / 1.44269504, g_m)
+        tl.store(l_ptrs, lse_val)
 
 
 @triton.jit


### PR DESCRIPTION
## Summary

In `_splitK_reduce`, every K-block program stores `lse` to the same address. Guard the store with `pid_k == 0`, the way this repository already guards K-split-redundant work elsewhere.

## Motivation

The split-K decode reduction is launched on a 3-D grid whose third axis partitions the head dimension:

```python
reduce_grid = (batch_size * n_group_q * heads_per_group_q, seqlen_q, k_block_num)
```

```python
pid_k = tl.program_id(2)
offs_k = pid_k * K_BLOCK_SIZE + tl.arange(0, K_BLOCK_SIZE)
```

The **output** store is partitioned by that offset, as intended:

```python
out_ptr = out_offset + pid_m * stride_om_i64 + offs_k
tl.store(out_ptr, acc_out, mask=o_mask)
```

The **lse** store two lines below is not:

```python
l_ptrs = LSE + pid_zhg * stride_lse_zhg_i64 + pid_m   # no pid_k term
tl.store(l_ptrs, lse_val)
```

So whenever `k_block_num > 1`, all K-block programs write the *same* location concurrently. `k_block_num` is 2 exactly when

```python
batch_size * n_group_q * heads_per_group_q * seqlen_q < 512
```

i.e. in the small-batch decode regime, which is the common inference path; large batches take the `k_block_num = 1` branch and are unaffected.

The stored value is the same in every program: `lse_val` derives from `g_m` and `g_sum`, which come from

```python
metadata_ptr = metadata_offset + offs_splitK * stride_ms_i64 + pid_m * stride_mm_i64
```

a chain with no `pid_k` term (`acc`, the only `pid_k`-dependent quantity, feeds `acc_out`, not `lse_val`). Results are therefore unaffected today, but it is an unsynchronized inter-program write-write conflict on global memory, plus one redundant global store of `lse` per launch.

## Changes

- `aiter/ops/triton/_triton_kernels/flash_attn_triton_amd/fwd_decode.py`: wrap the `lse` store in `_splitK_reduce` with `if pid_k == 0:`, with a comment explaining why.

This is the same convention already used for K-split-redundant work in this repository, e.g. the bias load in `_triton_kernels/moe/moe_op_gemm_a8w8.py` (and its a8w4 / a4w4 / a16w4 / int8_smoothquant / blockscale siblings), and `NUM_KSPLIT == 1 or (SKIP_REDUCE and pid_k == 0)` in `_triton_kernels/gemm/basic/gemm_a16w16.py` and `_triton_kernels/gemm/fused/fused_gemm_afp4wfp4_a16w16.py`.

No API, layout, or numerics change: `LSE` is documented as `[B*H*G, M]` and has no K-block dimension, so the surviving store writes exactly the values every program previously wrote.

## Testing

`op_tests/triton_tests/attention/test_mha_v3.py`, before and after the change: **586 passed, 104 skipped** both times (identical selection; the skips are architecture-gated cases).

Caveat on hardware: I do not have an AMD GPU, so this was exercised on an RTX 4090 with the upstream Triton backend rather than on MI250X/MI300X. The change is arch-independent Python (a guard on a `program_id` comparison), and the redundant-write condition follows from the grid and the address expressions above, so it should reproduce identically on ROCm; a quick confirmation on MI300X would be welcome.

## Documentation

No documentation changes needed.

## Dependencies

No new dependencies.

## Breaking Changes

None.
