### PR TITLE
[CI] Run extended test dispatch on internal runner

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -6,6 +6,7 @@ self-hosted-runner:
     - aiter-di-ci-spur-login-vllm
     - aiter-gfx1100
     - build-only-aiter
+    - linux-aiter-build-mi250
     - linux-aiter-do-mi350x-1
     - linux-aiter-do-mi350x-2
     - linux-aiter-do-mi350x-4

--- a/.github/workflows/extended-test.yaml
+++ b/.github/workflows/extended-test.yaml
@@ -29,7 +29,7 @@ jobs:
         contains(github.event.pull_request.labels.*.name, 'ci:extended-test')
       ) &&
       (github.event.action != 'labeled' || github.event.label.name == 'ci:extended-test')
-    runs-on: ubuntu-latest
+    runs-on: linux-aiter-build-mi250
 
     steps:
       - name: Build dispatch payload


### PR DESCRIPTION
Update the Extended Test dispatch job to run on the internal linux-aiter-build-mi250 runner instead of GitHub hosted ubuntu-latest. This lets the dispatch call reach the private AMD-ROCm-Internal/fw-bringup repository from an allowed network path.