### PR TITLE
[ASM] [HIP] fix(mla): mark bf16 mla_pfl prefill CSV/lookup as causal

### DIFF
--- a/csrc/py_itfs_cu/asm_mla.cu
+++ b/csrc/py_itfs_cu/asm_mla.cu
@@ -1281,7 +1281,7 @@ void mla_prefill_asm_fwd(
     
     int ps = 0; // prefill without persistent scheduling
     int prefill = 1; // prefill stage
-    int causal_flag = 0;
+    int causal_flag = 1;
     int qseqlen = 0;
     std::string kernelName = get_heuristic_kernel_mla(q_type, kv_type, gqa_ratio, ps, prefill, causal_flag, qseqlen, arch_id, config_map);
     

--- a/hsa/gfx942/mla/mla_asm.csv
+++ b/hsa/gfx942/mla/mla_asm.csv
@@ -15,8 +15,8 @@ fp8,fp8,16,0,1,0,1,0,_ZN5aiter33mla_a8w8_qh16_qseqlen1_gqaratio16E,mla_a8w8_qh16
 fp8,fp8,16,0,2,0,1,0,_ZN5aiter33mla_a8w8_qh16_qseqlen2_gqaratio16E,mla_a8w8_qh16_qseqlen2_gqaratio16.co
 fp8,fp8,16,0,4,0,1,0,_ZN5aiter33mla_a8w8_qh64_qseqlen4_gqaratio16E,mla_a8w8_qh64_qseqlen4_gqaratio16.co
 fp8,fp8,128,0,0,0,1,0,_ZN5aiter31mla_a8w8_qh128_m32x4_n16x2_msk1E,mla_a8w8_qh128_m32x4_n16x2_msk1.co
-bf16,bf16,16,0,0,1,0,0,_ZN5aiter39mla_pfl_bf16_a16w16_causal_subQ16_mqa16E,mla_pfl_bf16_a16w16_causal_subQ16_mqa16.co
-bf16,bf16,128,0,0,1,0,0,_ZN5aiter41mla_pfl_bf16_a16w16_causal_subQ128_mqa128E,mla_pfl_bf16_a16w16_causal_subQ128_mqa128.co
+bf16,bf16,16,0,0,1,1,0,_ZN5aiter39mla_pfl_bf16_a16w16_causal_subQ16_mqa16E,mla_pfl_bf16_a16w16_causal_subQ16_mqa16.co
+bf16,bf16,128,0,0,1,1,0,_ZN5aiter41mla_pfl_bf16_a16w16_causal_subQ128_mqa128E,mla_pfl_bf16_a16w16_causal_subQ128_mqa128.co
 fp8,fp8,128,1,0,0,1,0,_ZN5aiter34mla_a8w8_qh128_m32x4_n16x2_msk0_psE,mla_a8w8_qh128_m32x4_n16x2_msk0_ps.co
 fp8,fp8,1,1,0,1,1,0,_ZN5aiter40mla_pfl_qh192_vh128_m32x8_n128x1_causal1E,mla_pfl_qh192_vh128_m32x8_n128x1_causal1.co
 fp8,fp8,1,1,0,1,0,0,_ZN5aiter40mla_pfl_qh192_vh128_m32x8_n128x1_causal0E,mla_pfl_qh192_vh128_m32x8_n128x1_causal0.co

--- a/hsa/gfx950/mla/mla_asm.csv
+++ b/hsa/gfx950/mla/mla_asm.csv
@@ -23,8 +23,8 @@ fp8,fp8,16,1,4,0,1,1,1,_ZN5aiter48mla_a8w8_qh16_qseqlen4_gqaratio16_lse_cprr_v3_
 fp8,fp8,32,1,4,0,1,0,1,_ZN5aiter41mla_a8w8_qh32_qseqlen4_gqaratio32_cprr_psE,mla_a8w8_qh32_qseqlen4_gqaratio32_cprr_ps.co
 fp8,fp8,32,1,4,0,1,1,1,_ZN5aiter45mla_a8w8_qh32_qseqlen4_gqaratio32_lse_cprr_psE,mla_a8w8_qh32_qseqlen4_gqaratio32_lse_cprr_ps.co
 fp8,fp8,128,0,0,0,1,0,0,_ZN5aiter31mla_a8w8_qh128_m32x4_n16x2_msk1E,mla_a8w8_qh128_m32x4_n16x2_msk1.co
-bf16,bf16,16,0,0,1,0,0,0,_ZN5aiter39mla_pfl_bf16_a16w16_causal_subQ16_mqa16E,mla_pfl_bf16_a16w16_causal_subQ16_mqa16.co
-bf16,bf16,128,0,0,1,0,0,0,_ZN5aiter41mla_pfl_bf16_a16w16_causal_subQ128_mqa128E,mla_pfl_bf16_a16w16_causal_subQ128_mqa128.co
+bf16,bf16,16,0,0,1,1,0,0,_ZN5aiter39mla_pfl_bf16_a16w16_causal_subQ16_mqa16E,mla_pfl_bf16_a16w16_causal_subQ16_mqa16.co
+bf16,bf16,128,0,0,1,1,0,0,_ZN5aiter41mla_pfl_bf16_a16w16_causal_subQ128_mqa128E,mla_pfl_bf16_a16w16_causal_subQ128_mqa128.co
 fp8,fp8,1,1,0,1,1,0,0,_ZN5aiter40mla_pfl_qh192_vh128_m32x8_n128x1_causal1E,mla_pfl_qh192_vh128_m32x8_n128x1_causal1.co
 fp8,fp8,1,1,0,1,0,0,0,_ZN5aiter40mla_pfl_qh192_vh128_m32x8_n128x1_causal0E,mla_pfl_qh192_vh128_m32x8_n128x1_causal0.co
 bf16,bf16,32,0,0,0,1,0,0,_ZN5aiter39mla_a16w16_qh16_m16x4_n32x1_coex0_mask1E,MLA_A16W16_1TG_4W_16mx4_32nx1_Coex0_Msk1_QH16.co


### PR DESCRIPTION


## Motivation

The shipped mla_pfl_bf16_* kernels apply a causal mask (matches absorb torch ref; diverges from non-causal), but the CSV causal column and mla_prefill_asm_fwd heuristic key were 0. Align both to 1 on gfx942/gfx950
so metadata matches behavior and dispatch still finds the kernel.


## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
