### PR TITLE
[CI] Drop registry credentials after jobs on persistent runners (SEC-00837)

### DIFF
--- a/.github/workflows/aiter-test.yaml
+++ b/.github/workflows/aiter-test.yaml
@@ -358,6 +358,14 @@ jobs:
           compression-level: 0
           retention-days: 14
 
+      - name: Drop registry credentials
+        if: always()
+        run: |
+          # Self-hosted runners are persistent: drop the registry credentials
+          # written by the "Docker login" step so they do not outlive this job
+          # (SEC-00837 / ROCM-26712).
+          docker logout || true
+
   upload_s3_manifest:
     if: ${{ github.ref == 'refs/heads/main' && github.event_name != 'schedule' }}
     needs: [build_aiter_wheels]
@@ -950,6 +958,10 @@ jobs:
         if: always()
         run: |
           docker rm -f aiter_test || true
+          # Self-hosted runners are persistent: drop the registry credentials
+          # written by the "Docker login" step so they do not outlive this job
+          # (SEC-00837 / ROCM-26712).
+          docker logout || true
 
   standard-test-finish:
     if: >-
@@ -1222,6 +1234,10 @@ jobs:
         if: always()
         run: |
           docker rm -f aiter_test || true
+          # Self-hosted runners are persistent: drop the registry credentials
+          # written by the "Docker login" step so they do not outlive this job
+          # (SEC-00837 / ROCM-26712).
+          docker logout || true
 
       - name: Clean up Rocm processes
         if: always()


### PR DESCRIPTION
Immediate mitigation for Mythos scan finding **SEC-00837** (ROCM-26712).

## The problem

Self-hosted runners are non-ephemeral. `docker login` writes credentials to
`~/.docker/config.json` on the runner host, and nothing removes them — so they
outlive the job and are readable by whatever runs next on that machine.

`aiter-test.yaml` has **three `Docker login` steps and zero `docker logout`**:

| job | runner | had a cleanup step? |
|---|---|---|
| `build_aiter_wheels` | `build-only-aiter` | **no** |
| `standard` | `${{ matrix.runner }}` | yes (`Cleanup container`) |
| `multi-gpu` | `${{ matrix.runner }}` | yes (`Cleanup container`) |

## The change

- add `docker logout` to the two existing `Cleanup container` steps
- give `build_aiter_wheels` the cleanup step it was missing

All three run under `if: always()`. Login/logout now pair 3-for-3.

No new steps in the two jobs that already had cleanup — the line goes into the
existing step, so the diff stays small.

## This is mitigation, not the fix

It narrows the window; it does not close it:

- credentials still sit on disk between login and logout
- a cancelled job may skip cleanup entirely (`cancel-in-progress: true` is set
  in `concurrency`)

**The actual fix is `--ephemeral` runner registration** (or `ephemeral: true`
under actions-runner-controller), so each job gets a clean machine. That lives in
the runner infrastructure, not in this repo, and needs the runner owner.

## Already-present partial mitigation (unchanged here)

All three `Docker login` steps are gated on
`!github.event.pull_request.head.repo.fork`, so **fork PRs never write
credentials in the first place**. The exposure is limited to credentials left by
non-fork jobs.

## Verification

`actionlint`: clean. YAML parses; all 13 jobs load.

## Related

- **ROCM-26681** (SEC-00227) — closed as false positive
- **ROCM-26711** (SEC-00830) — hardening PR #5109, same reviewer

Refs: ROCM-26712 / SEC-00837
