### PR TITLE
[HIP] fix(sampling): drop unused out_idx workspace in topk_renorm_from_probs

### DIFF
--- a/csrc/cpp_itfs/sampling/sampling.cuh
+++ b/csrc/cpp_itfs/sampling/sampling.cuh
@@ -1423,8 +1423,9 @@ static void topk_renorm_from_probs(
 
     size_t pivot_bytes      = (size_t)batch_size * sizeof(float);
     size_t normalizer_bytes = (size_t)batch_size * sizeof(float);
-    size_t out_idx_bytes    = (size_t)batch_size * max_k * sizeof(int);
-    size_t total_bytes = radix_buf_size + pivot_bytes + normalizer_bytes + out_idx_bytes;
+    // No out_idx: unused here, and unsafe -- the kernel strides it by max_k but
+    // bounds writes by the per-row k, so k > max_k ran past the workspace.
+    size_t total_bytes = radix_buf_size + pivot_bytes + normalizer_bytes;
 
     static void* s_workspace = nullptr;
     static size_t s_workspace_size = 0;
@@ -1437,12 +1438,11 @@ static void topk_renorm_from_probs(
     char* ptr = static_cast<char*>(s_workspace);
     void*  radix_buf  = ptr;                             ptr += radix_buf_size;
     float* pivot_buf  = reinterpret_cast<float*>(ptr);   ptr += pivot_bytes;
-    float* norm_buf   = reinterpret_cast<float*>(ptr);   ptr += normalizer_bytes;
-    int*   out_idx    = reinterpret_cast<int*>(ptr);
+    float* norm_buf   = reinterpret_cast<float*>(ptr);
 
     radix_topk::standalone_stable_radix_10bits<float, int, false>(
         radix_buf, radix_buf_size, probs, batch_size, (int64_t)vocab_size,
-        nullptr, nullptr, max_k, nullptr, out_idx, true, stream, 0,
+        nullptr, nullptr, max_k, nullptr, nullptr, true, stream, 0,
         pivot_buf, norm_buf, top_k_arr);
 
     constexpr int BT = 1024;

--- a/op_tests/test_sampling.py
+++ b/op_tests/test_sampling.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: MIT
 # Copyright (C) 2025, Advanced Micro Devices, Inc. All rights reserved.
 
+import subprocess
+import sys
 import warnings
 
 import pytest
@@ -69,6 +71,90 @@ def test_top_k_renorm_probs(batch_size, vocab_size, k):
             rtol=1e-3,
             atol=1e-3,
         )
+
+
+@pytest.mark.parametrize("batch_size", [2, 19, 99])
+@pytest.mark.parametrize("vocab_size", [500, 32000, 128256])
+def test_top_k_renorm_probs_per_row_k(batch_size, vocab_size):
+    """Per-row top-k tensor: small k, k > 50, and disabled (k == vocab_size).
+
+    Only the scalar overload was covered, and it is the one case where the
+    host-side `max_k` always equals the per-row k. A tensor sends
+    `top_k_val = 0`, which falls back to `max_k = 50`.
+    """
+    torch.manual_seed(42)
+    pre_norm_prob = torch.rand(batch_size, vocab_size).to(0)
+    normalized_prob = pre_norm_prob / pre_norm_prob.sum(dim=-1, keepdim=True)
+
+    choices = [10, 100, vocab_size]
+    k_arr = torch.tensor(
+        [choices[i % len(choices)] for i in range(batch_size)], dtype=torch.int32
+    )
+
+    sorted_prob, _ = torch.sort(normalized_prob, descending=True)
+    renorm_prob_ground_truth = normalized_prob.clone()
+    for i in range(batch_size):
+        k = int(k_arr[i])
+        if k < vocab_size:
+            pivot = sorted_prob[i, k - 1]
+            renorm_prob_ground_truth[i][normalized_prob[i] < pivot] = 0
+    renorm_prob_ground_truth = renorm_prob_ground_truth / renorm_prob_ground_truth.sum(
+        dim=-1, keepdim=True
+    )
+
+    renorm_prob = torch.ops.aiter.top_k_renorm_probs(
+        normalized_prob, *_to_tensor_scalar_tuple(k_arr)
+    )
+    for i in range(batch_size):
+        torch.testing.assert_close(
+            renorm_prob_ground_truth[i],
+            renorm_prob[i],
+            rtol=1e-3,
+            atol=1e-3,
+        )
+
+
+# Runs in a child process: the workspace is a function-local `static`, malloc'd
+# once per process, so a process that already called this op is a spent trial.
+_MIXED_TOP_K_BATCH = """
+import torch
+from aiter.ops import sampling  # noqa: F401
+
+torch.set_default_device("cuda")
+
+vocab_size = {vocab_size}
+probs = torch.rand(2, vocab_size)
+probs = probs / probs.sum(dim=-1, keepdim=True)
+
+# One request setting top_k, one leaving it disabled: the mixture vLLM
+# produces when both land in the same sampler batch.
+top_k_arr = torch.tensor([50, vocab_size], dtype=torch.int32)
+out = torch.ops.aiter.top_k_renorm_probs(probs, top_k_arr, 0)
+torch.cuda.synchronize()
+assert torch.isfinite(out).all()
+"""
+
+
+def test_top_k_renorm_probs_mixed_batch_does_not_fault():
+    """Regression guard for the out-of-bounds workspace write.
+
+    The overrun runs off the end, past everything that is read back, so the
+    values stay correct and there is nothing to assert but survival. The vocab
+    is oversized on purpose: at ~160K the ~640 KB overrun usually hides in the
+    allocator's 2 MB slack, while 1M puts it ~4 MB out. MI355X: 5/5 fresh
+    processes abort before the fix, 6/6 pass after.
+    """
+    proc = subprocess.run(
+        [sys.executable, "-c", _MIXED_TOP_K_BATCH.format(vocab_size=1 << 20)],
+        capture_output=True,
+        text=True,
+        timeout=900,
+        check=False,
+    )
+    assert proc.returncode == 0, (
+        f"top_k_renorm_probs faulted on a mixed top-k batch, k = [50, {1 << 20}]\n"
+        f"stdout:\n{proc.stdout}\nstderr:\n{proc.stderr}"
+    )
 
 
 @pytest.mark.parametrize("batch_size", [1, 19, 99, 989])


### PR DESCRIPTION
## Motivation

`top_k_renorm_probs` writes out of bounds on any sampler batch that mixes a request setting `top_k` with one that does not. This crashes vLLM serving Kimi-K3 on MI355X with `Memory access fault by GPU node-N`, one fault per TP rank. No unusual flags are needed - two ordinary concurrent requests are enough.

At a production vocab the same write usually does *not* fault: the overrun is ~640 KB, which typically lands inside the allocator's 2 MB rounding slack and corrupts silently instead. The write happens on **every** mixed-`top_k` batch; only the crash is probabilistic. An absence of reported crashes is therefore not evidence that the bug is absent.

## Technical Details

The op takes `(probs, maybe_top_k_arr, top_k_val)`. Per the convention this repo's own tests use (`_to_tensor_scalar_tuple` in `op_tests/test_sampling.py`), passing a per-row tensor sends `top_k_val = 0`, so the host wrapper falls back to a hardcoded `max_k`:

```cpp
int max_k = top_k_val;                                            // sampling.cuh:1414
if (max_k <= 0) max_k = 50;                                       // :1415
size_t out_idx_bytes = (size_t)batch_size * max_k * sizeof(int);  // :1426
```

`radix_topk_one_block_kernel` then takes its stride from that host scalar but its bound from the per-row array:

```cpp
const IdxT k_actual = (top_k_arr != nullptr) ? top_k_arr[batch_id] : k;  // :458
if (out_idx) out_idx += batch_id * k;                                   // :474  stride = max_k = 50
...
out_idx[i] = i < row_len ? i + rowStart : -1;   // bounded by k_actual  // :480
```

Any row with `k > 50` overruns its 50-int slot. vLLM encodes "top_k disabled" as `k = vocab_size`, so such a row takes the `row_len <= k_actual` branch at `:477` and writes `vocab_size` ints - 163840 for Kimi-K3, ~640 KB - into a 200-byte slot, running off the ee
nd of the workspace.

The fix is to stop allocating and passing that buffer. `out_idx` has no consumer on this path: the only downstream reader is `TopKRenormWriteOnlyKernel(probs, pivot_buf, norm_buf, renormed_probs, vocab_size)` at `:1450`, which takes no indices. Every `out_idx` store is already null-guarded, and `WRITE_TOPK_VALUES` is `false` here, so the value store nested inside the `if (out_idx)` guard at `:481` is compiled out regardless - no writes are lost. `max_k` still drives `k_actual` correctly on the scalar path, which is unaffected.

Present since #3217.

## Test Plan

Two tests added to `op_tests/test_sampling.py`:

- `test_top_k_renorm_probs_per_row_k` - per-row tensor path, mixing `k=10`, `k=100` and `k=vocab_size`. The existing `test_top_k_renorm_probs` only ever passes a Python `int`, taking the scalar path where `max_k == k_actual` and the indexing is exactly in bounds. Thh
e tensor overload had no coverage at all, which is why CI never caught this.
- `test_top_k_renorm_probs_mixed_batch_does_not_fault` - regression guard for `k = [50, vocab_size]`. Runs in a child process, because the workspace is a per-process `static` allocated on first call, so a process that has already called the op is a spent trial. Usess
 a 1M vocab to put the overrun ~4 MB past the end, clearing the 2 MB slack so it faults deterministically rather than flaking.

Reproduction note: `not_built()` (`csrc/cpp_itfs/utils.py:297`) keys the JIT cache on `lib.so` existing, and the folder name is the md5 of the kwargs - empty for this op - so editing `sampling.cuh` silently reuses a stale binary. Use a fresh `AITER_ROOT_DIR` whee
n comparing before and after.

## Test Result

MI355X (gfx950), ROCm 7.2, torch 2.10:

- Regression guard, unpatched: **5/5** fresh processes abort with `Memory access fault by GPU node-N` at a 2 MB-aligned address. Patched: **6/6** pass.
- At vocab 163840 the unpatched build survived, confirming the silent-corruption case described above.
- Full `op_tests/test_sampling.py` on the patched build: **358 passed, 4 skipped**.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
