### PR TITLE
[HIP] pa_sparse_prefill: address out with its own strides

### DIFF
--- a/csrc/include/pa_sparse_prefill_opus.h
+++ b/csrc/include/pa_sparse_prefill_opus.h
@@ -129,6 +129,10 @@ struct pa_sparse_prefill_kargs
     int total_tokens;
     int stride_qo_n;
     int stride_qo_h;
+    // Output strides, taken from the out tensor; q and out may have different
+    // layouts (e.g. a strided q view with a contiguous out).
+    int stride_o_n;
+    int stride_o_h;
     int stride_kv_page;
     float softmax_scale;
 };
@@ -1618,6 +1622,7 @@ __global__ __launch_bounds__(Traits::BLOCK_SIZE, 2) void pa_prefill_16mx8_32nx1_
 
     const int h_block_start = h_block_idx * T::NUM_WARPS * T::Q_TILE_SIZE;
     const int64_t qo_gmem_offset = static_cast<int64_t>(q_token_idx) * kargs.stride_qo_n + static_cast<int64_t>(h_block_start) * kargs.stride_qo_h;
+    const int64_t o_gmem_offset  = static_cast<int64_t>(q_token_idx) * kargs.stride_o_n + static_cast<int64_t>(h_block_start) * kargs.stride_o_h;
 
     __shared__ char smem_kv_buf[T::smem_size_bytes()];
 
@@ -1686,12 +1691,12 @@ __global__ __launch_bounds__(Traits::BLOCK_SIZE, 2) void pa_prefill_16mx8_32nx1_
     D_ACC o_scale = (l_final > D_ACC(0.0f)) ? (alpha / l_final) : D_ACC(0.0f);
     scale_output_tile<T>(v_o, o_scale);
 
-    auto g_o = make_gmem(reinterpret_cast<D_ATTN*>(kargs.out_ptr) + qo_gmem_offset, (kargs.H - h_block_start) * kargs.stride_qo_h * sizeof(D_ATTN));
+    auto g_o = make_gmem(reinterpret_cast<D_ATTN*>(kargs.out_ptr) + o_gmem_offset, (kargs.H - h_block_start) * kargs.stride_o_h * sizeof(D_ATTN));
     // Recompute lane/warp decomposition to prevent CSE with Q-load layout
     int lane_id_o = thread_id_x() % T::WARP_SIZE;
     asm volatile("" : "+v"(lane_id_o));
     int warp_id_o = __builtin_amdgcn_readfirstlane(thread_id_x() / T::WARP_SIZE);
-    auto u_o = make_layout_o<T>(warp_id_o, lane_id_o, kargs.stride_qo_h);
+    auto u_o = make_layout_o<T>(warp_id_o, lane_id_o, kargs.stride_o_h);
     auto v_o_attn = cast<D_ATTN>(v_o);
     store<T::VEC_O>(g_o, v_o_attn, u_o);
 }
@@ -2115,6 +2120,7 @@ __global__ __launch_bounds__(Traits::BLOCK_SIZE, 2) void pa_prefill_16mx1_16nx4_
 
     const int h_block_start = h_block_idx * T::T_M * T::Q_TILE_SIZE;
     const int64_t qo_gmem_offset = static_cast<int64_t>(q_token_idx) * kargs.stride_qo_n + static_cast<int64_t>(h_block_start) * kargs.stride_qo_h;
+    const int64_t o_gmem_offset  = static_cast<int64_t>(q_token_idx) * kargs.stride_o_n + static_cast<int64_t>(h_block_start) * kargs.stride_o_h;
 
     __shared__ char smem_kv[T::smem_kv_tile_elems * sizeof(D_ATTN)]; // for KV tiles
     __shared__ char smem_ml[2 * T::T_N * T::W_M * sizeof(D_ACC)];  // for inter-warp reduction
