### PR TITLE
[CI] Avoid direct github.event interpolation in run: blocks (SEC-00830)

### DIFF
--- a/.github/workflows/aiter-test.yaml
+++ b/.github/workflows/aiter-test.yaml
@@ -203,7 +203,7 @@ jobs:
         if: ${{ matrix.build_enabled && steps.restore_aiter_wheel.outputs.cache-hit != 'true' }}
         run: |
           set -ex
-          if [ "${{ github.event_name }}" = "schedule" ]; then
+          if [ "${GITHUB_EVENT_NAME}" = "schedule" ]; then
             echo "Nightly build: syncing latest CK from develop branch..."
             git submodule set-branch --branch develop 3rdparty/composable_kernel
             git submodule sync
@@ -828,7 +828,7 @@ jobs:
       - name: Sync CK submodule
         run: |
           set -ex
-          if [ "${{ github.event_name }}" = "schedule" ]; then
+          if [ "${GITHUB_EVENT_NAME}" = "schedule" ]; then
             echo "Nightly build: syncing latest CK from develop branch..."
             git submodule set-branch --branch develop 3rdparty/composable_kernel
             git submodule sync
@@ -895,13 +895,14 @@ jobs:
           PY
 
       - name: Install triton
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref || github.ref_name }}
         run: |
           # Ensure install_triton.sh is available even when the PR branch
           # was created before the script was added to main (#2959).
           # The workflow file always comes from the base branch, so we
           # materialize the script from the base ref when missing.
           if [ ! -f .github/scripts/install_triton.sh ]; then
-            BASE_REF="${{ github.event.pull_request.base.ref || github.ref_name }}"
             mkdir -p .github/scripts
             curl -fsSL \
               "https://raw.githubusercontent.com/${{ github.repository }}/${BASE_REF}/.github/scripts/install_triton.sh" \
@@ -1108,7 +1109,7 @@ jobs:
       - name: Sync CK submodule
         run: |
           set -ex
-          if [ "${{ github.event_name }}" = "schedule" ]; then
+          if [ "${GITHUB_EVENT_NAME}" = "schedule" ]; then
             echo "Nightly build: syncing latest CK from develop branch..."
             git submodule set-branch --branch develop 3rdparty/composable_kernel
             git submodule sync
@@ -1176,13 +1177,14 @@ jobs:
           PY
 
       - name: Install triton
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref || github.ref_name }}
         run: |
           # Ensure install_triton.sh is available even when the PR branch
           # was created before the script was added to main (#2959).
           # The workflow file always comes from the base branch, so we
           # materialize the script from the base ref when missing.
           if [ ! -f .github/scripts/install_triton.sh ]; then
-            BASE_REF="${{ github.event.pull_request.base.ref || github.ref_name }}"
             mkdir -p .github/scripts
             curl -fsSL \
               "https://raw.githubusercontent.com/${{ github.repository }}/${BASE_REF}/.github/scripts/install_triton.sh" \


### PR DESCRIPTION
Hardening for Mythos scan finding **SEC-00830** (ROCM-26711).

## What the scanner flagged

GitHub Actions event context interpolated directly into `run:` shell blocks.
`${{ ... }}` is textual substitution — the value is pasted into the script *before*
the shell parses it, so attacker-controlled data becomes executable code.

## What is actually in this file

`aiter-test.yaml` already uses the `env:`-indirection pattern in most places —
15 `env:` blocks, and `${GITHUB_EVENT_NAME}` at lines 50 and 537. **This PR brings
the five remaining spots in line with that existing convention.** It does not
introduce a new pattern.

| count | before | after |
|---|---|---|
| 3 | `if [ "${{ github.event_name }}" = "schedule" ]` | `if [ "${GITHUB_EVENT_NAME}" = "schedule" ]` |
| 2 | `BASE_REF="${{ github.event.pull_request.base.ref \|\| github.ref_name }}"` (inside `run:`) | hoisted to a step-level `env:` block |

After this change, **no `${{ github.event* }}` remains inside any `run:` block.**

## This is hardening, not a bug fix

The scanner's stated attack surface — `github.event.pull_request.title` — **does not
appear in any `run:` block** in this file. Of the five occurrences that do exist:

- 3 are `github.event_name`: an enumerated value (`push` / `pull_request` /
  `schedule` / …) filled in by GitHub. Not attacker-controllable.
- 2 are `github.event.pull_request.base.ref`: the PR's **target** branch, not the
  contributor's source branch. This workflow is constrained to `branches: [main]`,
  so the value can only be `main`. An external contributor cannot name it.

So there is no exploitable path today. The reason to change it anyway is that the
*shape* invites one: the next person to add a field here could reach for
`head.ref` or `title` and turn it into a real injection. Removing the pattern
closes that door.

## Verification

- `actionlint`: clean, and identical before/after
- YAML parses; all 13 jobs load
- No behavioural change — `GITHUB_EVENT_NAME` is GitHub's own built-in env var with
  the same value as `github.event_name`, and `BASE_REF` keeps the same fallback
  expression, just evaluated in `env:` instead of inline

## Related tickets

- **ROCM-26681** (SEC-00227, `pull_request_target` RCE) — closed as false positive.
  This workflow uses `pull_request`, and did so already at the ticket's creation
  date. Repo-wide, only `pr-title-tags.yaml` and `pr-welcome-comment.yaml` use
  `pull_request_target`; neither checks out PR code and both run on `ubuntu-latest`.
- **ROCM-26712** (SEC-00837, non-ephemeral self-hosted runners) — **still open, and
  the one real issue of the three.** Self-hosted runners are in use and there is no
  `docker logout` anywhere in the workflow. Not addressed by this PR.

Refs: ROCM-26711 / SEC-00830
