### PR TITLE
[Triton/Gluon] [BENCHMARK] Adding utility function for torch profiler based benchmarking

### DIFF
--- a/op_tests/op_benchmarks/triton/bench_fp8_mqa_logits.py
+++ b/op_tests/op_benchmarks/triton/bench_fp8_mqa_logits.py
@@ -8,9 +8,17 @@ from aiter.ops.triton.utils.types import e4m3_dtype
 from op_tests.op_benchmarks.triton.utils.benchmark_utils import (
     get_caller_name_no_ext,
 )
+from op_tests.op_benchmarks.triton.utils.profiler_bench import do_bench_profiler
 from op_tests.triton_tests.attention.test_fp8_mqa_logits import (
     per_custom_dims_cast_to_fp8,
 )
+
+# Matches both the triton (_fp8_mqa_logits_kernel) and the gluon
+# (_gluon_fp8_mqa_logits_kernel) variant of the op.
+KERNEL_NAME = "fp8_mqa_logits_kernel"
+# With clean_logits the op pre-fills its fp32 output with -inf via torch.full,
+# which is a real part of its cost.
+FILL_KERNEL_NAME = "FillFunctor<float>"
 
 
 def calculate_tflops(start_inds, end_inds, num_heads_q, head_dim, time_ms):
@@ -65,7 +73,7 @@ def run_benchmark(args):
         styles=[("green", "-")],
         ylabel=ylabel,
         plot_name=get_caller_name_no_ext(),
-        args={"metric": args.metric},
+        args={"metric": args.metric, "flush_l2": args.flush_l2},
     )
 
     @triton.testing.perf_report([benchmark])
@@ -77,6 +85,7 @@ def run_benchmark(args):
         head_dim,
         clean_logits,
         metric,
+        flush_l2,
         **kwargs,
     ):
         s_q = batch_size * seq_q_l
@@ -102,7 +111,18 @@ def run_benchmark(args):
         def func():
             return fp8_mqa_logits(q_fp8, kv_fp8, scales, weights, ks, ke, clean_logits)
 
-        time_ms = triton.testing.do_bench(func, warmup=25, rep=100)
+        kernel_names = [KERNEL_NAME]
+        if clean_logits:
+            kernel_names.append(FILL_KERNEL_NAME)
+
+        time_ms = do_bench_profiler(
+            func,
+            kernel_names,
+            num_warmup=25,
+            num_iters=100,
+            flush_l2=flush_l2,
+            return_mode="median",
+        )
         tflops = calculate_tflops(ks, ke, num_heads_q, head_dim, time_ms)
 
         # Return exactly one scalar depending on which metric is active
