### PR TITLE
[HIP] fix(mla/metadata): scale the auto KV-split count with the machine width

### DIFF
--- a/csrc/kernels/mla/metadata/v1_2_device.cuh
+++ b/csrc/kernels/mla/metadata/v1_2_device.cuh
@@ -29,23 +29,32 @@ static constexpr int32_t MLA_V12_FILL_WARPS = 8;
 static constexpr float MLA_V12_SPLIT_COEF = 1.2f;
 
 // Workload-adaptive KV-split count for "auto" mode (max_split_per_batch < 0).
-// The old policy pinned splits to num_clusters regardless of workload, which
-// over-splits short/medium ctx (reduction dominates, ~2x slower) while the
-// legacy cap of 16 under-splits long ctx. Split-K optimum for a unit of weight w
-// is ~coef*sqrt(w) (compute ~w/e, reduction ~e). The grid is shared across all
-// units, so the budget is the SUM of per-unit sqrt(w) -- passed in as
-// sum_sqrt_blocks -- not sqrt(sum(w)), which under-splits with >1 unit. eff is
-// clamped to [1, num_splits]; eff <= num_splits keeps the reduce-buffer
-// worst-case reservation valid (CUDA-graph safe). coef is MLA_V12_SPLIT_COEF.
+// The legacy cap of 16 under-splits long ctx, so the count is derived from the
+// workload instead. Both terms of the cost are spread over the machine: stage1
+// wall ~ a*W/e (e workgroups run concurrently, W = sum_blocks total) and the
+// reduction wall ~ b*e/num_clusters (e partials over the same clusters), so the
+// optimum is e* = sqrt((a/b) * W * num_clusters) -- it scales with the WIDTH of
+// the machine, not just the work. In auto mode num_splits is num_clusters, so it
+// doubles as that width here. eff is clamped to [1, num_splits]; eff <=
+// num_splits keeps the reduce-buffer worst-case reservation valid (CUDA-graph
+// safe). coef is MLA_V12_SPLIT_COEF.
+//
+// A per-unit sum(sqrt(w_i)) instead of sqrt(W * num_clusters) is only equivalent
+// when the unit count already equals num_clusters; with n units it is off by
+// sqrt(num_clusters / n), i.e. 16x low for a single unit on a 256-CU part, which
+// starves exactly the low-concurrency decode it is meant to serve.
+//
 // Explicit (>= 0) requests keep the exact count asked for.
 __device__ __forceinline__ int32_t
-mla_v12_effective_splits(const MlaMetadataV1KernelParameter& params, const float sum_sqrt_blocks)
+mla_v12_effective_splits(const MlaMetadataV1KernelParameter& params, const int32_t sum_blocks)
 {
     if(!params.auto_split)
     {
         return params.num_splits;
     }
-    int32_t eff = static_cast<int32_t>(lrintf(MLA_V12_SPLIT_COEF * sum_sqrt_blocks));
+    const float work = static_cast<float>(max(1, sum_blocks)) *
+                       static_cast<float>(max(1, params.num_splits));
+    int32_t eff = static_cast<int32_t>(lrintf(MLA_V12_SPLIT_COEF * sqrtf(work)));
     return max(1, min(eff, params.num_splits));
 }
 
