### PR TITLE
[HIP] Guard MLA decode output dtype before kernel launch

### DIFF
--- a/aiter/mla.py
+++ b/aiter/mla.py
@@ -570,6 +570,12 @@ def mla_decode_fwd(
     cp_rank=0,
     causal=True,
 ):
+    if o.dtype not in (dtypes.bf16, dtypes.fp16):
+        raise ValueError(
+            "mla_decode_fwd output must use a 16-bit floating dtype "
+            f"(BF16 or FP16), got {o.dtype}."
+        )
+
     device = q.device
     assert logit_cap <= 0, f"{logit_cap=} is not support yet"
     if kv_buffer.dtype != torch.uint8:

--- a/csrc/py_itfs_cu/asm_mla.cu
+++ b/csrc/py_itfs_cu/asm_mla.cu
@@ -687,6 +687,11 @@ void mla_decode_stage1_asm_fwd(
 
     const HipDeviceGuard device_guard(Q->device_id);
 
+    AITER_CHECK(output->dtype() == AITER_DTYPE_bf16 || output->dtype() == AITER_DTYPE_fp16,
+                __func__,
+                ": output must use a 16-bit floating dtype (BF16 or FP16), got ",
+                AiterDtype_to_str(output->dtype()));
+
     std::string arch_id = get_gpu_arch();
     if(arch_id == "gfx1250")
     {

--- a/op_tests/test_mla_output_dtype.py
+++ b/op_tests/test_mla_output_dtype.py
@@ -1,0 +1,27 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+import pytest
+import torch
+
+from aiter import dtypes
+from aiter.mla import mla_decode_fwd
+
+
+@pytest.mark.parametrize("output_dtype", [dtypes.fp8, dtypes.fp32])
+def test_mla_decode_rejects_unsupported_output_dtype(output_dtype):
+    q = torch.empty((1, 16, 576), dtype=dtypes.bf16)
+    kv = torch.empty((1, 1, 1, 576), dtype=dtypes.bf16)
+    output = torch.empty((1, 16, 512), dtype=output_dtype)
+
+    with pytest.raises(ValueError, match="output must use a 16-bit floating dtype"):
+        mla_decode_fwd(
+            q,
+            kv,
+            output,
+            None,
+            None,
+            None,
+            None,
+            1,
+        )


### PR DESCRIPTION
## Motivation

`mla_decode_fwd` accepted an arbitrary output dtype. Several assembly paths
write a 16-bit result directly, including the non-persistent single-split path
where logits may alias the final output. An FP8-sized output can therefore turn
a caller contract error into a GPU out-of-bounds write instead of a useful
exception.

This was observed from an SGLang DSA caller on MI350X: an FP8 query was used to
derive an FP8 output allocation, and AITER's direct BF16 write produced a GPU
memory-access fault at a long prefill shape.

The caller-side allocation fix is sgl-project/sglang#37114.

## Changes

- Reject output tensors other than BF16/FP16 in the Python entry point.
- Enforce the same contract at the HIP assembly ABI for direct callers.
- Add regression coverage for FP8 and FP32 output tensors.

The guard is checked before kernel launch, so the bad call fails deterministically
without touching GPU memory.

## Validation

- Python syntax, `git diff --check`, Black on the new test, and clang-format on
  the new C++ guard hunk pass.
- The invalid-output pytest requires a visible ROCm GPU because importing AITER
  probes `rocminfo`; the current shared node was fully reserved, so this test is
  left to CI.
- The corresponding caller-side BF16 allocation was validated with a 22,025
  token GLM-5.2 server repro on MI350X.
