### PR TITLE
[CI] CI: respect docker login input in release builds

### DIFF
--- a/.github/workflows/aiter-release.yaml
+++ b/.github/workflows/aiter-release.yaml
@@ -167,11 +167,11 @@ jobs:
       USE_MANYLINUX: ${{ inputs.use_manylinux || github.event.inputs.use_manylinux || (startsWith(matrix.docker_image, 'pytorch/manylinux') && 'true') || 'false' }}
       TORCH_PIN: ${{ inputs.torch_pin || '' }}
       TORCH_INDEX_URL: ${{ inputs.torch_index_url || '' }}
-      DOCKER_USERNAME_SECRET: ${{ (github.event_name == 'workflow_dispatch' || inputs.docker_login) && needs.ci_config.outputs.docker_username_secret || '' }}
-      DOCKER_PASSWORD_SECRET: ${{ (github.event_name == 'workflow_dispatch' || inputs.docker_login) && needs.ci_config.outputs.docker_password_secret || '' }}
+      DOCKER_USERNAME_SECRET: ${{ inputs.docker_login && needs.ci_config.outputs.docker_username_secret || '' }}
+      DOCKER_PASSWORD_SECRET: ${{ inputs.docker_login && needs.ci_config.outputs.docker_password_secret || '' }}
       BUILD_REF: ${{ inputs.commit || github.event.inputs.commit || '' }}
       ARTIFACT_SUFFIX: ${{ inputs.artifact_suffix || '' }}
-      DOCKER_LOGIN: ${{ github.event_name == 'workflow_dispatch' || inputs.docker_login }}
+      DOCKER_LOGIN: ${{ inputs.docker_login }}
 
     steps:
       - name: Checkout aiter repo


### PR DESCRIPTION
## Summary
- Add an explicit `docker_login` input to the direct Aiter Release Package manual workflow.
- Stop treating every `workflow_dispatch` event as an implicit Docker login request.
- Only configure Docker Hub secret names and run Docker login when `inputs.docker_login` is true.

This fixes release automation manual runs where the caller passes `docker_login: false`, but the reusable workflow previously converted it back to true because the caller event was `workflow_dispatch`.

## Test plan
- python3 -c "import yaml; yaml.safe_load(open('.github/workflows/aiter-release.yaml')); print('yaml ok')"
- git diff --check