@@ -2169,9 +2175,9 @@ __global__ __launch_bounds__(Traits::BLOCK_SIZE, 2) void pa_prefill_16mx1_16nx4_
     D_ACC o_scale = (l_final > D_ACC(0.0f)) ? (alpha / l_final) : D_ACC(0.0f);
     scale_output_tile<T>(v_o, o_scale);
 
-    auto g_o = make_gmem(reinterpret_cast<D_ATTN*>(kargs.out_ptr) + qo_gmem_offset, (kargs.H - h_block_start) * kargs.stride_qo_h * sizeof(D_ATTN));
+    auto g_o = make_gmem(reinterpret_cast<D_ATTN*>(kargs.out_ptr) + o_gmem_offset, (kargs.H - h_block_start) * kargs.stride_o_h * sizeof(D_ATTN));
     int warp_id = __builtin_amdgcn_readfirstlane(thread_id_x() / T::WARP_SIZE);
-    auto u_o = make_layout_o<T>(warp_id, lane_id, kargs.stride_qo_h);
+    auto u_o = make_layout_o<T>(warp_id, lane_id, kargs.stride_o_h);
     auto v_o_attn = cast<D_ATTN>(v_o);
     store<T::VEC_O>(g_o, v_o_attn, u_o);
 }

--- a/csrc/include/pa_sparse_prefill_opus.h
+++ b/csrc/include/pa_sparse_prefill_opus.h
@@ -129,12 +129,19 @@ struct pa_sparse_prefill_kargs
     int total_tokens;
     int stride_qo_n;
     int stride_qo_h;
-    // Output strides, taken from the out tensor; q and out may have different
-    // layouts (e.g. a strided q view with a contiguous out).
-    int stride_o_n;
-    int stride_o_h;
     int stride_kv_page;
     float softmax_scale;
+};
+
+// gfx950 adds the out strides so a strided q view can write a differently laid
+// out (usually contiguous) out. The gfx1250 prebuilt code objects consume
+// pa_sparse_prefill_kargs verbatim and their kernarg ABI is pinned by
+// PA_GFX1250_CO_ABI, so the extra fields live here instead of in the base
+// struct; the gfx1250 launcher instead requires out to share q's strides.
+struct pa_sparse_prefill_kargs_gfx950 : pa_sparse_prefill_kargs
+{
+    int stride_o_n;
+    int stride_o_h;
 };
 
 // Kernel arguments for the split-precision (NoPE fp8 / RoPE bf16) DSA prefill.
