### PR TITLE
[FlyDSL] Relax GDR decode test mismatch tolerance

### DIFF
--- a/op_tests/test_flydsl_linear_attention.py
+++ b/op_tests/test_flydsl_linear_attention.py
@@ -39,7 +39,7 @@ _MAX_PERF_ROTATIONS = 101
 # stores bf16 while the reference accumulates in fp32, so a value sitting on a
 # rounding boundary can land one ULP away -- a handful of such elements per
 # tensor is expected. A real correctness break moves far more than this.
-_TOL_ERR_RATIO = 1e-4
+_TOL_ERR_RATIO = 1e-3
 
 
 @dataclass
@@ -765,19 +765,6 @@ def main():
             )
         except ValueError as exc:
             parser.error(str(exc))
-        # TODO: re-enable once _TOL_ERR_RATIO is scaled by output size. On MI35X
-        # this case lands a single bf16 ULP off (max abs delta 0.0078125, 1 of
-        # 2048 elements), giving a mismatch ratio of 1/2048 = 4.883e-04 against
-        # a flat 1e-4 threshold -- i.e. the check currently allows zero
-        # mismatching elements for a 2048-element output.
-        if (
-            dtype == dtypes.bf16
-            and batch == 2
-            and sq == 1
-            and tuple(head_config) == (2, 8, 128, 128)
-            and not l2norm
-        ):
-            continue
         rows.append(
             test_flydsl_gdr_decode(
                 batch,


### PR DESCRIPTION
## Motivation
FlyDSL and the Triton reference use different reduction orders, which can occasionally produce one-ULP BF16 output differences. The existing `1e-4` threshold effectively allows zero mismatches for small outputs, causing flaky CI failures across different configurations.

## Summary
- Increase the mismatch tolerance from `1e-4` to `1e-3`.
- Re-enable the previously skipped BF16 no-L2 configuration.
- Ensure all sweep combinations remain covered.
