### PR TITLE
[Bugfix] Make `_fold_seqlen_indptr` cudagraph-safe (avoid scalar H2D copy)

### DIFF
--- a/aiter/mla.py
+++ b/aiter/mla.py
@@ -402,13 +402,8 @@ def _fold_seqlen_indptr(indptr, fold_factor):
     """Repeat each batch's seqlen ``fold_factor`` times (head-folding pseudo-batches)."""
     lens = indptr[1:] - indptr[:-1]
     folded_lens = lens.repeat_interleave(fold_factor)
-    out = torch.empty(
-        indptr.shape[0] + (fold_factor - 1) * (indptr.shape[0] - 1),
-        dtype=indptr.dtype,
-        device=indptr.device,
-    )
-    out[0] = 0
-    out[1:] = torch.cumsum(folded_lens, dim=0).to(indptr.dtype)
+    cumsum = torch.cumsum(folded_lens, dim=0).to(indptr.dtype)
+    out = torch.nn.functional.pad(cumsum, (1, 0), value=0)
     return out
 
 

--- a/op_tests/test_mla_persistent.py
+++ b/op_tests/test_mla_persistent.py
@@ -93,6 +93,72 @@ def check_support(dtype, kv_dtype, nhead):
     return not (dtype == dtypes.bf16 and nhead == 32 and get_gfx() == "gfx942")
 
 