@@ -477,9 +484,9 @@ __host__ __device__ inline int ceil_div(int a, int b) { return (a + b - 1) / b; 
 
 // Device kernel templates — declared here, defined in the device pass below.
 template <class Traits>
-__global__ void pa_prefill_16mx8_32nx1_kernel(pa_sparse_prefill_kargs kargs);
+__global__ void pa_prefill_16mx8_32nx1_kernel(pa_sparse_prefill_kargs_gfx950 kargs);
 template <class Traits>
-__global__ void pa_prefill_16mx1_16nx4_kernel(pa_sparse_prefill_kargs kargs);
+__global__ void pa_prefill_16mx1_16nx4_kernel(pa_sparse_prefill_kargs_gfx950 kargs);
 template <class Traits>
 __global__ void pa_prefill_16mx8_32nx1_fp8_kernel(pa_fp8_kargs kargs);
 template <class Traits>
@@ -488,11 +495,11 @@ __global__ void pa_prefill_16mx1_16nx4_fp8_kernel(pa_fp8_kargs kargs);
 // Pull in the device kernel template bodies only on the gfx950 device pass.
 #if !defined(__HIP_DEVICE_COMPILE__) || !defined(__gfx950__)
 template <class Traits>
-__global__ void pa_prefill_16mx8_32nx1_kernel(pa_sparse_prefill_kargs)
+__global__ void pa_prefill_16mx8_32nx1_kernel(pa_sparse_prefill_kargs_gfx950)
 {
 }
 template <class Traits>
-__global__ void pa_prefill_16mx1_16nx4_kernel(pa_sparse_prefill_kargs)
+__global__ void pa_prefill_16mx1_16nx4_kernel(pa_sparse_prefill_kargs_gfx950)
 {
 }
 template <class Traits>
@@ -1607,7 +1614,7 @@ __device__ void pa_prefill_accum_pipelined(pa_sparse_prefill_kargs kargs,
 
 // ─── PA kernel: template on traits; K/V in shared, Q in registers, Flash Attention online softmax ───
 template<class Traits>
-__global__ __launch_bounds__(Traits::BLOCK_SIZE, 2) void pa_prefill_16mx8_32nx1_kernel(pa_sparse_prefill_kargs kargs) {
+__global__ __launch_bounds__(Traits::BLOCK_SIZE, 2) void pa_prefill_16mx8_32nx1_kernel(pa_sparse_prefill_kargs_gfx950 kargs) {
     using namespace opus;
     using namespace pa_16mx8_32nx1;
     using T = opus::remove_cvref_t<Traits>;
@@ -2106,7 +2113,7 @@ __device__ void pa_prefill_16mx1_16nx4_pipeline(pa_sparse_prefill_kargs kargs,
 
 // ─── PA kernel: template on traits; K/V in shared, Q in registers, Flash Attention online softmax ───
 template<class Traits>
-__global__ __launch_bounds__(Traits::BLOCK_SIZE, 2) void pa_prefill_16mx1_16nx4_kernel(pa_sparse_prefill_kargs kargs) {
+__global__ __launch_bounds__(Traits::BLOCK_SIZE, 2) void pa_prefill_16mx1_16nx4_kernel(pa_sparse_prefill_kargs_gfx950 kargs) {
     using namespace opus;
     using namespace pa_16mx1_16nx4;
     using T = opus::remove_cvref_t<Traits>;

--- a/csrc/py_itfs_cu/pa_sparse_prefill_opus_kernels.cu
+++ b/csrc/py_itfs_cu/pa_sparse_prefill_opus_kernels.cu
@@ -102,6 +102,8 @@ void pa_sparse_prefill_gfx950_opus_fwd(aiter_tensor_t& q,
     // head dim contiguous; we already enforced stride(D) == 1 above.
     kargs.stride_qo_n       = static_cast<int>(q.stride(0));
     kargs.stride_qo_h       = static_cast<int>(q.stride(1));
+    kargs.stride_o_n        = static_cast<int>(out.stride(0));
+    kargs.stride_o_h        = static_cast<int>(out.stride(1));
     kargs.stride_kv_page    = static_cast<int>(unified_kv.stride(0));
     AITER_CHECK(kargs.stride_kv_page == static_cast<int>(kv.stride(0)),
                 "unified_kv and kv must share row stride along the D dim");

--- a/csrc/py_itfs_cu/pa_sparse_prefill_opus_kernels.cu
+++ b/csrc/py_itfs_cu/pa_sparse_prefill_opus_kernels.cu
@@ -83,7 +83,7 @@ void pa_sparse_prefill_gfx950_opus_fwd(aiter_tensor_t& q,
     if (N == 0) return;
 
     // ---- Build kernel args -----------------------------------------------
-    pa_sparse_prefill_kargs kargs{};
+    pa_sparse_prefill_kargs_gfx950 kargs{};
     kargs.q_ptr             = q.data_ptr();
     kargs.unified_kv_ptr    = unified_kv.data_ptr();
     kargs.kv_ptr            = kv.data_ptr();
@@ -468,6 +468,12 @@ void pa_sparse_prefill_gfx1250_opus_fwd(aiter_tensor_t& q,
     args.total_tokens      = static_cast<int>(kv.size(0));
     args.stride_qo_n       = static_cast<int>(q.stride(0));
     args.stride_qo_h       = static_cast<int>(q.stride(1));
+    // The prebuilt code objects store the output through q's strides (their
+    // kernarg ABI has no separate out strides), so out must match q's layout.
+    AITER_CHECK(out.stride(0) == q.stride(0) && out.stride(1) == q.stride(1),
+                "gfx1250 pa_sparse_prefill requires out to share q's strides; "
+                "got out=(", out.stride(0), ",", out.stride(1),
+                ") q=(", q.stride(0), ",", q.stride(1), ")");
     args.stride_kv_page    = static_cast<int>(unified_kv.stride(0));
     AITER_CHECK(args.stride_kv_page == static_cast<int>(kv.stride(0)),
                 "unified_kv and kv must share row stride along the D dim");

--- a/op_tests/test_pa_sparse_prefill.py
+++ b/op_tests/test_pa_sparse_prefill.py
@@ -307,12 +307,19 @@ def _make_inputs(
     mode: str = "sparse",
     device: torch.device | str = "cuda",
     seed: int = 0,
+    head_padded_q: bool = False,
 ) -> dict:
     assert mode in _MODES
     torch.manual_seed(seed)
     device = torch.device(device)
 
     q = (torch.randn(n, h, d, device=device, dtype=torch.float32) * 0.5).to(dtype)
+    if head_padded_q:
+        # A [N, H, D] view into a wider head buffer (TP-padded q), so q's head
+        # stride differs from a contiguous out's.
+        q_pad = torch.empty(n, max(64, h), d, device=device, dtype=dtype)
+        q_pad[:, :h] = q
+        q = q_pad[:, :h, :]
     unified_kv = (
         torch.randn(total_pages, d, device=device, dtype=torch.float32) * 0.5
     ).to(dtype)
@@ -635,6 +642,20 @@ def test_pa_sparse_prefill(prec, n, h, total_pages, total_tokens, mode):
         verify=True,
         bench=False,
     )
+
+
+@pytest.mark.parametrize("mode", _PYTEST_MODES)
+def test_pa_sparse_prefill_head_padded_q(mode):
+    """A strided (head-padded) q with the default contiguous out must match
+    the reference; the kernel used to address out with q's strides."""
+    n, h, d = 64, 16, 512
+    inputs = _make_inputs(
+        n, h, d, 256, 256, torch.bfloat16, mode=mode, seed=7, head_padded_q=True
+    )
+    scale = 1.0 / math.sqrt(d)
+    out = pa_sparse_prefill_opus(**inputs, softmax_scale=scale)
+    ref = _ref_pa_sparse_prefill_opus(**inputs, softmax_scale=scale)
+    torch.testing.assert_close(out.float(), ref.float(), rtol=1e-2, atol=1e-2)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- `pa_sparse_prefill_kargs` gets its own `stride_o_n` / `stride_o_h`, filled from `out` in the launcher, and both bf16 kernel variants use them at the out store (the fp8 variants already had separate out strides)
- add `test_pa_sparse_prefill_head_padded_q`: a head-padded `[N, H, D]` q view with the default contiguous `out`, checked against the reference

## Why
The bf16 kernel read q and wrote out through one shared stride set taken from q, so out was only correct when it mirrored q's layout. A strided q view (e.g. a TP head-padded slice of a wider buffer) with the wrapper's default `out=torch.empty_like(q)` -- contiguous for a non-dense view -- made the kernel write out at q's offsets: wrong results, or a memory fault when the offsets left the allocation. Callers currently have to allocate an out that copies q's (padded) strides to stay correct; with this change any out layout works.

## Validation
- gfx950 (8x MI350X): head-padded q with contiguous out, with mirrored-stride out, and with `out=None` all match the reference to the suite tolerance (max err 3.9e-3, `_RTOL=_ATOL=1e-2`)
- `op_tests/test_pa_sparse_prefill_opus.py`: 36 passed on the same build
- no change for callers whose out already mirrors q (contiguous q/out is the identity case)
