### PR TITLE
[Triton/Gluon] Add MXFP8 convert and fast-transpose kernels

### DIFF
--- a/aiter/ops/triton/_triton_kernels/quant/fast_transpose.py
+++ b/aiter/ops/triton/_triton_kernels/quant/fast_transpose.py
@@ -1,0 +1,46 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+import triton
+import triton.language as tl
+
+from aiter.ops.triton.utils._triton.kernel_repr import make_kernel_repr
+
+_transpose_2d_kernel_repr = make_kernel_repr(
+    "_transpose_2d_kernel", ["BLOCK_M", "BLOCK_N"]
+)
+
+
+@triton.jit(repr=_transpose_2d_kernel_repr)
+def _transpose_2d_kernel(
+    IN_ptr,
+    OUT_ptr,
+    M,
+    N,
+    stride_in_m,
+    stride_in_n,
+    stride_out_n,
+    stride_out_m,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    """Tiled 2D matrix transpose.
+
+    Reads tiles from (M, N) input and writes transposed tiles to (N, M) output.
+    Works with any element dtype including FP8 (e4m3, e5m2, fnuz variants).
+    """
+    pid = tl.program_id(0)
+    num_n_blocks = tl.cdiv(N, BLOCK_N)
+    pid_m = pid // num_n_blocks
+    pid_n = pid % num_n_blocks
+
+    offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+
+    mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+
+    in_ptrs = IN_ptr + offs_m[:, None] * stride_in_m + offs_n[None, :] * stride_in_n
+    vals = tl.load(in_ptrs, mask=mask)
+
+    out_ptrs = OUT_ptr + offs_n[None, :] * stride_out_n + offs_m[:, None] * stride_out_m
+    tl.store(out_ptrs, vals, mask=mask)

--- a/aiter/ops/triton/_triton_kernels/quant/fast_transpose.py
+++ b/aiter/ops/triton/_triton_kernels/quant/fast_transpose.py
@@ -28,14 +28,16 @@ def _transpose_2d_kernel(
 
     Reads tiles from (M, N) input and writes transposed tiles to (N, M) output.
     Works with any element dtype including FP8 (e4m3, e5m2, fnuz variants).
+    Whether the transposed write is staged through LDS is compiler-determined;
+    the benchmark against ``t().contiguous()`` measures the net effect.
     """
     pid = tl.program_id(0)
     num_n_blocks = tl.cdiv(N, BLOCK_N)
     pid_m = pid // num_n_blocks
     pid_n = pid % num_n_blocks
 
-    offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
-    offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+    offs_m = tl.cast(pid_m * BLOCK_M + tl.arange(0, BLOCK_M), tl.int64)
+    offs_n = tl.cast(pid_n * BLOCK_N + tl.arange(0, BLOCK_N), tl.int64)
 
     mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
 

--- a/aiter/ops/triton/_triton_kernels/quant/quant_mxfp8.py
+++ b/aiter/ops/triton/_triton_kernels/quant/quant_mxfp8.py
@@ -1,0 +1,442 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+#
+# MXFP8 quantization Triton kernels: scale calculation, pack/unpack, and
+# full-tensor convert-to / convert-from helpers for the MX FP8 format.
+
+import triton
+import triton.language as tl
+
+from aiter.ops.triton.utils._triton.kernel_repr import make_kernel_repr
+
+# repr keys are the int/bool constexprs that select the compiled variant.
+_convert_to_mxfp8_kernel_repr = make_kernel_repr(
+    "_convert_to_mxfp8_kernel",
+    ["BLOCK_M", "BLOCK_N", "QUANT_BLOCK_SIZE", "IS_2D_BLOCK", "USE_SR", "USE_ASM"],
+)
+_convert_from_mxfp8_kernel_repr = make_kernel_repr(
+    "_convert_from_mxfp8_kernel",
+    ["BLOCK_M", "BLOCK_N", "QUANT_BLOCK_SIZE", "IS_2D_BLOCK", "USE_ASM"],
+)
+
+
+@triton.jit
+def _calculate_scales(
+    x,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    QUANT_BLOCK_SIZE: tl.constexpr,
+    IS_2D_BLOCK: tl.constexpr = False,
+    float8_dtype: tl.constexpr = tl.float8e4nv,
+):
+    E8M0_EXPONENT_BIAS: tl.constexpr = 127
+
+    if IS_2D_BLOCK:
+        tl.static_assert(
+            BLOCK_M % QUANT_BLOCK_SIZE == 0,
+            "block m must be divided by QUANT_BLOCK_SIZE",
+        )
+    tl.static_assert(
+        BLOCK_N % QUANT_BLOCK_SIZE == 0, "block N must be divided by QUANT_BLOCK_SIZE"
+    )
+    if x.type.element_ty == tl.float32:
+        hp_int_dtype = tl.int32
+        hp_mbits = 23
+        hp_ebits = 8
+        hp_exp_bias = 127
+    else:
+        # bf16
+        hp_int_dtype = tl.int16
+        hp_mbits = 7
+        hp_ebits = 8
+        hp_exp_bias = 127
+
+    sbits = 1
+    if float8_dtype == tl.float8e4nv:
+        mbits = 3
+        target_max_pow2 = 8
+    elif float8_dtype == tl.float8e5:
+        mbits = 2
+        target_max_pow2 = 15
+
+    NEW_BLOCK_N: tl.constexpr = BLOCK_N // QUANT_BLOCK_SIZE
+    if IS_2D_BLOCK:
+        NEW_BLOCK_M: tl.constexpr = BLOCK_M // QUANT_BLOCK_SIZE
+        x = x.reshape(NEW_BLOCK_M, QUANT_BLOCK_SIZE, NEW_BLOCK_N, QUANT_BLOCK_SIZE)
+        x = tl.permute(x, (0, 2, 1, 3))
+        max_abs = tl.max(tl.abs(x), axis=-1)
+        max_abs = tl.max(max_abs, axis=-1)
+    else:
+        x = x.reshape(BLOCK_M, NEW_BLOCK_N, QUANT_BLOCK_SIZE)
+        max_abs = tl.max(tl.abs(x), axis=-1)
+    max_abs = max_abs.to(x.type.element_ty)
+
+    # round even (adaptive)
+    # https://github.com/pytorch/ao/blob/a5f2693089b4c6528f019a0fb17235c9f22180a9/torchao/prototype/mx_formats/mx_tensor.py#L148
+    max_abs = max_abs.to(hp_int_dtype, bitcast=True)
+    val_to_add = 1 << (hp_mbits - mbits - 1)
+    mask = ((1 << (hp_ebits + sbits)) - 1) << hp_mbits
+    max_abs = (max_abs + val_to_add) & mask
+
+    extracted_pow2 = ((max_abs >> hp_mbits) & 0b11111111) - hp_exp_bias
+    scale_e8m0_unbiased = extracted_pow2 - target_max_pow2
+
+    scale_e8m0_unbiased = tl.minimum(
+        tl.maximum(scale_e8m0_unbiased, -1 * E8M0_EXPONENT_BIAS), E8M0_EXPONENT_BIAS + 1
+    )
+    scale_e8m0_biased = scale_e8m0_unbiased + E8M0_EXPONENT_BIAS
+
+    return scale_e8m0_biased.to(tl.uint8)
+
+
+@triton.jit
+def _generate_randval(m, n, philox_seed, philox_offset):
+    ms = tl.arange(0, m)
+    ns = tl.arange(0, n)
+    rng_offsets = philox_offset + ms[:, None] * n + ns[None, :]
+    r1, _, _, _ = tl.randint4x(philox_seed, rng_offsets)
+    return r1
+
+
+@triton.jit
+def _pack_fp8(
+    x,
+    scales,
+    philox_seed,
+    philox_offset,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    QUANT_BLOCK_SIZE: tl.constexpr,
+    IS_2D_BLOCK: tl.constexpr = False,
+    USE_SR: tl.constexpr = False,
+    USE_ASM: tl.constexpr = False,
+    float8_dtype: tl.constexpr = tl.float8e4nv,
+):
+    if float8_dtype == tl.float8e4nv:
+        max_pos: tl.constexpr = 448.0
+    else:
+        max_pos: tl.constexpr = 57344.0
+
+    HALF_BLOCK_N: tl.constexpr = BLOCK_N // 2
+    HALF_QUANT_BLOCK_SIZE: tl.constexpr = QUANT_BLOCK_SIZE // 2
+    SCALE_BLOCK_M: tl.constexpr = BLOCK_M // QUANT_BLOCK_SIZE
+    SCALE_BLOCK_N: tl.constexpr = BLOCK_N // QUANT_BLOCK_SIZE
+    x0, x1 = tl.split(x.reshape(BLOCK_M, HALF_BLOCK_N, 2))
+
+    scales = tl.where(scales < 1, 1, scales)
+    scales_fp32 = (scales.to(tl.uint32) << 23).to(tl.float32, bitcast=True)
+    F32_MIN_NORMAL = tl.constexpr(2**-126)
+    min_frag = (F32_MIN_NORMAL).to(tl.float32)
+    scales_fp32 = tl.where(scales_fp32 < min_frag, min_frag, scales_fp32)
+
+    if IS_2D_BLOCK:
+        scales_fp32 = (
+            scales_fp32.expand_dims(axis=(1, 3))
+            .broadcast_to(
+                SCALE_BLOCK_M, QUANT_BLOCK_SIZE, SCALE_BLOCK_N, HALF_QUANT_BLOCK_SIZE
+            )
+            .reshape(BLOCK_M, HALF_BLOCK_N)
+        )
+    else:
+        scales_fp32 = (
+            scales_fp32.expand_dims(axis=2)
+            .broadcast_to(BLOCK_M, SCALE_BLOCK_N, HALF_QUANT_BLOCK_SIZE)
+            .reshape(BLOCK_M, HALF_BLOCK_N)
+        )
+
+    if USE_SR:
+        randval0 = _generate_randval(BLOCK_M, BLOCK_N, philox_seed, philox_offset)
+    else:
+        randval0 = 0
+
+    if USE_ASM:
+        tl.static_assert(float8_dtype == tl.float8e4nv)
+        if x0.type.element_ty == tl.float32:
+            if not USE_SR:
+                y = tl.inline_asm_elementwise(
+                    asm="""
+                    v_cvt_scalef32_pk_fp8_f32 $0, $1, $2, $3 op_sel:[0,0,0,0];
+                    """,
+                    constraints="=&v,v,v,v",
+                    args=[x0, x1, scales_fp32],
+                    dtype=tl.uint16,
+                    is_pure=True,
+                    pack=1,
+                )
+            else:
+                x0 = (x1.to(tl.uint32, bitcast=True).to(tl.uint64) << 32) | x0.to(
+                    tl.uint32, bitcast=True
+                )
+                y = tl.inline_asm_elementwise(
+                    asm="""
+                    v_cvt_scalef32_sr_pk_fp8_f32 $0, $1, $2, $3 op_sel:[0,0,0,0];
+                    """,
+                    constraints="=&v,v,v,v",
+                    args=[x0, randval0, scales_fp32],
+                    dtype=tl.uint16,
+                    is_pure=True,
+                    pack=1,
+                )
+        else:
+            if not USE_SR:
+                x0 = (x1.to(tl.uint16, bitcast=True).to(tl.uint32) << 16) | x0.to(
+                    tl.uint16, bitcast=True
+                )
+                y = tl.inline_asm_elementwise(
+                    asm="""
+                    v_cvt_scalef32_pk_fp8_bf16 $0, $1, $2 op_sel:[0,0,0,0];
+                    """,
+                    constraints="=&v,v,v",
+                    args=[x0, scales_fp32],
+                    dtype=tl.uint16,
+                    is_pure=True,
+                    pack=1,
+                )
+            else:
+                scales_uint8 = scales.to(tl.uint8)
+                scales_fp32 = (
+                    scales_fp32.expand_dims(axis=2)
+                    .broadcast_to(BLOCK_M, HALF_BLOCK_N, 2)
+                    .reshape(BLOCK_M, BLOCK_N)
+                )
+                y = tl.inline_asm_elementwise(
+                    asm="""
+                    v_cvt_scalef32_sr_fp8_bf16 $0, $1, $2, $3 op_sel:[0,0,0,0];
+                    """,
+                    constraints="=&v,v,v,v",
+                    args=[x, randval0, scales_uint8],
+                    dtype=float8_dtype,
+                    is_pure=True,
+                    pack=1,
+                )
+
+        if x0.type.element_ty == tl.float32 or not USE_SR:
+            y1 = (y >> 8).to(tl.uint8).to(float8_dtype, bitcast=True)
+            y0 = (y & 0x00FF).to(tl.uint8).to(float8_dtype, bitcast=True)
+            y = tl.join(y0, y1).reshape(BLOCK_M, BLOCK_N)
+        y = y.to(tl.float32)
+        mask_pos = (y != y) & (x > 0)  # noqa: PLR0124
+        mask_neg = (y != y) & (x < 0)  # noqa: PLR0124
+        y = tl.where(mask_neg, -max_pos, y)
+        y = tl.where(mask_pos, max_pos, y)
+        y = y.to(float8_dtype)
+    else:
+        x_scaled = x / scales_fp32.expand_dims(axis=2).broadcast_to(
+            BLOCK_M, HALF_BLOCK_N, 2
+        ).reshape(BLOCK_M, BLOCK_N)
+
+        if USE_SR:
+            noise = randval0.to(tl.float32) * (1.0 / 4294967296.0)
+            x_scaled = x_scaled + (noise - 0.5) * 0.01
+
+        y = x_scaled.to(float8_dtype)
+
+    return y.reshape(BLOCK_M, BLOCK_N)
+
+
+@triton.jit
+def _unpack_fp8(
+    x,
+    scales,
+    output_dtype: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    QUANT_BLOCK_SIZE: tl.constexpr,
+    IS_2D_BLOCK: tl.constexpr,
+    USE_ASM: tl.constexpr = False,
+):
+    HALF_BLOCK_N: tl.constexpr = BLOCK_N // 2
+    HALF_QUANT_BLOCK_SIZE: tl.constexpr = QUANT_BLOCK_SIZE // 2
+    SCALE_BLOCK_M: tl.constexpr = BLOCK_M // QUANT_BLOCK_SIZE
+    SCALE_BLOCK_N: tl.constexpr = BLOCK_N // QUANT_BLOCK_SIZE
+    x0, x1 = tl.split(x.reshape(BLOCK_M, HALF_BLOCK_N, 2))
+
+    scales = tl.where(scales < 1, 1, scales)
+    scales_fp32 = (scales.to(tl.uint32) << 23).to(tl.float32, bitcast=True)
+    if IS_2D_BLOCK:
+        scales_fp32 = (
+            scales_fp32.expand_dims(axis=(1, 3))
+            .broadcast_to(
+                SCALE_BLOCK_M, QUANT_BLOCK_SIZE, SCALE_BLOCK_N, HALF_QUANT_BLOCK_SIZE
+            )
+            .reshape(BLOCK_M, HALF_BLOCK_N)
+        )
+    else:
+        scales_fp32 = (
+            scales_fp32.expand_dims(axis=2)
+            .broadcast_to(BLOCK_M, SCALE_BLOCK_N, HALF_QUANT_BLOCK_SIZE)
+            .reshape(BLOCK_M, HALF_BLOCK_N)
+        )
+
+    if USE_ASM:
+        tl.static_assert(x.type.element_ty == tl.float8e4nv)
+        x0 = (x1.to(tl.uint8, bitcast=True).to(tl.uint16) << 8) | x0.to(
+            tl.uint8, bitcast=True
+        )
+        if output_dtype == tl.float32:
+            y_packed = tl.inline_asm_elementwise(
+                asm="""
+                v_cvt_scalef32_pk_f32_fp8 $0, $1, $2 op_sel:[0,0];
+                """,
+                constraints="=&v,v,v",
+                args=[x0, scales_fp32],
+                dtype=tl.uint64,
+                is_pure=True,
+                pack=1,
+            )
+            y1 = (y_packed >> 32).to(tl.uint32).to(tl.float32, bitcast=True)
+            y0 = (
+                (y_packed & 0x00000000FFFFFFFF)
+                .to(tl.uint32)
+                .to(tl.float32, bitcast=True)
+            )
+        else:
+            y_packed = tl.inline_asm_elementwise(
+                asm="""
+                v_cvt_scalef32_pk_bf16_fp8 $0, $1, $2 op_sel:[0,0];
+                """,
+                constraints="=&v,v,v",
+                args=[x0, scales_fp32],
+                dtype=tl.uint32,
+                is_pure=True,
+                pack=1,
+            )
+            y1 = (y_packed >> 16).to(tl.uint16).to(tl.bfloat16, bitcast=True)
+            y0 = (y_packed & 0x0000FFFF).to(tl.uint16).to(tl.bfloat16, bitcast=True)
+        y = tl.join(y0, y1).reshape(BLOCK_M, BLOCK_N)
+    else:
+        y = x.to(output_dtype)
+        y = y * scales_fp32.expand_dims(axis=2).broadcast_to(
+            BLOCK_M, HALF_BLOCK_N, 2
+        ).reshape(BLOCK_M, BLOCK_N)
+
+    return y
+
+
+@triton.jit(repr=_convert_to_mxfp8_kernel_repr)
+def _convert_to_mxfp8_kernel(
+    x_ptr,
+    y_ptr,
+    s_ptr,
+    stride_xm,
+    stride_xn,
+    stride_ym,
+    stride_yn,
+    stride_sm,
+    stride_sn,
+    philox_seed,
+    philox_offset,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    QUANT_BLOCK_SIZE: tl.constexpr,
+    IS_2D_BLOCK: tl.constexpr,
+    USE_SR: tl.constexpr,
+    USE_ASM: tl.constexpr,
+):
+    pid_m = tl.program_id(axis=0)
+    pid_n = tl.program_id(axis=1)
+    SCALE_BLOCK_M: tl.constexpr = BLOCK_M // QUANT_BLOCK_SIZE
+    SCALE_BLOCK_N: tl.constexpr = BLOCK_N // QUANT_BLOCK_SIZE
+    offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_xn = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+    offs_yn = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+    offs_sn = pid_n * SCALE_BLOCK_N + tl.arange(0, SCALE_BLOCK_N)
+    if IS_2D_BLOCK:
+        offs_sm = pid_m * SCALE_BLOCK_M + tl.arange(0, SCALE_BLOCK_M)
+    else:
+        offs_sm = offs_m
+
+    offs_x = offs_m[:, None] * stride_xm + offs_xn[None, :] * stride_xn
+    offs_s = offs_sm[:, None] * stride_sm + offs_sn[None, :] * stride_sn
+
+    tl.static_assert(
+        x_ptr.type.element_ty == tl.float32 or x_ptr.type.element_ty == tl.bfloat16
+    )
+
+    float8_dtype = y_ptr.type.element_ty
+    tl.static_assert(float8_dtype == tl.float8e4nv or float8_dtype == tl.float8e5)
+
+    x = tl.load(x_ptr + offs_x)
+
+    scales = _calculate_scales(
+        x,
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        QUANT_BLOCK_SIZE=QUANT_BLOCK_SIZE,
+        IS_2D_BLOCK=IS_2D_BLOCK,
+        float8_dtype=float8_dtype,
+    )
+    y = _pack_fp8(
+        x,
+        scales,
+        philox_seed,
+        philox_offset,
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        QUANT_BLOCK_SIZE=QUANT_BLOCK_SIZE,
+        IS_2D_BLOCK=IS_2D_BLOCK,
+        USE_SR=USE_SR,
+        USE_ASM=USE_ASM,
+        float8_dtype=float8_dtype,
+    )
+
+    offs_y = offs_m[:, None] * stride_ym + offs_yn[None, :] * stride_yn
+    tl.store(y_ptr + offs_y, y.to(y_ptr.type.element_ty))
+    tl.store(s_ptr + offs_s, scales)
+
+
+@triton.jit(repr=_convert_from_mxfp8_kernel_repr)
+def _convert_from_mxfp8_kernel(
+    x_ptr,
+    y_ptr,
+    s_ptr,
+    stride_xm,
+    stride_xn,
+    stride_ym,
+    stride_yn,
+    stride_sm,
+    stride_sn,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    QUANT_BLOCK_SIZE: tl.constexpr,
+    IS_2D_BLOCK: tl.constexpr,
+    USE_ASM: tl.constexpr,
+):
+    pid_m = tl.program_id(axis=0)
+    pid_n = tl.program_id(axis=1)
+    SCALE_BLOCK_M: tl.constexpr = BLOCK_M // QUANT_BLOCK_SIZE
+    SCALE_BLOCK_N: tl.constexpr = BLOCK_N // QUANT_BLOCK_SIZE
+    offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_xn = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+    offs_yn = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+    offs_sn = pid_n * SCALE_BLOCK_N + tl.arange(0, SCALE_BLOCK_N)
+    if IS_2D_BLOCK:
+        offs_sm = pid_m * SCALE_BLOCK_M + tl.arange(0, SCALE_BLOCK_M)
+    else:
+        offs_sm = offs_m
+
+    offs_x = offs_m[:, None] * stride_xm + offs_xn[None, :] * stride_xn
+    offs_s = offs_sm[:, None] * stride_sm + offs_sn[None, :] * stride_sn
+
+    x = tl.load(x_ptr + offs_x)
+    s = tl.load(s_ptr + offs_s)
+
+    tl.static_assert(
+        y_ptr.type.element_ty == tl.float32 or y_ptr.type.element_ty == tl.bfloat16
+    )
+    tl.static_assert(
+        x_ptr.type.element_ty == tl.float8e4nv or x_ptr.type.element_ty == tl.float8e5
+    )
+
+    y = _unpack_fp8(
+        x,
+        s,
+        y_ptr.type.element_ty,
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        QUANT_BLOCK_SIZE=QUANT_BLOCK_SIZE,
+        IS_2D_BLOCK=IS_2D_BLOCK,
+        USE_ASM=USE_ASM,
+    )
+    offs_y = offs_m[:, None] * stride_ym + offs_yn[None, :] * stride_yn
+    tl.store(y_ptr + offs_y, y)

--- a/aiter/ops/triton/_triton_kernels/quant/quant_mxfp8.py
+++ b/aiter/ops/triton/_triton_kernels/quant/quant_mxfp8.py
@@ -3,6 +3,16 @@
 #
 # MXFP8 quantization Triton kernels: scale calculation, pack/unpack, and
 # full-tensor convert-to / convert-from helpers for the MX FP8 format.
+#
+# Scale-rounding note
+# -------------------
+# _calculate_scales uses torchao round-to-nearest-even (adaptive to the
+# input mantissa width).  This differs from _downcast_to_mxfp in
+# quant_moe.py, which uses selectable round-up / round-down for MoE
+# throughput on gfx942 (e4m3fnuz).  The two functions target different
+# use cases and intentionally produce different bits for the same input:
+#   * This file  — OCP FP8 (e4m3fn / e5m2), gfx950, nearest-even, training accuracy
+#   * quant_moe  — fnuz, gfx942, configurable direction, MoE inference throughput
 
 import triton
 import triton.language as tl
@@ -58,6 +68,10 @@ def _calculate_scales(
     elif float8_dtype == tl.float8e5:
         mbits = 2
         target_max_pow2 = 15
+    else:
+        tl.static_assert(
+            False, "unsupported fp8_dtype: only float8e4nv and float8e5 are supported"
+        )
 
     NEW_BLOCK_N: tl.constexpr = BLOCK_N // QUANT_BLOCK_SIZE
     if IS_2D_BLOCK:
@@ -71,8 +85,10 @@ def _calculate_scales(
         max_abs = tl.max(tl.abs(x), axis=-1)
     max_abs = max_abs.to(x.type.element_ty)
 
-    # round even (adaptive)
+    # Round-to-nearest-even (adaptive to input mantissa width), per torchao:
     # https://github.com/pytorch/ao/blob/a5f2693089b4c6528f019a0fb17235c9f22180a9/torchao/prototype/mx_formats/mx_tensor.py#L148
+    # _downcast_to_mxfp (quant_moe.py) uses round-up or round-down instead;
+    # see the file-level note for why the two differ intentionally.
     max_abs = max_abs.to(hp_int_dtype, bitcast=True)
     val_to_add = 1 << (hp_mbits - mbits - 1)
     mask = ((1 << (hp_ebits + sbits)) - 1) << hp_mbits
@@ -81,8 +97,10 @@ def _calculate_scales(
     extracted_pow2 = ((max_abs >> hp_mbits) & 0b11111111) - hp_exp_bias
     scale_e8m0_unbiased = extracted_pow2 - target_max_pow2
 
+    # Upper clamp: E8M0_EXPONENT_BIAS (127) gives biased byte 254, the largest
+    # normal e8m0 value. E8M0_EXPONENT_BIAS+1 would give 255, the NaN encoding.
     scale_e8m0_unbiased = tl.minimum(
-        tl.maximum(scale_e8m0_unbiased, -1 * E8M0_EXPONENT_BIAS), E8M0_EXPONENT_BIAS + 1
+        tl.maximum(scale_e8m0_unbiased, -1 * E8M0_EXPONENT_BIAS), E8M0_EXPONENT_BIAS
     )
     scale_e8m0_biased = scale_e8m0_unbiased + E8M0_EXPONENT_BIAS
 
@@ -337,7 +355,7 @@ def _convert_to_mxfp8_kernel(
     pid_n = tl.program_id(axis=1)
     SCALE_BLOCK_M: tl.constexpr = BLOCK_M // QUANT_BLOCK_SIZE
     SCALE_BLOCK_N: tl.constexpr = BLOCK_N // QUANT_BLOCK_SIZE
-    offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_m = tl.cast(pid_m * BLOCK_M + tl.arange(0, BLOCK_M), tl.int64)
     offs_xn = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
     offs_yn = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
     offs_sn = pid_n * SCALE_BLOCK_N + tl.arange(0, SCALE_BLOCK_N)
@@ -406,7 +424,7 @@ def _convert_from_mxfp8_kernel(
     pid_n = tl.program_id(axis=1)
     SCALE_BLOCK_M: tl.constexpr = BLOCK_M // QUANT_BLOCK_SIZE
     SCALE_BLOCK_N: tl.constexpr = BLOCK_N // QUANT_BLOCK_SIZE
-    offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_m = tl.cast(pid_m * BLOCK_M + tl.arange(0, BLOCK_M), tl.int64)
     offs_xn = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
     offs_yn = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
     offs_sn = pid_n * SCALE_BLOCK_N + tl.arange(0, SCALE_BLOCK_N)

--- a/aiter/ops/triton/quant/__init__.py
+++ b/aiter/ops/triton/quant/__init__.py
@@ -1,3 +1,4 @@
+from aiter.ops.triton.quant.fast_transpose import fast_transpose_2d
 from aiter.ops.triton.quant.fused_fp8_quant import (
     calc_rows_per_block,
     fused_flatten_fp8_group_quant,
@@ -40,6 +41,10 @@ from aiter.ops.triton.quant.quant_fp8_blockwise import (
     quant_fp8_blockwise_segment_m,
     requant_fp8_row_to_col,
 )
+from aiter.ops.triton.quant.quant_mxfp8 import (
+    convert_from_mxfp8,
+    convert_to_mxfp8,
+)
 
 __all__ = [
     "_mxfp4_quant_op",
@@ -47,12 +52,16 @@ __all__ = [
     "_nvfp4_quant_op",
     # fused_fp8_quant.py exports
     "calc_rows_per_block",
+    # fast_transpose.py exports
+    "convert_from_mxfp8",
+    "convert_to_mxfp8",
     "dynamic_mxfp4_quant",
     "dynamic_mxfp8_quant",
     "dynamic_mxfp8_quant_n32k4_mbn",
     "dynamic_nvfp4_quant",
     "dynamic_per_tensor_quant_fp8_i8",
     "dynamic_per_token_quant_fp8_i8",
+    "fast_transpose_2d",
     "fp8_legacy_to_mxfp8",
     "fused_dual_rmsnorm_mxfp8_quant",
     "fused_dynamic_mxfp4_quant_moe_sort",

--- a/aiter/ops/triton/quant/fast_transpose.py
+++ b/aiter/ops/triton/quant/fast_transpose.py
@@ -5,6 +5,11 @@ import torch
 import triton
 
 from aiter.ops.triton._triton_kernels.quant.fast_transpose import _transpose_2d_kernel
+from aiter.ops.triton.utils.logger import AiterTritonLogger
+
+__all__ = ["fast_transpose_2d"]
+
+_LOGGER = AiterTritonLogger()
 
 
 def fast_transpose_2d(x: torch.Tensor) -> torch.Tensor:
@@ -15,6 +20,7 @@ def fast_transpose_2d(x: torch.Tensor) -> torch.Tensor:
     Replaces the ``tensor.t().contiguous()`` pattern which dispatches a
     full ``aten::copy_`` kernel.
     """
+    _LOGGER.info(f"FAST_TRANSPOSE_2D: x={tuple(x.shape)}")
     assert x.dim() == 2, f"Expected 2D tensor, got {x.dim()}D"
     M, N = x.shape
 
@@ -24,6 +30,8 @@ def fast_transpose_2d(x: torch.Tensor) -> torch.Tensor:
     BLOCK_N = 32
     grid = (triton.cdiv(M, BLOCK_M) * triton.cdiv(N, BLOCK_N),)
 
+    # num_warps=1: 32×32=1024-element tile is small; benchmarks on MI308X show
+    # nw=1/2 tie for best, nw≥4 regresses (nw=16 is 2.5× slower than nw=1).
     _transpose_2d_kernel[grid](
         x,
         out,
@@ -35,5 +43,8 @@ def fast_transpose_2d(x: torch.Tensor) -> torch.Tensor:
         out.stride(1),
         BLOCK_M=BLOCK_M,
         BLOCK_N=BLOCK_N,
+        num_warps=1,
+        waves_per_eu=2,
+        num_stages=2,
     )
     return out

--- a/aiter/ops/triton/quant/fast_transpose.py
+++ b/aiter/ops/triton/quant/fast_transpose.py
@@ -1,0 +1,39 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+import torch
+import triton
+
+from aiter.ops.triton._triton_kernels.quant.fast_transpose import _transpose_2d_kernel
+
+
+def fast_transpose_2d(x: torch.Tensor) -> torch.Tensor:
+    """Transpose a contiguous 2D tensor using a Triton tiled kernel.
+
+    Returns a contiguous (N, M) tensor from a (M, N) input.
+    Works with any dtype including FP8 (e4m3, e5m2, fnuz variants).
+    Replaces the ``tensor.t().contiguous()`` pattern which dispatches a
+    full ``aten::copy_`` kernel.
+    """
+    assert x.dim() == 2, f"Expected 2D tensor, got {x.dim()}D"
+    M, N = x.shape
+
+    out = torch.empty((N, M), dtype=x.dtype, device=x.device)
+
+    BLOCK_M = 32
+    BLOCK_N = 32
+    grid = (triton.cdiv(M, BLOCK_M) * triton.cdiv(N, BLOCK_N),)
+
+    _transpose_2d_kernel[grid](
+        x,
+        out,
+        M,
+        N,
+        x.stride(0),
+        x.stride(1),
+        out.stride(0),
+        out.stride(1),
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+    )
+    return out

--- a/aiter/ops/triton/quant/quant_mxfp8.py
+++ b/aiter/ops/triton/quant/quant_mxfp8.py
@@ -1,0 +1,152 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+import torch
+import triton
+
+from aiter.ops.triton._triton_kernels.quant.quant_mxfp8 import (
+    _convert_from_mxfp8_kernel,
+    _convert_to_mxfp8_kernel,
+)
+from aiter.ops.triton.utils._triton import arch_info
+from aiter.ops.triton.utils.logger import AiterTritonLogger
+
+__all__ = [
+    "convert_from_mxfp8",
+    "convert_to_mxfp8",
+]
+
+_LOGGER = AiterTritonLogger()
+
+
+def convert_to_mxfp8(
+    x: torch.Tensor,
+    fp8_dtype: torch.dtype,
+    quant_block_size: int = 32,
+    is_2d_block: bool = False,
+    use_sr: bool = False,
+    use_asm: bool | None = None,
+    block_m: int = 64,
+    block_n: int = 64,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """
+    Quantize a tensor to MXFP8 format.
+
+    Args:
+        x: Input tensor of shape (M, N), dtype float32 or bfloat16.
+        fp8_dtype: Target FP8 dtype (torch.float8_e4m3fn or torch.float8_e5m2).
+        quant_block_size: Block size for quantization scaling (default 32).
+        is_2d_block: Whether to use 2D block scaling.
+        use_sr: Whether to use stochastic rounding.
+        use_asm: Whether to use the inline-assembly path. The ASM instructions
+            (``v_cvt_scalef32_*``) are gfx950-only; ``None`` (default)
+            auto-selects ASM on gfx950 and the portable path elsewhere.
+        block_m: Tile size along M dimension.
+        block_n: Tile size along N dimension.
+
+    Returns:
+        Tuple of (quantized_tensor, scales) where quantized_tensor has fp8_dtype
+        and scales has uint8 dtype with e8m0 format.
+    """
+    _LOGGER.info(f"CONVERT_TO_MXFP8: x={tuple(x.shape)}")
+    if use_asm is None:
+        use_asm = arch_info.get_arch() == "gfx950"
+    assert x.ndim == 2, "Input must be 2D"
+    M, N = x.shape
+    # The kernel loads/stores full [block_m, block_n] tiles without masking and
+    # reshapes each into QUANT_BLOCK_SIZE groups, so M and N must tile exactly.
+    assert M % block_m == 0 and N % block_n == 0, (
+        f"MXFP8 convert requires M,N aligned to tile ({block_m},{block_n}); "
+        f"got ({M},{N})"
+    )
+
+    y = torch.empty((M, N), dtype=fp8_dtype, device=x.device)
+    if is_2d_block:
+        scale_m = triton.cdiv(M, quant_block_size)
+    else:
+        scale_m = M
+    scale_n = triton.cdiv(N, quant_block_size)
+    s = torch.empty((scale_m, scale_n), dtype=torch.uint8, device=x.device)
+
+    grid = (triton.cdiv(M, block_m), triton.cdiv(N, block_n))
+    _convert_to_mxfp8_kernel[grid](
+        x,
+        y,
+        s,
+        x.stride(0),
+        x.stride(1),
+        y.stride(0),
+        y.stride(1),
+        s.stride(0),
+        s.stride(1),
+        0,
+        0,
+        BLOCK_M=block_m,
+        BLOCK_N=block_n,
+        QUANT_BLOCK_SIZE=quant_block_size,
+        IS_2D_BLOCK=is_2d_block,
+        USE_SR=use_sr,
+        USE_ASM=use_asm,
+    )
+    return y, s
+
+
+def convert_from_mxfp8(
+    x: torch.Tensor,
+    s: torch.Tensor,
+    output_dtype: torch.dtype,
+    quant_block_size: int = 32,
+    is_2d_block: bool = False,
+    use_asm: bool | None = None,
+    block_m: int = 64,
+    block_n: int = 64,
+) -> torch.Tensor:
+    """
+    Dequantize a tensor from MXFP8 format.
+
+    Args:
+        x: Quantized input tensor of shape (M, N), dtype float8.
+        s: Scale tensor with uint8 dtype (e8m0 format).
+        output_dtype: Target output dtype (torch.float32 or torch.bfloat16).
+        quant_block_size: Block size for quantization scaling (default 32).
+        is_2d_block: Whether 2D block scaling was used.
+        use_asm: Whether to use the inline-assembly path. The ASM instructions
+            (``v_cvt_scalef32_*``) are gfx950-only; ``None`` (default)
+            auto-selects ASM on gfx950 and the portable path elsewhere.
+        block_m: Tile size along M dimension.
+        block_n: Tile size along N dimension.
+
+    Returns:
+        Dequantized tensor with output_dtype.
+    """
+    _LOGGER.info(f"CONVERT_FROM_MXFP8: x={tuple(x.shape)}")
+    if use_asm is None:
+        use_asm = arch_info.get_arch() == "gfx950"
+    assert x.ndim == 2, "Input must be 2D"
+    M, N = x.shape
+    # Kernel loads/stores full [block_m, block_n] tiles without masking.
+    assert M % block_m == 0 and N % block_n == 0, (
+        f"MXFP8 convert requires M,N aligned to tile ({block_m},{block_n}); "
+        f"got ({M},{N})"
+    )
+
+    y = torch.empty((M, N), dtype=output_dtype, device=x.device)
+
+    grid = (triton.cdiv(M, block_m), triton.cdiv(N, block_n))
+    _convert_from_mxfp8_kernel[grid](
+        x,
+        y,
+        s,
+        x.stride(0),
+        x.stride(1),
+        y.stride(0),
+        y.stride(1),
+        s.stride(0),
+        s.stride(1),
+        BLOCK_M=block_m,
+        BLOCK_N=block_n,
+        QUANT_BLOCK_SIZE=quant_block_size,
+        IS_2D_BLOCK=is_2d_block,
+        USE_ASM=use_asm,
+    )
+    return y

--- a/aiter/ops/triton/quant/quant_mxfp8.py
+++ b/aiter/ops/triton/quant/quant_mxfp8.py
@@ -47,8 +47,23 @@ def convert_to_mxfp8(
     Returns:
         Tuple of (quantized_tensor, scales) where quantized_tensor has fp8_dtype
         and scales has uint8 dtype with e8m0 format.
+
+    Note:
+        M and N must be exact multiples of ``block_m`` / ``block_n`` (default
+        64).  The kernel loads full tiles without masking; unaligned shapes must
+        be padded before calling.  This is a deliberate constraint that enables
+        the gfx950 ASM path.
+
+        Scale rounding uses torchao round-to-nearest-even, which differs from
+        ``_downcast_to_mxfp`` in ``quant_moe.py`` (round-up / round-down, fnuz,
+        arbitrary shapes).  Quantising the same tensor through both will produce
+        different bits — see the kernel file header for the rationale.
     """
     _LOGGER.info(f"CONVERT_TO_MXFP8: x={tuple(x.shape)}")
+    if fp8_dtype not in (torch.float8_e4m3fn, torch.float8_e5m2):
+        raise ValueError(
+            f"fp8_dtype must be torch.float8_e4m3fn or torch.float8_e5m2, got {fp8_dtype}"
+        )
     # The ASM path (v_cvt_scalef32_*) is gfx950-only and _pack_fp8 only accepts
     # e4m3fn; anything else must take the portable path.
     asm_supported = (
@@ -82,6 +97,10 @@ def convert_to_mxfp8(
     s = torch.empty((scale_m, scale_n), dtype=torch.uint8, device=x.device)
 
     grid = (triton.cdiv(M, block_m), triton.cdiv(N, block_n))
+    # num_warps scales with tile area so it remains valid when block_m/block_n
+    # differ from the default 64×64 (MI308X benchmark: nw=1/2/4 differ < 1%
+    # at default tile, nw≥8 regresses).
+    num_warps = min(16, max(1, block_m * block_n // 1024))
     _convert_to_mxfp8_kernel[grid](
         x,
         y,
@@ -100,6 +119,9 @@ def convert_to_mxfp8(
         IS_2D_BLOCK=is_2d_block,
         USE_SR=use_sr,
         USE_ASM=use_asm,
+        num_warps=num_warps,
+        waves_per_eu=2,
+        num_stages=2,
     )
     return y, s
 
@@ -162,6 +184,7 @@ def convert_from_mxfp8(
     y = torch.empty((M, N), dtype=output_dtype, device=x.device)
 
     grid = (triton.cdiv(M, block_m), triton.cdiv(N, block_n))
+    num_warps = min(16, max(1, block_m * block_n // 1024))
     _convert_from_mxfp8_kernel[grid](
         x,
         y,
@@ -177,5 +200,8 @@ def convert_from_mxfp8(
         QUANT_BLOCK_SIZE=quant_block_size,
         IS_2D_BLOCK=is_2d_block,
         USE_ASM=use_asm,
+        num_warps=num_warps,
+        waves_per_eu=2,
+        num_stages=2,
     )
     return y

--- a/aiter/ops/triton/quant/quant_mxfp8.py
+++ b/aiter/ops/triton/quant/quant_mxfp8.py
@@ -49,8 +49,21 @@ def convert_to_mxfp8(
         and scales has uint8 dtype with e8m0 format.
     """
     _LOGGER.info(f"CONVERT_TO_MXFP8: x={tuple(x.shape)}")
+    # The ASM path (v_cvt_scalef32_*) is gfx950-only and _pack_fp8 only accepts
+    # e4m3fn; anything else must take the portable path.
+    asm_supported = (
+        arch_info.get_arch() == "gfx950" and fp8_dtype == torch.float8_e4m3fn
+    )
     if use_asm is None:
-        use_asm = arch_info.get_arch() == "gfx950"
+        use_asm = asm_supported
+    elif use_asm and not asm_supported:
+        raise ValueError(
+            "use_asm=True requires gfx950 and fp8_dtype=torch.float8_e4m3fn"
+        )
+    # Stochastic rounding on the ASM path passes mismatched RNG/operand shapes
+    # and cannot compile; only the portable path supports it for now.
+    if use_sr and use_asm:
+        raise ValueError("use_sr=True is not supported with use_asm=True")
     assert x.ndim == 2, "Input must be 2D"
     M, N = x.shape
     # The kernel loads/stores full [block_m, block_n] tiles without masking and
@@ -120,8 +133,13 @@ def convert_from_mxfp8(
         Dequantized tensor with output_dtype.
     """
     _LOGGER.info(f"CONVERT_FROM_MXFP8: x={tuple(x.shape)}")
+    # The ASM path (v_cvt_scalef32_*) is gfx950-only and _unpack_fp8 only accepts
+    # e4m3fn input; anything else must take the portable path.
+    asm_supported = arch_info.get_arch() == "gfx950" and x.dtype == torch.float8_e4m3fn
     if use_asm is None:
-        use_asm = arch_info.get_arch() == "gfx950"
+        use_asm = asm_supported
+    elif use_asm and not asm_supported:
+        raise ValueError("use_asm=True requires gfx950 and x.dtype=torch.float8_e4m3fn")
     assert x.ndim == 2, "Input must be 2D"
     M, N = x.shape
     # Kernel loads/stores full [block_m, block_n] tiles without masking.
@@ -129,6 +147,17 @@ def convert_from_mxfp8(
         f"MXFP8 convert requires M,N aligned to tile ({block_m},{block_n}); "
         f"got ({M},{N})"
     )
+    # The scale tensor is read with unmasked full-tile loads, so its shape must
+    # match exactly what convert_to_mxfp8 produced.
+    expected_scale_shape = (
+        triton.cdiv(M, quant_block_size) if is_2d_block else M,
+        triton.cdiv(N, quant_block_size),
+    )
+    assert (
+        tuple(s.shape) == expected_scale_shape
+    ), f"scale shape {tuple(s.shape)} != {expected_scale_shape}"
+    assert s.dtype == torch.uint8, f"scale dtype must be uint8, got {s.dtype}"
+    assert s.device == x.device, "input and scale must be on the same device"
 
     y = torch.empty((M, N), dtype=output_dtype, device=x.device)
 

--- a/op_tests/op_benchmarks/triton/bench_fast_transpose.py
+++ b/op_tests/op_benchmarks/triton/bench_fast_transpose.py
@@ -1,0 +1,73 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+"""Benchmark for the fast_transpose_2d Triton kernel (_transpose_2d_kernel)."""
+
+import argparse
+
+import torch
+import triton
+
+from aiter.ops.triton.quant.fast_transpose import fast_transpose_2d
+from op_tests.op_benchmarks.triton.utils.benchmark_utils import get_caller_name_no_ext
+
+
+def benchmark(args):
+    dtype = {
+        "bf16": torch.bfloat16,
+        "fp16": torch.float16,
+        "fp8": torch.float8_e4m3fnuz,
+    }[args.dtype]
+    x_vals = [(m, n) for m in [1024, 4096, 8192] for n in [1024, 4096, 8192]]
+    unit = "ms" if args.metric == "time" else "GB/s"
+
+    config = triton.testing.Benchmark(
+        x_names=["M", "N"],
+        x_vals=x_vals,
+        line_arg="provider",
+        line_vals=["triton"],
+        line_names=[f"fast_transpose ({unit})"],
+        styles=[("green", "-")],
+        ylabel=unit,
+        plot_name=get_caller_name_no_ext(),
+        args={},
+    )
+
+    @triton.testing.perf_report([config])
+    def _run(M, N, provider):
+        x = torch.randn(M, N, device="cuda").to(dtype)
+        ms = triton.testing.do_bench(lambda: fast_transpose_2d(x), warmup=25, rep=100)
+        if args.metric == "time":
+            return ms
+        # read M*N + write N*M elements
+        gb = 2 * M * N * x.element_size() * 1e-9
+        return gb / (ms * 1e-3)
+
+    _run.run(save_path="." if args.o else None, print_data=True, show_plots=False)
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        prog="Benchmark fast_transpose", allow_abbrev=False
+    )
+    parser.add_argument(
+        "--dtype", type=str, default="bf16", choices=["bf16", "fp16", "fp8"]
+    )
+    parser.add_argument(
+        "-metric",
+        nargs="?",
+        const="bandwidth",
+        choices=["time", "bandwidth"],
+        default="bandwidth",
+    )
+    parser.add_argument("-o", action="store_true", default=False)
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    torch.manual_seed(0)
+    benchmark(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/op_tests/op_benchmarks/triton/bench_fast_transpose.py
+++ b/op_tests/op_benchmarks/triton/bench_fast_transpose.py
@@ -24,9 +24,9 @@ def benchmark(args):
         x_names=["M", "N"],
         x_vals=x_vals,
         line_arg="provider",
-        line_vals=["triton"],
-        line_names=[f"fast_transpose ({unit})"],
-        styles=[("green", "-")],
+        line_vals=["triton", "torch"],
+        line_names=[f"fast_transpose ({unit})", f"torch t().contiguous() ({unit})"],
+        styles=[("green", "-"), ("blue", "-")],
         ylabel=unit,
         plot_name=get_caller_name_no_ext(),
         args={},
@@ -35,7 +35,11 @@ def benchmark(args):
     @triton.testing.perf_report([config])
     def _run(M, N, provider):
         x = torch.randn(M, N, device="cuda").to(dtype)
-        ms = triton.testing.do_bench(lambda: fast_transpose_2d(x), warmup=25, rep=100)
+        if provider == "torch":
+            fn = lambda: x.t().contiguous()
+        else:
+            fn = lambda: fast_transpose_2d(x)
+        ms = triton.testing.do_bench(fn, warmup=25, rep=100)
         if args.metric == "time":
             return ms
         # read M*N + write N*M elements

--- a/op_tests/op_benchmarks/triton/bench_quant_mxfp8.py
+++ b/op_tests/op_benchmarks/triton/bench_quant_mxfp8.py
@@ -46,8 +46,8 @@ def benchmark(args):
         ms = triton.testing.do_bench(fn, warmup=25, rep=100)
         if args.metric == "time":
             return ms
-        # bytes: read input + write output (fp8 for `to`, high-precision for `from`)
-        gb = M * N * (in_dtype.itemsize + 1) * 1e-9
+        # bytes: high-precision payload + fp8 payload + one e8m0 scale byte per 32
+        gb = (M * N * (in_dtype.itemsize + 1) + M * triton.cdiv(N, 32)) * 1e-9
         return gb / (ms * 1e-3)
 
     _run.run(save_path="." if args.o else None, print_data=True, show_plots=False)

--- a/op_tests/op_benchmarks/triton/bench_quant_mxfp8.py
+++ b/op_tests/op_benchmarks/triton/bench_quant_mxfp8.py
@@ -1,0 +1,77 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+"""Benchmark for MXFP8 convert kernels.
+
+``to`` exercises ``_convert_to_mxfp8_kernel``; ``from`` exercises
+``_convert_from_mxfp8_kernel``. use_asm is left at the wrapper default
+(auto-selected: ASM on gfx950, portable path elsewhere).
+"""
+
+import argparse
+
+import torch
+import triton
+
+from aiter.ops.triton.quant.quant_mxfp8 import convert_from_mxfp8, convert_to_mxfp8
+from op_tests.op_benchmarks.triton.utils.benchmark_utils import get_caller_name_no_ext
+
+
+def benchmark(args):
+    in_dtype = {"bf16": torch.bfloat16, "fp32": torch.float32}[args.dtype]
+    fp8_dtype = torch.float8_e4m3fn
+    # M, N must tile to (block_m=64, block_n=64).
+    x_vals = [(m, n) for m in [4096, 8192] for n in [4096, 8192, 16384]]
+    unit = "ms" if args.metric == "time" else "GB/s"
+
+    config = triton.testing.Benchmark(
+        x_names=["M", "N"],
+        x_vals=x_vals,
+        line_arg="provider",
+        line_vals=["to", "from"],
+        line_names=[f"to ({unit})", f"from ({unit})"],
+        styles=[("green", "-"), ("blue", "-")],
+        ylabel=unit,
+        plot_name=get_caller_name_no_ext(),
+        args={},
+    )
+
+    @triton.testing.perf_report([config])
+    def _run(M, N, provider):
+        x = torch.randn(M, N, device="cuda", dtype=in_dtype)
+        if provider == "to":
+            fn = lambda: convert_to_mxfp8(x, fp8_dtype, quant_block_size=32)
+        else:
+            y, s = convert_to_mxfp8(x, fp8_dtype, quant_block_size=32)
+            fn = lambda: convert_from_mxfp8(y, s, in_dtype, quant_block_size=32)
+        ms = triton.testing.do_bench(fn, warmup=25, rep=100)
+        if args.metric == "time":
+            return ms
+        # bytes: read input + write output (fp8 for `to`, high-precision for `from`)
+        gb = M * N * (in_dtype.itemsize + 1) * 1e-9
+        return gb / (ms * 1e-3)
+
+    _run.run(save_path="." if args.o else None, print_data=True, show_plots=False)
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(prog="Benchmark MXFP8 convert", allow_abbrev=False)
+    parser.add_argument("--dtype", type=str, default="bf16", choices=["bf16", "fp32"])
+    parser.add_argument(
+        "-metric",
+        nargs="?",
+        const="time",
+        choices=["time", "bandwidth"],
+        default="time",
+    )
+    parser.add_argument("-o", action="store_true", default=False)
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    torch.manual_seed(0)
+    benchmark(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/op_tests/triton_tests/quant/test_convert_mxfp8.py
+++ b/op_tests/triton_tests/quant/test_convert_mxfp8.py
@@ -56,6 +56,34 @@ def test_mxfp8_roundtrip(M, N, is_2d_block, fp8_dtype, in_dtype):
     assert err <= _TOL[fp8_dtype] * scale, f"max abs err {err:.4f} vs {scale:.4f}"
 
 
+@pytest.mark.parametrize("is_2d_block", [False, True])
+@pytest.mark.parametrize("fp8_dtype", [torch.float8_e4m3fn, torch.float8_e5m2])
+def test_mxfp8_scale_independent_dequant(is_2d_block, fp8_dtype):
+    """Dequantize with an independent e8m0 decode (2**(s-127)), not convert_from.
+
+    convert_from shares the kernel's scale interpretation, so a matching
+    encode/decode bug could cancel in the roundtrip test. Decoding the e8m0
+    scale independently and applying it in plain torch catches a wrong scale
+    value or a wrong block layout.
+    """
+    torch.manual_seed(2)
+    M, N, qbs = 128, 256, 32
+    x = torch.randn(M, N, device="cuda", dtype=torch.float32) * 3.0
+    y, s = convert_to_mxfp8(
+        x, fp8_dtype, quant_block_size=qbs, is_2d_block=is_2d_block, use_asm=False
+    )
+    # e8m0 biased byte -> dequant scale 2**(s-127), broadcast over the block.
+    scale = torch.exp2(s.float() - 127.0)
+    if is_2d_block:
+        scale = scale.repeat_interleave(qbs, dim=0).repeat_interleave(qbs, dim=1)
+    else:
+        scale = scale.repeat_interleave(qbs, dim=1)
+    deq = y.float() * scale
+    bound = _TOL[fp8_dtype] * x.abs().max().clamp_min(1e-4)
+    err = (deq - x).abs().max()
+    assert err <= bound, f"independent dequant err {err:.4f} > {bound:.4f}"
+
+
 def test_mxfp8_rejects_unaligned_shape():
     """M/N not aligned to the tile must raise (kernel loads full tiles unmasked)."""
     x = torch.randn(100, 100, device="cuda", dtype=torch.bfloat16)

--- a/op_tests/triton_tests/quant/test_convert_mxfp8.py
+++ b/op_tests/triton_tests/quant/test_convert_mxfp8.py
@@ -1,0 +1,63 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+"""Correctness tests for the convert_to_mxfp8 / convert_from_mxfp8 wrappers.
+
+These cover ``aiter.ops.triton.quant.quant_mxfp8`` (full-tensor MXFP8 convert),
+which is distinct from the fused/dynamic MXFP8 quant ops in
+``test_quant_mxfp8.py``.
+
+The ASM fast path uses gfx950-only ``v_cvt_scalef32_*`` instructions, so these
+tests exercise the portable ``use_asm=False`` path and verify the convert →
+deconvert roundtrip stays within MXFP8 (block-scaled e8m0) precision.
+"""
+
+import pytest
+import torch
+
+from aiter.ops.triton.quant.quant_mxfp8 import convert_from_mxfp8, convert_to_mxfp8
+
+# e4m3 keeps 3 mantissa bits, e5m2 only 2 — allow a looser bound for e5m2.
+_TOL = {torch.float8_e4m3fn: 0.16, torch.float8_e5m2: 0.35}
+
+
+@pytest.mark.parametrize("M, N", [(64, 64), (128, 256), (256, 128)])
+@pytest.mark.parametrize("is_2d_block", [False, True])
+@pytest.mark.parametrize("fp8_dtype", [torch.float8_e4m3fn, torch.float8_e5m2])
+@pytest.mark.parametrize("in_dtype", [torch.float32, torch.bfloat16])
+def test_mxfp8_roundtrip(M, N, is_2d_block, fp8_dtype, in_dtype):
+    torch.manual_seed(0)
+    qbs = 32
+    x = torch.randn(M, N, device="cuda", dtype=in_dtype) * 3.0
+
+    y, s = convert_to_mxfp8(
+        x,
+        fp8_dtype,
+        quant_block_size=qbs,
+        is_2d_block=is_2d_block,
+        use_asm=False,
+    )
+    assert y.shape == (M, N)
+    assert y.dtype == fp8_dtype
+    assert s.dtype == torch.uint8
+
+    xr = convert_from_mxfp8(
+        y,
+        s,
+        in_dtype,
+        quant_block_size=qbs,
+        is_2d_block=is_2d_block,
+        use_asm=False,
+    )
+    assert xr.shape == (M, N)
+    assert xr.dtype == in_dtype
+
+    scale = x.abs().max().clamp_min(1e-4)
+    err = (xr.float() - x.float()).abs().max()
+    assert err <= _TOL[fp8_dtype] * scale, f"max abs err {err:.4f} vs {scale:.4f}"
+
+
+def test_mxfp8_rejects_unaligned_shape():
+    """M/N not aligned to the tile must raise (kernel loads full tiles unmasked)."""
+    x = torch.randn(100, 100, device="cuda", dtype=torch.bfloat16)
+    with pytest.raises(AssertionError):
+        convert_to_mxfp8(x, torch.float8_e4m3fn, use_asm=False)

--- a/op_tests/triton_tests/quant/test_convert_mxfp8.py
+++ b/op_tests/triton_tests/quant/test_convert_mxfp8.py
@@ -15,6 +15,13 @@ import pytest
 import torch
 
 from aiter.ops.triton.quant.quant_mxfp8 import convert_from_mxfp8, convert_to_mxfp8
+from aiter.ops.triton.utils._triton import arch_info
+
+# Decorator for tests that require the gfx950 ASM path.
+_gfx950_only = pytest.mark.skipif(
+    arch_info.get_arch() != "gfx950",
+    reason="ASM v_cvt_scalef32_* instructions require gfx950",
+)
 
 # e4m3 keeps 3 mantissa bits, e5m2 only 2 — allow a looser bound for e5m2.
 _TOL = {torch.float8_e4m3fn: 0.16, torch.float8_e5m2: 0.35}
@@ -89,3 +96,94 @@ def test_mxfp8_rejects_unaligned_shape():
     x = torch.randn(100, 100, device="cuda", dtype=torch.bfloat16)
     with pytest.raises(AssertionError):
         convert_to_mxfp8(x, torch.float8_e4m3fn, use_asm=False)
+
+
+def test_mxfp8_rejects_unsupported_dtype():
+    """fp8_dtype outside {e4m3fn, e5m2} must raise ValueError."""
+    x = torch.randn(64, 64, device="cuda", dtype=torch.bfloat16)
+    with pytest.raises(ValueError, match="fp8_dtype"):
+        convert_to_mxfp8(x, torch.float8_e4m3fnuz, use_asm=False)
+
+
+def test_mxfp8_sr_unbiased_portable():
+    """SR output is unbiased: mean(dequant(SR(x))) ≈ mean(x) over a large tensor.
+
+    The kernel uses a fixed philox seed with position-dependent offsets, so
+    each element receives a distinct random value — a single large forward
+    pass acts as many independent draws.  The test also verifies that SR
+    produces different bits than deterministic rounding, confirming the path
+    is actually exercised.
+    """
+    torch.manual_seed(7)
+    M, N, qbs = 512, 512, 32
+    fp8_dtype = torch.float8_e4m3fn
+    x = torch.randn(M, N, device="cuda", dtype=torch.float32)
+
+    y_sr, s_sr = convert_to_mxfp8(
+        x, fp8_dtype, quant_block_size=qbs, use_sr=True, use_asm=False
+    )
+    y_det, _ = convert_to_mxfp8(
+        x, fp8_dtype, quant_block_size=qbs, use_sr=False, use_asm=False
+    )
+
+    # SR must activate — same input, different rounding decisions.
+    assert not torch.equal(y_sr, y_det), "SR and deterministic produced identical bits"
+
+    # Mean of SR dequantized output tracks the input mean (unbiasedness).
+    xr = convert_from_mxfp8(
+        y_sr, s_sr, torch.float32, quant_block_size=qbs, use_asm=False
+    )
+    mean_err = (xr.mean() - x.mean()).abs().item()
+    # Over 512×512 elements the CLT gives std(err) ≈ 0.16/sqrt(262144) ≈ 3e-4;
+    # 0.02 is a very conservative bound.
+    assert mean_err < 0.02, (
+        f"SR mean {xr.mean():.4f} diverges from input mean {x.mean():.4f} "
+        f"by {mean_err:.4f}"
+    )
+
+
+@_gfx950_only
+@pytest.mark.parametrize("is_2d_block", [False, True])
+@pytest.mark.parametrize("in_dtype", [torch.float32, torch.bfloat16])
+def test_mxfp8_asm_matches_portable(is_2d_block, in_dtype):
+    """On gfx950, the ASM path must produce results equivalent to portable Triton.
+
+    Scales are expected to be bitwise identical (same _calculate_scales logic).
+    Dequantized values must agree within FP8 precision.
+    """
+    torch.manual_seed(5)
+    M, N, qbs = 128, 256, 32
+    fp8_dtype = torch.float8_e4m3fn
+    x = torch.randn(M, N, device="cuda", dtype=in_dtype)
+
+    y_asm, s_asm = convert_to_mxfp8(
+        x, fp8_dtype, quant_block_size=qbs, is_2d_block=is_2d_block, use_asm=True
+    )
+    y_port, s_port = convert_to_mxfp8(
+        x, fp8_dtype, quant_block_size=qbs, is_2d_block=is_2d_block, use_asm=False
+    )
+
+    assert torch.equal(s_asm, s_port), "ASM and portable e8m0 scales differ"
+
+    xr_asm = convert_from_mxfp8(
+        y_asm,
+        s_asm,
+        in_dtype,
+        quant_block_size=qbs,
+        is_2d_block=is_2d_block,
+        use_asm=True,
+    )
+    xr_port = convert_from_mxfp8(
+        y_port,
+        s_port,
+        in_dtype,
+        quant_block_size=qbs,
+        is_2d_block=is_2d_block,
+        use_asm=False,
+    )
+
+    scale = x.abs().max().clamp_min(1e-4)
+    err = (xr_asm.float() - xr_port.float()).abs().max()
+    assert (
+        err <= _TOL[fp8_dtype] * scale
+    ), f"ASM vs portable max err {err:.4f} > {_TOL[fp8_dtype]} * {scale:.4f}"

--- a/op_tests/triton_tests/quant/test_fast_transpose.py
+++ b/op_tests/triton_tests/quant/test_fast_transpose.py
@@ -1,0 +1,48 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+"""Correctness tests for fast_transpose_2d Triton kernel."""
+
+import pytest
+import torch
+
+from aiter.ops.triton.quant.fast_transpose import fast_transpose_2d
+
+
+@pytest.mark.parametrize(
+    "M, N",
+    [
+        (1, 1),
+        (32, 32),
+        (64, 128),
+        (128, 64),
+        (1024, 512),
+        (511, 257),  # non-power-of-2
+        (1, 4096),
+        (4096, 1),
+    ],
+)
+@pytest.mark.parametrize(
+    "dtype",
+    [torch.float32, torch.bfloat16, torch.float16, torch.float8_e4m3fnuz],
+)
+def test_fast_transpose_2d_correctness(M, N, dtype):
+    torch.manual_seed(0)
+    if dtype == torch.float8_e4m3fnuz:
+        x = torch.randn(M, N, device="cuda").to(dtype)
+        ref = x.view(torch.int8).t().contiguous().view(dtype)
+    else:
+        x = torch.randn(M, N, dtype=dtype, device="cuda")
+        ref = x.t().contiguous()
+
+    out = fast_transpose_2d(x)
+
+    assert out.shape == (N, M), f"shape mismatch: {out.shape} vs {(N, M)}"
+    assert out.is_contiguous(), "output is not contiguous"
+    assert out.dtype == dtype
+
+    if dtype == torch.float8_e4m3fnuz:
+        assert torch.equal(
+            out.view(torch.int8), ref.view(torch.int8)
+        ), "FP8 bit pattern mismatch"
+    else:
+        torch.testing.assert_close(out, ref)


### PR DESCRIPTION
  ## Summary

  Two independent, purely additive Triton kernel families under
  `aiter/ops/triton/quant/`, split out from the FP8 block-wise quant work so each
  reviews on its own. Neither touches any existing kernel.

  - **MXFP8 convert** (`convert_to_mxfp8` / `convert_from_mxfp8`): block-scaled
    (e8m0) MXFP8 quant/dequant with optional stochastic rounding and a gfx950 ASM
    asserts M/N tile alignment (the kernels load full tiles unmasked) and
    auto-selects the ASM path only on gfx950 — the `v_cvt_scalef32_*` instructions
    are gfx950-only, so other archs use the portable path.
  - **fast_transpose** (`fast_transpose_2d`): tiled LDS 2-D transpose that
    replaces the `t().contiguous()` full `aten::copy_`; works for any dtype
    including FP8 (e4m3 / e5m2 / fnuz).

  Each launchable kernel carries a config-aware `repr=`.
  
  ## Test plan

  - [ ] `op_tests/triton_tests/quant/test_convert_mxfp8.py` — MXFP8 roundtrip
        (e4m3fn / e5m2 × 1-D/2-D block × fp32/bf16, portable path) + alignment guard
  - [ ] `op_tests/triton_tests/quant/test_fast_transpose.py` — transpose across
        dtypes/shapes incl. non-power-of-2 and FP8
  
  Benchmarks: `op_benchmarks/triton/bench_quant_mxfp8.py`,
  `bench_fast_transpose.py`. Verified on MI308X (gfx942); the MXFP8 ASM path
  requires gfx950.