### PR TITLE
[CI] CI: set release publish repository context

### DIFF
--- a/.github/workflows/release-automation.yaml
+++ b/.github/workflows/release-automation.yaml
@@ -319,6 +319,7 @@ jobs:
       actions: read
     env:
       GH_TOKEN: ${{ github.token }}
+      GH_REPO: ${{ github.repository }}
       RELEASE_TAG: ${{ needs.prepare.outputs.release_tag }}
       RELEASE_VERSION: ${{ needs.prepare.outputs.release_version }}
       RELEASE_KIND: ${{ needs.prepare.outputs.release_kind }}


### PR DESCRIPTION
## Summary
- Set `GH_REPO` in the release automation publish job so `gh release` commands have repository context even without a checkout.
- Fixes the final publish failure from run 33586350146 where `gh release view` failed with `fatal: not a git repository`.

## Test plan
- python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release-automation.yaml')); print('yaml ok')"
- git diff --check