@@ -132,6 +152,12 @@ def main():
     )
     parser.add_argument(
         "--clean_logits", type=int, default=1, help="Clean the untouched logits"
+    )
+    parser.add_argument(
+        "--flush_l2",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Flush the L2 cache before every benchmark iteration",
     )
     parser.add_argument(
         "-o", action="store_true", help="Write performance results to CSV file"

--- a/op_tests/op_benchmarks/triton/utils/profiler_bench.py
+++ b/op_tests/op_benchmarks/triton/utils/profiler_bench.py
@@ -140,9 +140,7 @@ def do_bench_profiler(
         run(i)
     torch.cuda.synchronize()
 
-    with tpf.profile(
-        activities=[tpf.ProfilerActivity.CPU, tpf.ProfilerActivity.CUDA]
-    ) as prof:
+    with tpf.profile(activities=[tpf.ProfilerActivity.CUDA]) as prof:
         for i in range(num_iters):
             run(i)
         torch.cuda.synchronize()

--- a/op_tests/op_benchmarks/triton/utils/profiler_bench.py
+++ b/op_tests/op_benchmarks/triton/utils/profiler_bench.py
@@ -1,0 +1,128 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+"""Torch-profiler based timing, filtered by GPU kernel name.
+
+``triton.testing.do_bench`` times the callable from the host, so everything
+``fn`` does besides the kernel of interest (setup, reference ops, the cache
+flush itself) ends up in the number. Here only the device time of the named
+kernels is summed, which also works when an op launches several kernels or
+sits inside a larger wrapper.
+"""
+
+import statistics
+import warnings
+from collections.abc import Callable, Sequence
+from typing import Any
+
+import torch
+import torch.profiler as tpf
+
+_REDUCE = {
+    "mean": statistics.fmean,
+    "median": statistics.median,
+    "min": min,
+    "max": max,
+}
+
+
+def _is_device_event(ev) -> bool:
+    return "CUDA" in str(getattr(ev, "device_type", ""))
+
+
+def _call(fn, data):
+    if data is None:
+        return fn()
+    if isinstance(data, tuple):
+        return fn(*data)
+    if isinstance(data, dict):
+        return fn(**data)
+    return fn(data)
+
+
+def _reduce(times_us, num_iters, return_mode):
+    """Sum the launches belonging to one iteration, then reduce across iterations."""
+    if len(times_us) % num_iters != 0:
+        warnings.warn(
+            f"{len(times_us)} launches over {num_iters} iterations: the kernel count "
+            "per iteration is not constant, falling back to mean.",
+            stacklevel=3,
+        )
+        return sum(times_us) / num_iters / 1000
+    per_iter = len(times_us) // num_iters
+    totals = [
+        sum(times_us[i * per_iter : (i + 1) * per_iter]) for i in range(num_iters)
+    ]
+    return _REDUCE[return_mode](totals) / 1000
+
+
+def do_bench_profiler(
+    fn: Callable,
+    kernel_names: str | Sequence[str],
+    num_warmup: int = 25,
+    num_iters: int = 100,
+    flush_l2: bool = True,
+    cache_size_mb: int = 512,
+    data_gen: Callable[[], Any] | None = None,
+    num_copies: int = 1,
+    return_mode: str = "mean",
+    per_kernel: bool = False,
+):
+    """Time the kernels named in ``kernel_names`` while running ``fn``.
+
+    A kernel is selected when one of ``kernel_names`` is a substring of its
+    profiler name, so launch overhead, cache flushes and everything else ``fn``
+    does are left out of the measurement.
+
+    Pass ``data_gen`` to rotate over ``num_copies`` input sets built up front
+    instead of flushing: iteration ``i`` gets copy ``i % num_copies``, called as
+    ``fn(*data)`` for a tuple, ``fn(**data)`` for a dict, else ``fn(data)``.
+
+    Returns the per-iteration time in ms, or, with ``per_kernel=True``, one
+    ``{name: ms}`` entry per name in ``kernel_names``.
+    """
+    if isinstance(kernel_names, str):
+        kernel_names = [kernel_names]
+    assert num_iters > 0, "num_iters must be > 0"
+    assert return_mode in _REDUCE, f"return_mode must be one of {list(_REDUCE)}"
+
+    copies = [data_gen() for _ in range(max(num_copies, 1))] if data_gen else None
+    flush_buf = (
+        torch.empty(cache_size_mb * 1024 * 1024, dtype=torch.int8, device="cuda")
+        if flush_l2
+        else None
+    )
+
+    def run(i):
+        if flush_buf is not None:
+            flush_buf.zero_()
+        _call(fn, copies[i % len(copies)] if copies else None)
+
+    for i in range(num_warmup):
+        run(i)
+    torch.cuda.synchronize()
+
+    with tpf.profile(
+        activities=[tpf.ProfilerActivity.CPU, tpf.ProfilerActivity.CUDA]
+    ) as prof:
+        for i in range(num_iters):
+            run(i)
+        torch.cuda.synchronize()
+
+    events = [ev for ev in prof.events() if _is_device_event(ev)]
+    matched = []
+    for ev in sorted(events, key=lambda ev: ev.time_range.start):
+        key = next((k for k in kernel_names if k in ev.name), None)
+        if key is not None:
+            matched.append((key, ev.self_device_time_total))
+    if not matched:
+        raise ValueError(
+            f"no kernel matched {list(kernel_names)}. Kernels seen: "
+            f"{sorted({ev.name for ev in events})}"
+        )
+
+    if per_kernel:
+        return {
+            key: _reduce([t for k, t in matched if k == key], num_iters, return_mode)
+            for key in dict.fromkeys(k for k, _ in matched)
+        }
+    return _reduce([t for _, t in matched], num_iters, return_mode)

--- a/op_tests/op_benchmarks/triton/utils/profiler_bench.py
+++ b/op_tests/op_benchmarks/triton/utils/profiler_bench.py
@@ -2,13 +2,15 @@
 # Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
 """Torch-profiler based timing, filtered by GPU kernel name.
 
-``triton.testing.do_bench`` times the callable from the host, so everything
-``fn`` does besides the kernel of interest (setup, reference ops, the cache
-flush itself) ends up in the number. Here only the device time of the named
-kernels is summed, which also works when an op launches several kernels or
-sits inside a larger wrapper.
+triton.testing.do_bench times the callable from the host, so everything fn does
+besides the kernel of interest ends up in the number.
+Here only the device time of the named kernels is summed,
+which also works when an op launches several kernels or sits inside a larger
+wrapper.
 """
 
+import math
+import re
 import statistics
 import warnings
 from collections.abc import Callable, Sequence
@@ -23,6 +25,30 @@ _REDUCE = {
     "min": min,
     "max": max,
 }
+_PERCENTILE = re.compile(r"p(\d+(?:\.\d+)?)")
+
+# Usable as argparse choices; any other "pNN" percentile is accepted too.
+RETURN_MODES = (*_REDUCE, "p25", "p50", "p75", "p90", "p99")
+
+
+def _percentile(values, q):
+    """Linear interpolation between the closest ranks, as numpy.percentile does."""
+    values = sorted(values)
+    idx = (len(values) - 1) * q / 100
+    lo, hi = math.floor(idx), math.ceil(idx)
+    return values[lo] + (values[hi] - values[lo]) * (idx - lo)
+
+
+def _reducer(return_mode):
+    if return_mode in _REDUCE:
+        return _REDUCE[return_mode]
+    match = _PERCENTILE.fullmatch(str(return_mode))
+    if match and 0 <= float(match.group(1)) <= 100:
+        return lambda values: _percentile(values, float(match.group(1)))
+    raise ValueError(
+        f"unknown return_mode {return_mode!r}: expected one of {list(RETURN_MODES)}, "
+        "or any percentile 'pNN'"
+    )
 
 
 def _is_device_event(ev) -> bool:
@@ -39,7 +65,7 @@ def _call(fn, data):
     return fn(data)
 
 
-def _reduce(times_us, num_iters, return_mode):
+def _reduce(times_us, num_iters, reduce_fns, single):
     """Sum the launches belonging to one iteration, then reduce across iterations."""
     if len(times_us) % num_iters != 0:
         warnings.warn(
@@ -47,12 +73,14 @@ def _reduce(times_us, num_iters, return_mode):
             "per iteration is not constant, falling back to mean.",
             stacklevel=3,
         )
-        return sum(times_us) / num_iters / 1000
-    per_iter = len(times_us) // num_iters
-    totals = [
-        sum(times_us[i * per_iter : (i + 1) * per_iter]) for i in range(num_iters)
-    ]
-    return _REDUCE[return_mode](totals) / 1000
+        values = [sum(times_us) / num_iters / 1000] * len(reduce_fns)
+    else:
+        per_iter = len(times_us) // num_iters
+        totals = [
+            sum(times_us[i * per_iter : (i + 1) * per_iter]) for i in range(num_iters)
+        ]
+        values = [fn(totals) / 1000 for fn in reduce_fns]
+    return values[0] if single else values
 
 
 def do_bench_profiler(
@@ -64,26 +92,37 @@ def do_bench_profiler(
     cache_size_mb: int = 512,
     data_gen: Callable[[], Any] | None = None,
     num_copies: int = 1,
-    return_mode: str = "mean",
+    return_mode: str | Sequence[str] = "mean",
     per_kernel: bool = False,
 ):
-    """Time the kernels named in ``kernel_names`` while running ``fn``.
+    """Time the kernels named in kernel_names while running fn.
 
-    A kernel is selected when one of ``kernel_names`` is a substring of its
-    profiler name, so launch overhead, cache flushes and everything else ``fn``
-    does are left out of the measurement.
+    A kernel is selected when one of kernel_names is a substring of its profiler
+    name, so launch overhead, cache flushes and everything else fn does are left
+    out of the measurement.
 
-    Pass ``data_gen`` to rotate over ``num_copies`` input sets built up front
-    instead of flushing: iteration ``i`` gets copy ``i % num_copies``, called as
-    ``fn(*data)`` for a tuple, ``fn(**data)`` for a dict, else ``fn(data)``.
+    The flush is itself a fill kernel over an int8 buffer, so keep kernel_names
+    narrow enough not to match it.
 
-    Returns the per-iteration time in ms, or, with ``per_kernel=True``, one
-    ``{name: ms}`` entry per name in ``kernel_names``.
+    Pass data_gen to rotate over num_copies input sets built up front instead of
+    flushing: iteration i gets copy i % num_copies, called as fn(*data) for a
+    tuple, fn(**data) for a dict, else fn(data).
+
+    return_mode is one of RETURN_MODES: mean, median, min, max, or a percentile
+    such as p25/p50/p75 (any pNN works). Pass a list of modes, e.g.
+    ["mean", "p50", "p90"], to get one value back per mode.
+
+    Returns the per-iteration time in ms, or, with per_kernel=True, one
+    {name: ms} entry per name in kernel_names. Each ms is a list of ms when
+    return_mode is a list.
     """
     if isinstance(kernel_names, str):
         kernel_names = [kernel_names]
     assert num_iters > 0, "num_iters must be > 0"
-    assert return_mode in _REDUCE, f"return_mode must be one of {list(_REDUCE)}"
+    single = isinstance(return_mode, str)
+    modes = [return_mode] if single else list(return_mode)
+    assert modes, "return_mode must not be empty"
+    reduce_fns = [_reducer(mode) for mode in modes]
 
     copies = [data_gen() for _ in range(max(num_copies, 1))] if data_gen else None
     flush_buf = (
@@ -122,7 +161,9 @@ def do_bench_profiler(
 
     if per_kernel:
         return {
-            key: _reduce([t for k, t in matched if k == key], num_iters, return_mode)
+            key: _reduce(
+                [t for k, t in matched if k == key], num_iters, reduce_fns, single
+            )
             for key in dict.fromkeys(k for k, _ in matched)
         }
-    return _reduce([t for _, t in matched], num_iters, return_mode)
+    return _reduce([t for _, t in matched], num_iters, reduce_fns, single)


### PR DESCRIPTION
## Motivation

Currently, triton benchmarks rely on triton.testing.do_bench but its defaults are not very accurate isolating per kernel times. This PR introduces a new bench. utility that uses torch profiler under the hood and can better strip out the wrapper overhead. Under cuda-graph, the wrapper overhead is rarely seen in traces so measuring actual kernel time provides a more accurate signal.

It also supports l2 cache flushing and rotating buffers to simulate cold cache runtime.

I changed the profiler for bench_fp8_mqa_logits.py to the new one to use as an example.
 ## Technical Details
Adds `do_bench_profiler()` in `op_tests/op_benchmarks/triton/utils/profiler_bench.py`. It runs `fn` under `torch.profiler`, keeps only the device events whose name matches one of the kernel names you pass, groups the launches back into iterations and reduces across them. Returns per-iteration milliseconds, same unit as `do_bench`, so it drops into existing scripts without rescaling.

- `num_warmup` / `num_iters` are literal iteration counts, not `do_bench`'s ms budgets.
- `flush_l2` (on by default) with `cache_size_mb` (512).
- `data_gen` + `num_copies` build rotating input sets up front as an alternative to flushing. Iteration `i` gets copy `i % num_copies`, called as `fn(*data)` for a tuple, `fn(**data)` for a dict, else `fn(data)`.
- `return_mode` takes mean/median/min/max or any percentile (`p25`, `p50`, `p90`, ...). Pass a list to get several statistics out of a single run instead of re-benchmarking per statistic. `RETURN_MODES` is exported for use as argparse choices.
- `per_kernel=True` returns a dict keyed by filter name rather than the aggregate, which is the multi-kernel breakdown.