+def test_fold_seqlen_indptr_cuda_graph_capture(fold_factor, num_batches=(1, 8, 37)):
+    """Regression test: _fold_seqlen_indptr must be safe to capture into a
+    CUDA graph.
+
+    mla_decode_fwd's nhead-folding branch (nhead in range(32, 128+1, 16),
+    persistent_mode) calls _fold_seqlen_indptr to build the folded qo/kv
+    indptrs. It used to build its output with:
+        out = torch.empty(...)
+        out[0] = 0
+        out[1:] = torch.cumsum(...)
+    `out[0] = 0` assigns a Python scalar into a CUDA tensor, which lowers
+    to an unpinned host->device copy -- illegal while a CUDA graph is
+    being captured. Real callers (e.g. vLLM) capture this exact branch
+    during CUDA-graph warmup/memory-profiling, so this crashed in
+    production despite passing eager-mode-only accuracy tests.
+
+    This captures the helper directly (with the documented side-stream
+    warmup prerequisite for torch.cuda.graph()), replays with DIFFERENT
+    indptr contents than were captured, and checks the replayed result
+    against an eager-mode reference -- following the same pattern as
+    test_moe_sorting_flydsl_cuda_graph_capture (itself a regression test
+    for an analogous .item()/host-copy capture-safety bug).
+    """
+    device = "cuda"
+    dtype = torch.int32  # matches qo_indptr/kv_indptr dtype used in practice
+
+    def make_indptr(batch_size, seed):
+        g = torch.Generator(device=device).manual_seed(seed)
+        seqlens = torch.randint(0, 4096, (batch_size,), device=device, generator=g)
+        indptr = torch.zeros(batch_size + 1, dtype=dtype, device=device)
+        indptr[1:] = torch.cumsum(seqlens, dim=0).to(dtype)
+        return indptr
+
+    for batch_size in num_batches:
+        capture_indptr = make_indptr(batch_size, seed=0)
+
+        # Standard torch.cuda.graph() prerequisite: warm up on a side stream.
+        warmup_stream = torch.cuda.Stream()
+        warmup_stream.wait_stream(torch.cuda.current_stream())
+        with torch.cuda.stream(warmup_stream):
+            for _ in range(3):
+                aiter.mla._fold_seqlen_indptr(capture_indptr, fold_factor)
+        torch.cuda.current_stream().wait_stream(warmup_stream)
+        torch.cuda.synchronize()
+
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph):
+            out = aiter.mla._fold_seqlen_indptr(capture_indptr, fold_factor)
+        torch.cuda.synchronize()
+
+        # Replay with different *contents* at the same address -- indptr is
+        # captured by reference, so mutating it (not the tensor object) is
+        # what a real decode step does across replays with a new batch.
+        replay_indptr = make_indptr(batch_size, seed=1)
+        capture_indptr.copy_(replay_indptr)
+        graph.replay()
+        torch.cuda.synchronize()
+
+        ref = aiter.mla._fold_seqlen_indptr(replay_indptr, fold_factor)
+        assert torch.equal(out, ref), (
+            f"_fold_seqlen_indptr cuda-graph replay mismatch "
+            f"(fold_factor={fold_factor}, batch_size={batch_size}): "
+            f"captured/replayed={out}, eager_ref={ref}"
+        )
+
+
 def init_3buffer_kv_cache(
     num_page: int,
     page_size: int,
@@ -2080,3 +2146,18 @@ for nhead, decode_qlen in args.nhead:
     # df.to_csv(f"mla_nhead{nhead}decode_qlen{decode_qlen}.csv")
     df_md = df.to_markdown(index=False)
     aiter.logger.info("mla_persistent summary (markdown):\n%s", df_md)
+
+# CUDA-graph capture-safety regression check for the nhead-folding branch
+# (nhead in range(32, 128+1, 16), persistent_mode) -- runs for whichever fold
+# factors the requested -n/--nhead configs actually exercise.
+tested_fold_factors = sorted(
+    {nhead // 16 for nhead, _ in args.nhead if nhead in range(32, 128 + 1, 16)}
+)
+for fold_factor in tested_fold_factors:
+    test_fold_seqlen_indptr_cuda_graph_capture(fold_factor)
+if tested_fold_factors:
+    aiter.logger.info(
+        "_fold_seqlen_indptr cuda-graph capture/replay: all passed "
+        "(fold_factor=%s)",
+        tested_fold_factors,
+    )

--- a/op_tests/test_mla_persistent.py
+++ b/op_tests/test_mla_persistent.py
@@ -93,70 +93,22 @@ def check_support(dtype, kv_dtype, nhead):
     return not (dtype == dtypes.bf16 and nhead == 32 and get_gfx() == "gfx942")
 
 
-def test_fold_seqlen_indptr_cuda_graph_capture(fold_factor, num_batches=(1, 8, 37)):
-    """Regression test: _fold_seqlen_indptr must be safe to capture into a
-    CUDA graph.
+def check_fold_seqlen_indptr_cuda_graph_capture():
+    """_fold_seqlen_indptr must be capturable into a CUDA graph (see PR desc)."""
+    indptr = torch.zeros(9, dtype=torch.int32, device="cuda")
+    indptr[1:] = torch.cumsum(
+        torch.randint(0, 4096, (8,), dtype=torch.int32, device="cuda"), dim=0
+    )
 
-    mla_decode_fwd's nhead-folding branch (nhead in range(32, 128+1, 16),
-    persistent_mode) calls _fold_seqlen_indptr to build the folded qo/kv
-    indptrs. It used to build its output with:
-        out = torch.empty(...)
-        out[0] = 0
-        out[1:] = torch.cumsum(...)
-    `out[0] = 0` assigns a Python scalar into a CUDA tensor, which lowers
-    to an unpinned host->device copy -- illegal while a CUDA graph is
-    being captured. Real callers (e.g. vLLM) capture this exact branch
-    during CUDA-graph warmup/memory-profiling, so this crashed in
-    production despite passing eager-mode-only accuracy tests.
+    warmup_stream = torch.cuda.Stream()
+    warmup_stream.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(warmup_stream):
+        aiter.mla._fold_seqlen_indptr(indptr, 3)
+    torch.cuda.current_stream().wait_stream(warmup_stream)
+    torch.cuda.synchronize()
 
-    This captures the helper directly (with the documented side-stream
-    warmup prerequisite for torch.cuda.graph()), replays with DIFFERENT
-    indptr contents than were captured, and checks the replayed result
-    against an eager-mode reference -- following the same pattern as
-    test_moe_sorting_flydsl_cuda_graph_capture (itself a regression test
-    for an analogous .item()/host-copy capture-safety bug).
-    """
-    device = "cuda"
-    dtype = torch.int32  # matches qo_indptr/kv_indptr dtype used in practice
-
-    def make_indptr(batch_size, seed):
-        g = torch.Generator(device=device).manual_seed(seed)
-        seqlens = torch.randint(0, 4096, (batch_size,), device=device, generator=g)
-        indptr = torch.zeros(batch_size + 1, dtype=dtype, device=device)
-        indptr[1:] = torch.cumsum(seqlens, dim=0).to(dtype)
-        return indptr
-
-    for batch_size in num_batches:
-        capture_indptr = make_indptr(batch_size, seed=0)
-
-        # Standard torch.cuda.graph() prerequisite: warm up on a side stream.
-        warmup_stream = torch.cuda.Stream()
-        warmup_stream.wait_stream(torch.cuda.current_stream())
-        with torch.cuda.stream(warmup_stream):
-            for _ in range(3):
-                aiter.mla._fold_seqlen_indptr(capture_indptr, fold_factor)
-        torch.cuda.current_stream().wait_stream(warmup_stream)
-        torch.cuda.synchronize()
-
-        graph = torch.cuda.CUDAGraph()
-        with torch.cuda.graph(graph):
-            out = aiter.mla._fold_seqlen_indptr(capture_indptr, fold_factor)
-        torch.cuda.synchronize()
-
-        # Replay with different *contents* at the same address -- indptr is
-        # captured by reference, so mutating it (not the tensor object) is
-        # what a real decode step does across replays with a new batch.
-        replay_indptr = make_indptr(batch_size, seed=1)
-        capture_indptr.copy_(replay_indptr)
-        graph.replay()
-        torch.cuda.synchronize()
-
-        ref = aiter.mla._fold_seqlen_indptr(replay_indptr, fold_factor)
-        assert torch.equal(out, ref), (
-            f"_fold_seqlen_indptr cuda-graph replay mismatch "
-            f"(fold_factor={fold_factor}, batch_size={batch_size}): "
-            f"captured/replayed={out}, eager_ref={ref}"
-        )
+    with torch.cuda.graph(torch.cuda.CUDAGraph()):
+        aiter.mla._fold_seqlen_indptr(indptr, 3)
 
 
 def init_3buffer_kv_cache(
@@ -2147,17 +2099,6 @@ for nhead, decode_qlen in args.nhead:
     df_md = df.to_markdown(index=False)
     aiter.logger.info("mla_persistent summary (markdown):\n%s", df_md)
 
-# CUDA-graph capture-safety regression check for the nhead-folding branch
-# (nhead in range(32, 128+1, 16), persistent_mode) -- runs for whichever fold
-# factors the requested -n/--nhead configs actually exercise.
-tested_fold_factors = sorted(
-    {nhead // 16 for nhead, _ in args.nhead if nhead in range(32, 128 + 1, 16)}
-)
-for fold_factor in tested_fold_factors:
-    test_fold_seqlen_indptr_cuda_graph_capture(fold_factor)
-if tested_fold_factors:
-    aiter.logger.info(
-        "_fold_seqlen_indptr cuda-graph capture/replay: all passed "
-        "(fold_factor=%s)",
-        tested_fold_factors,
-    )
+if __name__ == "__main__":
+    check_fold_seqlen_indptr_cuda_graph_capture()
+    aiter.logger.info("_fold_seqlen_indptr cuda-graph capture: passed")


### PR DESCRIPTION
## Motivation

This PR fixes a bug in `_fold_seqlen_indptr` (introduced in #4964) in which the function is not cudagraph safe as it can trigger a H2D transfer.

## Technical Details

`_fold_seqlen_indptr` does:
```
out = torch.empty(..., device=indptr.device)
out[0] = 0
out[1:] = torch.cumsum(folded_lens, dim=0).to(indptr.dtype)
```

`out[0] = 0` is unsafe during cuda graph capture as it can be lowered to an H2D copy, resulting in `operation not permitted when stream is capturing`.

## Test Plan

This was first exposed in vLLM CI when running the following test on MI300 `HIP_VISIBLE_DEVICES=0 pytest -v -s tests/v1/e2e/spec_decode/eagle/test_eagle_correctness.py::test_eagle_correctness_light[ROCM_AITER_FA-deepseek_eagle]` 
https://buildkite.com/vllm/amd-ci/builds/12434/list?jid=01a05932-e4b1-4cd7-90df-6cefc7be92f9&tab=output#L1820
```
(EngineCore pid=7775) ERROR 08-31 19:15:40 [core.py:1374]   File "/usr/local/lib/python3.12/dist-packages/vllm/_aiter_ops.py", line 2731, in mla_decode_fwd
(EngineCore pid=7775) ERROR 08-31 19:15:40 [core.py:1374]     torch.ops.vllm.rocm_aiter_mla_decode_fwd(
(EngineCore pid=7775) ERROR 08-31 19:15:40 [core.py:1374]   File "/usr/local/lib/python3.12/dist-packages/torch/_ops.py", line 1275, in __call__
(EngineCore pid=7775) ERROR 08-31 19:15:40 [core.py:1374]     return self._op(*args, **kwargs)
(EngineCore pid=7775) ERROR 08-31 19:15:40 [core.py:1374]            ^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=7775) ERROR 08-31 19:15:40 [core.py:1374]   File "/usr/local/lib/python3.12/dist-packages/vllm/_aiter_ops.py", line 604, in _rocm_aiter_mla_decode_fwd_impl
(EngineCore pid=7775) ERROR 08-31 19:15:40 [core.py:1374]     mla_decode_fwd(
(EngineCore pid=7775) ERROR 08-31 19:15:40 [core.py:1374]   File "/usr/local/lib/python3.12/dist-packages/aiter/mla.py", line 862, in mla_decode_fwd
(EngineCore pid=7775) ERROR 08-31 19:15:40 [core.py:1374]     qo_indptr = _fold_seqlen_indptr(qo_indptr, fold_factor)
(EngineCore pid=7775) ERROR 08-31 19:15:40 [core.py:1374]                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=7775) ERROR 08-31 19:15:40 [core.py:1374]   File "/usr/local/lib/python3.12/dist-packages/aiter/mla.py", line 410, in _fold_seqlen_indptr
(EngineCore pid=7775) ERROR 08-31 19:15:40 [core.py:1374]     out[0] = 0
(EngineCore pid=7775) ERROR 08-31 19:15:40 [core.py:1374]     ~~~^^^
(EngineCore pid=7775) ERROR 08-31 19:15:40 [core.py:1374] RuntimeError: Cannot copy between CPU and CUDA tensors during CUDA graph capture unless the CPU tensor is pinned. Please use tensor.pin_memory() or allocate the tensor with pin_memory=True.
```

## Test Result

Test passes with this PR:
```
============ 1 passed, 14 warnings in 696.39s (0:11:36) ==================
```

