### PR TITLE
[Triton/Gluon] Add `repr` to DiT fused kernels + Cover `round_intermediate` in tests

### DIFF
--- a/aiter/ops/triton/_triton_kernels/fusions/fused_rmsnorm_indexed_adaln.py
+++ b/aiter/ops/triton/_triton_kernels/fusions/fused_rmsnorm_indexed_adaln.py
@@ -4,8 +4,15 @@
 import triton
 import triton.language as tl
 
+from aiter.ops.triton.utils._triton.kernel_repr import make_kernel_repr
 
-@triton.jit
+_fused_rmsnorm_indexed_adaln_repr = make_kernel_repr(
+    "_fused_rmsnorm_indexed_adaln_kernel",
+    ["BLOCK_M", "BLOCK_N", "ROUND_INTERMEDIATE"],
+)
+
+
+@triton.jit(repr=_fused_rmsnorm_indexed_adaln_repr)
 def _fused_rmsnorm_indexed_adaln_kernel(
     out_ptr,
     x_ptr,

--- a/aiter/ops/triton/_triton_kernels/rope/fused_qk_norm_rope_cached.py
+++ b/aiter/ops/triton/_triton_kernels/rope/fused_qk_norm_rope_cached.py
@@ -4,8 +4,15 @@
 import triton
 import triton.language as tl
 
+from aiter.ops.triton.utils._triton.kernel_repr import make_kernel_repr
 
-@triton.jit
+_fused_qk_norm_rope_cached_repr = make_kernel_repr(
+    "_fused_qk_norm_rope_cached_kernel",
+    ["BLOCK_H", "BLOCK_D"],
+)
+
+
+@triton.jit(repr=_fused_qk_norm_rope_cached_repr)
 def _fused_qk_norm_rope_cached_kernel(
     q_ptr,
     k_ptr,

--- a/op_tests/triton_tests/fusions/test_fused_rmsnorm_indexed_adaln.py
+++ b/op_tests/triton_tests/fusions/test_fused_rmsnorm_indexed_adaln.py
@@ -9,12 +9,15 @@ from aiter.ops.triton.fusions.fused_rmsnorm_indexed_adaln import (
 )
 
 
-def reference(x, weight, shift, scale, indices, eps):
+def reference(x, weight, shift, scale, indices, eps, round_intermediate=False):
     """What the fused op replaces: a norm, then a gathered affine."""
     normed = torch.nn.functional.rms_norm(x, (x.shape[-1],), weight, eps)
-    return normed * (1.0 + scale.index_select(0, indices)) + shift.index_select(
-        0, indices
-    )
+    if round_intermediate:
+        normed = normed.to(x.dtype)
+    modulated = normed * (1.0 + scale.index_select(0, indices))
+    if round_intermediate:
+        modulated = modulated.to(x.dtype)
+    return modulated + shift.index_select(0, indices)
 
 
 def make(M, N, G, dtype, device, *, runs=True, seed=0):
@@ -37,6 +40,7 @@ def make(M, N, G, dtype, device, *, runs=True, seed=0):
     return x, weight, shift, scale, indices
 
 
+@pytest.mark.parametrize("round_intermediate", [False, True])
 @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16, torch.float32])
 @pytest.mark.parametrize(
     "M,N,G",
@@ -50,11 +54,21 @@ def make(M, N, G, dtype, device, *, runs=True, seed=0):
     ],
 )
 @pytest.mark.parametrize("runs", [True, False])
-def test_matches_norm_then_gathered_affine(dtype, M, N, G, runs):
+def test_matches_norm_then_gathered_affine(dtype, M, N, G, runs, round_intermediate):
     dev = "cuda"
     x, weight, shift, scale, indices = make(M, N, G, dtype, dev, runs=runs)
-    got = fused_rmsnorm_indexed_adaln(x, weight, shift, scale, indices, eps=1e-5)
-    want = reference(x, weight, shift, scale, indices, 1e-5)
+    got = fused_rmsnorm_indexed_adaln(
+        x,
+        weight,
+        shift,
+        scale,
+        indices,
+        eps=1e-5,
+        round_intermediate=round_intermediate,
+    )
+    want = reference(
+        x, weight, shift, scale, indices, 1e-5, round_intermediate=round_intermediate
+    )
 
     assert got.shape == x.shape and got.dtype == x.dtype
     # The fused path keeps the row in fp32 across the norm and the affine, so it

