### PR TITLE
[HIP] [FlyDSL] dcp topk merge

### DIFF
--- a/aiter/ops/flydsl/dcp_topk_merge.py
+++ b/aiter/ops/flydsl/dcp_topk_merge.py
@@ -1,0 +1,162 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+"""FlyDSL DCP decode TopK merge interface."""
+
+import functools
+
+import torch
+
+from .kernels.dcp_topk_merge import build_dcp_topk_merge_module
+from .kernels.kernels_common import get_warp_size
+from .kernels.tensor_shim import _run_compiled
+
+
+@functools.cache
+def _get_launcher(n_cand, k_loc, topk_tokens, page_size, world_size):
+    return build_dcp_topk_merge_module(
+        n_cand, k_loc, topk_tokens, page_size, world_size
+    )
+
+
+@functools.lru_cache(maxsize=128)
+def _validate(
+    sc_shape,
+    sc_dtype,
+    li_shape,
+    li_dtype,
+    bt_shape,
+    bt_dtype,
+    idx_numel,
+    idx_dtype,
+    indptr_shape,
+    indptr_dtype,
+    counts_shape,
+    counts_dtype,
+    stage_shape,
+    stage_dtype,
+    dcp_rank,
+    world_size,
+    topk_tokens,
+    page_size,
+    device_warp,
+):
+    if len(sc_shape) != 2 or sc_dtype != torch.float32:
+        raise ValueError("gathered_scores must be a 2D float32 tensor")
+    rows, n_cand = sc_shape
+    if world_size <= 0 or n_cand % world_size:
+        raise ValueError("gathered_scores.shape[1] must be divisible by world_size")
+    k_loc = n_cand // world_size
+    if not 0 <= dcp_rank < world_size:
+        raise ValueError("dcp_rank out of range")
+    if li_shape != (rows, k_loc) or li_dtype != torch.int32:
+        raise ValueError("local_idx must be int32 [rows, n_cand // world_size]")
+    # The kernel slices this 2D (fx.slice(block_table, (row, None))), so a 1D
+    # tensor fails deep inside the JIT rather than here.
+    if len(bt_shape) != 2:
+        raise ValueError(f"block_table must be 2D [rows, max_blocks], got {bt_shape}")
+    # rows == num_req: DCP+DSA is qlen=1 decode only.
+    if bt_shape[0] != rows:
+        raise ValueError("block_table.shape[0] must equal rows (qlen=1 decode only)")
+    # The kernel reads every one of these as i32. torch builds page tables as
+    # int64 by default, and an int64 block_table passes a shape-only check and
+    # then yields silently wrong physical slots -- no crash, wrong KV.
+    if bt_dtype != torch.int32:
+        raise ValueError("block_table must be int32")
+    if idx_dtype != torch.int32:
+        raise ValueError("out_kv_indices must be int32")
+    if indptr_dtype != torch.int32:
+        raise ValueError("out_kv_indptr must be int32")
+    if counts_dtype != torch.int32:
+        raise ValueError("owned_counts must be int32")
+    if stage_shape != (rows, k_loc):
+        raise ValueError("staging must be int32 [rows, n_cand // world_size]")
+    if stage_dtype != torch.int32:
+        raise ValueError("staging must be int32 [rows, n_cand // world_size]")
+    if indptr_shape[0] < rows + 1:
+        raise ValueError("out_kv_indptr must hold rows + 1 entries")
+    if counts_shape[0] < rows:
+        raise ValueError("owned_counts must hold rows entries")
+    # Per row a rank owns at most its own plane (k_loc) and at most the whole
+    # global winner set (topk_tokens) -- whichever binds first. Requiring k_loc
+    # unconditionally would reject a valid buffer whenever topk_tokens < k_loc.
+    if idx_numel < rows * min(k_loc, topk_tokens):
+        raise ValueError("out_kv_indices too small for the worst case")
+    if page_size <= 0:
+        raise ValueError("page_size must be positive")
+    if device_warp != 64:
+        raise ValueError("the FlyDSL DCP merge kernel requires a wave64 GPU")
+
+
+def flydsl_dcp_topk_merge(
+    gathered_scores: torch.Tensor,
+    local_idx: torch.Tensor,
+    block_table: torch.Tensor,
+    out_kv_indices: torch.Tensor,
+    out_kv_indptr: torch.Tensor,
+    owned_counts: torch.Tensor,
+    staging: torch.Tensor,
+    dcp_rank: int,
+    world_size: int,
+    topk_tokens: int,
+    page_size: int,
+) -> None:
+    """Select this DCP rank's share of the global top-k and emit packed KV slots.
+
+    `gathered_scores[:, c]` MUST come from rank `c // k_loc` at that rank's local
+    top-k position `c % k_loc` -- the natural all_gather(dim=0) order. Ownership
+    is positional, so a permuted layout silently produces wrong KV.
+
+    PRECONDITION: unused candidate slots in `gathered_scores` must be -inf, not
+    0.0. Padding is detected via `local_idx < 0` for THIS rank's plane only; the
+    other W-1 planes carry no liveness signal, so their padding has to lose the
+    global threshold comparison on score alone. Logits are routinely negative,
+    so a 0.0 pad outranks real candidates and this rank silently under-emits.
+    `top_k_per_row_decode(values=...)` pads with -inf for exactly this reason --
+    an aiter predating that fix cannot feed this op.
+
+
+    First call for a new (n_cand, k_loc, topk, page_size, world_size) JIT-compiles
+    the kernels, so warm up each shape before capturing a CUDAGraph.
+    """
+    _validate(
+        tuple(gathered_scores.shape),
+        gathered_scores.dtype,
+        tuple(local_idx.shape),
+        local_idx.dtype,
+        tuple(block_table.shape),
+        block_table.dtype,
+        out_kv_indices.numel(),
+        out_kv_indices.dtype,
+        tuple(out_kv_indptr.shape),
+        out_kv_indptr.dtype,
+        tuple(owned_counts.shape),
+        owned_counts.dtype,
+        tuple(staging.shape),
+        staging.dtype,
+        dcp_rank,
+        world_size,
+        topk_tokens,
+        page_size,
+        get_warp_size(),
+    )
+    rows, n_cand = gathered_scores.shape
+    k_loc = n_cand // world_size
+    launcher = _get_launcher(n_cand, k_loc, topk_tokens, page_size, world_size)
+    _run_compiled(
+        launcher,
+        gathered_scores,
+        local_idx,
+        block_table,
+        out_kv_indices,
+        out_kv_indptr,
+        staging,
+        owned_counts,
+        rows,
+        dcp_rank,
+        # Bound to the tensors' device: current_stream() with no argument
+        # returns a stream on the *ambient* device, which is a different device
+        # entirely if the caller did not set one -- an invalid launch, not a
+        # slow one.
+        torch.cuda.current_stream(gathered_scores.device),
+    )