@@ -79,11 +88,9 @@ mla_v12_compute_sum_blocks(const MlaMetadataV1KernelParameter& params,
                            int32_t* p_lds_seqlens_kv,
                            const int32_t ori_seqlen_qo,
                            const int32_t num_batches,
-                           const int32_t lane_idx,
-                           float& sum_sqrt_blocks_out)
+                           const int32_t lane_idx)
 {
-    int32_t sum_blocks      = 0;
-    float   sum_sqrt_blocks = 0.0f;
+    int32_t sum_blocks = 0;
     for(int32_t bid = lane_idx; bid < num_batches; bid += opus::get_warp_size())
     {
         const int32_t bid_ori = Traits::kIsSparse ? (bid / ori_seqlen_qo / params.qk_batch_ratio)
@@ -103,9 +110,6 @@ mla_v12_compute_sum_blocks(const MlaMetadataV1KernelParameter& params,
         const int32_t num_qo_tiles = mla_v12_num_qo_tiles<Traits>(params, qo_state, bid);
         const int32_t unit_blocks  = num_blocks + params.fixed_over_head_num_blocks;
         sum_blocks += unit_blocks * num_qo_tiles;
-        // per (batch, qo_tile) work unit: num_qo_tiles terms of sqrt(unit_blocks)
-        sum_sqrt_blocks += static_cast<float>(num_qo_tiles) *
-                           sqrtf(static_cast<float>(max(1, unit_blocks)));
 
         if constexpr(QoState<Traits>::is_unique() == false)
         {
@@ -114,8 +118,6 @@ mla_v12_compute_sum_blocks(const MlaMetadataV1KernelParameter& params,
         }
     }
 
-    sum_sqrt_blocks_out =
-        aiter::warpReduce<aiter::AddFunctor, float, opus::get_warp_size()>(sum_sqrt_blocks);
     return aiter::warpReduce<aiter::AddFunctor, decltype(sum_blocks), opus::get_warp_size()>(
         sum_blocks);
 }
@@ -161,17 +163,15 @@ __launch_bounds__(opus::get_warp_size() * MLA_V12_FILL_WARPS, 1) __global__
     // Phase 1 (warp 0): closed-form scan, no stores
     if(warp_id == 0)
     {
-        float         sum_sqrt_blocks = 0.0f;
-        const int32_t sum_blocks      = mla_v12_compute_sum_blocks<Traits>(params,
+        const int32_t sum_blocks = mla_v12_compute_sum_blocks<Traits>(params,
                                                                       qo_state,
                                                                       p_lds_seqlens_qo,
                                                                       p_lds_seqlens_kv,
                                                                       ori_seqlen_qo,
                                                                       num_batches,
-                                                                      lane_idx,
-                                                                      sum_sqrt_blocks);
+                                                                      lane_idx);
 
-        const int32_t eff_splits    = mla_v12_effective_splits(params, sum_sqrt_blocks);
+        const int32_t eff_splits    = mla_v12_effective_splits(params, sum_blocks);
         const int32_t payload       = integer_divide_ceil(sum_blocks, eff_splits) + overhead;
         const int32_t blocks_per_cu = payload - overhead;
 
@@ -431,15 +431,13 @@ __launch_bounds__(opus::get_warp_size(), 1) __global__
 
     MlaWorkInfo* p_work_info_set = reinterpret_cast<MlaWorkInfo*>(params.p_work_info_set_raw);
 
-    float         sum_sqrt_blocks = 0.0f;
-    const int32_t sum_blocks      = mla_v12_compute_sum_blocks<Traits>(params,
+    const int32_t sum_blocks = mla_v12_compute_sum_blocks<Traits>(params,
                                                                   qo_state,
                                                                   p_lds_seqlens_qo,
                                                                   p_lds_seqlens_kv,
                                                                   ori_seqlen_qo,
                                                                   num_batches,
-                                                                  lane_idx,
-                                                                  sum_sqrt_blocks);
+                                                                  lane_idx);
 
     if(lane_idx == 0)
     {
@@ -452,7 +450,7 @@ __launch_bounds__(opus::get_warp_size(), 1) __global__
     }
 
     // same eff_splits as the phase-1 count so fill and count agree
-    const int32_t eff_splits = mla_v12_effective_splits(params, sum_sqrt_blocks);
+    const int32_t eff_splits = mla_v12_effective_splits(params, sum_blocks);
     const int32_t payload =
         integer_divide_ceil(sum_blocks, eff_splits) + params.fixed_over_head_num_blocks;
     const int32_t page_size   = params.page_size;


### PR DESCRIPTION
## Summary

The auto KV-split count (`max_split_per_batch < 0`) introduced in #4899 is derived as `coef * sum_i sqrt(w_i)` over the per-`(batch, qo_tile)` work units. **That form has no notion of how wide the machine is**, so it under-splits whenever the batch alone does not already fill the clusters.

Both terms of the cost are spread over the machine: stage1 wall `~ a*W/e` (the `e` workgroups run concurrently, `W = sum_blocks`) and the reduction wall `~ b*e/num_clusters`. The optimum is therefore

```
e* = sqrt((a/b) * W * num_clusters)
```

Against that, `sum_i sqrt(w_i)` is short by `sqrt(num_clusters / n)` for `n` units — **16x for a single unit on a 256-CU part** — which starves exactly the low-concurrency decode the heuristic is meant to serve. The two forms coincide at `n == num_clusters`, so `MLA_V12_SPLIT_COEF` stays at `1.2` and its original calibration point is untouched.

Dropping `sum_sqrt_blocks` also removes one warp reduction from the planner's phase-1 scan.

## Measurements

gfx950 (MI355X, 256 CU), persistent MLA decode. For each shape I swept explicit budgets to find the per-shape optimum, then scored each policy by its **regret** against that optimum. The grid follows how the shapes actually occur in deployment: batch 1-4 with 7 speculative tokens, batch 8-32 with 3, plain decode above that. Context 8K-256K, 16 heads, fp8/fp8, `kv_granularity=128`.

| policy | mean regret | worst |
|---|---|---|
| `1.2 * sum sqrt(w_i)` (current) | 1.299 | **2.040** |
| `1.2 * sqrt(W * num_clusters)` (this PR) | 1.014 | 1.070 |

Broken down by regime:

| regime | before | after |
|---|---|---|
| batch 1-4, 7 spec tokens | 1.06 – **2.04x** | ≤ 1.07 |
| batch 8-32, 3 spec tokens | 1.00 – 1.33x | ≤ 1.05 |
| batch >= 64, plain decode | 1.000 | 1.000 |

At batch >= 64 both forms saturate the clamp and emit identical plans, so that row is unchanged by construction.

Concretely at batch 1, 64K context (512 blocks): the old form asks for **27** splits and the kernel takes **101.2us**; the new form asks for 171 and takes **58.4us**, matching the best explicit budget.

This is not shape-specific. Sweeping `qlen=1` decode across 16/64/128 heads and both fp8 and bf16, the old policy was short by 1.1x-1.97x in every configuration measured (worst: 128 heads bf16, batch 1, 2K context — 60.8us vs 31.0us).

## Correctness

`op_tests/test_mla_persistent.py -ms -1` over batch 1/3/16/64, context 21..8192, nhead `16,1` and `128,2`, both uniform and `--varlen`: **identical pass/fail set to the unpatched baseline** (the pre-existing 16 `atol=rtol=0.01` failures on `mla_decode-absorb`/`_fp8` reproduce unchanged on `main`).

Note that the suite's default `-ms 32` takes the explicit branch and never exercises this path; `-ms -1` is required to cover it.
