### PR TITLE
[Triton/Gluon] unified_attention: split the straggler generation of the 2-D prefill launch (KR_TAILSPLIT, gfx950)

### DIFF
--- a/aiter/ops/triton/_triton_kernels/attention/kr_split.py
+++ b/aiter/ops/triton/_triton_kernels/attention/kr_split.py
@@ -1,0 +1,297 @@
+import torch
+import triton
+import triton.language as tl
+
+from aiter.ops.triton.utils.types import e4m3_dtype
+from aiter.ops.triton._triton_kernels.attention.unified_attention import (
+    cdiv_fn,
+    find_seq_idx,
+)
+
+float8_info = torch.finfo(e4m3_dtype)
+
+
+# ---- KR tailsplit ----
+# Split-KV variant of kernel_unified_attention_2d used to fill the trailing,
+# partially-occupied dispatch round of the 2-D launch.  Same math (online
+# softmax), but the KV range of each q-block is split NUM_SEGMENTS ways and the
+# per-segment (acc, max, expsum) are reduced by reduce_segments_tail.
+
+
+@triton.jit
+def kernel_unified_attention_2d_split(
+    segm_output_ptr,  # [nrows, NUM_SEGMENTS, HEAD_SIZE_PADDED] fp32
+    segm_max_ptr,  # [nrows, NUM_SEGMENTS] fp32
+    segm_expsum_ptr,  # [nrows, NUM_SEGMENTS] fp32
+    query_ptr,
+    key_cache_ptr,
+    value_cache_ptr,
+    sink_ptr,
+    block_tables_ptr,
+    seq_lens_ptr,
+    scale: tl.constexpr,
+    q_descale_ptr,
+    k_descale_ptr,
+    v_descale_ptr,
+    num_query_heads: tl.constexpr,
+    num_queries_per_kv: tl.constexpr,
+    num_kv_heads: tl.constexpr,
+    block_table_stride: tl.int64,
+    query_stride_0: tl.int64,
+    query_stride_1: tl.int64,
+    BLOCK_SIZE: tl.constexpr,
+    TILE_SIZE: tl.constexpr,
+    HEAD_SIZE: tl.constexpr,
+    HEAD_SIZE_PADDED: tl.constexpr,
+    USE_SINKS: tl.constexpr,
+    stride_k_cache_0: tl.int64,
+    stride_k_cache_1: tl.int64,
+    stride_k_cache_2: tl.int64,
+    stride_k_cache_3: tl.constexpr,
+    stride_v_cache_0: tl.int64,
+    stride_v_cache_1: tl.int64,
+    stride_v_cache_2: tl.int64,
+    stride_v_cache_3: tl.constexpr,
+    query_start_len_ptr,
+    BLOCK_Q: tl.constexpr,
+    num_seqs: tl.int32,
+    BLOCK_M: tl.constexpr,
+    q_block_offset: tl.int32,
+    NUM_SEGMENTS: tl.constexpr,
+):
+    kv_head_idx = tl.program_id(0)
+    tail_blk = tl.program_id(1)
+    segm_idx = tl.program_id(2)
+
+    RCP_LN2 = 1.4426950408889634
+    qk_scale = scale * RCP_LN2
+
+    q_block_global_idx = q_block_offset + tail_blk
+
+    seq_idx = find_seq_idx(
+        query_start_len_ptr, q_block_global_idx, num_seqs, BLOCK_Q, True
+    )
+    q_block_start_idx = tl.load(query_start_len_ptr + seq_idx) // BLOCK_Q + seq_idx
+    q_block_local_idx = q_block_global_idx - q_block_start_idx
+    cur_batch_in_all_start_index = tl.load(query_start_len_ptr + seq_idx)
+    cur_batch_in_all_stop_index = tl.load(query_start_len_ptr + seq_idx + 1)
+    cur_batch_query_len = cur_batch_in_all_stop_index - cur_batch_in_all_start_index
+
+    if q_block_local_idx * BLOCK_Q >= cur_batch_query_len:
+        return
+
+    offs_m = tl.arange(0, BLOCK_M)
+    offs_d = tl.arange(0, HEAD_SIZE_PADDED)
+    offs_t = tl.arange(0, TILE_SIZE)
+    query_pos = q_block_local_idx * BLOCK_Q + offs_m // num_queries_per_kv
+
+    query_offset_0 = cur_batch_in_all_start_index + query_pos
+    query_offset_1 = kv_head_idx * num_queries_per_kv + offs_m % num_queries_per_kv
+    query_offset = (
+        query_offset_0[:, None] * query_stride_0
+        + query_offset_1[:, None] * query_stride_1
+        + offs_d[None, :]
+    )
+
+    if HEAD_SIZE_PADDED != HEAD_SIZE:
+        dim_mask = offs_d < HEAD_SIZE
+    else:
+        dim_mask = tl.full((1,), 1, dtype=tl.int1)
+    query_mask_0 = query_pos < cur_batch_query_len
+    query_mask_1 = query_offset_1 < num_query_heads
+
+    Q = tl.load(
+        query_ptr + query_offset,
+        mask=dim_mask[None, :] & query_mask_0[:, None] & query_mask_1[:, None],
+        other=0.0,
+    )
+
+    block_table_offset = seq_idx * block_table_stride
+
+    if USE_SINKS and segm_idx == 0:
+        M = (
+            tl.load(
+                sink_ptr + query_offset_1, mask=query_mask_1, other=float("-inf")
+            ).to(dtype=tl.float32)
+            * RCP_LN2
+        )
+    else:
+        M = tl.full([BLOCK_M], float("-inf"), dtype=tl.float32)
+
+    L = tl.full([BLOCK_M], 1.0, dtype=tl.float32)
+    acc = tl.zeros([BLOCK_M, HEAD_SIZE_PADDED], dtype=tl.float32)
+
+    seq_len = tl.load(seq_lens_ptr + seq_idx)
+    context_len = seq_len - cur_batch_query_len
+
+    max_seq_prefix_len = (
+        context_len
+        + q_block_local_idx * BLOCK_Q
+        + (BLOCK_M - 1) // num_queries_per_kv
+        + 1
+    )
+    max_seq_prefix_len = tl.minimum(max_seq_prefix_len, seq_len)
+    num_tiles = cdiv_fn(max_seq_prefix_len, TILE_SIZE)
+
+    tiles_per_segment = cdiv_fn(num_tiles, NUM_SEGMENTS)
+    tile_start = segm_idx * tiles_per_segment
+    tile_end = tl.minimum(tile_start + tiles_per_segment, num_tiles)
+
+    if q_descale_ptr is not None:
+        qk_scale = qk_scale * tl.load(q_descale_ptr)
+    if k_descale_ptr is not None and v_descale_ptr is not None:
+        k_descale = tl.load(k_descale_ptr)
+        v_descale = tl.load(v_descale_ptr)
+        qk_scale = qk_scale * k_descale
+    else:
+        v_descale = None
+
+    for j in range(tile_start, tile_end):
+        seq_offset = j * TILE_SIZE + offs_t
+        if TILE_SIZE == BLOCK_SIZE:
+            tile_mask = tl.full((1,), 1, dtype=tl.int1)
+        else:
+            tile_mask = seq_offset < max_seq_prefix_len
+
+        physical_block_idx = tl.load(
+            block_tables_ptr + block_table_offset + seq_offset // BLOCK_SIZE
+        ).to(tl.int64)
+
+        v_offset = (
+            physical_block_idx[:, None] * stride_v_cache_0
+            + kv_head_idx * stride_v_cache_2
+            + offs_d[None, :] * stride_v_cache_3
+            + (seq_offset % BLOCK_SIZE)[:, None] * stride_v_cache_1
+        )
+        v_mask = dim_mask[None, :] & tile_mask[:, None]
+
+        k_offset = (
+            physical_block_idx[None, :] * stride_k_cache_0
+            + kv_head_idx * stride_k_cache_2
+            + offs_d[:, None] * stride_k_cache_3
+            + (seq_offset % BLOCK_SIZE)[None, :] * stride_k_cache_1
+        )
+        k_mask = dim_mask[:, None] & tile_mask[None, :]
+
+        K = tl.load(key_cache_ptr + k_offset, mask=k_mask, other=0.0).to(Q.dtype)
+        V = tl.load(value_cache_ptr + v_offset, mask=v_mask, other=0.0).to(Q.dtype)
+
+        S = qk_scale * tl.dot(Q, K)
+
+        seq_mask = seq_offset[None, :] < context_len + query_pos[:, None] + 1
+        S = tl.where(
+            query_mask_1[:, None] & query_mask_0[:, None] & seq_mask, S, float("-inf")
+        )
+
+        m_j = tl.maximum(M, tl.max(S, axis=1))
+        m_j = tl.where(m_j > float("-inf"), m_j, 0.0)
+        P = tl.math.exp2(S - m_j[:, None])
+        l_j = tl.sum(P, axis=1)
+        alpha = tl.math.exp2(M - m_j)
+        acc = acc * alpha[:, None]
+        L = L * alpha + l_j
+        M = m_j
+        acc = tl.dot(P.to(V.dtype), V, acc=acc)
+
+    if v_descale is not None:
+        acc = acc * v_descale
+
+    row = (tail_blk * num_kv_heads + kv_head_idx).to(tl.int64) * BLOCK_M + offs_m.to(
+        tl.int64
+    )
+    segm_output_offset = (
+        row[:, None] * (NUM_SEGMENTS * HEAD_SIZE_PADDED)
+        + segm_idx * HEAD_SIZE_PADDED
+        + offs_d[None, :]
+    )
+    tl.store(
+        segm_output_ptr + segm_output_offset,
+        acc,
+        mask=dim_mask[None, :] & query_mask_0[:, None] & query_mask_1[:, None],
+    )
+    segm_offset = row * NUM_SEGMENTS + segm_idx
+    tl.store(segm_max_ptr + segm_offset, M, mask=query_mask_0 & query_mask_1)
+    tl.store(segm_expsum_ptr + segm_offset, L, mask=query_mask_0 & query_mask_1)
+
+
+@triton.jit
+def reduce_segments_tail(
+    output_ptr,
+    segm_output_ptr,
+    segm_max_ptr,
+    segm_expsum_ptr,
+    query_start_len_ptr,
+    out_scale_ptr,
+    num_seqs: tl.int32,
+    num_query_heads: tl.constexpr,
+    num_queries_per_kv: tl.constexpr,
+    num_kv_heads: tl.constexpr,
+    output_stride_0: tl.int64,
+    output_stride_1: tl.int64,
+    HEAD_SIZE: tl.constexpr,
+    HEAD_SIZE_PADDED: tl.constexpr,
+    BLOCK_Q: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    NUM_SEGMENTS: tl.constexpr,
+    q_block_offset: tl.int32,
+    FP8_MIN: tl.constexpr = float8_info.min,
+    FP8_MAX: tl.constexpr = float8_info.max,
+):
+    row = tl.program_id(0)
+    m = row % BLOCK_M
+    t = row // BLOCK_M
+    kv_head_idx = t % num_kv_heads
+    tail_blk = t // num_kv_heads
+
+    q_block_global_idx = q_block_offset + tail_blk
+    seq_idx = find_seq_idx(
+        query_start_len_ptr, q_block_global_idx, num_seqs, BLOCK_Q, True
+    )
+    q_block_start_idx = tl.load(query_start_len_ptr + seq_idx) // BLOCK_Q + seq_idx
+    q_block_local_idx = q_block_global_idx - q_block_start_idx
+    cur_batch_in_all_start_index = tl.load(query_start_len_ptr + seq_idx)
+    cur_batch_in_all_stop_index = tl.load(query_start_len_ptr + seq_idx + 1)
+    cur_batch_query_len = cur_batch_in_all_stop_index - cur_batch_in_all_start_index
+
+    query_pos = q_block_local_idx * BLOCK_Q + m // num_queries_per_kv
+    head_idx = kv_head_idx * num_queries_per_kv + m % num_queries_per_kv
+    if query_pos >= cur_batch_query_len:
+        return
+    if head_idx >= num_query_heads:
+        return
+
+    offs_s = tl.arange(0, NUM_SEGMENTS)
+    offs_d = tl.arange(0, HEAD_SIZE_PADDED)
+    base = row.to(tl.int64) * NUM_SEGMENTS
+
+    segm_max = tl.load(segm_max_ptr + base + offs_s)
+    overall_max = tl.max(segm_max)
+    rescale = tl.math.exp2(segm_max - overall_max)
+    segm_expsum = tl.load(segm_expsum_ptr + base + offs_s)
+    overall_expsum = tl.sum(segm_expsum * rescale)
+
+    segm_output = tl.load(
+        segm_output_ptr
+        + base * HEAD_SIZE_PADDED
+        + offs_s[:, None] * HEAD_SIZE_PADDED
+        + offs_d[None, :],
+        mask=(offs_d < HEAD_SIZE)[None, :],
+        other=0.0,
+    )
+    acc_sum = tl.sum(segm_output * rescale[:, None], axis=0)
+    acc = tl.where(overall_expsum == 0.0, 0.0, acc_sum / overall_expsum)
+    if out_scale_ptr is not None:
+        acc = acc / tl.load(out_scale_ptr)
+    if output_ptr.type.element_ty.is_fp8():
+        acc = tl.clamp(acc, FP8_MIN, FP8_MAX)
+
+    out_off = (
+        (cur_batch_in_all_start_index + query_pos).to(tl.int64) * output_stride_0
+        + head_idx * output_stride_1
+        + offs_d
+    )
+    tl.store(
+        output_ptr + out_off,
+        acc.to(output_ptr.type.element_ty),
+        mask=offs_d < HEAD_SIZE,
+    )

