### PR TITLE
Fix stale TopK availability checks

### DIFF
--- a/aiter/ops/topk.py
+++ b/aiter/ops/topk.py
@@ -475,17 +475,6 @@ _FLYDSL_TOPK_DECODE_GATES = {
 _FLYDSL_TOPK_DECODE_KS = (512, 1024, 2048, 4096)
 
 
-@functools.lru_cache(maxsize=1)
-def _flydsl_topk_decode_available() -> bool:
-    """Whether the optional FlyDSL package is available on this device."""
-    try:
-        from .flydsl.utils import is_flydsl_available
-
-        return is_flydsl_available()
-    except (ImportError, OSError, RuntimeError):
-        return False
-
-
 @functools.lru_cache(maxsize=128)
 def _flydsl_topk_decode_shape_supported(
     arch: str,
@@ -524,7 +513,7 @@ def _should_use_flydsl_topk_decode(
         return False
 
     arch = get_gfx()
-    if arch not in _FLYDSL_TOPK_DECODE_GATES or not _flydsl_topk_decode_available():
+    if arch not in _FLYDSL_TOPK_DECODE_GATES:
         return False
 
     if not _flydsl_topk_decode_shape_supported(

--- a/op_tests/test_topk_per_row.py
+++ b/op_tests/test_topk_per_row.py
@@ -6,7 +6,6 @@ import torch
 
 import aiter
 from aiter.jit.utils.chip_info import get_gfx
-from aiter.ops.flydsl.utils import is_flydsl_available
 from aiter.test_common import benchmark, perftest
 
 
@@ -510,7 +509,7 @@ aiter.logger.info("topk_per_row_prefill summary (markdown):\n%s", df_md)
 
 
 df = []
-flydsl_available = get_gfx() in ("gfx942", "gfx950") and is_flydsl_available()
+flydsl_available = get_gfx() in ("gfx942", "gfx950")
 for data_generation in args.data_generation:
     for m in args.decode_batch_size:
         for ctx in args.context_len:


### PR DESCRIPTION
## Summary

- remove stale references to the deleted `aiter.ops.flydsl.utils` module
- restore FlyDSL decode TopK dispatch on supported gfx942/gfx950 systems
- fix `op_tests/test_topk_per_row.py` collection in the standard-test suite

## Context

[#5116](https://github.com/ROCm/aiter/pull/5116) removed the optional FlyDSL availability helper and made FlyDSL imports unconditional. [#5011](https://github.com/ROCm/aiter/pull/5011) landed later with two references to the removed helper:

- the test imports it eagerly and fails collection with `ModuleNotFoundError`
- the runtime dispatch catches the same import failure and silently disables the FlyDSL TopK path

This was observed in the [MI35X standard-test failure](https://github.com/ROCm/aiter/actions/runs/33607831567/job/100210655925) on #4761. The failure occurs before any GPU kernel executes.

## Test plan

- [x] `PYTHONPYCACHEPREFIX=/tmp/aiter-topk-fix-pycache python3 -m py_compile aiter/ops/topk.py op_tests/test_topk_per_row.py`
- [x] `git diff --check`
- [x] verify no Python references to `aiter.ops.flydsl.utils` or `is_flydsl_available` remain
- [ ] upstream CI

Made with [Cursor](https://cursor.com)