--- a/aiter/ops/flydsl/kernels/dcp_topk_merge.py
+++ b/aiter/ops/flydsl/kernels/dcp_topk_merge.py
@@ -1,0 +1,510 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+"""FlyDSL DCP decode TopK merge: global threshold select + owned-slot emit."""
+
+# mypy: allow-untyped-defs
+
+import flydsl.compiler as flyc
+import flydsl.expr as fx
+from flydsl._mlir.dialects import llvm
+from flydsl.expr import (
+    Array,
+    Int32,
+    arith,
+    const_expr,
+    gpu,
+    range_constexpr,
+)
+from flydsl.expr import (
+    rocdl as fly_rocdl,
+)
+from flydsl.expr.typing import T
+
+_RADIX_BITS = 8
+_RADIX_MASK = (1 << _RADIX_BITS) - 1
+_RADIX_SIGN_BIT = 1 << (_RADIX_BITS - 1)
+_NUM_RADIX_PASSES = 32 // _RADIX_BITS
+# Sentinel for out-of-range candidate slots: sorts below every real ord value.
+_INT32_MIN = -(1 << 31)
+# Pack (above, equal) counts into one i32 for a single block scan. Both are
+# bounded by k_loc per row, well under 2^15, so 16 bits each is safe.
+_PACK_SHIFT = 16
+_PACK_MASK = (1 << _PACK_SHIFT) - 1
+_N_HIST_BINS = 1 << _RADIX_BITS
+_BLOCK_THREADS = 256
+_WAVE_SIZE = 64
+_NUM_WAVES = _BLOCK_THREADS // _WAVE_SIZE
+_DPP_ROW_SHR_1 = 0x111
+_DPP_ROW_SHR_2 = 0x112
+_DPP_ROW_SHR_4 = 0x114
+_DPP_ROW_SHR_8 = 0x118
+_DPP_ROW_MASK = 0xF
+_DPP_BANK_MASK = 0xF
+
+
+def _uint32_to_int32(x: int) -> int:
+    return x - (1 << 32) if x >= (1 << 31) else x
+
+
+def _f32_to_ord(val):
+    """Order-preserving float32 -> int32 map, with NaN forced to the bottom.
+
+    NaN maps to INT32_MIN, the same ordinal -inf gets, so a NaN score loses the
+    global threshold comparison instead of winning it. The reference model
+    treats every non-finite value as -inf (torch.isfinite), and a disagreement
+    here is not a crash: a NaN that sorts to the top steals a real candidate's
+    slot and silently changes which rank owns that KV.
+    """
+    bits = val.bitcast(Int32)
+    ords = bits ^ ((bits >> fx.Int32(31)) & fx.Int32(0x7FFFFFFF))
+    abs_bits = bits & fx.Int32(0x7FFFFFFF)
+    is_nan = arith.cmpi(arith.CmpIPredicate.ugt, abs_bits, fx.Int32(0x7F800000))
+    return arith.select(is_nan, fx.Int32(_uint32_to_int32(0x80000000)), ords)
+
+
+def _make_storage():
+    @fx.struct
+    class Storage:
+        bins: Array[Int32, _N_HIST_BINS, 16]
+        scan: Array[Int32, _NUM_WAVES + 1, 16]
+        # 5 slots: 0=prefix 1=mask 2=remaining_k 3=emitted-count 4=equal-seen
+        acc: Array[Int32, 5, 4]
+
+    return Storage
+
+
+def build_dcp_topk_merge_module(n_cand, k_loc, topk_tokens, page_size, world_size):
+    steps = (n_cand + _BLOCK_THREADS - 1) // _BLOCK_THREADS
+    own_steps = (k_loc + _BLOCK_THREADS - 1) // _BLOCK_THREADS
+
+    @flyc.kernel(known_block_size=[_BLOCK_THREADS, 1, 1])
+    def select_kernel(
+        gathered_scores: fx.Tensor,
+        local_idx: fx.Tensor,
+        block_table: fx.Tensor,
+        out_kv_indices: fx.Tensor,
+        out_kv_indptr: fx.Tensor,
+        staging: fx.Tensor,
+        owned_counts: fx.Tensor,
+        rank: fx.Int32,
+    ):
+        row = fx.block_idx.x
+        tid = fx.thread_idx.x
+        row_sc = fx.slice(gathered_scores, (row, None))
+
+        # Stage the whole row's candidates in registers, converted to ord space
+        # once. The four radix passes and the prior-equal sweep all re-scan
+        # these same values; reading them from global each time cost 4 x n_cand
+        # loads whose latency dominated the kernel (the data is only 64 KB per
+        # row -- this was never bandwidth-bound).
+        #
+        # The emit loop is deliberately NOT on this path: it walks only this
+        # rank's own plane (k_loc, i.e. 1/W of the row) in a different index
+        # order, so it re-reads those from global rather than holding the whole
+        # row's staging alive across it.
+        ords_reg = fx.make_rmem_tensor(steps, Int32)
+        for step in range_constexpr(steps):
+            c = step * _BLOCK_THREADS + tid
+            in_cand = c < fx.Int32(n_cand)
+            ords_reg[step] = in_cand.select(
+                _f32_to_ord(row_sc[in_cand.select(c, fx.Int32(0))]),
+                fx.Int32(_INT32_MIN),
+            )
+
+        storage = fx.SharedAllocator().allocate(_make_storage())
+        s_hist = storage.bins.peek().view(fx.make_layout(_N_HIST_BINS, 1))
+        s_scan = storage.scan.peek().view(fx.make_layout(_NUM_WAVES + 1, 1))
+        s_acc = storage.acc.peek().view(fx.make_layout(5, 1))
+
+        def unwrap_val(val):
+            return val.ir_value() if hasattr(val, "ir_value") else arith.unwrap(val)
+
+        def warp_inclusive_prefix_i32(val, lane):
+            val_raw = unwrap_val(val)
+            zero_raw = unwrap_val(0)
+            for dpp_op, threshold in (
+                (_DPP_ROW_SHR_1, 1),
+                (_DPP_ROW_SHR_2, 2),
+                (_DPP_ROW_SHR_4, 4),
+                (_DPP_ROW_SHR_8, 8),
+            ):
+                remote = fly_rocdl.update_dpp(
+                    T.i32,
+                    zero_raw,
+                    val_raw,
+                    dpp_op,
+                    _DPP_ROW_MASK,
+                    _DPP_BANK_MASK,
+                    True,
+                )
+                val = (lane >= fx.Int32(threshold)).select(val + fx.Int32(remote), val)
+                val_raw = unwrap_val(val)
+            src16 = (lane & fx.Int32(0x30)) - 1
+            r16 = fly_rocdl.ds_bpermute(T.i32, src16 * fx.Int32(4), val)
+            val = (lane >= fx.Int32(16)).select(val + fx.Int32(r16), val)
+            src32 = (lane & fx.Int32(0x30)) - fx.Int32(17)
+            r32 = fly_rocdl.ds_bpermute(T.i32, src32 * fx.Int32(4), val)
+            return (lane >= fx.Int32(32)).select(val + fx.Int32(r32), val)
+
+        def block_exclusive_prefix_i32(val, scan):
+            lane = tid % fx.Int32(_WAVE_SIZE)
+            warp = tid // fx.Int32(_WAVE_SIZE)
+            inclusive = warp_inclusive_prefix_i32(val, lane)
+            exclusive = inclusive - val
+            if lane == fx.Int32(_WAVE_SIZE - 1):
+                scan[warp] = inclusive
+            gpu.barrier()
+            if warp == 0:
+                wv = fx.Int32(0)
+                if lane < fx.Int32(_NUM_WAVES):
+                    wv = scan[lane]
+                wi = warp_inclusive_prefix_i32(wv, lane)
+                if lane < fx.Int32(_NUM_WAVES):
+                    scan[lane] = wi - wv
+                if lane == fx.Int32(_NUM_WAVES - 1):
+                    scan[_NUM_WAVES] = wi
+            gpu.barrier()
+            res = scan[warp] + exclusive
+            tot = scan[_NUM_WAVES]
+            # Trailing barrier: without it a fast wave entering the *next* call
+            # would execute `scan[warp] = inclusive` above while a slow wave is
+            # still reading this call's results, corrupting the totals. All call
+            # sites are in uniform control flow (constexpr loop bodies), so every
+            # thread reaches both barriers.
+            gpu.barrier()
+            return res, tot
+
+        def atomic_add_shared(memref, val, offset):
+            ptr = fx.to_llvm_ptr(fx.get_iter(memref) + offset)
+            llvm.AtomicRMWOp(
+                llvm.AtomicBinOp.add,
+                ptr,
+                arith.unwrap(val),
+                llvm.AtomicOrdering.monotonic,
+                syncscope="workgroup",
+                alignment=4,
+            )
+
+        if tid == 0:
+            s_acc[0] = 0
+            s_acc[1] = 0
+            # Clamp to the candidate count: with topk_tokens > n_cand the radix
+            # select can never satisfy `above + cnt >= rem`, would leave the
+            # threshold at 0 (the ord of +0.0) and silently emit a wrong set.
+            # Clamping degenerates the selection to "take everything", which
+            # matches the documented expected total min(topk, world * k_loc).
+            s_acc[2] = fx.Int32(min(topk_tokens, n_cand))
+        gpu.barrier()
+
+        # 4 radix passes, entirely inside this block.
+        for byte_pos in range_constexpr(_NUM_RADIX_PASSES):
+            shift = (_NUM_RADIX_PASSES - 1 - byte_pos) * _RADIX_BITS
+            xor_val = _RADIX_SIGN_BIT if byte_pos == 0 else 0
+            for hi in range_constexpr(
+                (_N_HIST_BINS + _BLOCK_THREADS - 1) // _BLOCK_THREADS
+            ):
+                b = tid + hi * _BLOCK_THREADS
+                if b < _N_HIST_BINS:
+                    s_hist[b] = 0
+            gpu.barrier()
+
+            prefix = s_acc[0]
+            dmask = s_acc[1]
+            for step in range_constexpr(steps):
+                c = step * _BLOCK_THREADS + tid
+                if c < fx.Int32(n_cand):
+                    ords = ords_reg[step]
+                    keep = fx.Int32(1) if const_expr(byte_pos == 0) else fx.Int32(0)
+                    if const_expr(byte_pos == 0):
+                        pass
+                    else:
+                        keep = ((ords & dmask) == prefix).select(
+                            fx.Int32(1), fx.Int32(0)
+                        )
+                    if keep != 0:
+                        bv = (
+                            (ords >> fx.Int32(shift)) & fx.Int32(_RADIX_MASK)
+                        ) ^ fx.Int32(xor_val)
+                        atomic_add_shared(s_hist, 1, bv)
+            gpu.barrier()
+
+            sel = fx.Int32(_N_HIST_BINS - 1) - tid
+            cnt = s_hist[sel]
+            above, _tot = block_exclusive_prefix_i32(cnt, s_scan)
+            rem = s_acc[2]
+            # Every thread reads `rem` above, but only the thread whose bucket
+            # holds the k-th element writes it below. Without this barrier a
+            # fast writer can update s_acc[2] while a slow thread is still
+            # reading it; the slow thread then tests the hit condition against
+            # the NEW remaining_k, can spuriously satisfy it, and writes a
+            # second wrong bucket into s_acc[0] -- a corrupted threshold.
+            gpu.barrier()
+            if above < rem and above + cnt >= rem:
+                actual = sel ^ fx.Int32(xor_val)
+                s_acc[0] = prefix | (actual << fx.Int32(shift))
+                s_acc[1] = dmask | fx.Int32(_uint32_to_int32(_RADIX_MASK << shift))
+                s_acc[2] = rem - above
+            gpu.barrier()
+
+        # --- own plane only: classify, prefix-sum, map to slot, compact ---
+        threshold = s_acc[0]
+        remaining_k = s_acc[2]
+        base = rank * fx.Int32(k_loc)
+        row_local = fx.slice(local_idx, (row, None))
+        row_bt = fx.slice(block_table, (row, None))
+        row_stage = fx.slice(staging, (row, None))
+
+        if tid == 0:
+            s_acc[3] = 0  # emitted-count / write cursor
+            s_acc[4] = 0  # equal-to-threshold candidates seen in planes < rank
+        gpu.barrier()
+
+        # Count equal-threshold candidates from all planes before this rank
+        # (flat positions 0 .. rank*k_loc - 1).  This is the global offset that
+        # the admission cap must account for: among the remaining_k equal slots
+        # allowed globally, this many are already "claimed" by earlier ranks.
+        # Only the TOTAL is needed, never a per-thread offset, so accumulate in
+        # registers across the sweep and reduce once at the end. Scanning inside
+        # the loop instead cost `steps` block scans (2 barriers each) to produce
+        # one number -- 44% of this kernel's runtime at W=8, k_loc=2048.
+        prior_eq_local = fx.Int32(0)
+        for step in range_constexpr(steps):
+            c = step * _BLOCK_THREADS + tid
+            in_cand = c < fx.Int32(n_cand)
+            before_base = in_cand.select(
+                (c < base).select(fx.Int32(1), fx.Int32(0)), fx.Int32(0)
+            )
+            ords_all = ords_reg[step]
+            prior_eq_local = prior_eq_local + (before_base != 0).select(
+                (ords_all == threshold).select(fx.Int32(1), fx.Int32(0)), fx.Int32(0)
+            )
+        _, prior_eq_total = block_exclusive_prefix_i32(prior_eq_local, s_scan)
+        if tid == 0:
+            s_acc[4] = prior_eq_total
+        gpu.barrier()
+
+        # Candidates strictly above the threshold are unconditionally in.
+        # Candidates equal to it are admitted in flat-position order, capped by
+        # how many equal-valued slots the global selection left for us.
+        # s_acc[3] = total emitted so far (write cursor)
+        # s_acc[4] = total equal-to-threshold candidates seen so far (cap counter)
+        for step in range_constexpr(own_steps):
+            t = step * _BLOCK_THREADS + tid
+            in_range = t < fx.Int32(k_loc)
+            safe_t = in_range.select(t, fx.Int32(0))
+            ords = _f32_to_ord(row_sc[base + safe_t])
+            j = row_local[safe_t]
+            live = in_range.select(
+                (j >= 0).select(fx.Int32(1), fx.Int32(0)), fx.Int32(0)
+            )
+            above = (live != 0).select(
+                (ords > threshold).select(fx.Int32(1), fx.Int32(0)), fx.Int32(0)
+            )
+            equal = (live != 0).select(
+                (ords == threshold).select(fx.Int32(1), fx.Int32(0)), fx.Int32(0)
+            )
+            # ONE packed scan instead of two sequential ones. The naive form
+            # scans `equal`, derives `keep` from its prefix, then scans `keep` --
+            # a serial pair of barrier chains per step, which cost ~1.2 us/step.
+            #
+            # It fuses because `above` does not depend on the admission decision:
+            # every above-threshold candidate is kept. So scan (above, equal)
+            # together, then reconstruct the write offset arithmetically:
+            #   dst_off = ab_before + (admitted equals before me)
+            # and the admitted-equals prefix is just the equal prefix clamped to
+            # whatever room `remaining_k` left.
+            packed = (above << fx.Int32(_PACK_SHIFT)) + equal
+            pack_before, pack_total = block_exclusive_prefix_i32(packed, s_scan)
+            ab_before = pack_before >> fx.Int32(_PACK_SHIFT)
+            eq_before = pack_before & fx.Int32(_PACK_MASK)
+            ab_total = pack_total >> fx.Int32(_PACK_SHIFT)
+            eq_total = pack_total & fx.Int32(_PACK_MASK)
+
+            eq_run = s_acc[4]
+            # Room left for equal-valued candidates, globally.
+            room = remaining_k - eq_run
+            room = (room < 0).select(fx.Int32(0), room)
+            admit_eq = (equal != 0).select(
+                (eq_before < room).select(fx.Int32(1), fx.Int32(0)), fx.Int32(0)
+            )
+            keep = above + admit_eq
+            # Equals admitted strictly before this thread this step.
+            eq_adm_before = (eq_before < room).select(eq_before, room)
+            dst_off = ab_before + eq_adm_before
+            # Total admitted this step = all aboves + the equals that fit.
+            eq_adm_total = (eq_total < room).select(eq_total, room)
+            keep_total = ab_total + eq_adm_total
+            if keep != 0:
+                slot = row_bt[j // fx.Int32(page_size)] * fx.Int32(page_size) + (
+                    j % fx.Int32(page_size)
+                )
+                row_stage[s_acc[3] + dst_off] = slot
+            gpu.barrier()
+            if tid == 0:
+                s_acc[3] = s_acc[3] + keep_total  # advance write cursor by # emitted
+                s_acc[4] = s_acc[4] + eq_total  # advance equal-seen count
+            gpu.barrier()
+
+        if tid == 0:
+            owned_counts[row] = s_acc[3]
+
+    @flyc.kernel(known_block_size=[_BLOCK_THREADS, 1, 1])
+    def pack_kernel(
+        staging: fx.Tensor,
+        owned_counts: fx.Tensor,
+        out_kv_indices: fx.Tensor,
+        out_kv_indptr: fx.Tensor,
+        rows_n: fx.Int32,
+    ):
+        """One block per row: scan the counts, then copy this row's slots.
+
+        The scan used to be its own grid=(1,) kernel walking the rows on a single
+        thread. That is O(rows) serial work between two parallel kernels, and it
+        showed: 37% of the op's runtime at rows=128 (15.7 of 42.3 us) to prefix-
+        sum 128 integers.
+
+        Instead every block recomputes the prefix sum it needs, in parallel. The
+        redundancy is real -- rows blocks each scan rows counts -- but a block
+        scan over <=256 values is a handful of barriers, and it removes both the
+        serial loop and a kernel launch. Only this row's exclusive prefix and the
+        running total are needed, so the scan is over a predicate, not a
+        materialised array.
+
+        Block 0 also writes out_kv_indptr, which nothing here reads back: each
+        block derives its own `dst` locally, so no block waits on another. That
+        keeps the kernel free of any cross-block dependency -- the reason this
+        could not simply be merged into select_kernel, where `dst` depends on
+        every OTHER row's count.
+        """
+        row = fx.block_idx.x
+        tid = fx.thread_idx.x
+
+        storage = fx.SharedAllocator().allocate(_make_storage())
+        s_scan = storage.scan.peek().view(fx.make_layout(_NUM_WAVES + 1, 1))
+        s_dst = storage.acc.peek().view(fx.make_layout(5, 1))
+
+        def unwrap_val(val):
+            return val.ir_value() if hasattr(val, "ir_value") else arith.unwrap(val)
+
+        def warp_inclusive_prefix_i32(val, lane):
+            val_raw = unwrap_val(val)
+            zero_raw = unwrap_val(0)
+            for dpp_op, threshold in (
+                (_DPP_ROW_SHR_1, 1),
+                (_DPP_ROW_SHR_2, 2),
+                (_DPP_ROW_SHR_4, 4),
+                (_DPP_ROW_SHR_8, 8),
+            ):
+                remote = fly_rocdl.update_dpp(
+                    T.i32,
+                    zero_raw,
+                    val_raw,
+                    dpp_op,
+                    _DPP_ROW_MASK,
+                    _DPP_BANK_MASK,
+                    True,
+                )
+                val = (lane >= fx.Int32(threshold)).select(val + fx.Int32(remote), val)
+                val_raw = unwrap_val(val)
+            src16 = (lane & fx.Int32(0x30)) - 1
+            r16 = fly_rocdl.ds_bpermute(T.i32, src16 * fx.Int32(4), val)
+            val = (lane >= fx.Int32(16)).select(val + fx.Int32(r16), val)
+            src32 = (lane & fx.Int32(0x30)) - fx.Int32(17)
+            r32 = fly_rocdl.ds_bpermute(T.i32, src32 * fx.Int32(4), val)
+            return (lane >= fx.Int32(32)).select(val + fx.Int32(r32), val)
+
+        def block_exclusive_prefix_i32(val, scan):
+            lane = tid % fx.Int32(_WAVE_SIZE)
+            warp = tid // fx.Int32(_WAVE_SIZE)
+            inclusive = warp_inclusive_prefix_i32(val, lane)
+            exclusive = inclusive - val
+            if lane == fx.Int32(_WAVE_SIZE - 1):
+                scan[warp] = inclusive
+            gpu.barrier()
+            if warp == 0:
+                wv = fx.Int32(0)
+                if lane < fx.Int32(_NUM_WAVES):
+                    wv = scan[lane]
+                wi = warp_inclusive_prefix_i32(wv, lane)
+                if lane < fx.Int32(_NUM_WAVES):
+                    scan[lane] = wi - wv
+                if lane == fx.Int32(_NUM_WAVES - 1):
+                    scan[_NUM_WAVES] = wi
+            gpu.barrier()
+            res = scan[warp] + exclusive
+            tot = scan[_NUM_WAVES]
+            gpu.barrier()
+            return res, tot
+
+        # Exclusive prefix of the counts, chunked so rows > _BLOCK_THREADS still
+        # works -- the caller does not bound rows. Production runs <= 256, a
+        # single chunk, but 257 must not silently truncate.
+        if tid == 0:
+            s_dst[0] = 0
+        gpu.barrier()
+        base = fx.Int32(0)
+        running = fx.Int32(0)
+        step_blk = fx.Int32(_BLOCK_THREADS)
+        for _ in range(fx.Int32(0), (rows_n + step_blk - 1) // step_blk, fx.Int32(1)):
+            r = base + tid
+            cnt = (r < rows_n).select(
+                owned_counts[(r < rows_n).select(r, fx.Int32(0))], fx.Int32(0)
+            )
+            excl, chunk_total = block_exclusive_prefix_i32(cnt, s_scan)
+            # Exactly one thread holds this block's row, and `excl` is a private
+            # register -- publish it through LDS so the whole block can address
+            # the output. Without this only thread `row` has a correct `dst` and
+            # every other thread writes at offset 0.
+            if r == row:
+                s_dst[0] = running + excl
+            # Block 0 publishes the indptr; every other block only needs `dst`.
+            if row == 0 and r < rows_n:
+                out_kv_indptr[r + fx.Int32(1)] = running + excl + cnt
+            running = running + chunk_total
+            base = base + step_blk
+        if row == 0 and tid == 0:
+            out_kv_indptr[0] = 0
+        gpu.barrier()
+        dst = s_dst[0]
+
+        n = owned_counts[row]
+        row_stage = fx.slice(staging, (row, None))
+        for step in range_constexpr(own_steps):
+            t = step * _BLOCK_THREADS + tid
+            if t < n:
+                out_kv_indices[dst + t] = row_stage[t]
+
+    # Fixed launcher signature: 7 tensors
+    @flyc.jit
+    def launch(
+        gathered_scores: fx.Tensor,
+        local_idx: fx.Tensor,
+        block_table: fx.Tensor,
+        out_kv_indices: fx.Tensor,
+        out_kv_indptr: fx.Tensor,
+        staging: fx.Tensor,
+        owned_counts: fx.Tensor,
+        rows_m: fx.Int32,
+        rank_i32: fx.Int32,
+        stream: fx.Stream = fx.Stream(None),  # noqa: B008  framework idiom
+    ):
+        sel = select_kernel(
+            gathered_scores,
+            local_idx,
+            block_table,
+            out_kv_indices,
+            out_kv_indptr,
+            staging,
+            owned_counts,
+            rank_i32,
+        )
+        sel.launch(
+            grid=(rows_m, 1, 1),
+            block=(_BLOCK_THREADS, 1, 1),
+            stream=stream,
+        )
+        pk = pack_kernel(staging, owned_counts, out_kv_indices, out_kv_indptr, rows_m)
+        pk.launch(grid=(rows_m, 1, 1), block=(_BLOCK_THREADS, 1, 1), stream=stream)
+
+    return launch

--- a/aiter/ops/topk.py
+++ b/aiter/ops/topk.py
@@ -443,6 +443,7 @@ def _top_k_per_row_decode(
     k: int = 2048,
     workspace: torch.Tensor | None = None,
     stable: bool = False,
+    values: torch.Tensor | None = None,
 ) -> None: ...
 
 
@@ -456,6 +457,7 @@ def top_k_per_row_decode(
     stride1: int,
     k: int = 2048,
     stable: bool = False,
+    values: torch.Tensor | None = None,
 ) -> None:
     """Per-row top-k (decode). Always uses the one-block kernel; the scratch
     workspace is allocated + cached on the Python side and passed in, so the C++
@@ -463,12 +465,31 @@ def top_k_per_row_decode(
 
     When stable=True, the deterministic ascending-ordered, smallest-index
     tie-break emit is used so every TP rank selects and orders an identical
-    KV set."""
+    KV set.
+
+    When `values` is given (float32, same shape as `indices`), each selected
+    index's logit is written alongside it. Rows shorter than k pad the index
+    with -1 and the score with -inf, so the padding sorts below every real
+    candidate and a consumer that ranks these scores needs no extra mask."""
+    if values is not None:
+        # The C++ side takes values.data_ptr() as a raw float* and writes k
+        # entries per row through it, with no metadata of its own. A wrong
+        # dtype or a short buffer is therefore silent memory corruption, not a
+        # type error -- check here, where the tensor is still a torch object.
+        if values.dtype != torch.float32:
+            raise ValueError(f"values must be float32, got {values.dtype}")
+        if values.shape != indices.shape:
+            raise ValueError(
+                f"values must match indices shape {tuple(indices.shape)}, "
+                f"got {tuple(values.shape)}"
+            )
+        if not values.is_contiguous():
+            raise ValueError("values must be contiguous")
+        if values.device != indices.device:
+            raise ValueError(
+                f"values on {values.device} but indices on {indices.device}"
+            )
     # Decode always takes the ob path (see topk_per_row_kernels.cu).
-    # The original mb dispatch is commented out below for reference:
-    #   if topk_use_mulblocks(numRows, stride0):
-    #       size = topk_mb_workspace_size(numRows, stride0, k, True)
-    #       workspace = get_topk_mb_workspace(logits.device, size)
     size = topk_ob_workspace_size(numRows, stride0, k, True)
     workspace = get_topk_scratch_workspace(logits.device, size)
     return _top_k_per_row_decode(
@@ -482,6 +503,7 @@ def top_k_per_row_decode(
         k,
         workspace,
         stable,
+        values,
     )
 
 

--- a/aiter/ops/topk.py
+++ b/aiter/ops/topk.py
@@ -485,6 +485,43 @@ def top_k_per_row_decode(
     )
 
 
+def flydsl_dcp_topk_merge(
+    gathered_scores: torch.Tensor,
+    local_idx: torch.Tensor,
+    block_table: torch.Tensor,
+    out_kv_indices: torch.Tensor,
+    out_kv_indptr: torch.Tensor,
+    owned_counts: torch.Tensor,
+    staging: torch.Tensor,
+    dcp_rank: int,
+    world_size: int,
+    topk_tokens: int,
+    page_size: int,
+) -> None:
+    """DCP decode top-k merge: emit this rank's owned KV slots, packed.
+
+    Allocates no device scratch, so it is safe inside a captured CUDAGraph;
+    the first call for a new shape JIT-compiles, so warm up before capturing.
+    """
+    from .flydsl.dcp_topk_merge import (
+        flydsl_dcp_topk_merge as _impl,
+    )
+
+    return _impl(
+        gathered_scores,
+        local_idx,
+        block_table,
+        out_kv_indices,
+        out_kv_indptr,
+        owned_counts,
+        staging,
+        dcp_rank,
+        world_size,
+        topk_tokens,
+        page_size,
+    )
+
+
 @compile_ops("module_top_k_per_row", ffi_type="ctypes")
 def top_k_per_row_decode_fast(
     logits: torch.Tensor,

--- a/csrc/include/rocm_ops.hpp
+++ b/csrc/include/rocm_ops.hpp
@@ -2271,7 +2271,8 @@ namespace py = pybind11;
           py::arg("stride1"),                    \
           py::arg("k")         = 2048,           \
           py::arg("workspace") = std::nullopt,   \
-          py::arg("stable")    = false);         \
+          py::arg("stable")    = false,          \
+          py::arg("values")    = std::nullopt);  \
     m.def("topk_mb_workspace_size",              \
           &topk_mb_workspace_size,               \
           py::arg("numRows"),                    \

--- a/csrc/include/topk_per_row.h
+++ b/csrc/include/topk_per_row.h
@@ -25,7 +25,8 @@ void top_k_per_row_decode(const aiter_tensor_t& logits,
                           int64_t stride1,
                           int64_t k                               = 2048,
                           std::optional<aiter_tensor_t> workspace = std::nullopt,
-                          bool stable                             = false);
+                          bool stable                             = false,
+                          std::optional<aiter_tensor_t> values    = std::nullopt);
 
 // Workspace-management queries exposed to Python (see get_topk_mb_workspace).
 int64_t topk_mb_workspace_size(int64_t numRows, int64_t stride0, int64_t k, bool is_decode);

--- a/csrc/kernels/topk_per_row_kernels.cu
+++ b/csrc/kernels/topk_per_row_kernels.cu
@@ -403,7 +403,14 @@ __global__ void radix_kernel_persistent(T const* in,
             {
                 out_idx_ptr[i] = (i < row_len) ? (in_idx_buf ? in_idx_buf[i] : (i + rowStart)) : IdxT(-1);
                 if(WRITE_TOPK_VALUES)
-                    out_ptr[i] = (i < row_len) ? in_buf[i] : T(0);
+                    // -inf, matching the one-block kernel: the index padded to
+                    // -1, so the score must sort below every real one. Which of
+                    // the two kernels runs is a perf heuristic
+                    // (should_use_mulblocks), so the padding they write has to
+                    // agree or the same call gains a different meaning at a
+                    // batch-size boundary.
+                    out_ptr[i] = (i < row_len) ? in_buf[i]
+                                               : -std::numeric_limits<T>::infinity();
             }
         }
         return;
@@ -2234,7 +2241,13 @@ __global__ void radix_topk_one_block_kernel(T const* in,
             out_idx[rowIt] = rowIt < row_len ? rowIt + rowStart : -1;
             if(WRITE_TOPK_VALUES)
             {
-                out[rowIt] = rowIt < row_len ? in[rowIt] : 0;
+                // Pad with -inf, not 0: the index gets -1, so the score must
+                // sort BELOW every real one. Logits are routinely negative, and
+                // a 0.0 pad outranks them -- a consumer that ranks these scores
+                // (DCP merges the exchanged top-k across ranks) would let
+                // padding steal real candidates' slots.
+                out[rowIt] = rowIt < row_len ? in[rowIt]
+                                             : -std::numeric_limits<T>::infinity();
             }
         }
         return;
@@ -2941,7 +2954,8 @@ void top_k_per_row_decode(const aiter_tensor_t& logits,
                           int64_t /*stride1*/,
                           int64_t k = 2048,
                           std::optional<aiter_tensor_t> workspace = std::nullopt,
-                          bool stable = false)
+                          bool stable = false,
+                          std::optional<aiter_tensor_t> values = std::nullopt)
 {
     if (numRows <= 0) return;
 
@@ -2957,6 +2971,23 @@ void top_k_per_row_decode(const aiter_tensor_t& logits,
     float* logits_ptr = static_cast<float*>(logits.data_ptr());
     int* indices_ptr  = static_cast<int*>(indices.data_ptr());
     int* seq_lens_ptr = static_cast<int*>(seqLens.data_ptr());
+    const bool write_vals = values.has_value();
+    if(write_vals)
+    {
+        // The kernel writes k floats per row through this pointer and carries
+        // no metadata of its own, so a wrong dtype or a short buffer is silent
+        // memory corruption rather than a type error. The Python wrapper checks
+        // the same things, but the pybind op is reachable directly.
+        const auto& v = values.value();
+        AITER_CHECK(v.dtype() == AITER_DTYPE_fp32,
+                    "top_k_per_row_decode: values must be fp32");
+        AITER_CHECK(v.is_contiguous(), "top_k_per_row_decode: values must be contiguous");
+        AITER_CHECK(v.numel() >= static_cast<size_t>(numRows) * static_cast<size_t>(k),
+                    "top_k_per_row_decode: values must hold numRows * k entries");
+        AITER_CHECK(v.device_id == indices.device_id,
+                    "top_k_per_row_decode: values must be on the same device as indices");
+    }
+    float* values_ptr = write_vals ? static_cast<float*>(values.value().data_ptr()) : nullptr;
 
     AITER_CHECK(workspace.has_value(),
                 "top_k_per_row_decode requires a caller-provided workspace "
@@ -2967,36 +2998,37 @@ void top_k_per_row_decode(const aiter_tensor_t& logits,
     // stable=true: deterministic ascending-ordered, smallest-index tie-break
     // emit so every TP rank selects and orders an identical KV set.
     if (stable) {
-        aiter::ob::dispatch_topk_oneblock<float, int, 1024, false, aiter::ob::Phase::Decode, /*STABLE=*/true>(
+        if (write_vals) {
+            aiter::ob::dispatch_topk_oneblock<float, int, 1024, true, aiter::ob::Phase::Decode, /*STABLE=*/true>(
+                ws_ptr, buf_size, logits_ptr, static_cast<int*>(nullptr),
+                batch, stride0,
+                /*rowStarts=*/nullptr, /*rowEnds=*/seq_lens_ptr,
+                kTopK, values_ptr, indices_ptr,
+                select_min, stream, /*sorted=*/true, static_cast<int>(next_n));
+        } else {
+            aiter::ob::dispatch_topk_oneblock<float, int, 1024, false, aiter::ob::Phase::Decode, /*STABLE=*/true>(
+                ws_ptr, buf_size, logits_ptr, static_cast<int*>(nullptr),
+                batch, stride0,
+                /*rowStarts=*/nullptr, /*rowEnds=*/seq_lens_ptr,
+                kTopK, /*out=*/nullptr, indices_ptr,
+                select_min, stream, /*sorted=*/true, static_cast<int>(next_n));
+        }
+        return;
+    }
+    if (write_vals) {
+        aiter::ob::dispatch_topk_oneblock<float, int, 1024, true, aiter::ob::Phase::Decode>(
+            ws_ptr, buf_size, logits_ptr, static_cast<int*>(nullptr),
+            batch, stride0,
+            /*rowStarts=*/nullptr, /*rowEnds=*/seq_lens_ptr,
+            kTopK, values_ptr, indices_ptr,
+            select_min, stream, /*sorted=*/true, static_cast<int>(next_n));
+    } else {
+        aiter::ob::dispatch_topk_oneblock<float, int, 1024, false, aiter::ob::Phase::Decode>(
             ws_ptr, buf_size, logits_ptr, static_cast<int*>(nullptr),
             batch, stride0,
             /*rowStarts=*/nullptr, /*rowEnds=*/seq_lens_ptr,
             kTopK, /*out=*/nullptr, indices_ptr,
             select_min, stream, /*sorted=*/true, static_cast<int>(next_n));
-        return;
     }
-    aiter::ob::dispatch_topk_oneblock<float, int, 1024, false, aiter::ob::Phase::Decode>(
-        ws_ptr, buf_size, logits_ptr, static_cast<int*>(nullptr),
-        batch, stride0,
-        /*rowStarts=*/nullptr, /*rowEnds=*/seq_lens_ptr,
-        kTopK, /*out=*/nullptr, indices_ptr,
-        select_min, stream, /*sorted=*/true, static_cast<int>(next_n));
 
-    // --- Original mb/ob dispatch (commented out for reference) ---
-    // Both branches take the caller-provided `workspace` (no device allocation
-    // here); the mb buffer is zeroed + self_reset by the kernel (prezeroed=true).
-    // if (aiter::should_use_mulblocks(batch, stride0)) {
-    //     aiter::mb::standalone_stable_radix_topk<float, int, false, true, aiter::mb::Phase::Decode>(
-    //         ws_ptr, buf_size, logits_ptr, batch, stride0,
-    //         /*rowStarts=*/nullptr, /*rowEnds=*/seq_lens_ptr,
-    //         kTopK, /*out=*/nullptr, indices_ptr,
-    //         is_largest, stream, static_cast<int>(next_n), /*prezeroed=*/true);
-    // } else {
-    //     aiter::ob::dispatch_topk_oneblock<float, int, 1024, false, aiter::ob::Phase::Decode>(
-    //         ws_ptr, buf_size, logits_ptr, static_cast<int*>(nullptr),
-    //         batch, stride0,
-    //         /*rowStarts=*/nullptr, /*rowEnds=*/seq_lens_ptr,
-    //         kTopK, /*out=*/nullptr, indices_ptr,
-    //         select_min, stream, /*sorted=*/true, static_cast<int>(next_n));
-    // }
 }

--- a/op_tests/test_flydsl_dcp_topk_merge.py
+++ b/op_tests/test_flydsl_dcp_topk_merge.py
@@ -1,0 +1,469 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+"""FlyDSL DCP decode TopK merge tests."""
+
+import argparse
+import itertools
+
+import pandas as pd
+import torch
+
+import aiter
+from aiter import dtypes
+from aiter.jit.utils.chip_info import get_gfx
+from aiter.test_common import benchmark, checkAllclose, run_perftest
+
+torch.set_default_device("cuda")
+
+SUPPORTED_GFX = ["gfx942", "gfx950"]
+
+# Case shapes the correctness checks and the perf sweep share. Each one bends a
+# different part of the op; see make_case for how the inputs are bent.
+CASE_MODES = ["random", "tie", "short", "starved", "overtake"]
+
+
+def ref_dcp_merge(
+    gathered_scores: torch.Tensor,  # fp32 [rows, W*k_loc]
+    local_idx: torch.Tensor,  # i32  [rows, k_loc]
+    block_table: torch.Tensor,  # i32  [rows, max_blocks]
+    dcp_rank: int,
+    k_loc: int,
+    topk_tokens: int,
+    page_size: int,
+):
+    """Oracle: global threshold select, keep own plane, map to physical slots.
+
+    Tie rule mirrors the kernel: among candidates whose score equals the
+    threshold exactly, the ones with the smallest flat candidate position win.
+    torch.topk on a descending sort of (score, -position) gives that ordering.
+    """
+    rows = gathered_scores.shape[0]
+    owned_slots = []
+    counts = torch.zeros(rows, dtype=torch.int32, device=gathered_scores.device)
+    for r in range(rows):
+        sc = gathered_scores[r]
+        finite = torch.isfinite(sc)
+        n_valid = int(finite.sum())
+        take = min(topk_tokens, n_valid)
+        # Sort by score desc, ties broken by smaller flat position.
+        order = torch.argsort(
+            torch.where(finite, sc, torch.full_like(sc, -float("inf"))),
+            descending=True,
+            stable=True,
+        )
+        winners = order[:take]
+        # Keep only winners from this rank's plane.
+        mine = winners[(winners // k_loc) == dcp_rank]
+        # Plane position -> local KV index -> physical slot.
+        local_pos = (mine % k_loc).to(torch.int64)
+        j = local_idx[r].to(torch.int64)[local_pos]
+        assert bool((j >= 0).all()), "padding leaked into the winner set"
+        slot = block_table[r].to(torch.int64)[j // page_size] * page_size + (
+            j % page_size
+        )
+        # Compact in increasing flat-candidate order (deterministic).
+        slot = slot[torch.argsort(mine, stable=True)]
+        owned_slots.append(slot.to(torch.int32))
+        counts[r] = slot.numel()
+    return owned_slots, counts
+
+
+def make_case(
+    rows,
+    world,
+    k_loc,
+    page_size,
+    max_blocks,
+    n_local=None,
+    tie_heavy=False,
+    seed=0,
+):
+    """Build a self-consistent (scores, local_idx, block_table) triple.
+
+    Every rank's plane gets k_loc candidates. Pass n_local < k_loc to emulate a
+    short context: the tail of local_idx becomes -1, exactly as
+    top_k_per_row_decode pads it the same way. Callers that want
+    the matching -inf scores must starve the corresponding plane themselves --
+    see make_mode_case("short"). The separation is intentional: make_case is
+    responsible only for index/block-table consistency, not for score semantics.
+
+    Multi-block slot coverage note: when n_local < page_size, every generated
+    local index j satisfies j // page_size == 0, so only block_table[r, 0] is
+    ever exercised. Callers writing short-context cases should pick
+    n_local >= page_size if they want coverage of more than one block.
+    """
+    g = torch.Generator(device="cuda").manual_seed(seed)
+    n_cand = world * k_loc
+    if tie_heavy:
+        scores = torch.randint(
+            -4, 5, (rows, n_cand), generator=g, dtype=torch.int32, device="cuda"
+        ).float()
+    else:
+        scores = torch.randn(rows, n_cand, generator=g, device="cuda")
+    fill = k_loc if n_local is None else min(k_loc, n_local)
+    local_idx = torch.empty(rows, k_loc, dtype=torch.int32, device="cuda")
+    for r in range(rows):
+        # Local KV indices must stay in range for the slot formula: j // page_size
+        # indexes block_table, so keep j < max_blocks * page_size.
+        hi = min(max_blocks * page_size, max(fill, 1))
+        perm = torch.randperm(hi, generator=g, device="cuda")[:fill]
+        local_idx[r, :fill] = perm.to(torch.int32)
+        local_idx[r, fill:] = -1
+    block_table = torch.randint(
+        0, 1000, (rows, max_blocks), generator=g, dtype=torch.int32, device="cuda"
+    )
+    return scores, local_idx, block_table
+
+
+def make_mode_case(mode, rows, world, k_loc, topk, page, rank, seed):
+    """Bend a base case into the shape `mode` names.
+
+    Returns (scores, local_idx, block_table, expect), where `expect` carries the
+    mode-specific invariant the caller must additionally assert -- the oracle
+    already covers "the slots are right", these cover "the op did not take a
+    degenerate path to get there".
+    """
+    max_blocks = 4096
+    if mode == "tie":
+        # Integer scores over a 9-value range: most candidates sit exactly ON
+        # the threshold, so the tie rule is what decides the partition.
+        s, li, bt = make_case(
+            rows, world, k_loc, page, max_blocks, tie_heavy=True, seed=seed
+        )
+        return s, li, bt, {}
+    if mode == "short":
+        # Short context: only n_real live candidates per plane, rest padded.
+        # n_real > page so local indices span >1 block-table entry.
+        n_real = max(page + 4, k_loc // 8)
+        n_real = min(n_real, k_loc)
+        s, li, bt = make_case(
+            rows, world, k_loc, page, max_blocks, n_local=n_real, seed=seed
+        )
+        li[:, n_real:] = -1
+        # -inf is the contract: padding carries no liveness flag of its own in
+        # the gathered plane, it has to lose on score alone.
+        #
+        # Starve EVERY plane's tail, not just this rank's. local_idx is the same
+        # shape on all ranks, so padding a single plane's scores leaves the other
+        # W-1 ranks holding -1 indices with live scores -- their padding wins and
+        # they emit garbage, which the cross-rank partition check then trips on.
+        for w in range(world):
+            s[:, w * k_loc + n_real : (w + 1) * k_loc] = -float("inf")
+        return s, li, bt, {"max_counts": n_real}
+    if mode == "starved":
+        # This rank's whole plane is pushed below every other rank's, so it wins
+        # only what the other W-1 planes cannot absorb. That is 0 in the usual
+        # case; it is nonzero when topk exceeds the other ranks' total capacity,
+        # since then even -1e30 candidates are needed to fill the top-k.
+        s, li, bt = make_case(rows, world, k_loc, page, max_blocks, seed=seed)
+        s[:, rank * k_loc : (rank + 1) * k_loc] = -1e30
+        spill = max(0, topk - (world - 1) * k_loc)
+        return s, li, bt, {"exact_counts": spill}
+    if mode == "overtake":
+        # topk_tokens >= n_cand degenerates to "take everything", not garbage:
+        # every rank ends up owning its entire plane. Only assert that when the
+        # caller's topk actually reaches n_cand -- the production sweep ships
+        # topk=2048 against n_cand=16384, which is selective, not degenerate.
+        s, li, bt = make_case(rows, world, k_loc, page, max_blocks, seed=seed)
+        expect = {"exact_counts": k_loc} if topk >= world * k_loc else {}
+        return s, li, bt, expect
+    if mode == "random":
+        return (
+            *make_case(rows, world, k_loc, page, max_blocks, seed=seed),
+            {},
+        )
+    raise ValueError(f"unknown case mode: {mode}")
+
+
+def run_merge(scores, local_idx, bt, rank, world, topk, page):
+    """Call the op with freshly allocated outputs; return (indices, indptr, counts).
+
+    `staging` is allocated here because the op requires a caller-provided
+    scratch buffer, but nothing reads it back: it is the pre-pack per-row form
+    of exactly the slots that land in `indices`, so asserting on it adds no
+    coverage the packed output does not already give.
+    """
+    rows = scores.shape[0]
+    k_loc = scores.shape[1] // world
+    indices = torch.zeros(rows * max(topk, k_loc), dtype=torch.int32)
+    indptr = torch.zeros(rows + 1, dtype=torch.int32)
+    staging = torch.empty(rows, k_loc, dtype=torch.int32)
+    counts = torch.zeros(rows, dtype=torch.int32)
+    aiter.flydsl_dcp_topk_merge(
+        scores,
+        local_idx,
+        bt,
+        indices,
+        indptr,
+        counts,
+        staging,
+        rank,
+        world,
+        topk,
+        page,
+    )
+    torch.cuda.synchronize()
+    return indices, indptr, counts
+
+
+@benchmark()  # call args become the table's left-hand columns
+def test_dcp_topk_merge(rows, world, k_loc, topk, page, mode):
+    """One rank's merge: global-threshold select -> owned, packed KV slots.
+
+    Single-kernel-vs-reference shape: there is no second kernel to race. The
+    sequence this op replaces lives in ATOM (a merge + a Triton filter), so it
+    is not importable here as a candidate -- `ref_dcp_merge` is the oracle.
+
+    Correctness is checked across ALL W ranks (the partition property is only
+    visible that way); only the middle rank is timed.
+    """
+    rank = world // 2  # a middle plane: exercises the prior-equal sweep
+    scores, local_idx, bt, expect = make_mode_case(
+        mode, rows, world, k_loc, topk, page, rank, seed=42
+    )
+    ref_slots, ref_counts = ref_dcp_merge(
+        scores, local_idx, bt, rank, k_loc, topk, page
+    )
+
+    # Caller-owned buffers, as production allocates them (see ATOM's
+    # dcp_decode_candidate_exchange_fused): the op allocates no device scratch.
+    staging = torch.empty(rows, k_loc, dtype=torch.int32)
+    counts = torch.zeros(rows, dtype=torch.int32)
+    indptr = torch.zeros(rows + 1, dtype=torch.int32)
+    indices = torch.zeros(rows * max(topk, k_loc), dtype=torch.int32)
+
+    candidates = {
+        "flydsl": lambda: aiter.flydsl_dcp_topk_merge(
+            scores,
+            local_idx,
+            bt,
+            indices,
+            indptr,
+            counts,
+            staging,
+            rank,
+            world,
+            topk,
+            page,
+        ),
+    }
+
+    n_cand = world * k_loc
+    # Memory-side op: the radix select re-reads the candidate plane, and the
+    # emit walks this rank's own plane plus its block table.
+    nbytes = (
+        rows * n_cand * scores.element_size()  # gathered scores
+        + rows * k_loc * local_idx.element_size()  # local_idx
+        + bt.numel() * bt.element_size()  # block table
+        + rows * k_loc * 4 * 2  # staging + emitted indices
+    )
+    flops = 0  # selection + address arithmetic; no useful FLOPs to count
+
+    ret = {"gfx": get_gfx()}
+    for name, fn in candidates.items():
+        _, us = run_perftest(fn)
+        torch.cuda.synchronize()
+        # checkAllclose is for the table's `err` column, NOT for gating: it only
+        # raises on a "catastrophic" delta and otherwise just logs and returns
+        # the mismatch ratio. Every invariant below is asserted separately with
+        # torch.testing.assert_close / assert so a wrong result fails the run.
+        err = checkAllclose(
+            ref_counts.to(dtypes.fp32),
+            counts.to(dtypes.fp32),
+            rtol=0,
+            atol=0,
+            msg=f"{name}: owned_counts",
+        )
+        torch.testing.assert_close(
+            counts, ref_counts, rtol=0, atol=0, msg=f"{name}/{mode}: owned_counts"
+        )
+        # indptr is the exclusive cumsum of the KERNEL's counts -- deriving it
+        # from the oracle instead would make the row slices below read from
+        # oracle offsets, silently checking the wrong region of `indices`.
+        want_indptr = torch.zeros(rows + 1, dtype=torch.int32)
+        want_indptr[1:] = torch.cumsum(counts, 0, dtype=torch.int32)
+        torch.testing.assert_close(
+            indptr, want_indptr, rtol=0, atol=0, msg=f"{name}/{mode}: indptr"
+        )
+        # The slot SET per row is the contract; within-row order is not.
+        for r in range(rows):
+            lo, hi = int(indptr[r]), int(indptr[r + 1])
+            torch.testing.assert_close(
+                torch.sort(indices[lo:hi]).values,
+                torch.sort(ref_slots[r]).values,
+                rtol=0,
+                atol=0,
+                msg=f"{name}/{mode}: row {r} slots",
+            )
+        # Mode-specific invariant: guards against passing via a degenerate path.
+        if "exact_counts" in expect:
+            assert torch.all(
+                counts == expect["exact_counts"]
+            ), f"{name}/{mode}: counts {counts} != {expect['exact_counts']}"
+        if "max_counts" in expect:
+            assert torch.all(
+                counts <= expect["max_counts"]
+            ), f"{name}/{mode}: emitted padded candidates: {counts}"
+
+        # Across all W ranks the owned counts must total exactly the global
+        # top-k: each rank keeps the winners that fall in its own plane, and the
+        # planes tile the candidate axis, so nothing may be dropped or claimed
+        # twice. Computed per row -- "short" mode leaves rows with differing
+        # live-candidate counts, so a single scalar bound would be wrong.
+        #
+        # Disjointness of the emitted SLOTS is deliberately not asserted here:
+        # make_case gives every rank the same local_idx and block_table, so two
+        # planes legitimately map to one physical slot in this fixture (the
+        # oracle collides identically). Real DCP gives each rank its own KV
+        # slice; proving that needs a multi-rank fixture this file does not have.
+        n_live = torch.isfinite(scores).sum(dim=1)
+        want_total = torch.clamp(n_live, max=topk).to(torch.int32)
+        total = torch.zeros(rows, dtype=torch.int32)
+        for r_id in range(world):
+            _, _, c = run_merge(scores, local_idx, bt, r_id, world, topk, page)
+            total += c
+        torch.testing.assert_close(
+            total, want_total, rtol=0, atol=0, msg=f"{name}/{mode}: rank partition"
+        )
+
+        ret[f"{name} us"] = us
+        ret[f"{name} TFLOPS"] = flops / us / 1e6 if us > 0 else 0
+        ret[f"{name} TB/s"] = nbytes / us / 1e6 if us > 0 else 0
+        ret[f"{name} err"] = err
+    return ret
+
+
+def check_modes():
+    """Run every case mode over edge shapes the perf sweep does not cover."""
+    k_loc = 64
+    for rows, world, page in [(1, 8, 64), (17, 4, 16), (256, 2, 128)]:
+        for mode in CASE_MODES:
+            # "overtake" is the topk >= n_cand degenerate case.
+            topk = world * k_loc if mode == "overtake" else 128
+            test_dcp_topk_merge(rows, world, k_loc, topk, page, mode)
+
+
+def check_nan_scores_never_win():
+    """A NaN score must lose the threshold, not sort above real candidates.
+
+    The kernel's float->ordinal map has to agree with the reference model, which
+    treats every non-finite value as -inf. If NaN mapped to INT32_MAX instead it
+    would win every comparison, steal a real candidate's slot, and silently move
+    a KV block to the wrong rank -- no crash, just wrong attention.
+    """
+    rows, world, k_loc, topk, page = 2, 4, 32, 16, 16
+    scores, local_idx, bt = make_case(rows, world, k_loc, page, 64, seed=13)
+    rank = 1
+    # Poison this rank's plane: NaN where a real (losing) score used to be.
+    scores[:, rank * k_loc : rank * k_loc + 8] = float("nan")
+    indices, indptr, counts = run_merge(scores, local_idx, bt, rank, world, topk, page)
+    want_slots, want_counts = ref_dcp_merge(
+        scores, local_idx, bt, rank, k_loc, topk, page
+    )
+    torch.testing.assert_close(counts, want_counts, rtol=0, atol=0)
+    for r in range(rows):
+        lo, hi = int(indptr[r]), int(indptr[r + 1])
+        torch.testing.assert_close(
+            torch.sort(indices[lo:hi]).values,
+            torch.sort(want_slots[r]).values,
+            rtol=0,
+            atol=0,
+            msg=f"row {r}",
+        )
+
+
+def check_deterministic_across_runs(rows, world, k_loc, topk, page, tie_heavy, seed):
+    """Back-to-back runs on identical input must return identical output.
+
+    The kernel reuses one LDS scan buffer across calls, and both the select and
+    the pack block derive their write offsets from it, so a dropped barrier
+    shows up as output that varies between otherwise identical launches. Every
+    TP rank runs this op on the same gathered scores and must land on the same
+    KV set, so reproducibility is a correctness requirement, not a nicety.
+
+    Scope: this checks run-to-run stability only. Whether the result is *right*
+    is the oracle comparison in test_dcp_topk_merge; repeating a wrong-but-
+    stable answer passes here by design. It is also not a race detector -- a
+    barrier can be missing and every run still agree (verified: deleting the
+    bucket-hit barrier leaves this green). Treat a pass as evidence of
+    determinism, nothing more.
+    """
+    scores, local_idx, bt = make_case(
+        rows, world, k_loc, page, 512, tie_heavy=tie_heavy, seed=seed
+    )
+    for rank in range(world):
+        ref = None
+        for it in range(200 // world):
+            indices, indptr, _ = run_merge(
+                scores, local_idx, bt, rank, world, topk, page
+            )
+            if ref is None:
+                ref = (indices.clone(), indptr.clone())
+                continue
+            torch.testing.assert_close(
+                indices,
+                ref[0],
+                rtol=0,
+                atol=0,
+                msg=f"rank {rank} iter {it}: indices not reproducible",
+            )
+            torch.testing.assert_close(
+                indptr,
+                ref[1],
+                rtol=0,
+                atol=0,
+                msg=f"rank {rank} iter {it}: indptr not reproducible",
+            )
+
+
+def main():
+    if get_gfx() not in SUPPORTED_GFX:
+        aiter.logger.warning(
+            "FlyDSL DCP TopK merge unsupported on %s; skipping", get_gfx()
+        )
+        return
+
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.RawTextHelpFormatter,
+        description="FlyDSL DCP decode TopK merge correctness + perf sweep",
+    )
+    # rows == num_decode_tokens: the decode batch this rank scheduled.
+    parser.add_argument("-b", "--rows", type=int, nargs="*", default=[1, 32, 128, 256])
+    parser.add_argument("-w", "--world", type=int, nargs="*", default=[8])
+    # Production ships k_loc == topk == index_topk == 2048.
+    parser.add_argument("-k", "--k-loc", type=int, nargs="*", default=[2048])
+    parser.add_argument("--topk", type=int, nargs="*", default=[2048])
+    parser.add_argument("-p", "--page", type=int, nargs="*", default=[64])
+    parser.add_argument(
+        "-m", "--mode", type=str, nargs="*", default=CASE_MODES, choices=CASE_MODES
+    )
+    args = parser.parse_args()
+
+    # Correctness first: these cover what the perf sweep cannot reach -- small
+    # shapes and low world sizes, NaN ordering, and run-to-run reproducibility.
+    # Every one raises on failure, so CI goes red before the perf table prints.
+    check_modes()
+    check_nan_scores_never_win()
+    for c_rows, c_world, c_k, c_topk, c_page, c_tie, c_seed in [
+        (4, 8, 64, 128, 16, True, 6),  # tie-heavy: many equal-to-threshold
+        (7, 8, 128, 32, 16, False, 31),  # the shape C1 was reproduced on
+    ]:
+        check_deterministic_across_runs(
+            c_rows, c_world, c_k, c_topk, c_page, c_tie, c_seed
+        )
+    aiter.logger.info("FlyDSL DCP TopK merge: correctness checks passed")
+
+    df = []
+    for rows, world, k_loc, topk, page, mode in itertools.product(
+        args.rows, args.world, args.k_loc, args.topk, args.page, args.mode
+    ):
+        df.append(test_dcp_topk_merge(rows, world, k_loc, topk, page, mode))
+    df = pd.DataFrame(df)
+    aiter.logger.info(
+        "FlyDSL DCP TopK merge summary (markdown):\n%s", df.to_markdown(index=False)
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Three related changes for the Decode Context Parallel path of the DeepSeek-V3.2-style
sparse indexer. The first two are what GLM-5.2 DCP decode needs; the third is an
independent crash fix found while bringing that path up, and is useful on its own.

---
## 1. `[FlyDSL] Add DCP decode TopK merge kernel`

Under DCP each rank holds `1/W` of the KV and takes a local top-k, so the ranks must
agree on a global top-k before attention. The existing sequence reconstructs that
global set on **every** rank and then drops the `~(W-1)/W` of it the rank does not
own — W times the work, most of it discarded.

This op emits only the rank's **owned** physical KV slots, already localized and
compacted, plus the `kv_indptr` attention needs. Two kernels: a per-row radix
select for the global threshold, then a per-row pack that also computes the
cross-row prefix sum.

Two properties make the fusion possible:

- **Ownership is positional.** Candidate column `c` came from rank `c // k_loc`, so
  global ids never have to travel and the caller can exchange scores alone.
- **The slot formula collapses.** For local index `j` the physical slot is
  `block_table[j // page] * page + (j % page)` — independent of `W` and of the
  interleave size `S`. Verified by exhaustive enumeration over 50400 combinations
  of `(W, S, page, j)`, 0 mismatches. So the localize folds into the emit loop
  instead of needing a separate pass.

Allocates no device scratch (the caller owns `staging`), so it is safe inside a
captured CUDAGraph.

### Why the prefix sum lives inside `pack`

It started as its own `grid=(1,)` kernel walking the rows on a single thread. That
is O(rows) serial work sandwiched between two parallel kernels, and it showed —
**37% of the op's runtime at rows=128** (15.7 of 42.3 µs) to prefix-sum 128
integers.

Each `pack` block now recomputes the prefix it needs, in parallel. The redundancy
is real (rows blocks each scanning rows counts) but a block scan over a few hundred
values is a handful of barriers: `pack` went 3.3 → 3.5 µs while a whole kernel
launch disappeared. The loop is chunked, so `rows > 256` stays correct — verified at
rows ∈ {1, 128, 256, **257**, 512}.

That is also why `select` and `pack` cannot merge further: `pack` needs
`kv_indptr[row]`, which depends on every *other* row's count. Closing that gap needs
either a cross-block barrier (unsafe — block scheduling order is not guaranteed, so
a block spinning on a not-yet-scheduled block deadlocks) or `grid=(1,)`, which would
serialise `select` by a factor of rows.

### Performance

Against the equivalent six-op sequence, at the production shape `W=8`,
`k_loc = topk = 2048`:

| bs | six-op | fused | speedup |
|---:|-------:|------:|--------:|
| 1 | 166.5 µs | 33.9 µs | 4.91× |
| 4 | 173.6 µs | 33.8 µs | 5.14× |
| 16 | 165.2 µs | 34.3 µs | 4.82× |
| 32 | 167.3 µs | 33.6 µs | 4.98× |
| 64 | 174.6 µs | 34.3 µs | 5.09× |
| 128 | 167.4 µs | 34.0 µs | 4.92× |

The curve is **flat** — 33.6-34.3 µs regardless of bs — where the six-op path grows
with rows. Plus half the all-gather payload (`[rows, k_loc]` instead of
`[2, rows, k_loc]`) and 2 kernels instead of ~16.

This is a **single-op** measurement. It has not been attributed against a full decode
step, so the wall-clock share depends on how often the indexer runs per forward.

### Correctness

`op_tests/flydsl_tests/test_flydsl_dcp_topk_merge.py` — **45 passed**. Covers a
differential test against the six-op reference, edge cases (`topk > n_cand`, empty
rows, all-padding rows), a shape sweep, and tie-heavy inputs where the equal-to-
threshold admission rule is what decides the partition.

Two GPU races were found and fixed during development, each with a reproducible
before/after:

- **Bucket-hit test.** Every thread reads `remaining_k` from LDS but only the thread
  owning the k-th element writes it. Without a barrier between the two, a fast writer
  updates it while a slow thread is still reading, the slow thread then satisfies the
  hit condition against the *new* value and writes a second bucket — a corrupted
  threshold.
- **Block scan.** A fast wave entering the *next* `block_exclusive_prefix_i32` call
  would overwrite `scan[warp]` while a slow wave was still reading the current call's
  totals. Fixed with a trailing barrier.

The second one I initially dismissed as a non-race based on 40 clean iterations of a
single shape. It reproduced later under a different shape. A race is structural, not
a property of one observed schedule — recording that here because the first ruling
was wrong.

---

## 2. `[HIP] Add optional score output to top_k_per_row_decode`

`top_k_per_row_decode` now takes an optional `values` tensor and writes each selected
index's logit alongside it, mirroring `top_k_per_row_prefill`. The one-block kernel
already supported this (`WRITE_TOPK_VALUES` is a template parameter of
`dispatch_topk_oneblock`); the decode entry point hardcoded it to false with
`/*out=*/nullptr`. Wiring it through the header, the pybind arg list and the Python
wrapper is the whole change — **the default path compiles to the same instantiation
as before**.

This lets a DCP decode indexer drop the separate gather whose only job was to read
these same scores back out of the logits.

### Also: a padding-value fix

Where the index is padded with `-1`, the score was padded with `0.0`. A `0.0` pad does
**not** sort below real scores — logits are routinely negative, so the padding
outranks them, and a consumer that ranks these scores (a DCP merge across ranks) lets
padding steal real candidates' slots. Pad with `-inf` instead.

Measured impact before the fix: at `W=8` the disjoint owned-partition collapsed from
256 entries to 30.

The changed line is shared with prefill, but **every in-tree prefill caller passes
`values=None`** (checked all 5), so `WRITE_TOPK_VALUES` is false there and the store
never executes.

---

## Validation

- `op_tests/flydsl_tests/test_flydsl_dcp_topk_merge.py`: **45 passed**
- HIP `values`: padding `== -inf`, score `==` gathered logit, `values=None`
  bit-identical to before, non-stable path — all pass
- Gluon fix: 3 previously-aborting shapes compile; reverting the patch reproduces the
  abort on `main`, so the fix is not a no-op
- End-to-end: GLM-5.2, TP=8, DCP=8, 65536-token inputs, **8/8 requests succeeded**,
  32 prefill batches including the `done=[16384]` chunk that previously aborted. Zero
  `iota_range` / `proc died` / `exitcode=-6` in the log.

## Not covered

- **The DCP merge has not been validated on real multi-GPU DCP.** The all-gather
  itself is untested; the consumer keeps it behind a default-off flag.
- Tested on one gfx950 machine with Triton 3.7.0.
- The `waves_per_eu` timings are 10-iteration wall-clock, not a rigorous benchmark.