--- a/aiter/ops/triton/attention/kr_ua.py
+++ b/aiter/ops/triton/attention/kr_ua.py
@@ -1,0 +1,228 @@
+"""Tail-split schedule for the 2-D unified attention launch (gfx950 prefill).
+
+Measured on MI355X (256 CU, gfx950) with the gpt-oss-120b shape
+(64 q-heads / 8 kv-heads, d=64, page 64, sinks, 61.4k cached KV):
+
+  q-blocks | workgroups | kernel_unified_attention_2d
+     256   |    2048    |  6.55 ms
+     257   |    2056    |  8.26 ms   (+26%)
+     305   |    2440    |  8.11 ms   (flat all the way from 257)
+
+i.e. ~2048 workgroups are co-resident; anything past that runs as a nearly
+empty extra generation whose few stragglers are latency-bound and cost ~1.6 ms
+regardless of how little work they carry.  TTFT is therefore a staircase in the
+extend length, and a 4-token change can cost 12-26%.
+
+This wrapper splits the launch:
+  * head: the first `nb_full` q-blocks (a whole multiple of the co-residency
+    capacity) go through the unmodified kernel;
+  * tail: the remaining q-blocks run with the KV dimension split NUM_SEGMENTS
+    ways so the straggler work spreads over the whole machine, then the partial
+    (acc, max, expsum) triples are merged by reduce_segments_tail.
+
+It also trims the grid to the q-blocks that actually carry work: with
+breakable prefill CUDA graphs sglang pads the token count up to a capture
+bucket, and the padded q-blocks are launched only to return immediately.
+"""
+
+import os
+
+import torch
+import triton
+
+from aiter.ops.triton._triton_kernels.attention.kr_split import (
+    kernel_unified_attention_2d_split,
+    reduce_segments_tail,
+)
+from aiter.ops.triton._triton_kernels.attention.unified_attention import (
+    kernel_unified_attention_2d,
+)
+from aiter.ops.triton.attention.unified_attention import (
+    select_2d_config,
+    unified_attention as _unified_attention_base,
+    use_2d_kernel,
+)
+from aiter.ops.triton.utils.device_info import get_num_sms
+
+ENABLED = bool(int(os.environ.get("KR_TAILSPLIT", "0")))
+# workgroups co-resident per CU for the BLOCK_M=128 prefill config
+_OCC = int(os.environ.get("KR_TS_OCC", "8"))
+_MAX_SEGMENTS = int(os.environ.get("KR_TS_MAX_SEG", "64"))
+# Below ~8 segments the split tail costs about what the un-split straggler
+# generation costs, and the extra reduce makes it a small net loss (measured
+# crossover at tail ~40-63 q-blocks), so only split a genuinely thin tail.
+_MIN_SEGMENTS = int(os.environ.get("KR_TS_MIN_SEG", "8"))
+_CAP_BLOCKS = int(os.environ.get("KR_TS_CAP_BLOCKS", "0"))
+_TRIM_GRID = bool(int(os.environ.get("KR_TS_TRIM_GRID", "1")))
+_buf_cache = {}
+
+
+def _buffers(nrows, num_segments, head_size_padded, device):
+    key = (nrows, num_segments, head_size_padded, device)
+    buf = _buf_cache.get(key)
+    if buf is None:
+        buf = (
+            torch.empty(
+                nrows, num_segments, head_size_padded, dtype=torch.float32,
+                device=device,
+            ),
+            torch.empty(nrows, num_segments, dtype=torch.float32, device=device),
+            torch.empty(nrows, num_segments, dtype=torch.float32, device=device),
+        )
+        _buf_cache[key] = buf
+    return buf
+
+
+def plan_tail_split(active_blocks, num_kv_heads, cu_count):
+    """Return (nb_full, num_tail_blocks, num_segments) or None."""
+    cap_blocks = _CAP_BLOCKS or (_OCC * cu_count) // num_kv_heads
+    if cap_blocks < 2 or active_blocks <= cap_blocks:
+        return None
+    nb_full = (active_blocks // cap_blocks) * cap_blocks
+    tail = active_blocks - nb_full
+    if tail <= 0:
+        return None
+    seg = min(_MAX_SEGMENTS, max(1, cap_blocks // tail))
+    seg = 1 << (seg.bit_length() - 1)
+    if seg < _MIN_SEGMENTS:
+        return None
+    return nb_full, tail, seg
+
+
+def unified_attention_tailsplit(
+    q, k, v, out, cu_seqlens_q, max_seqlen_q, seqused_k, max_seqlen_k,
+    softmax_scale, causal, window_size, block_table, softcap, q_descale,
+    k_descale, v_descale, q_scales=None, alibi_slopes=None, output_scale=None,
+    qq_bias=None, sinks=None, shuffled_kv_cache: bool = False,
+    skip_reduce: bool = False,
+):
+    def _fallback():
+        return _unified_attention_base(
+            q, k, v, out, cu_seqlens_q, max_seqlen_q, seqused_k, max_seqlen_k,
+            softmax_scale, causal, window_size, block_table, softcap, q_descale,
+            k_descale, v_descale, q_scales=q_scales, alibi_slopes=alibi_slopes,
+            output_scale=output_scale, qq_bias=qq_bias, sinks=sinks,
+            shuffled_kv_cache=shuffled_kv_cache, skip_reduce=skip_reduce,
+        )
+
+    SLIDING_WINDOW = 1 + window_size[0]
+    q_dtype = q.dtype
+    kv_cache_dtype = k.dtype
+    num_tokens, num_query_heads, head_size = q.shape
+    num_seqs = len(seqused_k)
+
+    if (
+        not causal
+        or shuffled_kv_cache
+        or skip_reduce
+        or num_seqs != 1
+        or alibi_slopes is not None
+        or qq_bias is not None
+        or q_scales is not None
+        or output_scale is not None
+        or softcap
+        or SLIDING_WINDOW > 0
+        or int(max_seqlen_q) == 1
+        or q_dtype == torch.uint8
+        or kv_cache_dtype == torch.uint8
+        or k.dim() != 4
+    ):
+        return _fallback()
+
+    num_blocks, block_size, num_kv_heads, _ = k.shape
+    K_WIDTH = 16 if kv_cache_dtype.itemsize == 1 else 8
+    num_queries_per_kv = num_query_heads // num_kv_heads
+
+    BLOCK_M = (
+        16 if num_queries_per_kv <= 16 else triton.next_power_of_2(num_queries_per_kv)
+    )
+    BLOCK_Q = BLOCK_M // num_queries_per_kv
+    cu_count = get_num_sms()
+    total_num_q_blocks = num_tokens // BLOCK_Q + num_seqs
+    if not use_2d_kernel(
+        head_size, SLIDING_WINDOW, False, max_seqlen_q, max_seqlen_k,
+        cu_count * 4, total_num_q_blocks * num_kv_heads,
+    ):
+        return _fallback()
+
+    config = select_2d_config(
+        block_size, head_size, SLIDING_WINDOW, False, max_seqlen_q, max_seqlen_k,
+        num_queries_per_kv, total_num_q_blocks * num_kv_heads, q_dtype,
+        kv_cache_dtype, shuffled_kv_cache,
+    )
+    BLOCK_Q = config["BLOCK_Q"]
+    BLOCK_M = config["BLOCK_M"]
+    total_num_q_blocks = q.shape[0] // BLOCK_Q + num_seqs
+    # q-blocks that actually carry work (the rest are CUDA-graph padding)
+    active_blocks = (int(max_seqlen_q) + BLOCK_Q - 1) // BLOCK_Q
+    active_blocks = min(active_blocks, total_num_q_blocks)
+
+    plan = plan_tail_split(active_blocks, num_kv_heads, cu_count)
+    head_blocks = active_blocks if _TRIM_GRID else total_num_q_blocks
+    if plan is not None:
+        head_blocks, tail, num_segments = plan
+    if head_blocks <= 0:
+        return _fallback()
+
+    head_size_padded = triton.next_power_of_2(head_size)
+
+    kernel_unified_attention_2d[(num_kv_heads, head_blocks)](
+        output_ptr=out, query_ptr=q, key_cache_ptr=k, value_cache_ptr=v,
+        sink_ptr=sinks, block_tables_ptr=block_table, seq_lens_ptr=seqused_k,
+        alibi_slopes_ptr=None, qq_bias_ptr=None, scale=softmax_scale,
+        q_descale_ptr=q_descale, k_descale_ptr=k_descale, v_descale_ptr=v_descale,
+        out_scale_ptr=None, softcap=softcap, num_query_heads=num_query_heads,
+        num_queries_per_kv=num_queries_per_kv,
+        block_table_stride=block_table.stride(0), query_stride_0=q.stride(0),
+        query_stride_1=q.stride(1), output_stride_0=out.stride(0),
+        output_stride_1=out.stride(1), qq_bias_stride_0=0, BLOCK_SIZE=block_size,
+        HEAD_SIZE=head_size, HEAD_SIZE_PADDED=head_size_padded,
+        USE_ALIBI_SLOPES=False, USE_QQ_BIAS=False, USE_SOFTCAP=False,
+        USE_SINKS=(sinks is not None), SLIDING_WINDOW=SLIDING_WINDOW,
+        stride_k_cache_0=k.stride(0), stride_k_cache_1=k.stride(1),
+        stride_k_cache_2=k.stride(2), stride_k_cache_3=k.stride(3),
+        stride_v_cache_0=v.stride(0), stride_v_cache_1=v.stride(1),
+        stride_v_cache_2=v.stride(2), stride_v_cache_3=v.stride(3),
+        query_start_len_ptr=cu_seqlens_q, num_seqs=num_seqs, ALL_DECODE=False,
+        SHUFFLED_KV_CACHE=False, K_WIDTH=K_WIDTH, **config,
+    )
+    if plan is None:
+        return out
+
+    nrows = tail * num_kv_heads * BLOCK_M
+    segm_output, segm_max, segm_expsum = _buffers(
+        nrows, num_segments, head_size_padded, q.device
+    )
+
+    kernel_unified_attention_2d_split[(num_kv_heads, tail, num_segments)](
+        segm_output_ptr=segm_output, segm_max_ptr=segm_max,
+        segm_expsum_ptr=segm_expsum, query_ptr=q, key_cache_ptr=k,
+        value_cache_ptr=v, sink_ptr=sinks, block_tables_ptr=block_table,
+        seq_lens_ptr=seqused_k, scale=softmax_scale, q_descale_ptr=q_descale,
+        k_descale_ptr=k_descale, v_descale_ptr=v_descale,
+        num_query_heads=num_query_heads, num_queries_per_kv=num_queries_per_kv,
+        num_kv_heads=num_kv_heads, block_table_stride=block_table.stride(0),
+        query_stride_0=q.stride(0), query_stride_1=q.stride(1),
+        BLOCK_SIZE=block_size, TILE_SIZE=config["TILE_SIZE"], HEAD_SIZE=head_size,
+        HEAD_SIZE_PADDED=head_size_padded, USE_SINKS=(sinks is not None),
+        stride_k_cache_0=k.stride(0), stride_k_cache_1=k.stride(1),
+        stride_k_cache_2=k.stride(2), stride_k_cache_3=k.stride(3),
+        stride_v_cache_0=v.stride(0), stride_v_cache_1=v.stride(1),
+        stride_v_cache_2=v.stride(2), stride_v_cache_3=v.stride(3),
+        query_start_len_ptr=cu_seqlens_q, BLOCK_Q=BLOCK_Q, num_seqs=num_seqs,
+        BLOCK_M=BLOCK_M, q_block_offset=head_blocks, NUM_SEGMENTS=num_segments,
+        num_warps=config["num_warps"], num_stages=config["num_stages"],
+        waves_per_eu=config["waves_per_eu"],
+    )
+
+    reduce_segments_tail[(nrows,)](
+        output_ptr=out, segm_output_ptr=segm_output, segm_max_ptr=segm_max,
+        segm_expsum_ptr=segm_expsum, query_start_len_ptr=cu_seqlens_q,
+        out_scale_ptr=None, num_seqs=num_seqs, num_query_heads=num_query_heads,
+        num_queries_per_kv=num_queries_per_kv, num_kv_heads=num_kv_heads,
+        output_stride_0=out.stride(0), output_stride_1=out.stride(1),
+        HEAD_SIZE=head_size, HEAD_SIZE_PADDED=head_size_padded, BLOCK_Q=BLOCK_Q,
+        BLOCK_M=BLOCK_M, NUM_SEGMENTS=num_segments, q_block_offset=head_blocks,
+        num_warps=2, num_stages=1,
+    )
+    return out

--- a/aiter/ops/triton/attention/unified_attention.py
+++ b/aiter/ops/triton/attention/unified_attention.py
@@ -359,6 +359,37 @@ def unified_attention(
     shuffled_kv_cache: bool = False,
     skip_reduce: bool = False,
 ):
+    if _KR_TS is not None and _KR_TS.ENABLED:
+        _KR_TS.ENABLED = False
+        try:
+            return _KR_TS.unified_attention_tailsplit(
+                q,
+                k,
+                v,
+                out,
+                cu_seqlens_q,
+                max_seqlen_q,
+                seqused_k,
+                max_seqlen_k,
+                softmax_scale,
+                causal,
+                window_size,
+                block_table,
+                softcap,
+                q_descale,
+                k_descale,
+                v_descale,
+                q_scales=q_scales,
+                alibi_slopes=alibi_slopes,
+                output_scale=output_scale,
+                qq_bias=qq_bias,
+                sinks=sinks,
+                shuffled_kv_cache=shuffled_kv_cache,
+                skip_reduce=skip_reduce,
+            )
+        finally:
+            _KR_TS.ENABLED = True
+
     assert causal, "Only causal attention is supported"
 
     use_alibi_slopes = alibi_slopes is not None
@@ -958,3 +989,9 @@ def _gfx1250_unified_attention_2d(
         NUM_BUFFERS=num_buffers,
         LOOP_VARIANT=loop_variant,
     )
+
+
+try:
+    from aiter.ops.triton.attention import kr_ua as _KR_TS
+except Exception:  # noqa: E722
+    _KR_TS = None


### PR DESCRIPTION
## What

For the 2-D prefill launch of `kernel_unified_attention_2d`, TTFT at moderate query counts is a step function of the workgroup count: ~2048 workgroups are co-resident on a 256-CU gfx950 (8/CU at the BLOCK_M=128 / 4-warp prefill config), and everything past a whole multiple runs as a nearly empty extra generation whose stragglers are latency-bound — a flat ~1.6 ms per layer regardless of how little work they carry. Measured on MI355X (GQA 8, head_dim 64, 61k paged KV, sinks): extend 4094 → 6.59 ms/layer; extend 4098 → 8.28 ms/layer (+26% for 4 tokens).

This adds a planner (default off, `KR_TAILSPLIT=1`) that runs the first whole multiple of the co-residency capacity through the **unmodified** kernel and splits only the thin remainder across KV segments (`kernel_unified_attention_2d_split` + `reduce_segments_tail`, sinks carried by segment 0). Sliding-window, all-decode, multi-seq, alibi/softcap, shuffled/uint8-KV shapes, and near-full tails (`MIN_SEG` guard) fall back bit-for-bit to the existing path. One subtlety worth reviewers' attention: the planner sizes the grid from `cdiv(max_seqlen_q, BLOCK_Q)`, not `q.shape[0]`, because callers that pad the token buffer (e.g. CUDA-graph capture buckets) otherwise inflate the plan with do-nothing blocks.

## Measured (MI355X gfx950, gpt-oss-120b, 4k-token extends over 61k cached KV)

- Boundary step 4094→4098: 25.5% → **0.08%**.
- Serving cc1 (sglang, 200 prompts): TTFT mean −6.1%, median −9.3%, P99 −8.7%; the bimodal TTFT distribution collapses (mean == median). At cc2 in the full config stack: −8–9%.
- Numerics: max_abs 1.22e-4 at the boundary shape, exactly 0.0 wherever the fallback engages; end-to-end gsm8k paired delta +0.015 (n=200).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
