### PR TITLE
[Config] gptoss bf16 tuned gemm: drop the losing large-M QKV rows on gfx950 (tuned rows lose 16-27% to the hipBLASLt fallback)

### DIFF
--- a/aiter/configs/model_configs/gptoss_bf16_tuned_gemm.csv
+++ b/aiter/configs/model_configs/gptoss_bf16_tuned_gemm.csv
@@ -111,9 +111,6 @@ gfx950,256,320,5120,2880,True,torch.bfloat16,torch.bfloat16,False,False,flydsl,2
 gfx950,256,512,5120,2880,True,torch.bfloat16,torch.bfloat16,False,False,flydsl,1062,1,27.0753,flydsl_gemm3_abf16_wbf16_bf16_t128x64x64_split_k1_block_m_warp4_block_n_warp1_block_k_warp1_async_copyTrue_b_to_ldsTrue_b_preshuffleFalse_c_to_ldsFalse_gfx950,0.0,557.69,1391.79
 gfx950,256,1024,5120,2880,True,torch.bfloat16,torch.bfloat16,False,False,flydsl,792,1,45.3827,flydsl_gemm2_abf16_wbf16_bf16_t96x128x64_split_k1_block_m_warp2_block_n_warp2_block_k_warp1_async_copyTrue_b_to_ldsTrue_b_preshuffleFalse_c_to_ldsFalse_gfx950,0.0,665.43,1010.85
 gfx950,256,2048,5120,2880,True,torch.bfloat16,torch.bfloat16,False,False,flydsl,1796,1,88.1229,flydsl_gemm4_abf16_wbf16_bf16_t128x128x64_split_k1_block_m_warp4_block_n_warp2_block_k_warp1_async_copyTrue_b_to_ldsTrue_b_preshuffleFalse_c_to_ldsFalse_gfx950,0.0,685.38,706.5
-gfx950,256,4096,5120,2880,True,torch.bfloat16,torch.bfloat16,False,False,flydsl,1167,1,140.9515,flydsl_gemm3_abf16_wbf16_bf16_t256x128x64_split_k1_block_m_warp4_block_n_warp2_block_k_warp2_async_copyTrue_b_to_ldsTrue_b_preshuffleFalse_c_to_ldsFalse_gfx950,0.0042,857.0,674.18
-gfx950,256,8192,5120,2880,True,torch.bfloat16,torch.bfloat16,False,False,flydsl,1167,1,240.8619,flydsl_gemm3_abf16_wbf16_bf16_t256x128x64_split_k1_block_m_warp4_block_n_warp2_block_k_warp2_async_copyTrue_b_to_ldsTrue_b_preshuffleFalse_c_to_ldsFalse_gfx950,0.0042,1003.03,666.62
-gfx950,256,16384,5120,2880,True,torch.bfloat16,torch.bfloat16,False,False,triton,0,0,443.3406,auto,0.0,1089.87,657.81
 gfx950,256,1,201088,2880,False,torch.bfloat16,torch.bfloat16,False,False,triton,0,0,175.9884,auto,0.0,6.58,6583.81
 gfx950,256,2,201088,2880,False,torch.bfloat16,torch.bfloat16,False,False,triton,0,0,175.4143,auto,0.0,13.21,6607.69
 gfx950,256,4,201088,2880,False,torch.bfloat16,torch.bfloat16,False,False,triton,0,0,172.8587,auto,0.0,26.8,6710.1


### PR DESCRIPTION
## What

The gfx950 rows in `gptoss_bf16_tuned_gemm.csv` for the gpt-oss QKV projection shape (N=5120, K=2880, bias) at M=4096/8192/16384 pick kernels that lose to the plain hipBLASLt fallback on MI355X:

| M (lookup) | tuned pick | hipBLASLt (`torch.addmm`) | Δ |
|---|---|---|---|
| 61366 → 8192 row | flydsl, 1.744 ms | 1.271 ms | −27% |
| 4065 → 4096 row | flydsl | | −16.5% |
| 16384 row | "triton auto" | | −22% |

The o-projection shape — which has **no** tuned row — already runs at 93% of the measured 1424 TF/s GEMM ceiling through the same fallback, which is the tell. Delete the three rows so large-M lookups fall through to hipBLASLt; the small-M decode rows (M ≤ 64) keep flydsl, which wins there (+11.5% at M=64).

Verified on MI355X: the shapes take the hipBLASLt path with outputs identical to `torch.addmm` (max_abs 0.0), worth ~16 ms/request on a 61k-token gpt-oss prefill (36 launches). Suggests a broader guard for the tuning flow: reject a candidate row at table-generation time if it does not beat the untuned fallback for that shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