--- a/op_tests/triton_tests/fusions/test_fused_rmsnorm_indexed_adaln.py
+++ b/op_tests/triton_tests/fusions/test_fused_rmsnorm_indexed_adaln.py
@@ -10,14 +10,16 @@ from aiter.ops.triton.fusions.fused_rmsnorm_indexed_adaln import (
 
 
 def reference(x, weight, shift, scale, indices, eps, round_intermediate=False):
-    """What the fused op replaces: a norm, then a gathered affine."""
-    normed = torch.nn.functional.rms_norm(x, (x.shape[-1],), weight, eps)
+    """What the fused op replaces, with optional eager-style store rounding."""
+    normed = torch.nn.functional.rms_norm(
+        x.float(), (x.shape[-1],), weight.float(), eps
+    )
     if round_intermediate:
-        normed = normed.to(x.dtype)
-    modulated = normed * (1.0 + scale.index_select(0, indices))
+        normed = normed.to(x.dtype).float()
+    modulated = normed * (1.0 + scale.index_select(0, indices).float())
     if round_intermediate:
-        modulated = modulated.to(x.dtype)
-    return modulated + shift.index_select(0, indices)
+        modulated = modulated.to(x.dtype).float()
+    return (modulated + shift.index_select(0, indices).float()).to(x.dtype)
 
 
 def make(M, N, G, dtype, device, *, runs=True, seed=0):
@@ -71,9 +73,24 @@ def test_matches_norm_then_gathered_affine(dtype, M, N, G, runs, round_intermedi
     )
 
     assert got.shape == x.shape and got.dtype == x.dtype
-    # The fused path keeps the row in fp32 across the norm and the affine, so it
-    # is nearer the fp32 result than the reference is, not further.
-    tol = {torch.float32: 2e-6, torch.float16: 4e-3, torch.bfloat16: 3e-2}[dtype]
+    if round_intermediate and dtype != torch.float32:
+        full_precision = reference(
+            x, weight, shift, scale, indices, 1e-5, round_intermediate=False
+        )
+        assert not torch.equal(
+            want, full_precision
+        ), "test input does not expose intermediate rounding"
+        unrounded = fused_rmsnorm_indexed_adaln(
+            x, weight, shift, scale, indices, eps=1e-5, round_intermediate=False
+        )
+        assert not torch.equal(
+            got, unrounded
+        ), "round_intermediate=True did not change the kernel output"
+        tol = 2 * torch.finfo(dtype).eps
+    else:
+        # Without intermediate rounding the kernel keeps the row in fp32 across
+        # the norm and affine, so compare against the fp32-intermediate reference.
+        tol = {torch.float32: 2e-6, torch.float16: 4e-3, torch.bfloat16: 3e-2}[dtype]
     torch.testing.assert_close(got.float(), want.float(), atol=tol, rtol=tol)
 
 


### PR DESCRIPTION
## Motivation

This PR is a quick follow-up of https://github.com/ROCm/aiter/pull/4659. I reviewed, approved and merged https://github.com/ROCm/aiter/pull/4659/, however I forgot about the mandatory kernel `repr` string:

> **Kernel conventions:** Every new launchable Triton or Gluon kernel must set a config-aware `repr` using `make_kernel_repr` from `aiter.ops.triton.utils._triton.kernel_repr`:

```python
_kernel_repr = make_kernel_repr(
    "_kernel_name",
    ["BLOCK_SIZE_M", "BLOCK_SIZE_N", "num_warps"],
)

@triton.jit(repr=_kernel_repr)  # Triton entry kernel
# or
@gluon.jit(repr=_kernel_repr)   # Gluon entry kernel
```

## Technical Details

Both `_fused_rmsnorm_indexed_adaln_kernel` and `_fused_qk_norm_rope_cached_kernel` were missing the mandatory `repr` string, leaving different tile-size specializations indistinguishable in JIT artifacts and profiling traces. Adds `repr` with all meaningful `constexprs`.

Also extends `reference()` and `test_matches_norm_then_gathered_affine` to parametrize over `round_intermediate`, giving the `ROUND_INTERMEDIATE constexpr` test coverage.

## Test Plan

Run related unit tests:

```bash
pytest \
    op_tests/triton_tests/fusions/test_fused_rmsnorm_indexed_adaln.py \
    op_tests/triton_tests/rope/test_fused_qk_norm_rope_cached.py
```

## Test Result

Result of test execution in a `gfx950` host:

```text
============================================= test session starts ==============================================
platform linux -- Python 3.12.3, pytest-7.3.2, pluggy-1.6.0
rootdir: /workspace/aiter
plugins: shard-0.1.2, rerunfailures-14.0, cpp-2.3.0, xdoctest-1.3.0, subtests-0.13.1, hypothesis-6.156.6, xdist-3.3.1, flakefinder-1.1.0
collected 94 items
Running 94 items in this shard

op_tests/triton_tests/fusions/test_fused_rmsnorm_indexed_adaln.py ...................................... [ 40%]
.......................................                                                                  [ 81%]
op_tests/triton_tests/rope/test_fused_qk_norm_rope_cached.py .................                           [100%]

============================================= 94 passed in 22.73s ==============================================
```

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
