### PR TITLE
[OPUS] [Perf] Avoid zero-initializing the MoE Stage1 scale workspace

### DIFF
--- a/aiter/ops/opus/moe_stage1_a8w4.py
+++ b/aiter/ops/opus/moe_stage1_a8w4.py
@@ -87,7 +87,8 @@ def _make_out_scale(
     padded_rows = (sorted_size + 255) // 256 * 256
     scale_cols = inter_dim // _OPUS_MOE_STAGE1_A8W4_SCALE_GROUP
     padded_cols = (scale_cols + 7) // 8 * 8
-    return torch.zeros(
+    # Stage1 writes every valid-route scale, and Stage2 discards padding-route results.
+    return torch.empty(
         (padded_rows, padded_cols),
         dtype=torch.float8_e8m0fnu,
         device=sorted_token_ids.device,


### PR DESCRIPTION

## Motivation

OPUS MoE Stage1 allocated its aligned output-scale workspace with `torch.zeros` on every invocation. This launched an E8M0 elementwise fill kernel even though Stage1 overwrites every scale associated with a valid route and Stage2 discards results from padding routes.

For the DeepSeek-V4 workload, the aligned workspace has shape `(12288, 16)`. Zero-initializing it costs about 5 us per invocation and places a repeated fill kernel on the decode critical path. The goal of this PR is to remove that unnecessary initialization without changing the workspace layout, dtype, routing behavior, or kernel interfaces.

## Technical Details

- Change `_make_out_scale` in [`aiter/ops/opus/moe_stage1_a8w4.py`](https://github.com/ROCm/aiter/blob/opus_moe1_optimize/aiter/ops/opus/moe_stage1_a8w4.py) from `torch.zeros` to `torch.empty`.
- Preserve the existing 256-row and 8-column alignment, `torch.float8_e8m0fnu` dtype, device placement, and tensor shape.
- Stage1 writes every scale consumed by a valid route. Stage2 may load values for padding routes as part of tiled execution, but those lanes are discarded before output is committed.
- No HIP kernel, launch configuration, public API, or model configuration is changed.

## Test Plan

- Stress the padding region with `0x00`, `0x7F`, `0xFE`, `0xFF`, and random byte patterns, then compare valid Stage1 and Stage2 outputs bit for bit.
- Force allocator reuse from buffers prefilled with `0xFF` and `0xFE` before exercising the actual `torch.empty` path.
- Run the tuned DeepSeek-V4 fused-MoE operator for token counts 1 and 2, including strict accuracy checks and five alternating baseline/optimized performance runs.
- Run DeepSeek-V4-Pro end to end with TP8 using the latest ATOM main branch, including:
  - low-concurrency and concurrency-64 serving benchmarks;
  - the complete 1,319-sample GSM8K 5-shot evaluation;
  - Kineto traces from all eight ranks for a 128-token prefill followed by eight decode tokens.

Test environment:

- Architecture: gfx950, 8 GPUs
- ATOM commit: `cd161f16bd041b63bc3bc4f234f3d1915a80200d`
- Image: `rocm/atom-dev@sha256:1cd6abf29958cf0c332041b945249f7303ac86a36352f976b26d844ad72b4f5c`
- PyTorch: `2.10.0+rocm7.2.4.git3d3aa833`

## Test Result

Single-operator correctness passed:

- Valid outputs remained bitwise identical for every padding pattern tested, including the E8M0 NaN encoding `0xFF`.
- The real `torch.empty` path remained bitwise identical after forced allocator reuse from `0xFF`- and `0xFE`-prefilled buffers.
- The tuned DeepSeek-V4 token-count 1 and 2 strict accuracy tests passed with no NaNs.

Single-operator performance:

| Test | Before (`torch.zeros`) | After (`torch.empty`) | Result |
| --- | ---: | ---: | ---: |
| Scale allocation, shape `(12288, 16)` | 5.033 us | 1.681 us | -3.352 us (-66.6%) |
| Fused MoE, 1 token | 37.40 us | 35.42 us | 1.056x speedup |
| Fused MoE, 2 tokens | 41.61 us | 39.12 us | 1.064x speedup |

Full-model trace comparison:

| E8M0 `FillFunctor` metric | Before | After |
| --- | ---: | ---: |
| Calls per rank | 488 | 0 |
| Calls across 8 ranks | 3,904 | 0 |
| Average duration per call | 5.017 us | 0 |
| Summed GPU duration across 8 ranks | 19.586 ms | 0 |

The target `vectorized_elementwise_kernel<..., FillFunctor<c10::Float8_e8m0fnu>, ...>` was completely removed from all eight optimized traces. The summed duration above is an arithmetic sum across parallel ranks, not wall-clock latency.

End-to-end validation:

| Test | Before | After | Notes |
| --- | ---: | ---: | --- |
| GSM8K 5-shot strict/flexible exact match | 0.9522 | 0.9553 | All 1,319 requests completed |
| TP8, concurrency 1, P50 TPOT | 14.766 ms | 14.562 ms | 1.38% lower |
| TP8, concurrency 64, P50 TPOT | 20.950 ms | 20.805 ms | 0.48% lower |
<img width="1200" height="209" alt="image" src="https://github.com/user-attachments/assets/ac38bf4c-c554-4bf5-859c-59f807e5f632" />

The concurrent full-model runs showed noticeable run-to-run and tail-latency noise, so they are not used to claim a stable end-to-end throughput improvement. The deterministic result of this change is the complete removal of the targeted E8M0 fill launches. GSM8K showed no aggregate accuracy regression; concurrent serving was not byte-deterministic between runs, with 1,291 of 1,319 extracted answers matching and a net gain of four correct answers in the optimized run.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
