### PR TITLE
Fall back to cktile when the ck bpreshuffle instance rejects a shape

### DIFF
--- a/aiter/ops/gemm_op_a8w8.py
+++ b/aiter/ops/gemm_op_a8w8.py
@@ -771,15 +771,26 @@ def gemm_a8w8_bpreshuffle(
             return gemm_a8w8_bpreshuffle_flydsl(
                 XQ, WQ, x_scale, w_scale, Y, {"kernelName": ki.name}
             )
+    if w_k > k:
+        return gemm_a8w8_bpreshuffle_cktile(XQ, WQ, x_scale, w_scale, Y, 0)
     try:
-        if w_k > k:
-            return gemm_a8w8_bpreshuffle_cktile(XQ, WQ, x_scale, w_scale, Y, 0)
         return gemm_a8w8_bpreshuffle_ck(XQ, WQ, x_scale, w_scale, Y, 0)
-    except RuntimeError as e:
-        raise RuntimeError(
-            f"gemm_a8w8_bpreshuffle failed for shape M={m}, N={n}, K={k}, "
-            f"{dtype=}, config={config}: {e}"
-        ) from e
+    except RuntimeError as ck_error:
+        # The ck instances are GemmSpecialization::Default, so the one the
+        # heuristic picks rejects any N that its NPerBlock does not divide.
+        # cktile compiles a padded variant per kernel and takes every shape;
+        # it is slower on the skinny N it rescues, but it is not a crash.
+        logger.warning(
+            f"gemm_a8w8_bpreshuffle ck rejected M={m}, N={n}, K={k}; "
+            f"falling back to cktile."
+        )
+        try:
+            return gemm_a8w8_bpreshuffle_cktile(XQ, WQ, x_scale, w_scale, Y, 0)
+        except RuntimeError as e:
+            raise RuntimeError(
+                f"gemm_a8w8_bpreshuffle failed for shape M={m}, N={n}, K={k}, "
+                f"{dtype=}, config={config}: ck raised {ck_error}, cktile raised {e}"
+            ) from e
 
 
 def gemm_a8w8_blockscale_fake(


### PR DESCRIPTION
## Problem

`gemm_a8w8_bpreshuffle` raises for shapes it is able to compute:

```
RuntimeError: gemm_a8w8_bpreshuffle failed for shape M=16384, N=32, K=4096,
              dtype=torch.bfloat16, config=None: This GEMM is not supported!
```

The ck instances in `csrc/ck_gemm_a8w8_bpreshuffle/` are generated with `GemmSpecialization::Default` -- pre-shuffled weights are never N-padded -- so each one requires `N % NPerBlock == 0`. `rowwise_heuristic_dispatch` picks by shape, and for `K >= 1536` the `M >= 256` branch lands on `a8w8_bpreshuffle_256x128x64x128_...` with `NPerBlock=64`, while the `M < 256` branch lands on `a8w8_bpreshuffle_128x16x32x512_...` with `NPerBlock=32`.

Measured on gfx950, N=32, K=4096:

```
M=    1 : OK
M=    4 : OK
M=   64 : OK
M=  255 : OK
M=  256 : FAIL
M=  512 : FAIL
```

The same N is supported below M=256 and unsupported at and above it. For an inference server that means warmup and decode succeed and the first real prefill crashes the process -- which is how this was found: SGLang serving a quark-quantized Qwen3.5 at TP4, where `linear_attn.in_proj_ba` (N=128) shards to N=32.

## Fix

`gemm_a8w8_bpreshuffle_cktile` compiles a padded variant of every kernel (`gen_instances.py` emits nopad / pad_m / pad_n / pad_k / pad_mn / pad_mk / pad_nk / pad_mnk and selects at runtime from `M % MTile`, `N % NTile`, `K % KTile`), so it accepts any shape. Use it as the fallback when the ck instance rejects the arguments instead of propagating the error. If both fail, the raised message now carries both errors.

```
[aiter] gemm_a8w8_bpreshuffle ck rejected M=7237, N=32, K=4096; falling back to cktile.
M=7237 N=128 K=4096: OK
M=7237 N=64  K=4096: OK
M=7237 N=32  K=4096: OK   <- previously raised
```

cktile is bit-exact against `torch._scaled_mm` rowwise on these shapes (max abs err 0).

## Note on performance

This is a safety net, not a fast path. At M=16384 / N=32 / K=4096 on gfx950:

```
gemm_a8w8_bpreshuffle_cktile : 91.9 us
torch._scaled_mm rowwise     : 14.1 us
```

Half the MFMA issue goes into N-padding. A caller that owns the weight layout should avoid pre-shuffling for shapes like this and use a rowwise GEMM instead -- SGLang does that in sgl-project/sglang#37564. But a caller that has already shuffled has no way back, so the library should compute the answer rather than raise.

A follow-up worth considering is exporting a support/efficiency query so callers can make that decision without hardcoding `N % 64`; it is left out here because after this fallback the predicate is about speed rather than support, and that deserves its own discussion.
