### PR TITLE
[CI] Fix PR title tag workflow syntax

### DIFF
--- a/.github/workflows/pr-title-tags.yaml
+++ b/.github/workflows/pr-title-tags.yaml
@@ -72,7 +72,7 @@ jobs:
             const eventLabel = context.payload.label?.name;
             if ((action === 'labeled' || action === 'unlabeled')
                 && eventLabel !== 'no-auto-title'
-                && !Object.hasOwn(COMPONENT_LABELS, eventLabel))
+                && !Object.hasOwn(COMPONENT_LABELS, eventLabel)) {
               core.info(`Label '${eventLabel}' is not managed — skipping.`);
               return;
             }


### PR DESCRIPTION
## Summary
- Fix the missing block braces in the PR title/label sync workflow label-event guard.
- Preserve the existing behavior: unmanaged label events log and return early, while managed labels and normal PR events continue through the sync path.

## Validation
- Extracted the inline github-script body and parsed it with Node AsyncFunction: syntax ok.
- `Check GitHub Actions workflows` passed on this PR.

## Note
The `tag-title` check can still fail on this PR because `pull_request_target` runs the workflow from the base branch, and the base branch is exactly what this PR is fixing. After this merges, new runs should use the corrected script.

This addresses the SyntaxError seen in https://github.com/ROCm/aiter/actions/runs/33360744937/job/99391473322?pr=5131.