### PR TITLE
[HIP] [Feature] OPUS bf16 flash-attn: head dim 64, attention sinks, single-seq varlen routing (gfx950)

### DIFF
--- a/aiter/ops/mha.py
+++ b/aiter/ops/mha.py
@@ -413,6 +413,7 @@ def gen_fmha_fwd_bf16_opus_fwd_fake(
     seqstart_k_pad: Tensor | None = None,
     max_seqlen_q: int = 0,
     max_seqlen_k: int = 0,
+    sink: Tensor | None = None,
 ) -> None:
     return None
 
@@ -455,15 +456,20 @@ def fmha_fwd_bf16_opus_fwd(
     lse: Tensor | None = None,
     sink: Tensor | None = None,
 ) -> Tensor | tuple[Tensor, Tensor]:
-    """Public wrapper for the OPUS gfx950 bf16 dense (batch) forward (D=128 and
-    D_QK=192/D_V=128). q/k/v are dense bshd [B, S, H, D]; allocates `out`
-    ([B, S, H_q, D_v]) if needed and forwards. The kernel applies `softmax_scale`
-    to Q·K^T internally and handles GQA fan-out.
+    """Public wrapper for the OPUS gfx950 bf16 dense (batch) forward: symmetric
+    D_QK == D_V in {64, 128}, plus D_QK=192/D_V=128. q/k/v are dense bshd
+    [B, S, H, D]; allocates `out` ([B, S, H_q, D_v]) if needed and forwards.
+    The kernel applies `softmax_scale` to Q·K^T internally and handles GQA fan-out.
+
+    `sink` is an optional attention sink: one fp32 logit per query head ([H_q]),
+    acting as a valueless extra key in the softmax denominator. It attenuates O
+    and raises lse, and is supported only by the symmetric kernel.
 
     `lse` is an output buffer for the log-sum-exp of the scaled scores ([B, H_q, S]
-    float32, natural log; rows that see no keys get -inf), filled when supplied and
-    allocated here when `return_lse` is set. Like `out` it does not change the return
-    type on its own: only `return_lse` does, and then the return is `(out, lse)`.
+    float32, natural log; rows that see no keys get -inf, or the sink logit when a
+    sink is set), filled when supplied and allocated here when `return_lse` is set.
+    Like `out` it does not change the return type on its own: only `return_lse`
+    does, and then the return is `(out, lse)`.
 
     Varlen / packed inputs go through `fmha_fwd_bf16_opus_varlen_fwd` instead.
     """
@@ -516,8 +522,9 @@ def fmha_fwd_bf16_opus_varlen_fwd(
     `lse` is an output buffer for the log-sum-exp of the scaled scores ([H_q, total_q]
     float32, natural log), filled when supplied and allocated here when `return_lse` is
     set. Like `out` it does not change the return type on its own: only `return_lse`
-    does, and then the return is `(out, lse)`. Rows that see no keys get -inf; rows in
-    the padding gaps of a KV-padded layout are left untouched.
+    does, and then the return is `(out, lse)`. Rows that see no keys get -inf, or the
+    sink logit when a sink is set; rows in the padding gaps of a KV-padded layout are
+    left untouched.
 
     seqstart_q / seqstart_k          : cumulative REAL sequence lengths (int32, len
                                        num_groups+1; drive masks / tile counts).
@@ -1811,6 +1818,23 @@ def fmha_v3_varlen_bwd(
 ) -> tuple[Tensor, Tensor, Tensor, Tensor]: ...
 
 
+def _reject_sink_autograd(entry, bwd_entry, grad_enabled, sink_ptr, *tensors):
+    """The forward applies the sink but every backward hard-codes sink=None, so a
+    gradient-tracked sink call would get dQ/dK/dV from a different softmax (and no
+    d_sink). Reject it instead. `grad_enabled` is passed in because grad mode is already
+    off inside autograd.Function.forward, where torch.is_grad_enabled() reads False.
+    """
+    if (
+        sink_ptr is not None
+        and grad_enabled
+        and any(t.requires_grad for t in (*tensors, sink_ptr))
+    ):
+        raise NotImplementedError(
+            f"attention sink is not differentiable through {entry}; call under "
+            f"torch.no_grad() for inference, or use {bwd_entry} with d_sink"
+        )
+
+
 def maybe_contiguous(x):
     return x.contiguous() if x is not None and x.stride(-1) != 1 else x
 
@@ -1890,7 +1914,7 @@ def _flash_attn_forward(
     _, seqlen_k, nhead_k, hdim_v = v.shape
     if sink_ptr is not None:
         assert sink_ptr.device == q.device, "sink_ptr must be on the same device as q"
-        assert sink_ptr.shape[0] == nhead_q, "sink_ptr has incorrect shape"
+        assert sink_ptr.shape == (nhead_q,), "sink_ptr must have shape [nhead_q]"
         if sink_ptr.dtype != torch.float32:
             sink_ptr = sink_ptr.to(torch.float32)
     # mask
@@ -2089,7 +2113,7 @@ def _flash_attn_forward(
             or (
                 hdim_q == hdim_v
                 and sink_ptr.dtype == dtypes.fp32
-                and sink_ptr.numel() == nhead_q
+                and sink_ptr.shape == (nhead_q,)
                 # our launcher reads the sink at unit stride; don't hand it a
                 # non-contiguous one -- fall back instead of failing its check.
                 and sink_ptr.is_contiguous()
@@ -2183,9 +2207,9 @@ def _flash_attn_forward(
         S_dmask = torch.empty((0,), dtype=torch.float32, device=q.device)
         rng_state = torch.empty((2,), dtype=torch.int64, device=q.device)
     elif can_impl_fmha_fwd_bf16_opus():
-        # OPUS gfx950 dense forward (shared entry point; dispatches D=128 vs
-        # D_QK=192/D_V=128 in C++ by head dim). The S_dmask/rng slots stay unused
-        # placeholders (the gate guarantees no dropout mask).
+        # OPUS gfx950 dense forward (shared entry point; dispatches symmetric D=64/128
+        # vs D_QK=192/D_V=128 in C++). The S_dmask/rng slots stay unused placeholders
+        # (the gate guarantees no dropout mask).
         softmax_lse = torch.empty(
             (batch_size, nhead_q, seqlen_q) if return_lse else (0,),
             dtype=torch.float32,
@@ -2643,6 +2667,9 @@ class FlashAttnFunc(torch.autograd.Function):
         out: torch.Tensor | None = None,
     ):
         is_grad = is_grad_enabled and any(x.requires_grad for x in [q, k, v])
+        _reject_sink_autograd(
+            "flash_attn_func", "mha_bwd", is_grad_enabled, sink_ptr, q, k, v
+        )
         if softmax_scale is None:
             softmax_scale = q.shape[-1] ** (-0.5)
         head_size_q_og = q.size(3)
@@ -2766,7 +2793,8 @@ class FlashAttnFunc(torch.autograd.Function):
         #              bwd sink gradient d_sink is computed inside mha_bwd kernel,
         #              not returned here as a positional gradient.)
         # 19 num_splits
-        # Need to return exactly 19 gradient entries.
+        # 20 out
+        # Need to return exactly 20 gradient entries.
         return (
             dq,  # q
             dk,  # k
@@ -2787,6 +2815,7 @@ class FlashAttnFunc(torch.autograd.Function):
             None,  # cu_seqlens_kv
             None,  # sink_ptr (not differentiable; bwd uses sink/d_sink args separately)
             None,  # num_splits
+            None,  # out
         )
 
 
@@ -2852,6 +2881,8 @@ def flash_attn_func(
            (they might not have the right scaling).
         cu_seqlens_q: (batch_size + 1,). The cumulative sequence lengths of the query sequences.
         cu_seqlens_kv: (batch_size + 1,). The cumulative sequence lengths of the key/value sequences.
+        sink_ptr: (nheads,), fp32. Optional valueless attention-sink logit per query
+            head. Sink-enabled calls are forward-only and must run without autograd.
         num_splits: int. Number of key/value splits for the native split-K forward path.
             0 (default) lets aiter decide via a heuristic; 1 disables split-K (uses the
             standard CK/ASM dispatch); >=2 forces the native split-K kernel with that many
@@ -2867,6 +2898,10 @@ def flash_attn_func(
             The output of softmax (possibly with different scaling). It also encodes the dropout
             pattern (negative means that location was dropped, nonnegative means it was kept).
     """
+    _reject_sink_autograd(
+        "flash_attn_func", "mha_bwd", torch.is_grad_enabled(), sink_ptr, q, k, v
+    )
+
     # FlyDSL path returns result if supported, None otherwise. window_size[2] (sink
     # size) is unsupported: the FlyDSL gate rejects it, and this screen keeps it off
     # the path so a sink-token request is never silently dropped.
@@ -2892,6 +2927,7 @@ def flash_attn_func(
             deterministic=deterministic,
             return_attn_probs=return_attn_probs,
             sink=sink_ptr,
+            out=out,
         )
         if _flydsl_result is not None:
             return _flydsl_result
@@ -2981,7 +3017,7 @@ def _flash_attn_varlen_forward(
     hdim_v = v.shape[-1]
     if sink_ptr is not None:
         assert sink_ptr.device == q.device, "sink_ptr must be on the same device as q"
-        assert sink_ptr.shape[0] == nhead_q, "sink_ptr has incorrect shape"
+        assert sink_ptr.shape == (nhead_q,), "sink_ptr must have shape [nhead_q]"
         if sink_ptr.dtype != torch.float32:
             sink_ptr = sink_ptr.to(torch.float32)
     # mask
@@ -3098,8 +3134,13 @@ def _flash_attn_varlen_forward(
         if int(os.environ.get("AITER_ENABLE_FMHA_OPUS", "0")) == 0:
             return False
         ret = get_gfx() == "gfx950"
+        # One owner per shape: batch-1 goes through the router above, which reshapes to the
+        # dense entry and can slice an oversized K/V workspace. Group mode takes the rest.
+        ret = ret and (batch_size > 1)
         ret = ret and (q.dtype == dtypes.bf16)
         ret = ret and (hdim_q == hdim_v and hdim_q in (64, 128))
+        ret = ret and (k.shape[-1] == hdim_q and k.shape[-2] == nhead_k)
+        ret = ret and (k.shape[0] == v.shape[0])
         ret = ret and (nhead_q % nhead_k == 0)
         ret = ret and (not swa)
         ret = ret and (dropout_p == 0.0)
@@ -3118,7 +3159,7 @@ def _flash_attn_varlen_forward(
             sink_ptr is None
             or (
                 sink_ptr.dtype == dtypes.fp32
-                and sink_ptr.numel() == nhead_q
+                and sink_ptr.shape == (nhead_q,)
                 and sink_ptr.is_contiguous()
             )
         )
@@ -3527,6 +3568,15 @@ class FlashAttnVarlenFunc(torch.autograd.Function):
         sink_ptr=None,
     ):
         is_grad = is_grad_enabled and any(x.requires_grad for x in [q, k, v])
+        _reject_sink_autograd(
+            "flash_attn_varlen_func",
+            "mha_varlen_bwd",
+            is_grad_enabled,
+            sink_ptr,
+            q,
+            k,
+            v,
+        )
         if softmax_scale is None:
             softmax_scale = q.shape[-1] ** (-0.5)
         head_size_q_og = q.size(-1)
@@ -3726,6 +3776,15 @@ def flash_attn_varlen_func(
     cu_seqlens_k_padded: torch.Tensor | None = None,
     sink_ptr: Tensor | None = None,
 ):
+    _reject_sink_autograd(
+        "flash_attn_varlen_func",
+        "mha_varlen_bwd",
+        torch.is_grad_enabled(),
+        sink_ptr,
+        q,
+        k,
+        v,
+    )
     if block_table is not None and (
         cu_seqlens_q_padded is not None or cu_seqlens_k_padded is not None
     ):
@@ -3780,6 +3839,10 @@ def flash_attn_varlen_func(
         return_attn_probs: bool. Whether to return the attention probabilities. This option is for
            testing only. The returned probabilities are not guaranteed to be correct
            (they might not have the right scaling).
+        out: (total_q, nheads, headdim_v). Optional caller-owned output buffer,
+            written in place and returned.
+        sink_ptr: (nheads,), fp32. Optional valueless attention-sink logit per query
+            head. Sink-enabled calls are forward-only and must run without autograd.
     Return:
         out: (total, nheads, headdim_v).
         softmax_lse [optional, if return_attn_probs=True]: (nheads, total_q_seqlen). The
@@ -3855,9 +3918,8 @@ def flash_attn_varlen_func(
         )
 
     # A varlen batch holding exactly ONE sequence is the same problem as a dense
-    # batch-1 call, so route it to the dense entry -- which is where the OPUS
-    # symmetric-head-dim kernels live (they are batch-mode only). This is what lets a
-    # single-request prefill reach OPUS instead of falling back to CK.
+    # batch-1 call, so route it to the dense specialization. Besides avoiding group-mode
+    # overhead, this is what permits the oversized K/V workspace slicing below.
     #
     # Detection is deliberately sync-free: cu_seqlens has batch+1 entries so
     # numel() == 2 means one sequence (metadata only, no D2H), and max_seqlen_* are

--- a/aiter/ops/mha.py
+++ b/aiter/ops/mha.py
@@ -418,8 +418,8 @@ def gen_fmha_fwd_bf16_opus_fwd_fake(
 
 
 # OPUS gfx950 bf16 forward (shared entry point): low-level @compile_ops stub bound to
-# the pybind symbol via fc_name. Dispatches by head dim in C++ to the symmetric D=128
-# kernel (batch only) or the asymmetric D_QK=192/D_V=128 kernel (batch + group/varlen).
+# the pybind symbol via fc_name. Dispatches by head dim in C++ to the symmetric
+# D_QK = D_V in {64, 128} or the asymmetric D_QK=192/D_V=128 kernel; both do batch+group.
 # Writes `out` (and `lse`, when given) in place, returns None.
 @compile_ops(
     "module_fmha_fwd_bf16_opus",
@@ -505,9 +505,11 @@ def fmha_fwd_bf16_opus_varlen_fwd(
     seqstart_k_pad: Tensor | None = None,
     return_lse: bool = False,
     lse: Tensor | None = None,
+    sink: Tensor | None = None,
 ) -> Tensor | tuple[Tensor, Tensor]:
-    """Public wrapper for the OPUS gfx950 bf16 group/varlen forward (D_QK=192/D_V=128
-    only). q/k/v are packed [total, H, D]; allocates `out` ([total_q, H_q, D_v]) if
+    """Public wrapper for the OPUS gfx950 bf16 group/varlen forward (symmetric
+    D_QK=D_V in {64, 128}, and D_QK=192/D_V=128; `sink` is symmetric-only).
+    q/k/v are packed [total, H, D]; allocates `out` ([total_q, H_q, D_v]) if
     needed and forwards. The kernel applies `softmax_scale` to Q·K^T internally and
     handles GQA fan-out.
 
@@ -555,6 +557,7 @@ def fmha_fwd_bf16_opus_varlen_fwd(
         seqstart_k_pad if seqstart_k_pad is not None else seqstart_k,
         int(max_seqlen_q),
         int(max_seqlen_k),
+        sink,
     )
     return (out, lse) if return_lse else out
 
@@ -3088,9 +3091,70 @@ def _flash_attn_varlen_forward(
         ret = ret and (max_seqlen_q > 0 and max_seqlen_k > 0)
         return ret
 
+    def _can_impl_fmha_fwd_sym_bf16_opus_varlen():
+        # OPUS gfx950 group/varlen symmetric forward, D_QK == D_V in {64, 128}: the path a
+        # multi-sequence batch takes (the router in flash_attn_varlen_func handles batch-1).
+        # Opt-IN, matching the dense symmetric gate; d192/v128 above is opt-OUT.
+        if int(os.environ.get("AITER_ENABLE_FMHA_OPUS", "0")) == 0:
+            return False
+        ret = get_gfx() == "gfx950"
+        ret = ret and (q.dtype == dtypes.bf16)
+        ret = ret and (hdim_q == hdim_v and hdim_q in (64, 128))
+        ret = ret and (nhead_q % nhead_k == 0)
+        ret = ret and (not swa)
+        ret = ret and (dropout_p == 0.0)
+        ret = ret and (logits_soft_cap == 0.0)
+        ret = ret and (bias is None and alibi_slopes is None)
+        ret = ret and (q_descale is None and k_descale is None and v_descale is None)
+        ret = ret and (block_table is None)
+        ret = ret and (not return_softmax)
+        ret = ret and (max_seqlen_q > 0 and max_seqlen_k > 0)
+        # KV padding is unvalidated against this kernel; route it to CK rather than guess.
+        ret = ret and (cu_seqlens_q_padded is None and cu_seqlens_k_padded is None)
+        # sink_size (the "first N keys are sinks" variant) is a different feature.
+        ret = ret and (sink_size == 0)
+        # Sink IS supported; validate as the launcher reads it so a mismatch falls back.
+        ret = ret and (
+            sink_ptr is None
+            or (
+                sink_ptr.dtype == dtypes.fp32
+                and sink_ptr.numel() == nhead_q
+                and sink_ptr.is_contiguous()
+            )
+        )
+        # KV extent >= 2^32 wraps the kernel's 32-bit soffset. Packed, so stride(0);
+        # max_seqlen_k bounds every group (each is rebased to its own row offset).
+        if ret:
+            kv_stride = max(k.stride(0), v.stride(0))
+            ret = not (max_seqlen_k * kv_stride * k.element_size() >= 1 << 32)
+        return ret
+
     q, k, v = [maybe_contiguous(x) for x in (q, k, v)]
 
-    if can_impl_fmha_fwd_hd192_v128_bf16_opus_varlen():
+    if _can_impl_fmha_fwd_sym_bf16_opus_varlen():
+        # cu_seqlens_* go to the kernel as device pointers, so this stays sync-free.
+        softmax_lse = torch.empty(
+            (nhead_q, q.size(0)) if return_lse else (0,),
+            dtype=torch.float32,
+            device=q.device,
+        )
+        out = fmha_fwd_bf16_opus_varlen_fwd(
+            q,
+            k,
+            v,
+            softmax_scale=float(softmax_scale),
+            causal=bool(causal),
+            out=out,
+            seqstart_q=cu_seqlens_q,
+            seqstart_k=cu_seqlens_k,
+            max_seqlen_q=int(max_seqlen_q),
+            max_seqlen_k=int(max_seqlen_k),
+            lse=softmax_lse if return_lse else None,
+            sink=sink_ptr,
+        )
+        S_dmask = torch.empty((0,), dtype=torch.float32, device=q.device)
+        rng_state = torch.empty((2,), dtype=torch.int64, device=q.device)
+    elif can_impl_fmha_fwd_hd192_v128_bf16_opus_varlen():
         # OPUS gfx950 group/varlen D=192 path. cu_seqlens_* are the REAL cumulative
         # lengths (masks / tile counts); cu_seqlens_*_padded are the PHYSICAL row
         # offsets (KV padding). When no padded arrays are given, physical == real.

--- a/aiter/ops/mha.py
+++ b/aiter/ops/mha.py
@@ -3785,9 +3785,19 @@ def flash_attn_varlen_func(
             return False
         if cu_seqlens_q.numel() != 2 or cu_seqlens_k.numel() != 2:
             return False
-        if q.shape[0] != max_seqlen_q or k.shape[0] != max_seqlen_k:
+        # The K/V buffer may be LONGER than the sequence: vLLM's chunked-context path
+        # gathers into a fixed-size workspace (_CP_TOKENS_PER_ITER_ROCM) and then
+        # describes a shorter valid range, so requiring an exact match silently rejected
+        # every chunk that was not exactly workspace-sized. Accept an oversized K/V buffer
+        # and slice the valid prefix below. Q stays EXACT -- a varlen call returns one
+        # output row per query row, so an oversized Q buffer would silently drop rows.
+        #
+        # Slicing K/V to max_seqlen_k is safe because we already require exactly one
+        # sequence: by the varlen contract max_seqlen_k is the batch maximum, which for one
+        # sequence IS its length. Rows past it are stale workspace content, not attended.
+        if q.shape[0] != max_seqlen_q:
             return False
-        if v.shape[0] != max_seqlen_k:
+        if k.shape[0] < max_seqlen_k or v.shape[0] < max_seqlen_k:
             return False
         # flash_attn_func has no `out` parameter, and routing here with a caller
         # buffer would mean a hidden extra copy -- decline instead. (vLLM's extend
@@ -3809,11 +3819,12 @@ def flash_attn_varlen_func(
         return q.shape[-2] % k.shape[-2] == 0
 
     if can_route_single_seq_to_dense():
-        # unsqueeze is a view: a single packed sequence is already [S, H, D] contiguous.
+        # Q is exact; the K/V prefix slice and every unsqueeze are views -- a single
+        # packed sequence is a contiguous [S, H, D] prefix -- so this copies nothing.
         r = flash_attn_func(
             q.unsqueeze(0),
-            k.unsqueeze(0),
-            v.unsqueeze(0),
+            k[:max_seqlen_k].unsqueeze(0),
+            v[:max_seqlen_k].unsqueeze(0),
             dropout_p=dropout_p,
             softmax_scale=softmax_scale,
             causal=causal,
@@ -3822,6 +3833,8 @@ def flash_attn_varlen_func(
             return_lse=return_lse,
             sink_ptr=sink_ptr,
         )
+        # Output is [1, max_seqlen_q, H, D]; varlen callers expect [total_q, H, D], and
+        # total_q == max_seqlen_q for one sequence, so squeeze yields the right extent.
         if return_lse:
             dense_out, lse = r[0], r[1]
             # dense lse is [B, H, S]; varlen callers expect [H, total_q]

--- a/aiter/ops/mha.py
+++ b/aiter/ops/mha.py
@@ -3739,6 +3739,73 @@ def flash_attn_varlen_func(
             sink_ptr,
         )
 
+    # A varlen batch holding exactly ONE sequence is the same problem as a dense
+    # batch-1 call, so route it to the dense entry -- which is where the OPUS
+    # symmetric-head-dim kernels live (they are batch-mode only). This is what lets a
+    # single-request prefill reach OPUS instead of falling back to CK.
+    #
+    # Detection is deliberately sync-free: cu_seqlens has batch+1 entries so
+    # numel() == 2 means one sequence (metadata only, no D2H), and max_seqlen_* are
+    # already host ints. Reading cu_seqlens values would force a device sync on a
+    # path called once per layer. Multi-sequence batches fall through unchanged.
+    def can_route_single_seq_to_dense():
+        if get_gfx() != "gfx950" or q.dtype != dtypes.bf16:
+            return False
+        if int(os.environ.get("AITER_ENABLE_FMHA_OPUS", "0")) == 0:
+            return False
+        if q.dim() != 3 or k.dim() != 3 or v.dim() != 3:
+            return False
+        if not (q.shape[-1] == k.shape[-1] == v.shape[-1]):
+            return False
+        if q.shape[-1] not in (64, 128):
+            return False
+        # exactly one sequence, and it spans the whole packed tensor
+        if cu_seqlens_q is None or cu_seqlens_k is None:
+            return False
+        if cu_seqlens_q.numel() != 2 or cu_seqlens_k.numel() != 2:
+            return False
+        if q.shape[0] != max_seqlen_q or k.shape[0] != max_seqlen_k:
+            return False
+        if v.shape[0] != max_seqlen_k:
+            return False
+        # flash_attn_func has no `out` parameter, and routing here with a caller
+        # buffer would mean a hidden extra copy -- decline instead. (vLLM's extend
+        # path does not pass out=.)
+        if out is not None:
+            return False
+        # everything the dense OPUS gate also rejects
+        if block_table is not None or bias is not None or alibi_slopes is not None:
+            return False
+        if cu_seqlens_q_padded is not None or cu_seqlens_k_padded is not None:
+            return False
+        if dropout_p != 0.0 or logits_soft_cap != 0.0 or return_attn_probs:
+            return False
+        if window_size[0] != -1 or window_size[1] != -1:
+            return False
+        if (len(window_size) > 2 and window_size[2] != 0) or sink_ptr is not None:
+            return False
+        return q.shape[-2] % k.shape[-2] == 0
+
+    if can_route_single_seq_to_dense():
+        # unsqueeze is a view: a single packed sequence is already [S, H, D] contiguous.
+        r = flash_attn_func(
+            q.unsqueeze(0),
+            k.unsqueeze(0),
+            v.unsqueeze(0),
+            dropout_p=dropout_p,
+            softmax_scale=softmax_scale,
+            causal=causal,
+            window_size=window_size,
+            deterministic=deterministic,
+            return_lse=return_lse,
+        )
+        if return_lse:
+            dense_out, lse = r[0], r[1]
+            # dense lse is [B, H, S]; varlen callers expect [H, total_q]
+            return dense_out.squeeze(0), lse.squeeze(0)
+        dense_out = r[0] if isinstance(r, (tuple, list)) else r
+        return dense_out.squeeze(0)
+
     # FlyDSL path returns result if supported, None otherwise. window_size[2] (sink
     # size) is unsupported: the FlyDSL gate rejects it, and this screen keeps it off
     # the path so a sink-token request is never silently dropped.

--- a/aiter/ops/mha.py
+++ b/aiter/ops/mha.py
@@ -3122,6 +3122,19 @@ def _flash_attn_varlen_forward(
                 and sink_ptr.is_contiguous()
             )
         )
+        # The launcher requires out exactly [total_q, nhead_q, hdim_v]; decline anything
+        # else so a mis-shaped buffer falls back instead of tripping its TORCH_CHECK.
+        ret = ret and (
+            out is None
+            or (
+                out.dim() == 3
+                and out.shape[0] == q.shape[0]
+                and out.shape[1] == nhead_q
+                and out.shape[2] == hdim_v
+                and out.dtype == q.dtype
+                and out.stride(-1) == 1
+            )
+        )
         # KV extent >= 2^32 wraps the kernel's 32-bit soffset. Packed, so stride(0);
         # max_seqlen_k bounds every group (each is rebased to its own row offset).
         if ret:

--- a/aiter/ops/mha.py
+++ b/aiter/ops/mha.py
@@ -2038,10 +2038,12 @@ def _flash_attn_forward(
             ret = ret and (seqlen_k >= seqlen_q)
         return ret
 
-    def _can_impl_fmha_fwd_hd128_bf16_opus():
+    def _can_impl_fmha_fwd_sym_bf16_opus():
+        # Symmetric-head-dim OPUS forward: D_QK == D_V in {64, 128}. Both share one
+        # kernel template (opus_gqa_traits differs only in D_TILE_SIZE).
         if int(os.environ.get("AITER_ENABLE_FMHA_OPUS", "0")) == 0:
             return False
-        if not (hdim_q == 128 and hdim_v == 128):
+        if hdim_q != hdim_v or hdim_q not in (64, 128):
             return False
         # KV byte extent >= 2^32 wraps the kernel's 32-bit async-load soffset; fall back to
         # v3/CK. Actual seqlen stride (layout-aware, matches the C++ guard).
@@ -2073,7 +2075,7 @@ def _flash_attn_forward(
         ret = ret and (q_descale is None and k_descale is None and v_descale is None)
         ret = ret and (not return_softmax)
         ret = ret and (
-            _can_impl_fmha_fwd_hd128_bf16_opus()
+            _can_impl_fmha_fwd_sym_bf16_opus()
             or _can_impl_fmha_fwd_hd192_v128_bf16_opus()
         )
         return ret

--- a/aiter/ops/mha.py
+++ b/aiter/ops/mha.py
@@ -2637,6 +2637,7 @@ class FlashAttnFunc(torch.autograd.Function):
         cu_seqlens_kv: torch.Tensor | None = None,
         sink_ptr: Tensor | None = None,
         num_splits: int = 0,
+        out: torch.Tensor | None = None,
     ):
         is_grad = is_grad_enabled and any(x.requires_grad for x in [q, k, v])
         if softmax_scale is None:
@@ -2648,6 +2649,12 @@ class FlashAttnFunc(torch.autograd.Function):
             k = torch.nn.functional.pad(k, [0, 8 - head_size_q_og % 8])
         if head_size_v_og % 8 != 0:
             v = torch.nn.functional.pad(v, [0, 8 - head_size_v_og % 8])
+        # A padded head dim would make out_padded wider than the caller's buffer.
+        if out is not None and head_size_v_og % 8 != 0:
+            raise NotImplementedError(
+                "flash_attn_func: out= requires head_dim_v to be a multiple of 8, got "
+                f"{head_size_v_og}"
+            )
         out_padded, softmax_lse, S_dmask, rng_state = _flash_attn_forward(
             q,
             k,
@@ -2670,6 +2677,7 @@ class FlashAttnFunc(torch.autograd.Function):
             cu_seqlens_kv=cu_seqlens_kv,
             sink_ptr=sink_ptr,  # fwd kernel still uses sink_ptr naming
             num_splits=num_splits,
+            out=out,
         )
         if is_grad:
             assert return_lse
@@ -2797,6 +2805,7 @@ def flash_attn_func(
     cu_seqlens_kv: torch.Tensor | None = None,
     sink_ptr: Tensor | None = None,
     num_splits: int = 0,
+    out: Tensor | None = None,
 ):
     """dropout_p should be set to 0.0 during evaluation
     Supports multi-query and grouped-query attention (MQA/GQA) by passing in KV with fewer heads
@@ -2844,6 +2853,8 @@ def flash_attn_func(
             0 (default) lets aiter decide via a heuristic; 1 disables split-K (uses the
             standard CK/ASM dispatch); >=2 forces the native split-K kernel with that many
             splits when that path is applicable, otherwise num_splits is ignored.
+        out: (batch_size, seqlen, nheads, headdim_v). Optional caller-owned output buffer,
+            written in place and returned; mirrors `flash_attn_varlen_func`'s `out`.
     Return:
         out: (batch_size, seqlen, nheads, headdim_v).
         softmax_lse [optional, if return_attn_probs=True]: (batch_size, nheads, seqlen). The
@@ -2883,6 +2894,11 @@ def flash_attn_func(
             return _flydsl_result
 
     if not ENABLE_CK:
+        # The triton entry has no out=; fail loudly rather than leave it unwritten.
+        if out is not None:
+            raise NotImplementedError(
+                "flash_attn_func: out= is not supported on the triton path (ENABLE_CK=0)"
+            )
         from .triton.attention.mha import flash_attn_func as flash_attn_func_triton
 
         return flash_attn_func_triton(
@@ -2920,6 +2936,7 @@ def flash_attn_func(
         cu_seqlens_kv,
         sink_ptr,
         num_splits,
+        out,
     )
 
 
@@ -3799,11 +3816,16 @@ def flash_attn_varlen_func(
             return False
         if k.shape[0] < max_seqlen_k or v.shape[0] < max_seqlen_k:
             return False
-        # flash_attn_func has no `out` parameter, and routing here with a caller
-        # buffer would mean a hidden extra copy -- decline instead. (vLLM's extend
-        # path does not pass out=.)
+        # Forwarded to the dense entry as a view, so no copy. Requires exactly one output
+        # row per query row (an oversized out would leave a stale tail), plus matching
+        # dtype/heads and contiguity so the unsqueeze below stays a view.
         if out is not None:
-            return False
+            if out.dim() != 3 or out.shape[0] != q.shape[0]:
+                return False
+            if out.shape[-2] != q.shape[-2] or out.shape[-1] != v.shape[-1]:
+                return False
+            if out.dtype != q.dtype or not out.is_contiguous():
+                return False
         # everything the dense OPUS gate also rejects
         if block_table is not None or bias is not None or alibi_slopes is not None:
             return False
@@ -3832,6 +3854,7 @@ def flash_attn_varlen_func(
             deterministic=deterministic,
             return_lse=return_lse,
             sink_ptr=sink_ptr,
+            out=None if out is None else out.unsqueeze(0),
         )
         # Output is [1, max_seqlen_q, H, D]; varlen callers expect [total_q, H, D], and
         # total_q == max_seqlen_q for one sequence, so squeeze yields the right extent.

--- a/aiter/ops/mha.py
+++ b/aiter/ops/mha.py
@@ -440,6 +440,7 @@ def _fmha_fwd_bf16_opus_fwd(
     seqstart_k_pad: Tensor | None = None,
     max_seqlen_q: int = 0,
     max_seqlen_k: int = 0,
+    sink: Tensor | None = None,
 ) -> None: ...
 
 
@@ -452,6 +453,7 @@ def fmha_fwd_bf16_opus_fwd(
     out: Tensor | None = None,
     return_lse: bool = False,
     lse: Tensor | None = None,
+    sink: Tensor | None = None,
 ) -> Tensor | tuple[Tensor, Tensor]:
     """Public wrapper for the OPUS gfx950 bf16 dense (batch) forward (D=128 and
     D_QK=192/D_V=128). q/k/v are dense bshd [B, S, H, D]; allocates `out`
@@ -480,7 +482,11 @@ def fmha_fwd_bf16_opus_fwd(
             (batch, q_head_num, q_seq_len), dtype=torch.float32, device=q.device
         )
 
-    _fmha_fwd_bf16_opus_fwd(q, k, v, out, bool(causal), float(softmax_scale), lse=lse)
+    # `sink` is one fp32 learned logit per query head ([H_q]); it joins the softmax
+    # denominator as a valueless extra key, so it changes O and lse but needs no buffer.
+    _fmha_fwd_bf16_opus_fwd(
+        q, k, v, out, bool(causal), float(softmax_scale), lse=lse, sink=sink
+    )
     return (out, lse) if return_lse else out
 
 
@@ -2071,7 +2077,21 @@ def _flash_attn_forward(
         ret = ret and (bias is None and alibi_slopes is None)
         ret = ret and (dropout_p == 0.0)
         ret = ret and (window_size_left == -1 and window_size_right == -1)
-        ret = ret and (sink_size == 0 and sink_ptr is None)
+        # Sinks ARE supported by the symmetric (D_QK == D_V) kernel -- it folds the
+        # per-head logit into the softmax denominator. sink_size (the "first N keys are
+        # sinks" variant) is a different feature and is still unsupported.
+        ret = ret and (sink_size == 0)
+        ret = ret and (
+            sink_ptr is None
+            or (
+                hdim_q == hdim_v
+                and sink_ptr.dtype == dtypes.fp32
+                and sink_ptr.numel() == nhead_q
+                # our launcher reads the sink at unit stride; don't hand it a
+                # non-contiguous one -- fall back instead of failing its check.
+                and sink_ptr.is_contiguous()
+            )
+        )
         ret = ret and (q_descale is None and k_descale is None and v_descale is None)
         ret = ret and (not return_softmax)
         ret = ret and (
@@ -2176,6 +2196,7 @@ def _flash_attn_forward(
             causal=bool(causal),
             out=out,
             lse=softmax_lse if return_lse else None,
+            sink=sink_ptr,
         )
         S_dmask = torch.empty((0,), dtype=torch.float32, device=q.device)
         rng_state = torch.empty((2,), dtype=torch.int64, device=q.device)
@@ -3782,8 +3803,9 @@ def flash_attn_varlen_func(
             return False
         if window_size[0] != -1 or window_size[1] != -1:
             return False
-        if (len(window_size) > 2 and window_size[2] != 0) or sink_ptr is not None:
+        if len(window_size) > 2 and window_size[2] != 0:
             return False
+        # sink_ptr is allowed: the dense symmetric OPUS kernel supports it.
         return q.shape[-2] % k.shape[-2] == 0
 
     if can_route_single_seq_to_dense():
@@ -3798,6 +3820,7 @@ def flash_attn_varlen_func(
             window_size=window_size,
             deterministic=deterministic,
             return_lse=return_lse,
+            sink_ptr=sink_ptr,
         )
         if return_lse:
             dense_out, lse = r[0], r[1]

--- a/csrc/include/fmha_fwd_bf16_opus_launch.h
+++ b/csrc/include/fmha_fwd_bf16_opus_launch.h
@@ -143,13 +143,17 @@ inline bool launch_d128(const fmha_fwd_bf16_opus_args& a, hipStream_t stream)
         HIP_CALL_LAUNCH(hipGetLastError());
     };
 
-    if(a.causal)
+    // Tile shape (Q=32, KV=64, 8 waves) is shared by both head dims; only D_TILE_SIZE
+    // differs, and every derived count in opus_gqa_traits follows from it.
+    if(a.hdim_q == 128)
     {
-        launch(opus_gqa_traits<32, 64, 128, 8, true>{});
+        if(a.causal) { launch(opus_gqa_traits<32, 64, 128, 8, true>{}); }
+        else         { launch(opus_gqa_traits<32, 64, 128, 8, false>{}); }
     }
-    else
+    else // D=64 (the dispatcher only routes hdim 64 or 128 here)
     {
-        launch(opus_gqa_traits<32, 64, 128, 8, false>{});
+        if(a.causal) { launch(opus_gqa_traits<32, 64, 64, 8, true>{}); }
+        else         { launch(opus_gqa_traits<32, 64, 64, 8, false>{}); }
     }
     return true;
 }
@@ -286,7 +290,7 @@ inline bool fmha_fwd_bf16_opus_launch(const fmha_fwd_bf16_opus_args& a, hipStrea
 
     const bool is_group = (a.seqstart_q_ptr != nullptr);
 
-    if(a.hdim_q == 128 && a.hdim_v == 128)
+    if(a.hdim_q == a.hdim_v && (a.hdim_q == 64 || a.hdim_q == 128))
     {
         if(is_group)
             return false;

--- a/csrc/include/fmha_fwd_bf16_opus_launch.h
+++ b/csrc/include/fmha_fwd_bf16_opus_launch.h
@@ -34,6 +34,9 @@ struct fmha_fwd_bf16_opus_args
     void* o_ptr       = nullptr;
     // nullptr => the kernel skips the log-sum-exp store entirely.
     void* lse_ptr = nullptr;
+    // Optional attention sink: one fp32 logit per query head, [nhead]. nullptr => no sink.
+    // Symmetric (d128) kernel only; the d192/v128 kernel has no sink support.
+    const void* sink_ptr = nullptr;
 
     // Group / varlen, int32, length batch+1. A null seqstart_q_ptr selects batch mode.
     // The *_pad arrays give the physical row offsets (equal to the non-pad arrays when
@@ -132,6 +135,7 @@ inline bool launch_d128(const fmha_fwd_bf16_opus_args& a, hipStream_t stream)
     kargs.ptr_lse      = a.lse_ptr;
     kargs.stride_lse_b = a.stride_lse_b;
     kargs.stride_lse_h = a.stride_lse_h;
+    kargs.ptr_sink     = a.sink_ptr;  // nullptr => no sink (d192/v128 never sets it)
 
     auto launch = [&](auto traits_tag) {
         using Traits          = decltype(traits_tag);

--- a/csrc/include/fmha_fwd_bf16_opus_launch.h
+++ b/csrc/include/fmha_fwd_bf16_opus_launch.h
@@ -314,12 +314,9 @@ inline bool fmha_fwd_bf16_opus_launch(const fmha_fwd_bf16_opus_args& a, hipStrea
         return false;
     }
 
-    const bool is_group = (a.seqstart_q_ptr != nullptr);
-
     if(a.hdim_q == a.hdim_v && (a.hdim_q == 64 || a.hdim_q == 128))
     {
-        if(is_group)
-            return false;
+        // Batch and group both supported; launch_d128 selects on a.seqstart_q_ptr.
         return fmha_fwd_bf16_opus_detail::launch_d128(a, stream);
     }
     if(a.hdim_q == 192 && a.hdim_v == 128)

--- a/csrc/include/fmha_fwd_bf16_opus_launch.h
+++ b/csrc/include/fmha_fwd_bf16_opus_launch.h
@@ -88,13 +88,20 @@ inline float resolve_scale(float softmax_scale, int hdim_q)
     return 1.0f / std::sqrt(static_cast<float>(hdim_q));
 }
 
-// D_QK = D_V = 128 (symmetric), batch mode only.
+// D_QK = D_V in {64, 128} (symmetric), batch + group / varlen.
 inline bool launch_d128(const fmha_fwd_bf16_opus_args& a, hipStream_t stream)
 {
     // A kv extent reaching 2^32 wraps the async-load offset and silently produces wrong
-    // output, so refuse it instead.
+    // output, so refuse it instead. seqlen_k is max_seqlen_k in group mode and each group is
+    // rebased to its own row offset, so this bounds every group.
     const int kv_stride_n = (a.stride_k_n > a.stride_v_n ? a.stride_k_n : a.stride_v_n);
     if(static_cast<long long>(a.seqlen_k) * kv_stride_n * 2LL >= (1LL << 32))
+    {
+        return false;
+    }
+
+    const bool is_group = (a.seqstart_q_ptr != nullptr);
+    if(is_group && (!a.seqstart_k_ptr || !a.seqstart_q_pad_ptr || !a.seqstart_k_pad_ptr))
     {
         return false;
     }
@@ -137,28 +144,43 @@ inline bool launch_d128(const fmha_fwd_bf16_opus_args& a, hipStream_t stream)
     kargs.stride_lse_h = a.stride_lse_h;
     kargs.ptr_sink     = a.sink_ptr;  // nullptr => no sink (d192/v128 never sets it)
 
+    kargs.ptr_seqstart_q     = a.seqstart_q_ptr;
+    kargs.ptr_seqstart_k     = a.seqstart_k_ptr;
+    kargs.ptr_seqstart_q_pad = a.seqstart_q_pad_ptr;
+    kargs.ptr_seqstart_k_pad = a.seqstart_k_pad_ptr;
+
     auto launch = [&](auto traits_tag) {
         using Traits          = decltype(traits_tag);
         const int num_q_tiles = ceil_div(a.seqlen_q, Traits::Q_TILE_SIZE);
         const int num_q_blk   = ceil_div(num_q_tiles, Traits::NUM_WARPS);
-        dim3 grid(a.nhead, num_q_blk, a.batch);
+        // Group mode rotates the axes (head=x, group=y, Q-block=z) so the shorter groups'
+        // empty tail blocks short-circuit together; extent is the longest group.
+        dim3 grid = Traits::GROUP_MODE ? dim3(a.nhead, a.batch, num_q_blk)
+                                       : dim3(a.nhead, num_q_blk, a.batch);
         dim3 block(Traits::BLOCK_SIZE);
         gqa_d128_kernel<Traits><<<grid, block, 0, stream>>>(kargs);
         HIP_CALL_LAUNCH(hipGetLastError());
     };
 
     // Tile shape (Q=32, KV=64, 8 waves) is shared by both head dims; only D_TILE_SIZE
-    // differs, and every derived count in opus_gqa_traits follows from it.
-    if(a.hdim_q == 128)
-    {
-        if(a.causal) { launch(opus_gqa_traits<32, 64, 128, 8, true>{}); }
-        else         { launch(opus_gqa_traits<32, 64, 128, 8, false>{}); }
-    }
-    else // D=64 (the dispatcher only routes hdim 64 or 128 here)
-    {
-        if(a.causal) { launch(opus_gqa_traits<32, 64, 64, 8, true>{}); }
-        else         { launch(opus_gqa_traits<32, 64, 64, 8, false>{}); }
-    }
+    // differs, and every derived count in opus_gqa_traits follows from it. Instances are
+    // D x causal x group.
+    auto launch_by_d = [&](auto group_tag) {
+        constexpr bool G = decltype(group_tag)::value;
+        if(a.hdim_q == 128)
+        {
+            if(a.causal) { launch(opus_gqa_traits<32, 64, 128, 8, true, G>{}); }
+            else         { launch(opus_gqa_traits<32, 64, 128, 8, false, G>{}); }
+        }
+        else // D=64 (the dispatcher only routes hdim 64 or 128 here)
+        {
+            if(a.causal) { launch(opus_gqa_traits<32, 64, 64, 8, true, G>{}); }
+            else         { launch(opus_gqa_traits<32, 64, 64, 8, false, G>{}); }
+        }
+    };
+
+    if(is_group) { launch_by_d(std::true_type{}); }
+    else         { launch_by_d(std::false_type{}); }
     return true;
 }
 

--- a/csrc/include/fmha_fwd_bf16_opus_launch.h
+++ b/csrc/include/fmha_fwd_bf16_opus_launch.h
@@ -35,7 +35,7 @@ struct fmha_fwd_bf16_opus_args
     // nullptr => the kernel skips the log-sum-exp store entirely.
     void* lse_ptr = nullptr;
     // Optional attention sink: one fp32 logit per query head, [nhead]. nullptr => no sink.
-    // Symmetric (d128) kernel only; the d192/v128 kernel has no sink support.
+    // Symmetric D=64/128 kernels only; the d192/v128 kernel has no sink support.
     const void* sink_ptr = nullptr;
 
     // Group / varlen, int32, length batch+1. A null seqstart_q_ptr selects batch mode.
@@ -302,9 +302,8 @@ inline bool launch_d192_v128(const fmha_fwd_bf16_opus_args& a, hipStream_t strea
 
 // Launches the opus forward kernel that matches the argument head dims on `stream`.
 // Returns false when the input is outside what the kernels cover: a data type other than
-// bf16, a (hdim_q, hdim_v) other than (128,128) or (192,128), group mode asked of the
-// batch-only symmetric kernel, or (for the 128/128 kernel only) a kv extent past the
-// 32-bit async-load offset limit.
+// bf16, a (hdim_q, hdim_v) outside {(64,64), (128,128), (192,128)}, incomplete group
+// metadata, or (for a symmetric kernel) a KV extent past the 32-bit async-load limit.
 inline bool fmha_fwd_bf16_opus_launch(const fmha_fwd_bf16_opus_args& a, hipStream_t stream)
 {
     static const std::string arch_id = get_gpu_arch();

--- a/csrc/include/fmha_fwd_hd128_bf16_opus_defs.h
+++ b/csrc/include/fmha_fwd_hd128_bf16_opus_defs.h
@@ -36,15 +36,18 @@ struct opus_gqa_kargs {
 };
 
 // Configuration traits for the GQA kernel (tile sizes, data types, vector lengths,
-// MFMA config). This integration is D=128 only: MFMA 32x32x16 bf16, K/V loaded in
-// one shot (no D slicing).
+// MFMA config). MFMA 32x32x16 bf16, K/V loaded in one shot (no D slicing), which holds
+// for D=64 and D=128 alike — every quantity below is derived from D_TILE_SIZE and stays
+// integral at both. The static_asserts near the end of the struct enforce that rather
+// than relying on this list being kept in sync.
 template<int Q_TILE_SIZE_ = 32,
         int KV_TILE_SIZE_ = 64,
         int D_TILE_SIZE_ = 128,
         int NUM_WARPS_ = 8,
         bool CAUSAL_ = false>
 struct opus_gqa_traits {
-    static_assert(D_TILE_SIZE_ == 128, "fmha_fwd_hd128_bf16_opus supports D_TILE_SIZE 128 only");
+    static_assert(D_TILE_SIZE_ == 64 || D_TILE_SIZE_ == 128,
+                  "opus_gqa_traits supports D_TILE_SIZE 64 or 128");
 
     static constexpr int Q_TILE_SIZE = Q_TILE_SIZE_;
     static constexpr int KV_TILE_SIZE = KV_TILE_SIZE_;
@@ -105,7 +108,9 @@ struct opus_gqa_traits {
     static constexpr int smem_padding_16B = 16 / sizeof(D_ATTN);
     static constexpr int smem_padding_64B = 64 / sizeof(D_ATTN);
 
-    // K/V smem padding (D=128): K uses 16B padding, V uses 64B padding.
+    // K/V smem padding: K uses 16B padding, V uses 64B padding. Tuned at D=128; kept
+    // identical at D=64 so the port is behaviour-preserving, but it is a tuning knob
+    // (bank-conflict behaviour differs when smem_d_rpt drops from 2 to 1).
     static constexpr int smem_k_padding = smem_padding_16B;
     static constexpr int smem_v_padding = smem_padding_64B;
 
@@ -129,6 +134,18 @@ struct opus_gqa_traits {
     static constexpr int KEEP_VMCNT = k_buffer_load_insts + v_buffer_load_insts;
     static constexpr int k_ds_read_insts = (GEMM0_E_N * GEMM0_E_K * W_N * W_K) / (WARP_SIZE * VEC_KV);
     static constexpr int v_ds_read_insts = (GEMM1_E_N * GEMM1_E_K * W_N * W_K) / (WARP_SIZE * VEC_TR_V);
+
+    // D-generality guards: every derived count above must divide exactly, or the tiling
+    // silently drops work. Checked here so a new D_TILE_SIZE fails at compile time.
+    static_assert(D_TILE_SIZE % D_128B_SIZE == 0, "D_TILE_SIZE must be a multiple of 128B");
+    static_assert(SLICE_D % W_K == 0, "SLICE_D must divide the MFMA K (GEMM0_E_K)");
+    static_assert(SLICE_D % W_N == 0, "SLICE_D must divide the MFMA N (GEMM1_E_N)");
+    static_assert((KV_TILE_SIZE * D_TILE_SIZE) % (BLOCK_SIZE * VEC_KV) == 0,
+                  "K/V tile must divide evenly into whole-block vector loads");
+    static_assert((GEMM0_E_N * GEMM0_E_K * W_N * W_K) % (WARP_SIZE * VEC_KV) == 0,
+                  "K ds_read count must be integral");
+    static_assert((GEMM1_E_N * GEMM1_E_K * W_N * W_K) % (WARP_SIZE * VEC_TR_V) == 0,
+                  "V ds_read count must be integral");
 
     static constexpr size_t smem_size_bytes() {
         // Q-in-LDS layout (K double-buffered + Q/V aliased shared region).

--- a/csrc/include/fmha_fwd_hd128_bf16_opus_defs.h
+++ b/csrc/include/fmha_fwd_hd128_bf16_opus_defs.h
@@ -33,6 +33,11 @@ struct opus_gqa_kargs {
     void* __restrict__ ptr_lse;
     int stride_lse_b;
     int stride_lse_h;
+    // Optional attention sinks: one fp32 learned logit per QUERY head, [H], unit stride.
+    // A sink behaves as one extra key that contributes to the softmax denominator but
+    // carries no value, so it only shifts the normalizer (see store_result in the
+    // kernel). nullptr => no sink. gpt-oss sets one on every attention layer.
+    const void* __restrict__ ptr_sink;
 };
 
 // Configuration traits for the GQA kernel (tile sizes, data types, vector lengths,

--- a/csrc/include/fmha_fwd_hd128_bf16_opus_defs.h
+++ b/csrc/include/fmha_fwd_hd128_bf16_opus_defs.h
@@ -28,8 +28,17 @@ struct opus_gqa_kargs {
     int stride_v_n;
     int stride_v_h;
     float softmax_scale;  // QK^T scale (host passes 1/sqrt(D) by default)
-    // Optional fp32 log-sum-exp (natural log) output, [B, H, N] with unit stride along
-    // the query dim. nullptr => not produced (the kernel skips the store).
+    // ── group mode (varlen / packed sequences) ──
+    // Prefix sums (length B+1) locating each group in the packed buffers: *_seqstart_* are
+    // real lengths (masks / KV-tile count / short-circuit), *_seqstart_*_pad are physical
+    // row offsets (equal when unpadded). A null ptr_seqstart_q selects batch mode.
+    const int* ptr_seqstart_q;
+    const int* ptr_seqstart_k;
+    const int* ptr_seqstart_q_pad;
+    const int* ptr_seqstart_k_pad;
+    // Optional fp32 log-sum-exp (natural log), unit stride along the query dim; nullptr =>
+    // not produced. batch: [B, H, N] (stride_lse_b/h). group: [H, total_q] (stride_lse_h,
+    // row offset from seqstart_q_pad, as Q/O).
     void* __restrict__ ptr_lse;
     int stride_lse_b;
     int stride_lse_h;
@@ -49,7 +58,8 @@ template<int Q_TILE_SIZE_ = 32,
         int KV_TILE_SIZE_ = 64,
         int D_TILE_SIZE_ = 128,
         int NUM_WARPS_ = 8,
-        bool CAUSAL_ = false>
+        bool CAUSAL_ = false,
+        bool GROUP_MODE_ = false>
 struct opus_gqa_traits {
     static_assert(D_TILE_SIZE_ == 64 || D_TILE_SIZE_ == 128,
                   "opus_gqa_traits supports D_TILE_SIZE 64 or 128");
@@ -59,6 +69,8 @@ struct opus_gqa_traits {
     static constexpr int D_TILE_SIZE = D_TILE_SIZE_;
     static constexpr int NUM_WARPS = NUM_WARPS_;
     static constexpr bool CAUSAL = CAUSAL_;
+    // Group (varlen) mode: locate sequences via seqstart, not a uniform batch stride.
+    static constexpr bool GROUP_MODE = GROUP_MODE_;
 
     static constexpr int WARP_SIZE = 64; // AMD wavefront size
     static constexpr int BLOCK_SIZE = NUM_WARPS * WARP_SIZE;

--- a/csrc/include/fmha_fwd_hd128_bf16_opus_defs.h
+++ b/csrc/include/fmha_fwd_hd128_bf16_opus_defs.h
@@ -42,10 +42,8 @@ struct opus_gqa_kargs {
     void* __restrict__ ptr_lse;
     int stride_lse_b;
     int stride_lse_h;
-    // Optional attention sinks: one fp32 learned logit per QUERY head, [H], unit stride.
-    // A sink behaves as one extra key that contributes to the softmax denominator but
-    // carries no value, so it only shifts the normalizer (see store_result in the
-    // kernel). nullptr => no sink. gpt-oss sets one on every attention layer.
+    // Optional attention sink: one fp32 logit per QUERY head, [H], unit stride -- a
+    // valueless extra key in the softmax denominator (see store_result). nullptr => none.
     const void* __restrict__ ptr_sink;
 };
 
@@ -84,13 +82,13 @@ struct opus_gqa_traits {
     static constexpr int T_N = 1;         // waves along N
     static constexpr int T_K = 1;         // waves along K
 
-    // MFMA base tile (D=128): bf16 32x32x16
+    // MFMA instruction shape: bf16 32x32x16.
     static constexpr int W_M = 32;
     static constexpr int W_N = 32;
     static constexpr int W_K = 16;
 
-    // D=128 covers the full head dim in one MMA (no D slicing).
-    static constexpr int SLICE_D = D_TILE_SIZE;  // == 128
+    // Each kernel instance covers the full head dim without an outer D-slicing loop.
+    static constexpr int SLICE_D = D_TILE_SIZE;
     static constexpr int NUM_D_SLICES = 1;
     static_assert(D_TILE_SIZE % SLICE_D == 0);
 
@@ -125,9 +123,9 @@ struct opus_gqa_traits {
     static constexpr int smem_padding_16B = 16 / sizeof(D_ATTN);
     static constexpr int smem_padding_64B = 64 / sizeof(D_ATTN);
 
-    // K/V smem padding: K uses 16B padding, V uses 64B padding. Tuned at D=128; kept
-    // identical at D=64 so the port is behaviour-preserving, but it is a tuning knob
-    // (bank-conflict behaviour differs when smem_d_rpt drops from 2 to 1).
+    // K/V smem padding (K 16B, V 64B), unchanged from D=128. These are not independent
+    // tuning knobs: the store/read layouts use the same constants and must change with
+    // the allocations or their addressing will diverge.
     static constexpr int smem_k_padding = smem_padding_16B;
     static constexpr int smem_v_padding = smem_padding_64B;
 
@@ -155,8 +153,8 @@ struct opus_gqa_traits {
     // D-generality guards: every derived count above must divide exactly, or the tiling
     // silently drops work. Checked here so a new D_TILE_SIZE fails at compile time.
     static_assert(D_TILE_SIZE % D_128B_SIZE == 0, "D_TILE_SIZE must be a multiple of 128B");
-    static_assert(SLICE_D % W_K == 0, "SLICE_D must divide the MFMA K (GEMM0_E_K)");
-    static_assert(SLICE_D % W_N == 0, "SLICE_D must divide the MFMA N (GEMM1_E_N)");
+    static_assert(SLICE_D % W_K == 0, "SLICE_D must be divisible by the MFMA K");
+    static_assert(SLICE_D % W_N == 0, "SLICE_D must be divisible by the MFMA N");
     static_assert((KV_TILE_SIZE * D_TILE_SIZE) % (BLOCK_SIZE * VEC_KV) == 0,
                   "K/V tile must divide evenly into whole-block vector loads");
     static_assert((GEMM0_E_N * GEMM0_E_K * W_N * W_K) % (WARP_SIZE * VEC_KV) == 0,

--- a/csrc/include/fmha_fwd_hd128_bf16_opus_kernel.hpp
+++ b/csrc/include/fmha_fwd_hd128_bf16_opus_kernel.hpp
@@ -691,6 +691,30 @@ __device__ __attribute__((always_inline)) void gqa_d128_impl(opus_gqa_kargs karg
     // label_write_out`. The stagger balancing barrier stays outside it: the no-keys path
     // runs no prologue, so neither wave group owes the other one.
     auto store_result = [&]() {
+        // ── attention sink ────────────────────────────────────────────────────────────
+        // A learned per-head logit acting as one extra key that contributes to the
+        // softmax denominator but carries no value. Since
+        //   out = (sum_j exp(s_j - m) v_j) / (sum_j exp(s_j - m) + exp(sink - m))
+        // it enters ONLY the denominator: v_o needs no rescale, and folding it into l_row
+        // here fixes both the O normalization and the LSE below in one place.
+        //
+        // m_row/l_row are base-2 (exp2, with log2(e) folded into temperature_scale) while
+        // the sink arrives as a natural-log logit, hence the LOG2_E conversion.
+        //
+        // l_row == 0 means no key contributed (no keys at all, or all masked). m_row is
+        // then still lowest(), so referencing the exponent to it would overflow; reference
+        // the sink to itself instead, giving l_row = 1, O = 0 and lse = sink -- the
+        // correct "attends entirely to the sink" answer.
+        if (kargs.ptr_sink != nullptr) {
+            const D_ACC sink_b2 =
+                reinterpret_cast<const D_ACC*>(kargs.ptr_sink)[h] * D_ACC(LOG2_E);
+            const bool have_keys = (l_row > D_ACC(0.0f));
+            const D_ACC m_ref = have_keys ? m_row : sink_b2;
+            l_row = (have_keys ? l_row : D_ACC(0.0f)) +
+                    __builtin_amdgcn_exp2f(sink_b2 - m_ref);
+            m_row = m_ref;
+        }
+
         if (kargs.ptr_lse != nullptr && lane_id < T::W_M) {
             constexpr D_ACC LN2 = D_ACC(0.69314718055994531f);   // 1 / log2(e)
             const D_ACC lse = (l_row > D_ACC(0.0f))

--- a/csrc/include/fmha_fwd_hd128_bf16_opus_kernel.hpp
+++ b/csrc/include/fmha_fwd_hd128_bf16_opus_kernel.hpp
@@ -533,8 +533,6 @@ __device__ __attribute__((always_inline)) void gqa_d128_impl(opus_gqa_kargs karg
     using D_ACC = typename T::D_ACC;
 
     const int workgroup_x = block_id_x();
-    const int q_block_idx = block_id_y();
-    const int b = block_id_z();
     int warp_id = __builtin_amdgcn_readfirstlane(thread_id_x() / T::WARP_SIZE);
     int lane_id = thread_id_x() % T::WARP_SIZE;
     asm volatile("" : "+v"(lane_id));
@@ -544,28 +542,66 @@ __device__ __attribute__((always_inline)) void gqa_d128_impl(opus_gqa_kargs karg
     const int h = (workgroup_x % kargs.H_KV) * group_size + (workgroup_x / kargs.H_KV);
     const int h_kv = h / group_size;
     const int q_block_size = T::NUM_WARPS * T::Q_TILE_SIZE;
+
+    // Per-workgroup seqlens and per-(batch|group, head) base ROW offsets. GROUP_MODE reads
+    // both from the seqstart prefix sums; batch mode keeps the original batch-stride form.
+    // Everything below uses seqlen_q/seqlen_kv, not kargs.N/N_KV, so it is mode-agnostic.
+    int seqlen_q, seqlen_kv;
+    int64_t q_batch_base, o_batch_base, k_batch_base, v_batch_base, lse_batch_base;
+    int q_block_idx;
+    if constexpr (T::GROUP_MODE) {
+        // Rotated axes as in the d192/v128 group kernel: head=x, group=y, Q-block=z --
+        // Q-block slowest, so the shorter groups' empty tail blocks drop together.
+        const int g = block_id_y();
+        // Workgroup-uniform; readfirstlane pins them to SGPRs, off the VGPR budget.
+        auto sc = [](int x) { return __builtin_amdgcn_readfirstlane(x); };
+        const int q0 = sc(kargs.ptr_seqstart_q[g]);
+        const int k0 = sc(kargs.ptr_seqstart_k[g]);
+        seqlen_q  = sc(kargs.ptr_seqstart_q[g + 1]) - q0;
+        seqlen_kv = sc(kargs.ptr_seqstart_k[g + 1]) - k0;
+        const int64_t qpad = sc(kargs.ptr_seqstart_q_pad[g]);
+        const int64_t kpad = sc(kargs.ptr_seqstart_k_pad[g]);
+        q_batch_base   = qpad * kargs.stride_q_n;   // packed: row offset, no batch stride
+        o_batch_base   = qpad * kargs.stride_o_n;
+        k_batch_base   = kpad * kargs.stride_k_n;
+        v_batch_base   = kpad * kargs.stride_v_n;
+        lse_batch_base = qpad;                      // [H, total_q]: unit stride along the row
+        q_block_idx    = block_id_z();
+        // Grid is sized by the longest group; seqlen_q == 0 drops every workgroup.
+        if (q_block_idx >= ceil_div(seqlen_q, q_block_size)) return;
+    } else {
+        const int b    = block_id_z();
+        seqlen_q       = kargs.N;
+        seqlen_kv      = kargs.N_KV;
+        q_batch_base   = (int64_t)b * kargs.stride_q_b;
+        o_batch_base   = (int64_t)b * kargs.stride_o_b;
+        k_batch_base   = (int64_t)b * kargs.stride_k_b;
+        v_batch_base   = (int64_t)b * kargs.stride_v_b;
+        lse_batch_base = (int64_t)b * kargs.stride_lse_b;
+        q_block_idx    = block_id_y();
+    }
     const int q_block_start = q_block_idx * q_block_size;
     // int64 offsets: B*N*H*D can exceed INT_MAX at large shapes.
-    const int64_t q_gmem_offset = (int64_t)b * kargs.stride_q_b + (int64_t)q_block_start * kargs.stride_q_n + (int64_t)h * kargs.stride_q_h;
-    const int64_t o_gmem_offset = (int64_t)b * kargs.stride_o_b + (int64_t)q_block_start * kargs.stride_o_n + (int64_t)h * kargs.stride_o_h;
-    const int64_t k_gmem_offset = (int64_t)b * kargs.stride_k_b + (int64_t)h_kv * kargs.stride_k_h;
-    const int64_t v_gmem_offset = (int64_t)b * kargs.stride_v_b + (int64_t)h_kv * kargs.stride_v_h;
+    const int64_t q_gmem_offset = q_batch_base + (int64_t)q_block_start * kargs.stride_q_n + (int64_t)h * kargs.stride_q_h;
+    const int64_t o_gmem_offset = o_batch_base + (int64_t)q_block_start * kargs.stride_o_n + (int64_t)h * kargs.stride_o_h;
+    const int64_t k_gmem_offset = k_batch_base + (int64_t)h_kv * kargs.stride_k_h;
+    const int64_t v_gmem_offset = v_batch_base + (int64_t)h_kv * kargs.stride_v_h;
 
     // num_records (bytes) bounds each descriptor to its valid rows so an out-of-bounds
     // read (partial last KV tile / partial last Q block, arbitrary seqlen) returns 0 with
     // no fault, and an OOB O store is dropped by hardware (no store_if needed). KV bounded
-    // by seqlen_kv (N_KV), Q/O by this block's remaining rows. Capped to the 32-bit desc.
+    // by seqlen_kv, Q/O by this block's remaining rows. Capped to the 32-bit desc.
     auto rec_bytes = [](int64_t elems) -> unsigned int {
         const int64_t bytes = elems * (int64_t)sizeof(D_ATTN);
         return bytes >= (int64_t)0xffffffffu ? 0xffffffffu : (unsigned int)bytes;
     };
-    const unsigned int k_num_records = rec_bytes((int64_t)kargs.N_KV * kargs.stride_k_n);
-    const unsigned int v_num_records = rec_bytes((int64_t)kargs.N_KV * kargs.stride_v_n);
-    const unsigned int q_num_records = rec_bytes((int64_t)(kargs.N - q_block_start) * kargs.stride_q_n);
-    const unsigned int o_num_records = rec_bytes((int64_t)(kargs.N - q_block_start) * kargs.stride_o_n);
+    const unsigned int k_num_records = rec_bytes((int64_t)seqlen_kv * kargs.stride_k_n);
+    const unsigned int v_num_records = rec_bytes((int64_t)seqlen_kv * kargs.stride_v_n);
+    const unsigned int q_num_records = rec_bytes((int64_t)(seqlen_q - q_block_start) * kargs.stride_q_n);
+    const unsigned int o_num_records = rec_bytes((int64_t)(seqlen_q - q_block_start) * kargs.stride_o_n);
     // Same bound for the fp32 LSE buffer (different element size than D_ATTN).
     const unsigned int lse_num_records =
-        (unsigned int)((int64_t)(kargs.N - q_block_start) * (int64_t)sizeof(D_ACC));
+        (unsigned int)((int64_t)(seqlen_q - q_block_start) * (int64_t)sizeof(D_ACC));
 
     // Global memory tensors
     auto g_q = make_gmem(reinterpret_cast<const D_ATTN*>(kargs.ptr_q) + q_gmem_offset, q_num_records);
@@ -659,10 +695,10 @@ __device__ __attribute__((always_inline)) void gqa_d128_impl(opus_gqa_kargs karg
     // differ from seqlen_q (N) for cross-attention.
     const int k_tile_stride = T::KV_TILE_SIZE * kargs.stride_k_n;
     const int v_tile_stride = T::KV_TILE_SIZE * kargs.stride_v_n;
-    const int num_kv_tiles = ceil_div(kargs.N_KV, T::KV_TILE_SIZE);
+    const int num_kv_tiles = ceil_div(seqlen_kv, T::KV_TILE_SIZE);
     // causal bottom-right alignment: query at global pos q_pos attends to keys with
     // k_pos <= q_pos + causal_offset. offset==0 for self-attention (N_KV==N).
-    [[maybe_unused]] const int causal_offset = kargs.N_KV - kargs.N;
+    [[maybe_unused]] const int causal_offset = seqlen_kv - seqlen_q;
     int max_num_tiles = num_kv_tiles;
     if constexpr (T::CAUSAL) {
         const int q_block_end = q_block_start + q_block_size;
@@ -720,8 +756,9 @@ __device__ __attribute__((always_inline)) void gqa_d128_impl(opus_gqa_kargs karg
             const D_ACC lse = (l_row > D_ACC(0.0f))
                                   ? ((m_row + __builtin_amdgcn_logf(l_row)) * LN2)
                                   : -opus::numeric_limits<D_ACC>::infinity();
+            // lse_batch_base: b*stride_lse_b (batch, [B,H,N]) or the group's row offset.
             auto g_lse = make_gmem(reinterpret_cast<D_ACC*>(kargs.ptr_lse) +
-                                       (int64_t)b * kargs.stride_lse_b +
+                                       lse_batch_base +
                                        (int64_t)h * kargs.stride_lse_h + q_block_start,
                                    lse_num_records);
             g_lse.store(lse, warp_id * T::Q_TILE_SIZE + lane_id);
@@ -824,8 +861,8 @@ __device__ __attribute__((always_inline)) void gqa_d128_impl(opus_gqa_kargs karg
         } else {
             // Non-causal: mask padded columns (global KV idx >= seqlen_kv) of the last KV
             // tile when seqlen_kv is not a multiple of KV_TILE (arbitrary seqlen).
-            if ((kargs.N_KV % T::KV_TILE_SIZE) != 0 && t == max_num_tiles - 1) {
-                attn_mask_border_tile<T>(vs_cur.s, kargs.N_KV, t, neg_inf_v, lane_id);
+            if ((seqlen_kv % T::KV_TILE_SIZE) != 0 && t == max_num_tiles - 1) {
+                attn_mask_border_tile<T>(vs_cur.s, seqlen_kv, t, neg_inf_v, lane_id);
             }
         }
         s_waitcnt_lgkmcnt(0_I);
@@ -924,8 +961,8 @@ __device__ __attribute__((always_inline)) void gqa_d128_impl(opus_gqa_kargs karg
     } else {
         // Non-causal: border-mask tile 0 only when it is also the last tile (tiny seqlen,
         // num_kv_tiles==1) and seqlen_kv is not KV_TILE-aligned.
-        if ((kargs.N_KV % T::KV_TILE_SIZE) != 0 && max_num_tiles == 1) {
-            attn_mask_border_tile<T>(v_s0.s, kargs.N_KV, 0, neg_inf_v, lane_id);
+        if ((seqlen_kv % T::KV_TILE_SIZE) != 0 && max_num_tiles == 1) {
+            attn_mask_border_tile<T>(v_s0.s, seqlen_kv, 0, neg_inf_v, lane_id);
         }
     }
     m_row = attn_row_max<T>(v_s0.s);

--- a/csrc/include/fmha_fwd_hd128_bf16_opus_kernel.hpp
+++ b/csrc/include/fmha_fwd_hd128_bf16_opus_kernel.hpp
@@ -1,4 +1,4 @@
-// GQA flash attention kernel template for D=128 on gfx950
+// GQA flash attention kernel template for symmetric D in {64, 128} on gfx950.
 // Include this header from per-variant .cc files that instantiate specific traits.
 #pragma once
 
@@ -728,27 +728,24 @@ __device__ __attribute__((always_inline)) void gqa_d128_impl(opus_gqa_kargs karg
     // runs no prologue, so neither wave group owes the other one.
     auto store_result = [&]() {
         // ── attention sink ────────────────────────────────────────────────────────────
-        // A learned per-head logit acting as one extra key that contributes to the
-        // softmax denominator but carries no value. Since
-        //   out = (sum_j exp(s_j - m) v_j) / (sum_j exp(s_j - m) + exp(sink - m))
-        // it enters ONLY the denominator: v_o needs no rescale, and folding it into l_row
-        // here fixes both the O normalization and the LSE below in one place.
-        //
-        // m_row/l_row are base-2 (exp2, with log2(e) folded into temperature_scale) while
-        // the sink arrives as a natural-log logit, hence the LOG2_E conversion.
-        //
-        // l_row == 0 means no key contributed (no keys at all, or all masked). m_row is
-        // then still lowest(), so referencing the exponent to it would overflow; reference
-        // the sink to itself instead, giving l_row = 1, O = 0 and lse = sink -- the
-        // correct "attends entirely to the sink" answer.
+        // A per-head logit acting as one valueless extra key in the softmax denominator.
+        // Rebase onto M = max(m_row, sink) before folding it in so a dominant sink cannot
+        // overflow exp2. The numerator and denominator rescale by
+        // alpha = exp2(m_row - M); LOG2_E converts the natural-log sink to the kernel's
+        // base-2 exponent. alpha folds into l_inv below, so v_o is scaled once. With no
+        // keys, m_row=lowest and l_row=0, so alpha=0, l_row=1, O=0, and lse=sink.
+        D_ACC alpha = D_ACC(1.0f);
         if (kargs.ptr_sink != nullptr) {
             const D_ACC sink_b2 =
                 reinterpret_cast<const D_ACC*>(kargs.ptr_sink)[h] * D_ACC(LOG2_E);
-            const bool have_keys = (l_row > D_ACC(0.0f));
-            const D_ACC m_ref = have_keys ? m_row : sink_b2;
-            l_row = (have_keys ? l_row : D_ACC(0.0f)) +
-                    __builtin_amdgcn_exp2f(sink_b2 - m_ref);
-            m_row = m_ref;
+            const D_ACC m_new = (m_row > sink_b2) ? m_row : sink_b2;
+            alpha = __builtin_amdgcn_exp2f(m_row - m_new);
+            // Avoid exp2(+inf - +inf): when the sink is M its contribution is exactly 1.
+            const D_ACC sink_term =
+                (sink_b2 >= m_new) ? D_ACC(1.0f)
+                                   : __builtin_amdgcn_exp2f(sink_b2 - m_new);
+            l_row = l_row * alpha + sink_term;
+            m_row = m_new;
         }
 
         if (kargs.ptr_lse != nullptr && lane_id < T::W_M) {
@@ -764,7 +761,7 @@ __device__ __attribute__((always_inline)) void gqa_d128_impl(opus_gqa_kargs karg
             g_lse.store(lse, warp_id * T::Q_TILE_SIZE + lane_id);
         }
 
-        D_ACC l_inv = (l_row > D_ACC(0.0f)) ? (D_ACC(1.0f) / l_row) : D_ACC(0.0f);
+        D_ACC l_inv = (l_row > D_ACC(0.0f)) ? (alpha / l_row) : D_ACC(0.0f);
         static_for<o_len>([&](auto i) { v_o[i.value] *= l_inv; });
 
         // Widened store: each dwordx4 (VEC_O_X4) group is packed and stored one group at a

--- a/csrc/include/rocm_ops.hpp
+++ b/csrc/include/rocm_ops.hpp
@@ -1555,7 +1555,8 @@ namespace py = pybind11;
           py::arg("seqstart_q_pad") = std::nullopt, \
           py::arg("seqstart_k_pad") = std::nullopt, \
           py::arg("max_seqlen_q")   = 0,            \
-          py::arg("max_seqlen_k")   = 0);
+          py::arg("max_seqlen_k")   = 0,            \
+          py::arg("sink")           = std::nullopt);
 
 #define NORM_PYBIND                                \
     m.def("layernorm2d_fwd",                       \

--- a/csrc/include/torch/fmha_fwd_bf16_opus.h
+++ b/csrc/include/torch/fmha_fwd_bf16_opus.h
@@ -49,4 +49,5 @@ void fmha_fwd_bf16_opus_fwd(at::Tensor& q,
                             std::optional<at::Tensor> seqstart_q_pad = std::nullopt,
                             std::optional<at::Tensor> seqstart_k_pad = std::nullopt,
                             int max_seqlen_q = 0,
-                            int max_seqlen_k = 0);
+                            int max_seqlen_k = 0,
+                            std::optional<at::Tensor> sink = std::nullopt);

--- a/csrc/include/torch/fmha_fwd_bf16_opus.h
+++ b/csrc/include/torch/fmha_fwd_bf16_opus.h
@@ -3,7 +3,7 @@
 //
 // Shared public API for the OPUS gfx950 bf16 flash-attention forward kernels.
 // A single entry point dispatches (by head dim, inferred from the tensors) to:
-//   * the symmetric  D_QK=128 / D_V=128 kernel (gqa_d128_kernel), batch mode only, or
+//   * the symmetric  D_QK = D_V in {64, 128} kernel (gqa_d128_kernel), batch + group, or
 //   * the asymmetric D_QK=192 / D_V=128 kernel (gqa_d192_v128_kernel), batch + group.
 //
 // This replaces the former per-hd `fmha_fwd_hd128_bf16_opus_fwd`. The kernel/launch
@@ -19,8 +19,8 @@
 //   Group mode  : q [total_q, H, D_QK]  k [total_k, H_KV, D_QK]  v [total_k, H_KV, D_V]
 //                 out [total_q, H, D_V]   (packed / varlen; group = num sequences)
 //
-// Supported head dims: (D_QK, D_V) in {(128,128), (192,128)}. Group mode requires
-// (192,128) (the D=128 kernel is batch only).
+// Supported head dims: (D_QK, D_V) in {(64,64), (128,128), (192,128)}. Every one of them
+// supports batch and group mode; only the symmetric kernels accept `sink`.
 //
 // `causal` selects the causal mask (bottom-right aligned when seqlen_q != seqlen_kv).
 // `softmax_scale` is applied to Q·K^T internally (pass <= 0 for the default 1/sqrt(D_QK)).

--- a/csrc/include/torch/fmha_fwd_bf16_opus.h
+++ b/csrc/include/torch/fmha_fwd_bf16_opus.h
@@ -6,8 +6,8 @@
 //   * the symmetric  D_QK = D_V in {64, 128} kernel (gqa_d128_kernel), batch + group, or
 //   * the asymmetric D_QK=192 / D_V=128 kernel (gqa_d192_v128_kernel), batch + group.
 //
-// This replaces the former per-hd `fmha_fwd_hd128_bf16_opus_fwd`. The kernel/launch
-// logic for D=128 is unchanged (only moved under this shared entry point).
+// This replaces the former per-hd `fmha_fwd_hd128_bf16_opus_fwd`; the historical
+// `gqa_d128` implementation is traits-parameterized for both symmetric head dims.
 #pragma once
 #include <torch/extension.h>
 #include <optional>
@@ -28,8 +28,8 @@
 // `lse` (optional) receives the log-sum-exp of the scaled scores in natural log,
 // float32, contiguous along the query dim:
 //   batch mode: [B, H, N]        group mode: [H, total_q]
-// Rows that see no keys (causal with seqlen_q > seqlen_kv) get -inf, matching
-// torch.logsumexp. Pass std::nullopt to skip it (the kernel then stores nothing).
+// Rows that see no keys (causal with seqlen_q > seqlen_kv) get -inf, or the sink logit
+// when a sink is supplied. Pass std::nullopt to skip it (the kernel stores nothing).
 //
 // Group / varlen (all four seqstart tensors are int32, length num_groups+1; pass
 // std::nullopt for batch mode):

--- a/csrc/py_itfs_cu/fmha_fwd_bf16_opus_kernels.cu
+++ b/csrc/py_itfs_cu/fmha_fwd_bf16_opus_kernels.cu
@@ -44,11 +44,11 @@ void launch_d128(at::Tensor& q,
     const int H_KV = static_cast<int>(k.size(2));
     const int N_KV = static_cast<int>(k.size(1));      // seqlen_kv (cross-attn: may != N)
 
-    TORCH_CHECK(D == 128, "launch_d128 only compiles D=128, got D=", D);
+    TORCH_CHECK(D == 64 || D == 128, "launch_d128 compiles D=64 or D=128, got D=", D);
     TORCH_CHECK(k.size(0) == B && v.size(0) == B, "k/v batch must equal q batch B");
     TORCH_CHECK(v.size(1) == N_KV, "k/v seqlen must match (v seqlen != k seqlen)");
     TORCH_CHECK(v.size(2) == H_KV, "k/v must share H_KV");
-    TORCH_CHECK(k.size(3) == D && v.size(3) == D, "k/v head dim must equal D=128");
+    TORCH_CHECK(k.size(3) == D && v.size(3) == D, "k/v head dim must equal q head dim D");
     TORCH_CHECK(H_KV > 0 && (H % H_KV) == 0, "H must be divisible by H_KV (GQA group)");
     TORCH_CHECK(out.size(0) == B && out.size(1) == N && out.size(2) == H && out.size(3) == D,
                 "out shape must match q [B, N, H, D]");
@@ -61,7 +61,7 @@ void launch_d128(at::Tensor& q,
     const long long kv_slice_bytes =
         (long long)N_KV * std::max(k.stride(1), v.stride(1)) * 2LL;  // bf16
     TORCH_CHECK(kv_slice_bytes < (1LL << 32),
-                "OPUS D=128: KV byte extent ", kv_slice_bytes,
+                "OPUS D=", D, ": KV byte extent ", kv_slice_bytes,
                 " reaches the 32-bit buffer-offset limit (2^32); reduce seqlen_kv or use another backend");
 
     if (B == 0 || N == 0 || H == 0) return;
@@ -293,15 +293,17 @@ void fmha_fwd_bf16_opus_fwd(at::Tensor& q,
     const int D_V  = static_cast<int>(v.size(-1));
     const bool is_group = seqstart_q.has_value() && seqstart_q->numel() > 0;
 
-    if (D_QK == 128 && D_V == 128) {
-        TORCH_CHECK(!is_group, "OPUS D=128 kernel supports batch mode only (no varlen)");
+    if (D_QK == D_V && (D_QK == 64 || D_QK == 128)) {
+        TORCH_CHECK(!is_group, "OPUS symmetric D=", D_QK,
+                    " kernel supports batch mode only (no varlen)");
         launch_d128(q, k, v, out, causal, softmax_scale, lse);
     } else if (D_QK == 192 && D_V == 128) {
         launch_d192_v128(q, k, v, out, causal, softmax_scale, lse,
                          seqstart_q, seqstart_k, seqstart_q_pad, seqstart_k_pad,
                          max_seqlen_q, max_seqlen_k);
     } else {
-        TORCH_CHECK(false, "OPUS fwd supports (D_QK,D_V) in {(128,128),(192,128)}, got (",
+        TORCH_CHECK(false,
+                    "OPUS fwd supports (D_QK,D_V) in {(64,64),(128,128),(192,128)}, got (",
                     D_QK, ",", D_V, ")");
     }
 }

--- a/csrc/py_itfs_cu/fmha_fwd_bf16_opus_kernels.cu
+++ b/csrc/py_itfs_cu/fmha_fwd_bf16_opus_kernels.cu
@@ -30,7 +30,8 @@ void launch_d128(at::Tensor& q,
                  at::Tensor& out,
                  bool causal,
                  float softmax_scale,
-                 std::optional<at::Tensor>& lse)
+                 std::optional<at::Tensor>& lse,
+                 std::optional<at::Tensor>& sink)
 {
     TORCH_CHECK(q.dim() == 4, "q must be 4-D [B, N, H, D], got ndim=", q.dim());
     TORCH_CHECK(k.dim() == 4, "k must be 4-D [B, N, H_KV, D], got ndim=", k.dim());
@@ -106,6 +107,18 @@ void launch_d128(at::Tensor& q,
         args.lse_ptr      = l.data_ptr();
         args.stride_lse_b = static_cast<int>(l.stride(0));
         args.stride_lse_h = static_cast<int>(l.stride(1));
+    }
+
+    // Attention sinks: one fp32 logit per QUERY head, [H], unit stride. Only the
+    // denominator is affected, so no extra output buffer is needed.
+    if (sink.has_value()) {
+        const at::Tensor& s = *sink;
+        TORCH_CHECK(s.device() == q.device(), "sink must be on the same device as q");
+        TORCH_CHECK(s.scalar_type() == at::kFloat, "sink must be float32");
+        TORCH_CHECK(s.dim() == 1 && static_cast<int>(s.size(0)) == H,
+                    "sink must be 1-D [H] matching q head count");
+        TORCH_CHECK(s.stride(0) == 1, "sink must be contiguous");
+        args.sink_ptr = s.data_ptr();
     }
 
     HipDeviceGuard guard(q.device().index());
@@ -278,7 +291,8 @@ void fmha_fwd_bf16_opus_fwd(at::Tensor& q,
                             std::optional<at::Tensor> seqstart_q_pad,
                             std::optional<at::Tensor> seqstart_k_pad,
                             int max_seqlen_q,
-                            int max_seqlen_k)
+                            int max_seqlen_k,
+                            std::optional<at::Tensor> sink)
 {
     TORCH_CHECK(q.is_cuda(), "q must be a GPU tensor");
     TORCH_CHECK(k.device() == q.device() && v.device() == q.device() &&
@@ -296,8 +310,10 @@ void fmha_fwd_bf16_opus_fwd(at::Tensor& q,
     if (D_QK == D_V && (D_QK == 64 || D_QK == 128)) {
         TORCH_CHECK(!is_group, "OPUS symmetric D=", D_QK,
                     " kernel supports batch mode only (no varlen)");
-        launch_d128(q, k, v, out, causal, softmax_scale, lse);
+        launch_d128(q, k, v, out, causal, softmax_scale, lse, sink);
     } else if (D_QK == 192 && D_V == 128) {
+        TORCH_CHECK(!sink.has_value(),
+                    "OPUS D_QK=192/D_V=128 kernel does not support attention sinks");
         launch_d192_v128(q, k, v, out, causal, softmax_scale, lse,
                          seqstart_q, seqstart_k, seqstart_q_pad, seqstart_k_pad,
                          max_seqlen_q, max_seqlen_k);

--- a/csrc/py_itfs_cu/fmha_fwd_bf16_opus_kernels.cu
+++ b/csrc/py_itfs_cu/fmha_fwd_bf16_opus_kernels.cu
@@ -3,7 +3,7 @@
 //
 // Torch entry point for the OPUS gfx950 bf16 flash-attention forward kernels.
 // `fmha_fwd_bf16_opus_fwd` validates the tensors and dispatches by head dim:
-//   * (D_QK,D_V) = (128,128) -> gqa_d128_kernel        (batch mode only)
+//   * (D_QK,D_V) = (64,64) | (128,128) -> gqa_d128_kernel  (batch + group / varlen)
 //   * (D_QK,D_V) = (192,128) -> gqa_d192_v128_kernel   (batch + group / varlen)
 //
 // This file owns the torch-facing validation and the tensor -> stride extraction only. The
@@ -22,8 +22,7 @@
 
 namespace {
 
-// ─── D_QK=128 / D_V=128 (symmetric) launch — logic unchanged from the original
-//     fmha_fwd_hd128_bf16_opus_fwd, only moved under the shared entry point. ───
+// ─── D_QK = D_V in {64, 128} (symmetric) launch — batch + group (varlen). ───
 void launch_d128(at::Tensor& q,
                  at::Tensor& k,
                  at::Tensor& v,
@@ -31,43 +30,122 @@ void launch_d128(at::Tensor& q,
                  bool causal,
                  float softmax_scale,
                  std::optional<at::Tensor>& lse,
-                 std::optional<at::Tensor>& sink)
+                 std::optional<at::Tensor>& sink,
+                 std::optional<at::Tensor>& seqstart_q,
+                 std::optional<at::Tensor>& seqstart_k,
+                 std::optional<at::Tensor>& seqstart_q_pad,
+                 std::optional<at::Tensor>& seqstart_k_pad,
+                 int max_seqlen_q,
+                 int max_seqlen_k)
 {
-    TORCH_CHECK(q.dim() == 4, "q must be 4-D [B, N, H, D], got ndim=", q.dim());
-    TORCH_CHECK(k.dim() == 4, "k must be 4-D [B, N, H_KV, D], got ndim=", k.dim());
-    TORCH_CHECK(v.dim() == 4, "v must be 4-D [B, N, H_KV, D], got ndim=", v.dim());
-    TORCH_CHECK(out.dim() == 4, "out must be 4-D [B, N, H, D], got ndim=", out.dim());
+    const bool is_group = seqstart_q.has_value() && seqstart_q->numel() > 0;
 
-    const int B    = static_cast<int>(q.size(0));
-    const int N    = static_cast<int>(q.size(1));      // seqlen_q
-    const int H    = static_cast<int>(q.size(2));
-    const int D    = static_cast<int>(q.size(3));
-    const int H_KV = static_cast<int>(k.size(2));
-    const int N_KV = static_cast<int>(k.size(1));      // seqlen_kv (cross-attn: may != N)
+    int B, N, N_KV, H, H_KV, D;
+    int total_q = 0;   // group mode only, for the packed LSE extent
+    fmha_fwd_bf16_opus_args args{};
+
+    if (is_group) {
+        // Packed / varlen: q [total_q, H, D], k/v [total_k, H_KV, D], out [total_q, H, D].
+        // B is the group count; N/N_KV are the maxima that drive the grid, while each
+        // group's real length comes from seqstart in the kernel.
+        TORCH_CHECK(q.dim() == 3 && k.dim() == 3 && v.dim() == 3 && out.dim() == 3,
+                    "group mode expects packed 3-D q/k/v/out [total, H, D]");
+        D       = static_cast<int>(q.size(2));
+        H       = static_cast<int>(q.size(1));
+        H_KV    = static_cast<int>(k.size(1));
+        total_q = static_cast<int>(q.size(0));
+        TORCH_CHECK(static_cast<int>(k.size(2)) == D && static_cast<int>(v.size(2)) == D &&
+                        static_cast<int>(out.size(2)) == D,
+                    "group mode k/v/out head dim must equal q head dim D");
+        TORCH_CHECK(static_cast<int>(v.size(1)) == H_KV, "group mode k/v must share H_KV");
+        TORCH_CHECK(v.size(0) == k.size(0), "group mode k/v must share total_k");
+        TORCH_CHECK(static_cast<int>(out.size(0)) == total_q &&
+                        static_cast<int>(out.size(1)) == H,
+                    "group mode out must be [total_q, H, D]");
+        TORCH_CHECK(seqstart_k.has_value(), "group mode requires seqstart_k");
+        B = static_cast<int>(seqstart_q->numel()) - 1;   // num groups
+        TORCH_CHECK(B > 0, "group mode requires seqstart_q length >= 2");
+        TORCH_CHECK(max_seqlen_q > 0 && max_seqlen_k > 0,
+                    "group mode requires max_seqlen_q / max_seqlen_k > 0");
+        N    = max_seqlen_q;
+        N_KV = max_seqlen_k;
+
+        // Validate before reinterpreting the storage as int32: a wrong dtype, layout or
+        // length would silently corrupt every per-group offset.
+        auto check_seqstart = [&](const at::Tensor& s, const char* name) {
+            TORCH_CHECK(s.device() == q.device(), name, " must be on the same device as q");
+            TORCH_CHECK(s.scalar_type() == at::kInt, name, " must be int32");
+            TORCH_CHECK(s.dim() == 1, name, " must be 1-D");
+            TORCH_CHECK(s.is_contiguous(), name, " must be contiguous");
+            TORCH_CHECK(static_cast<int>(s.numel()) == B + 1, name, " length must be num_groups+1");
+        };
+        check_seqstart(*seqstart_q, "seqstart_q");
+        check_seqstart(*seqstart_k, "seqstart_k");
+        if (seqstart_q_pad.has_value()) check_seqstart(*seqstart_q_pad, "seqstart_q_pad");
+        if (seqstart_k_pad.has_value()) check_seqstart(*seqstart_k_pad, "seqstart_k_pad");
+
+        // Packed: no batch stride, the group's row offset comes from seqstart.
+        args.stride_q_b = 0; args.stride_q_n = static_cast<int>(q.stride(0));   args.stride_q_h = static_cast<int>(q.stride(1));
+        args.stride_o_b = 0; args.stride_o_n = static_cast<int>(out.stride(0)); args.stride_o_h = static_cast<int>(out.stride(1));
+        args.stride_k_b = 0; args.stride_k_n = static_cast<int>(k.stride(0));   args.stride_k_h = static_cast<int>(k.stride(1));
+        args.stride_v_b = 0; args.stride_v_n = static_cast<int>(v.stride(0));   args.stride_v_h = static_cast<int>(v.stride(1));
+
+        args.seqstart_q_ptr     = reinterpret_cast<const int*>(seqstart_q->data_ptr());
+        args.seqstart_k_ptr     = reinterpret_cast<const int*>(seqstart_k->data_ptr());
+        args.seqstart_q_pad_ptr = reinterpret_cast<const int*>(
+            (seqstart_q_pad.has_value() ? *seqstart_q_pad : *seqstart_q).data_ptr());
+        args.seqstart_k_pad_ptr = reinterpret_cast<const int*>(
+            (seqstart_k_pad.has_value() ? *seqstart_k_pad : *seqstart_k).data_ptr());
+    } else {
+        TORCH_CHECK(q.dim() == 4, "q must be 4-D [B, N, H, D], got ndim=", q.dim());
+        TORCH_CHECK(k.dim() == 4, "k must be 4-D [B, N, H_KV, D], got ndim=", k.dim());
+        TORCH_CHECK(v.dim() == 4, "v must be 4-D [B, N, H_KV, D], got ndim=", v.dim());
+        TORCH_CHECK(out.dim() == 4, "out must be 4-D [B, N, H, D], got ndim=", out.dim());
+
+        B    = static_cast<int>(q.size(0));
+        N    = static_cast<int>(q.size(1));      // seqlen_q
+        H    = static_cast<int>(q.size(2));
+        D    = static_cast<int>(q.size(3));
+        H_KV = static_cast<int>(k.size(2));
+        N_KV = static_cast<int>(k.size(1));      // seqlen_kv (cross-attn: may != N)
+
+        TORCH_CHECK(k.size(0) == B && v.size(0) == B, "k/v batch must equal q batch B");
+        TORCH_CHECK(v.size(1) == N_KV, "k/v seqlen must match (v seqlen != k seqlen)");
+        TORCH_CHECK(v.size(2) == H_KV, "k/v must share H_KV");
+        TORCH_CHECK(k.size(3) == D && v.size(3) == D, "k/v head dim must equal q head dim D");
+        TORCH_CHECK(out.size(0) == B && out.size(1) == N && out.size(2) == H && out.size(3) == D,
+                    "out shape must match q [B, N, H, D]");
+
+        args.stride_q_b  = static_cast<int>(q.stride(0));
+        args.stride_q_n  = static_cast<int>(q.stride(1));
+        args.stride_q_h  = static_cast<int>(q.stride(2));
+        args.stride_o_b  = static_cast<int>(out.stride(0));
+        args.stride_o_n  = static_cast<int>(out.stride(1));
+        args.stride_o_h  = static_cast<int>(out.stride(2));
+        args.stride_k_b  = static_cast<int>(k.stride(0));
+        args.stride_k_n  = static_cast<int>(k.stride(1));
+        args.stride_k_h  = static_cast<int>(k.stride(2));
+        args.stride_v_b  = static_cast<int>(v.stride(0));
+        args.stride_v_n  = static_cast<int>(v.stride(1));
+        args.stride_v_h  = static_cast<int>(v.stride(2));
+    }
 
     TORCH_CHECK(D == 64 || D == 128, "launch_d128 compiles D=64 or D=128, got D=", D);
-    TORCH_CHECK(k.size(0) == B && v.size(0) == B, "k/v batch must equal q batch B");
-    TORCH_CHECK(v.size(1) == N_KV, "k/v seqlen must match (v seqlen != k seqlen)");
-    TORCH_CHECK(v.size(2) == H_KV, "k/v must share H_KV");
-    TORCH_CHECK(k.size(3) == D && v.size(3) == D, "k/v head dim must equal q head dim D");
     TORCH_CHECK(H_KV > 0 && (H % H_KV) == 0, "H must be divisible by H_KV (GQA group)");
-    TORCH_CHECK(out.size(0) == B && out.size(1) == N && out.size(2) == H && out.size(3) == D,
-                "out shape must match q [B, N, H, D]");
-
-    TORCH_CHECK(q.stride(3) == 1 && k.stride(3) == 1 && v.stride(3) == 1 && out.stride(3) == 1,
+    TORCH_CHECK(q.stride(-1) == 1 && k.stride(-1) == 1 && v.stride(-1) == 1 &&
+                    out.stride(-1) == 1,
                 "q/k/v/out must be contiguous along the head dim D");
 
     // 32-bit KV buffer-offset guard: extent >= 2^32 wraps the async-load soffset (silent
-    // wrong output), reject instead.
+    // wrong output), reject instead. N_KV is max_seqlen_k in group mode, bounding all.
     const long long kv_slice_bytes =
-        (long long)N_KV * std::max(k.stride(1), v.stride(1)) * 2LL;  // bf16
+        (long long)N_KV * std::max(args.stride_k_n, args.stride_v_n) * 2LL;  // bf16
     TORCH_CHECK(kv_slice_bytes < (1LL << 32),
-                "OPUS D=", D, ": KV byte extent ", kv_slice_bytes,
+                "OPUS symmetric D=", D, ": KV byte extent ", kv_slice_bytes,
                 " reaches the 32-bit buffer-offset limit (2^32); reduce seqlen_kv or use another backend");
 
     if (B == 0 || N == 0 || H == 0) return;
 
-    fmha_fwd_bf16_opus_args args{};
     args.q_ptr    = q.data_ptr();
     args.k_ptr    = k.data_ptr();
     args.v_ptr    = v.data_ptr();
@@ -79,34 +157,32 @@ void launch_d128(at::Tensor& q,
     args.seqlen_k = N_KV;
     args.hdim_q   = D;
     args.hdim_v   = D;
-    args.stride_q_b  = static_cast<int>(q.stride(0));
-    args.stride_q_n  = static_cast<int>(q.stride(1));
-    args.stride_q_h  = static_cast<int>(q.stride(2));
-    args.stride_o_b  = static_cast<int>(out.stride(0));
-    args.stride_o_n  = static_cast<int>(out.stride(1));
-    args.stride_o_h  = static_cast<int>(out.stride(2));
-    args.stride_k_b  = static_cast<int>(k.stride(0));
-    args.stride_k_n  = static_cast<int>(k.stride(1));
-    args.stride_k_h  = static_cast<int>(k.stride(2));
-    args.stride_v_b  = static_cast<int>(v.stride(0));
-    args.stride_v_n  = static_cast<int>(v.stride(1));
-    args.stride_v_h  = static_cast<int>(v.stride(2));
     args.softmax_scale = softmax_scale;  // <= 0 picks the launcher's 1/sqrt(D) default
     args.causal        = causal;
 
-    // Optional LSE (fp32, natural log; one value per (head, query row)). Left as nullptr
-    // when absent, which the kernel reads as "skip the store".
+    // Optional LSE (fp32, natural log; one per (head, query row)); nullptr => skip the
+    // store. Batch: [B, H, N]. Group: packed [H, total_q], row offset from seqstart_q_pad.
     if (lse.has_value()) {
         const at::Tensor& l = *lse;
         TORCH_CHECK(l.device() == q.device(), "lse must be on the same device as q");
         TORCH_CHECK(l.scalar_type() == at::kFloat, "lse must be float32");
         TORCH_CHECK(l.stride(-1) == 1, "lse must be contiguous along the query dim");
-        TORCH_CHECK(l.dim() == 3 && static_cast<int>(l.size(0)) == B &&
-                        static_cast<int>(l.size(1)) == H && static_cast<int>(l.size(2)) == N,
-                    "lse must be [B, H, N]");
-        args.lse_ptr      = l.data_ptr();
-        args.stride_lse_b = static_cast<int>(l.stride(0));
-        args.stride_lse_h = static_cast<int>(l.stride(1));
+        if (is_group) {
+            TORCH_CHECK(l.dim() == 2 && static_cast<int>(l.size(0)) == H &&
+                            static_cast<int>(l.size(1)) == total_q,
+                        "group mode lse must be [H, total_q]");
+            args.lse_ptr      = l.data_ptr();
+            args.stride_lse_b = 0;
+            args.stride_lse_h = static_cast<int>(l.stride(0));
+        } else {
+            TORCH_CHECK(l.dim() == 3 && static_cast<int>(l.size(0)) == B &&
+                            static_cast<int>(l.size(1)) == H &&
+                            static_cast<int>(l.size(2)) == N,
+                        "lse must be [B, H, N]");
+            args.lse_ptr      = l.data_ptr();
+            args.stride_lse_b = static_cast<int>(l.stride(0));
+            args.stride_lse_h = static_cast<int>(l.stride(1));
+        }
     }
 
     // Attention sinks: one fp32 logit per QUERY head, [H], unit stride. Only the
@@ -123,7 +199,7 @@ void launch_d128(at::Tensor& q,
 
     HipDeviceGuard guard(q.device().index());
     TORCH_CHECK(fmha_fwd_bf16_opus_launch(args, at::hip::getCurrentHIPStream()),
-                "OPUS D=128: the launcher rejected this shape");
+                "OPUS symmetric D=", D, ": the launcher rejected this shape");
 }
 
 // ─── D_QK=192 / D_V=128 (asymmetric) launch — batch + group (varlen). ───
@@ -305,12 +381,11 @@ void fmha_fwd_bf16_opus_fwd(at::Tensor& q,
 
     const int D_QK = static_cast<int>(q.size(-1));
     const int D_V  = static_cast<int>(v.size(-1));
-    const bool is_group = seqstart_q.has_value() && seqstart_q->numel() > 0;
 
     if (D_QK == D_V && (D_QK == 64 || D_QK == 128)) {
-        TORCH_CHECK(!is_group, "OPUS symmetric D=", D_QK,
-                    " kernel supports batch mode only (no varlen)");
-        launch_d128(q, k, v, out, causal, softmax_scale, lse, sink);
+        launch_d128(q, k, v, out, causal, softmax_scale, lse, sink,
+                    seqstart_q, seqstart_k, seqstart_q_pad, seqstart_k_pad,
+                    max_seqlen_q, max_seqlen_k);
     } else if (D_QK == 192 && D_V == 128) {
         TORCH_CHECK(!sink.has_value(),
                     "OPUS D_QK=192/D_V=128 kernel does not support attention sinks");

--- a/csrc/py_itfs_cu/fmha_fwd_bf16_opus_kernels.cu
+++ b/csrc/py_itfs_cu/fmha_fwd_bf16_opus_kernels.cu
@@ -185,8 +185,8 @@ void launch_d128(at::Tensor& q,
         }
     }
 
-    // Attention sinks: one fp32 logit per QUERY head, [H], unit stride. Only the
-    // denominator is affected, so no extra output buffer is needed.
+    // Attention sink: one fp32 valueless logit per QUERY head, [H], unit stride. It
+    // changes the softmax denominator without requiring an extra value/output buffer.
     if (sink.has_value()) {
         const at::Tensor& s = *sink;
         TORCH_CHECK(s.device() == q.device(), "sink must be on the same device as q");

--- a/op_tests/test_mha.py
+++ b/op_tests/test_mha.py
@@ -1130,10 +1130,34 @@ _OPUS_BATCH_IDS = [
 ]
 
 
+def _opus_sink(nheads, enabled):
+    """One learned fp32 logit per query head, or None.
+
+    Swept over the heads so the "sink dominates every score" branch and the
+    max-reference path are both exercised within a single case.
+    """
+    if not enabled:
+        return None
+    return torch.linspace(-4, 12, nheads, device="cuda", dtype=torch.float32)
+
+
 def _run_opus_batch_case(
-    batch_size, seqlen_q, seqlen_kv, nheads, nheads_k, d_qk, d_v, causal
+    batch_size,
+    seqlen_q,
+    seqlen_kv,
+    nheads,
+    nheads_k,
+    d_qk,
+    d_v,
+    causal,
+    with_sink=False,
 ):
-    """Shared body: flash_attn_func with LSE, assert it routed to OPUS, check results."""
+    """Shared body: flash_attn_func with LSE, assert it routed to OPUS, check results.
+
+    with_sink adds one learned logit per query head. A sink joins the softmax
+    denominator only, so O is unchanged for rows that see keys, fully-masked rows
+    still produce O=0, and their LSE collapses to the sink logit itself.
+    """
     torch.manual_seed(0)
     q = torch.randn(
         batch_size, seqlen_q, nheads, d_qk, device="cuda", dtype=dtypes.bf16
@@ -1144,6 +1168,7 @@ def _run_opus_batch_case(
     v = torch.randn(
         batch_size, seqlen_kv, nheads_k, d_v, device="cuda", dtype=dtypes.bf16
     )
+    sink = _opus_sink(nheads, with_sink)
 
     with torch.no_grad():
         out, lse = aiter.flash_attn_func(
@@ -1156,29 +1181,37 @@ def _run_opus_batch_case(
             window_size=(-1, -1),
             return_lse=True,
             return_attn_probs=False,
+            sink_ptr=sink,
         )
         # The dispatch chain tries several backends before OPUS; without this the
         # checks below could be validating a different kernel.
         out_opus = fmha_fwd_bf16_opus_fwd(
-            q, k, v, softmax_scale=d_qk**-0.5, causal=causal
+            q, k, v, softmax_scale=d_qk**-0.5, causal=causal, sink=sink
         )
     assert torch.equal(
         out, out_opus
     ), f"flash_attn_func did not route to the opus d{d_qk} kernel"
 
-    tag = f"opus-d{d_qk}"
-    out_ref, _, _ = attention_ref(q, k, v, causal=causal)
-    out_pt, _, _ = attention_ref(q, k, v, causal=causal, upcast=False, reorder_ops=True)
+    tag = f"opus-d{d_qk}" + ("-sink" if with_sink else "")
+    out_ref, _, _ = attention_ref(q, k, v, causal=causal, sink=sink)
+    out_pt, _, _ = attention_ref(
+        q, k, v, causal=causal, sink=sink, upcast=False, reorder_ops=True
+    )
     out_tol = max(2 * (out_pt - out_ref).abs().max().item(), 0.01)
     out_diff = (out - out_ref).abs().max().item()
     print(f"[{tag}] out max diff: {out_diff} tol={out_tol}")
     assert out_diff <= out_tol
 
-    lse_ref = opus_ref_lse(q, k, causal)
+    # A sink does not create keys, so the no-key (-inf) rows come from the
+    # sink-free LSE. With a sink the denominator gains one column, which is
+    # exactly logaddexp(no-sink LSE, sink); for a fully-masked row that collapses
+    # to the sink logit, matching the kernel's "attend only the sink" result.
+    no_key = opus_ref_lse(q, k, causal)
+    lse_ref = torch.logaddexp(no_key, sink.view(1, nheads, 1)) if with_sink else no_key
     assert tuple(lse.shape) == (batch_size, nheads, seqlen_q), f"lse {tuple(lse.shape)}"
     opus_check_lse(tag, lse, lse_ref)
 
-    dead = torch.isneginf(lse_ref)  # rows that see no keys -> O must be exactly 0
+    dead = torch.isneginf(no_key)  # rows that see no keys -> O must be exactly 0
     if dead.any():
         dead_o = dead.permute(0, 2, 1).unsqueeze(-1).expand_as(out)
         assert (out[dead_o] == 0).all(), f"{tag}: fully-masked rows must produce O=0"
@@ -1224,4 +1257,234 @@ def test_flash_attn_func_opus_d192_v128(
         pytest.skip("opus D=192 kernel requires gfx950")
     _run_opus_batch_case(
         batch_size, seqlen_q, seqlen_kv, nheads, nheads_k, 192, 128, causal
+    )
+
+
+@pytest.mark.parametrize("causal", [False, True])
+@pytest.mark.parametrize(
+    "batch_size,seqlen_q,seqlen_kv,nheads,nheads_k",
+    _OPUS_BATCH_CASES,
+    ids=_OPUS_BATCH_IDS,
+)
+def test_flash_attn_func_opus_d64(
+    batch_size, seqlen_q, seqlen_kv, nheads, nheads_k, causal, monkeypatch
+):
+    """OPUS gfx950 dense D=64 forward through flash_attn_func, with LSE.
+
+    The symmetric kernel is traits-parameterised on D; this is the same coverage
+    as the D=128 test one head dim down. Env-gated like the D=128 case.
+    """
+    if get_gfx() != "gfx950":
+        pytest.skip("opus D=64 kernel requires gfx950")
+    monkeypatch.setenv("AITER_ENABLE_FMHA_OPUS", "1")
+    _run_opus_batch_case(
+        batch_size, seqlen_q, seqlen_kv, nheads, nheads_k, 64, 64, causal
+    )
+
+
+# Sink correctness: a representative subset, including a no-key case so the
+# "fully masked -> attend only the sink" branch is exercised.
+_OPUS_SINK_CASES = [
+    (2, 64, 64, 8, 2),  # GQA
+    (2, 128, 128, 16, 1),  # MQA
+    (1, 256, 256, 8, 8),  # MHA
+    (2, 300, 0, 8, 2),  # no keys -> every row attends only the sink
+]
+_OPUS_SINK_IDS = [
+    f"b{b}_sq{sq}_sk{sk}_h{h}_hkv{hk}" for (b, sq, sk, h, hk) in _OPUS_SINK_CASES
+]
+
+
+@pytest.mark.parametrize("d", [64, 128])
+@pytest.mark.parametrize("causal", [False, True])
+@pytest.mark.parametrize(
+    "batch_size,seqlen_q,seqlen_kv,nheads,nheads_k",
+    _OPUS_SINK_CASES,
+    ids=_OPUS_SINK_IDS,
+)
+def test_flash_attn_func_opus_sink(
+    batch_size, seqlen_q, seqlen_kv, nheads, nheads_k, causal, d, monkeypatch
+):
+    """OPUS symmetric kernel with a per-head attention sink (D in {64, 128}).
+
+    Checks O against attention_ref and the fp32 LSE against logaddexp(no-sink LSE,
+    sink) -- the LSE is the sharp check since the sink lives in the denominator.
+    """
+    if get_gfx() != "gfx950":
+        pytest.skip("opus symmetric kernel requires gfx950")
+    monkeypatch.setenv("AITER_ENABLE_FMHA_OPUS", "1")
+    _run_opus_batch_case(
+        batch_size, seqlen_q, seqlen_kv, nheads, nheads_k, d, d, causal, with_sink=True
+    )
+
+
+# Single-sequence shapes for the varlen router (batch is always 1 here).
+#   (seqlen_q, seqlen_kv, nheads, nheads_k)
+_OPUS_VARLEN_CASES = [
+    (64, 64, 8, 2),  # 1 KV tile, GQA
+    (128, 512, 16, 1),  # cross sq < sk, MQA
+    (512, 128, 8, 8),  # cross sq > sk, MHA
+    (4096, 1024, 8, 2),  # long-ish prefill, GQA
+]
+_OPUS_VARLEN_IDS = [
+    f"sq{sq}_sk{sk}_h{h}_hkv{hk}" for (sq, sk, h, hk) in _OPUS_VARLEN_CASES
+]
+
+
+def _run_opus_single_seq_varlen(
+    seqlen_q, seqlen_kv, nheads, nheads_k, d, causal, with_sink
+):
+    """A one-sequence varlen batch must route to the dense OPUS kernel and produce
+    output bit-identical to sending that sequence straight to the dense entry."""
+    torch.manual_seed(0)
+    q = torch.randn(seqlen_q, nheads, d, device="cuda", dtype=dtypes.bf16)
+    k = torch.randn(seqlen_kv, nheads_k, d, device="cuda", dtype=dtypes.bf16)
+    v = torch.randn(seqlen_kv, nheads_k, d, device="cuda", dtype=dtypes.bf16)
+    sink = _opus_sink(nheads, with_sink)
+    cu_q = torch.tensor([0, seqlen_q], dtype=torch.int32, device="cuda")
+    cu_k = torch.tensor([0, seqlen_kv], dtype=torch.int32, device="cuda")
+
+    with torch.no_grad():
+        out, lse = aiter.flash_attn_varlen_func(
+            q,
+            k,
+            v,
+            cu_q,
+            cu_k,
+            seqlen_q,
+            seqlen_kv,
+            causal=causal,
+            return_lse=True,
+            sink_ptr=sink,
+        )
+        # The same single sequence sent straight to the dense OPUS op.
+        out_dense = fmha_fwd_bf16_opus_fwd(
+            q.unsqueeze(0),
+            k.unsqueeze(0),
+            v.unsqueeze(0),
+            softmax_scale=d**-0.5,
+            causal=causal,
+            sink=sink,
+        )
+    tag = f"opus-varlen-d{d}" + ("-sink" if with_sink else "")
+    assert tuple(out.shape) == (
+        seqlen_q,
+        nheads,
+        d,
+    ), f"{tag}: out shape {tuple(out.shape)}"
+    assert tuple(lse.shape) == (
+        nheads,
+        seqlen_q,
+    ), f"{tag}: lse shape {tuple(lse.shape)}"
+    # Routing + view correctness in one check: varlen must equal the dense path.
+    assert torch.equal(
+        out, out_dense.squeeze(0)
+    ), f"{tag}: single-seq varlen did not route to the dense OPUS kernel"
+
+
+@pytest.mark.parametrize("with_sink", [False, True])
+@pytest.mark.parametrize("d", [64, 128])
+@pytest.mark.parametrize("causal", [False, True])
+@pytest.mark.parametrize(
+    "seqlen_q,seqlen_kv,nheads,nheads_k",
+    _OPUS_VARLEN_CASES,
+    ids=_OPUS_VARLEN_IDS,
+)
+def test_flash_attn_func_opus_varlen_single_seq(
+    seqlen_q, seqlen_kv, nheads, nheads_k, causal, d, with_sink, monkeypatch
+):
+    """flash_attn_varlen_func on a one-sequence batch routes to dense OPUS."""
+    if get_gfx() != "gfx950":
+        pytest.skip("opus symmetric kernel requires gfx950")
+    monkeypatch.setenv("AITER_ENABLE_FMHA_OPUS", "1")
+    _run_opus_single_seq_varlen(
+        seqlen_q, seqlen_kv, nheads, nheads_k, d, causal, with_sink
+    )
+
+
+# (valid_q, valid_k, buf_q, buf_k): the K/V buffer is LONGER than the valid range,
+# mirroring vLLM's fixed-size chunked-context workspace. Q is always exact (the router
+# requires it), so buf_q == valid_q.
+_OPUS_OVERSIZED_CASES = [
+    (128, 300, 128, 512),  # K/V oversized (the vLLM chunked-context shape)
+    (256, 512, 256, 1024),  # larger valid range, K/V oversized
+]
+_OPUS_OVERSIZED_IDS = [
+    f"vq{vq}_vk{vk}_bq{bq}_bk{bk}" for (vq, vk, bq, bk) in _OPUS_OVERSIZED_CASES
+]
+
+
+def _run_opus_oversized_buffer(
+    valid_q, valid_k, buf_q, buf_k, nheads, nheads_k, d, causal, with_sink
+):
+    """The single-seq router must attend only the valid prefix of an oversized
+    buffer. The tail past the valid range is poisoned so that attending any stale
+    row would move the result far outside tolerance."""
+    torch.manual_seed(0)
+    q = torch.randn(buf_q, nheads, d, device="cuda", dtype=dtypes.bf16)
+    k = torch.randn(buf_k, nheads_k, d, device="cuda", dtype=dtypes.bf16)
+    v = torch.randn(buf_k, nheads_k, d, device="cuda", dtype=dtypes.bf16)
+    k[valid_k:] = 50.0  # poison the stale tail
+    v[valid_k:] = -50.0
+    sink = _opus_sink(nheads, with_sink)
+    cu_q = torch.tensor([0, valid_q], dtype=torch.int32, device="cuda")
+    cu_k = torch.tensor([0, valid_k], dtype=torch.int32, device="cuda")
+
+    with torch.no_grad():
+        out, _ = aiter.flash_attn_varlen_func(
+            q,
+            k,
+            v,
+            cu_q,
+            cu_k,
+            valid_q,
+            valid_k,
+            causal=causal,
+            return_lse=True,
+            sink_ptr=sink,
+        )
+        # Dense OPUS on the CLEAN valid prefix only. Equality proves both that the
+        # call routed to OPUS and that the poisoned tail never entered the softmax.
+        out_ref = fmha_fwd_bf16_opus_fwd(
+            q[:valid_q].unsqueeze(0),
+            k[:valid_k].unsqueeze(0),
+            v[:valid_k].unsqueeze(0),
+            softmax_scale=d**-0.5,
+            causal=causal,
+            sink=sink,
+        )
+    tag = f"opus-oversized-d{d}"
+    assert tuple(out.shape) == (
+        valid_q,
+        nheads,
+        d,
+    ), f"{tag}: out shape {tuple(out.shape)}"
+    assert torch.equal(
+        out, out_ref.squeeze(0)
+    ), f"{tag}: poisoned tail leaked into the output (or did not route to OPUS)"
+
+
+@pytest.mark.parametrize("causal", [False, True])
+@pytest.mark.parametrize(
+    "valid_q,valid_k,buf_q,buf_k",
+    _OPUS_OVERSIZED_CASES,
+    ids=_OPUS_OVERSIZED_IDS,
+)
+def test_flash_attn_func_opus_oversized_buffer(
+    valid_q, valid_k, buf_q, buf_k, causal, monkeypatch
+):
+    """An oversized single-seq packed buffer attends only its valid prefix."""
+    if get_gfx() != "gfx950":
+        pytest.skip("opus symmetric kernel requires gfx950")
+    monkeypatch.setenv("AITER_ENABLE_FMHA_OPUS", "1")
+    _run_opus_oversized_buffer(
+        valid_q,
+        valid_k,
+        buf_q,
+        buf_k,
+        nheads=8,
+        nheads_k=2,
+        d=64,
+        causal=causal,
+        with_sink=True,
     )

--- a/op_tests/test_mha.py
+++ b/op_tests/test_mha.py
@@ -1488,3 +1488,127 @@ def test_flash_attn_func_opus_oversized_buffer(
         causal=causal,
         with_sink=True,
     )
+
+
+# ─── out= passthrough: dense entry, and the single-seq varlen router ──────────────
+# The buffer must be written IN PLACE (avoiding a hidden copy is the point) and the
+# routed result must stay bit-identical to the dense op.
+
+_OPUS_OUT_SHAPE = {
+    "seqlen_q": 128,
+    "seqlen_kv": 300,
+    "nheads": 8,
+    "nheads_k": 2,
+    "d": 64,
+}
+
+
+def _opus_out_qkv(seqlen_q, seqlen_kv, nheads, nheads_k, d, packed):
+    torch.manual_seed(0)
+    qs = (seqlen_q, nheads, d) if packed else (1, seqlen_q, nheads, d)
+    kvs = (seqlen_kv, nheads_k, d) if packed else (1, seqlen_kv, nheads_k, d)
+    return (
+        torch.randn(*qs, device="cuda", dtype=dtypes.bf16),
+        torch.randn(*kvs, device="cuda", dtype=dtypes.bf16),
+        torch.randn(*kvs, device="cuda", dtype=dtypes.bf16),
+    )
+
+
+@pytest.mark.parametrize("causal", [False, True])
+def test_flash_attn_func_out_param(causal):
+    """flash_attn_func(out=...) fills the caller's buffer in place and returns it.
+
+    Deliberately NOT gated on gfx950: every backend in _flash_attn_forward receives
+    `out`, so this also covers the CK fallback on other parts.
+    """
+    q, k, v = _opus_out_qkv(**_OPUS_OUT_SHAPE, packed=False)
+    with torch.no_grad():
+        ref = aiter.flash_attn_func(q, k, v, causal=causal)
+        out = torch.empty_like(ref)
+        got = aiter.flash_attn_func(q, k, v, causal=causal, out=out)
+    got = got[0] if isinstance(got, (tuple, list)) else got
+    assert got.data_ptr() == out.data_ptr(), "out= was not written in place"
+    assert torch.equal(out, ref), "out= changed the result"
+
+
+@pytest.mark.parametrize("with_sink", [False, True])
+@pytest.mark.parametrize("causal", [False, True])
+def test_flash_attn_func_opus_varlen_out_param(causal, with_sink, monkeypatch):
+    """A single-seq varlen call carrying out= still routes to dense OPUS, with the
+    caller's buffer written in place (no copy)."""
+    if get_gfx() != "gfx950":
+        pytest.skip("opus symmetric kernel requires gfx950")
+    monkeypatch.setenv("AITER_ENABLE_FMHA_OPUS", "1")
+    s = _OPUS_OUT_SHAPE
+    q, k, v = _opus_out_qkv(**s, packed=True)
+    sink = _opus_sink(s["nheads"], with_sink)
+    cu_q = torch.tensor([0, s["seqlen_q"]], dtype=torch.int32, device="cuda")
+    cu_k = torch.tensor([0, s["seqlen_kv"]], dtype=torch.int32, device="cuda")
+    out = torch.empty(
+        s["seqlen_q"], s["nheads"], s["d"], device="cuda", dtype=dtypes.bf16
+    )
+
+    with torch.no_grad():
+        got = aiter.flash_attn_varlen_func(
+            q,
+            k,
+            v,
+            cu_q,
+            cu_k,
+            s["seqlen_q"],
+            s["seqlen_kv"],
+            causal=causal,
+            sink_ptr=sink,
+            out=out,
+        )
+        ref = fmha_fwd_bf16_opus_fwd(
+            q.unsqueeze(0),
+            k.unsqueeze(0),
+            v.unsqueeze(0),
+            softmax_scale=s["d"] ** -0.5,
+            causal=causal,
+            sink=sink,
+        )
+    got = got[0] if isinstance(got, (tuple, list)) else got
+    tag = f"opus-varlen-out-d{s['d']}"
+    assert (
+        got.data_ptr() == out.data_ptr()
+    ), f"{tag}: out= buffer was copied, not filled"
+    assert torch.equal(
+        out, ref.squeeze(0)
+    ), f"{tag}: out= path did not route to the dense OPUS kernel"
+
+
+@pytest.mark.parametrize("causal", [False, True])
+def test_flash_attn_func_opus_varlen_out_param_declines(causal, monkeypatch):
+    """An out= buffer with more rows than Q must be DECLINED, not silently accepted:
+    a varlen call returns one row per query row, so routing an oversized out would
+    leave a stale tail. Declining has to remain numerically correct."""
+    if get_gfx() != "gfx950":
+        pytest.skip("opus symmetric kernel requires gfx950")
+    monkeypatch.setenv("AITER_ENABLE_FMHA_OPUS", "1")
+    s = _OPUS_OUT_SHAPE
+    q, k, v = _opus_out_qkv(**s, packed=True)
+    cu_q = torch.tensor([0, s["seqlen_q"]], dtype=torch.int32, device="cuda")
+    cu_k = torch.tensor([0, s["seqlen_kv"]], dtype=torch.int32, device="cuda")
+    # 64 extra rows, poisoned: if the router accepted this, the tail would survive.
+    out = torch.full(
+        (s["seqlen_q"] + 64, s["nheads"], s["d"]),
+        99.0,
+        device="cuda",
+        dtype=dtypes.bf16,
+    )
+
+    with torch.no_grad():
+        got = aiter.flash_attn_varlen_func(
+            q, k, v, cu_q, cu_k, s["seqlen_q"], s["seqlen_kv"], causal=causal, out=out
+        )
+    got = got[0] if isinstance(got, (tuple, list)) else got
+    assert got.shape[0] == s["seqlen_q"], f"declined path returned {tuple(got.shape)}"
+
+    qd, kd, vd = q.unsqueeze(0), k.unsqueeze(0), v.unsqueeze(0)
+    ref, _, _ = attention_ref(qd, kd, vd, causal=causal)
+    pt, _, _ = attention_ref(qd, kd, vd, causal=causal, upcast=False, reorder_ops=True)
+    tol = max(2 * (pt - ref).abs().max().item(), 0.01)
+    diff = (got - ref.squeeze(0)).abs().max().item()
+    assert diff <= tol, f"declined out= path is wrong: {diff} > {tol}"

--- a/op_tests/test_mha.py
+++ b/op_tests/test_mha.py
@@ -1580,10 +1580,13 @@ def test_flash_attn_func_opus_varlen_out_param(causal, with_sink, monkeypatch):
 
 
 @pytest.mark.parametrize("causal", [False, True])
-def test_flash_attn_func_opus_varlen_out_param_declines(causal, monkeypatch):
-    """An out= buffer with more rows than Q must be DECLINED, not silently accepted:
-    a varlen call returns one row per query row, so routing an oversized out would
-    leave a stale tail. Declining has to remain numerically correct."""
+def test_flash_attn_func_opus_varlen_out_param_oversized_rejected(causal, monkeypatch):
+    """An out= with more rows than Q must never be silently accepted.
+
+    A varlen call returns one row per query row, so an oversized out would leave a stale
+    tail. Both OPUS gates decline it and CK rejects it too, so the observable contract is
+    that the call RAISES rather than returning a truncated buffer.
+    """
     if get_gfx() != "gfx950":
         pytest.skip("opus symmetric kernel requires gfx950")
     monkeypatch.setenv("AITER_ENABLE_FMHA_OPUS", "1")
@@ -1591,7 +1594,6 @@ def test_flash_attn_func_opus_varlen_out_param_declines(causal, monkeypatch):
     q, k, v = _opus_out_qkv(**s, packed=True)
     cu_q = torch.tensor([0, s["seqlen_q"]], dtype=torch.int32, device="cuda")
     cu_k = torch.tensor([0, s["seqlen_kv"]], dtype=torch.int32, device="cuda")
-    # 64 extra rows, poisoned: if the router accepted this, the tail would survive.
     out = torch.full(
         (s["seqlen_q"] + 64, s["nheads"], s["d"]),
         99.0,
@@ -1599,19 +1601,10 @@ def test_flash_attn_func_opus_varlen_out_param_declines(causal, monkeypatch):
         dtype=dtypes.bf16,
     )
 
-    with torch.no_grad():
-        got = aiter.flash_attn_varlen_func(
+    with torch.no_grad(), pytest.raises(RuntimeError):
+        aiter.flash_attn_varlen_func(
             q, k, v, cu_q, cu_k, s["seqlen_q"], s["seqlen_kv"], causal=causal, out=out
         )
-    got = got[0] if isinstance(got, (tuple, list)) else got
-    assert got.shape[0] == s["seqlen_q"], f"declined path returned {tuple(got.shape)}"
-
-    qd, kd, vd = q.unsqueeze(0), k.unsqueeze(0), v.unsqueeze(0)
-    ref, _, _ = attention_ref(qd, kd, vd, causal=causal)
-    pt, _, _ = attention_ref(qd, kd, vd, causal=causal, upcast=False, reorder_ops=True)
-    tol = max(2 * (pt - ref).abs().max().item(), 0.01)
-    diff = (got - ref.squeeze(0)).abs().max().item()
-    assert diff <= tol, f"declined out= path is wrong: {diff} > {tol}"
 
 
 # ─── group (varlen) mode on the symmetric OPUS kernel ────────────────────────────

--- a/op_tests/test_mha.py
+++ b/op_tests/test_mha.py
@@ -1612,3 +1612,158 @@ def test_flash_attn_func_opus_varlen_out_param_declines(causal, monkeypatch):
     tol = max(2 * (pt - ref).abs().max().item(), 0.01)
     diff = (got - ref.squeeze(0)).abs().max().item()
     assert diff <= tol, f"declined out= path is wrong: {diff} > {tol}"
+
+
+# ─── group (varlen) mode on the symmetric OPUS kernel ────────────────────────────
+# A multi-sequence batch is what the single-sequence router cannot reach. Each sequence
+# is checked against a dense OPUS call on that sequence alone, and every sequence's K/V
+# is scaled distinctly so reading past its own seqlen is loud rather than a drift.
+# Bit-equality is the sharp assertion: group mode uses exactly the dense call's tiles,
+# so only the addressing differs.
+
+# Ragged on purpose: non-tile-aligned tails, and a seqlen_q > seqlen_kv group (which
+# makes the causal bottom-right offset negative).
+_OPUS_GROUP_CASES = [
+    ([128, 64], [300, 128]),
+    ([96, 160, 32], [96, 512, 300]),
+    ([64, 128], [512, 64]),  # group 1 has seqlen_q > seqlen_kv
+    ([128, 0, 64], [256, 128, 300]),  # empty middle group -> short-circuit
+]
+_OPUS_GROUP_IDS = [
+    f"g{len(q)}_q{'-'.join(map(str, q))}_k{'-'.join(map(str, k))}"
+    for (q, k) in _OPUS_GROUP_CASES
+]
+
+
+def _run_opus_group_case(q_lens, kv_lens, nheads, nheads_k, d, causal, with_sink):
+    torch.manual_seed(0)
+    total_q, total_k = sum(q_lens), sum(kv_lens)
+    q = torch.randn(total_q, nheads, d, device="cuda", dtype=dtypes.bf16)
+    k = torch.randn(total_k, nheads_k, d, device="cuda", dtype=dtypes.bf16)
+    v = torch.randn(total_k, nheads_k, d, device="cuda", dtype=dtypes.bf16)
+    # Distinct magnitude per sequence so cross-group leakage is loud, not subtle.
+    koff = 0
+    for i, kl in enumerate(kv_lens):
+        k[koff : koff + kl] *= float(2 * i + 1) * 4.0
+        v[koff : koff + kl] *= float(2 * i + 1) * 4.0
+        koff += kl
+
+    sink = _opus_sink(nheads, with_sink)
+    cu_q = torch.tensor(
+        [0, *itertools.accumulate(q_lens)], dtype=torch.int32, device="cuda"
+    )
+    cu_k = torch.tensor(
+        [0, *itertools.accumulate(kv_lens)], dtype=torch.int32, device="cuda"
+    )
+
+    with torch.no_grad():
+        out, lse = aiter.flash_attn_varlen_func(
+            q,
+            k,
+            v,
+            cu_q,
+            cu_k,
+            max(q_lens),
+            max(kv_lens),
+            causal=causal,
+            return_lse=True,
+            sink_ptr=sink,
+        )
+    tag = f"opus-group-d{d}-g{len(q_lens)}" + ("-sink" if with_sink else "")
+    assert tuple(out.shape) == (total_q, nheads, d), f"{tag}: out {tuple(out.shape)}"
+    assert tuple(lse.shape) == (nheads, total_q), f"{tag}: lse {tuple(lse.shape)}"
+
+    # Prefix sums, not a running counter: an empty group still consumes its K/V rows.
+    q_off = [0, *itertools.accumulate(q_lens)]
+    k_off = [0, *itertools.accumulate(kv_lens)]
+    for i, (ql, kl) in enumerate(zip(q_lens, kv_lens)):
+        qo, ko = q_off[i], k_off[i]
+        if ql == 0:
+            continue  # empty group: no rows to compare, the short-circuit wrote nothing
+        with torch.no_grad():
+            ref, ref_lse = fmha_fwd_bf16_opus_fwd(
+                q[qo : qo + ql].unsqueeze(0),
+                k[ko : ko + kl].unsqueeze(0),
+                v[ko : ko + kl].unsqueeze(0),
+                softmax_scale=d**-0.5,
+                causal=causal,
+                sink=sink,
+                return_lse=True,
+            )
+        assert torch.equal(out[qo : qo + ql], ref.squeeze(0)), (
+            f"{tag}: group {i} O differs from dense OPUS "
+            "(cross-group leakage, or it fell back to CK)"
+        )
+        assert torch.equal(lse[:, qo : qo + ql], ref_lse.squeeze(0)), (
+            f"{tag}: group {i} LSE differs from dense OPUS "
+            "(packed [H, total_q] offset is wrong)"
+        )
+
+
+@pytest.mark.parametrize("with_sink", [False, True])
+@pytest.mark.parametrize("d", [64, 128])
+@pytest.mark.parametrize("causal", [False, True])
+@pytest.mark.parametrize("q_lens,kv_lens", _OPUS_GROUP_CASES, ids=_OPUS_GROUP_IDS)
+def test_flash_attn_func_opus_group_varlen(
+    q_lens, kv_lens, causal, d, with_sink, monkeypatch
+):
+    """A multi-sequence varlen batch runs on the symmetric OPUS kernel in group mode,
+    each sequence matching a dense OPUS call on that sequence alone."""
+    if get_gfx() != "gfx950":
+        pytest.skip("opus symmetric kernel requires gfx950")
+    monkeypatch.setenv("AITER_ENABLE_FMHA_OPUS", "1")
+    _run_opus_group_case(
+        q_lens, kv_lens, nheads=8, nheads_k=2, d=d, causal=causal, with_sink=with_sink
+    )
+
+
+@pytest.mark.parametrize("causal", [False, True])
+def test_flash_attn_func_opus_group_declines_padded_cu(causal, monkeypatch):
+    """Caller-supplied KV padding is unvalidated for this kernel, so the group gate must
+    decline it and the call must still be numerically correct on the CK fallback."""
+    if get_gfx() != "gfx950":
+        pytest.skip("opus symmetric kernel requires gfx950")
+    monkeypatch.setenv("AITER_ENABLE_FMHA_OPUS", "1")
+    d, nheads, nheads_k = 64, 8, 2
+    q_lens, kv_lens = [128, 64], [256, 128]
+    torch.manual_seed(0)
+    q = torch.randn(sum(q_lens), nheads, d, device="cuda", dtype=dtypes.bf16)
+    k = torch.randn(sum(kv_lens), nheads_k, d, device="cuda", dtype=dtypes.bf16)
+    v = torch.randn(sum(kv_lens), nheads_k, d, device="cuda", dtype=dtypes.bf16)
+    cu_q = torch.tensor(
+        [0, *itertools.accumulate(q_lens)], dtype=torch.int32, device="cuda"
+    )
+    cu_k = torch.tensor(
+        [0, *itertools.accumulate(kv_lens)], dtype=torch.int32, device="cuda"
+    )
+
+    with torch.no_grad():
+        got = aiter.flash_attn_varlen_func(
+            q,
+            k,
+            v,
+            cu_q,
+            cu_k,
+            max(q_lens),
+            max(kv_lens),
+            causal=causal,
+            cu_seqlens_q_padded=cu_q.clone(),
+            cu_seqlens_k_padded=cu_k.clone(),
+        )
+    got = got[0] if isinstance(got, (tuple, list)) else got
+    assert tuple(got.shape) == (sum(q_lens), nheads, d)
+
+    qo = ko = 0
+    for ql, kl in zip(q_lens, kv_lens):
+        qd = q[qo : qo + ql].unsqueeze(0)
+        kd = k[ko : ko + kl].unsqueeze(0)
+        vd = v[ko : ko + kl].unsqueeze(0)
+        ref, _, _ = attention_ref(qd, kd, vd, causal=causal)
+        pt, _, _ = attention_ref(
+            qd, kd, vd, causal=causal, upcast=False, reorder_ops=True
+        )
+        tol = max(2 * (pt - ref).abs().max().item(), 0.01)
+        diff = (got[qo : qo + ql] - ref.squeeze(0)).abs().max().item()
+        assert diff <= tol, f"padded-cu fallback is wrong: {diff} > {tol}"
+        qo += ql
+        ko += kl

--- a/op_tests/test_mha.py
+++ b/op_tests/test_mha.py
@@ -1130,15 +1130,18 @@ _OPUS_BATCH_IDS = [
 ]
 
 
-def _opus_sink(nheads, enabled):
+def _opus_sink(nheads, enabled, hi=False):
     """One learned fp32 logit per query head, or None.
 
     Swept over the heads so the "sink dominates every score" branch and the
-    max-reference path are both exercised within a single case.
+    max-reference path are both exercised within a single case. ``hi`` selects
+    logits whose upper range exceeds the key-score max by more than fp32 exp2 can
+    represent, forcing the softmax to rebase onto max(m_row, sink).
     """
     if not enabled:
         return None
-    return torch.linspace(-4, 12, nheads, device="cuda", dtype=torch.float32)
+    lo, up = (60.0, 130.0) if hi else (-4.0, 12.0)
+    return torch.linspace(lo, up, nheads, device="cuda", dtype=torch.float32)
 
 
 def _run_opus_batch_case(
@@ -1151,12 +1154,13 @@ def _run_opus_batch_case(
     d_v,
     causal,
     with_sink=False,
+    sink_hi=False,
 ):
     """Shared body: flash_attn_func with LSE, assert it routed to OPUS, check results.
 
-    with_sink adds one learned logit per query head. A sink joins the softmax
-    denominator only, so O is unchanged for rows that see keys, fully-masked rows
-    still produce O=0, and their LSE collapses to the sink logit itself.
+    with_sink adds one learned logit per query head. A sink is a valueless extra key:
+    it leaves the softmax numerator unchanged but grows the denominator, attenuating O
+    and raising LSE. Fully-masked rows remain O=0 with LSE equal to the sink logit.
     """
     torch.manual_seed(0)
     q = torch.randn(
@@ -1168,7 +1172,7 @@ def _run_opus_batch_case(
     v = torch.randn(
         batch_size, seqlen_kv, nheads_k, d_v, device="cuda", dtype=dtypes.bf16
     )
-    sink = _opus_sink(nheads, with_sink)
+    sink = _opus_sink(nheads, with_sink, hi=sink_hi)
 
     with torch.no_grad():
         out, lse = aiter.flash_attn_func(
@@ -1318,6 +1322,106 @@ def test_flash_attn_func_opus_sink(
     )
 
 
+@pytest.mark.parametrize("d", [64, 128])
+@pytest.mark.parametrize("causal", [False, True])
+@pytest.mark.parametrize(
+    "batch_size,seqlen_q,seqlen_kv,nheads,nheads_k",
+    [(2, 64, 64, 8, 2), (1, 256, 256, 8, 8)],
+    ids=["b2_sq64_sk64_h8_hkv2", "b1_sq256_sk256_h8_hkv8"],
+)
+def test_flash_attn_func_opus_sink_dominant(
+    batch_size, seqlen_q, seqlen_kv, nheads, nheads_k, causal, d, monkeypatch
+):
+    """A dominant sink must remain finite by becoming the softmax reference max."""
+    if get_gfx() != "gfx950":
+        pytest.skip("opus symmetric kernel requires gfx950")
+    monkeypatch.setenv("AITER_ENABLE_FMHA_OPUS", "1")
+    _run_opus_batch_case(
+        batch_size,
+        seqlen_q,
+        seqlen_kv,
+        nheads,
+        nheads_k,
+        d,
+        d,
+        causal,
+        with_sink=True,
+        sink_hi=True,
+    )
+
+
+@pytest.mark.parametrize("d", [64, 128])
+@pytest.mark.parametrize("causal", [False, True])
+def test_flash_attn_func_opus_sink_posinf(causal, d, monkeypatch):
+    """A +inf sink receives all probability: O is zero and LSE is +inf."""
+    if get_gfx() != "gfx950":
+        pytest.skip("opus symmetric kernel requires gfx950")
+    monkeypatch.setenv("AITER_ENABLE_FMHA_OPUS", "1")
+    torch.manual_seed(0)
+    nheads, nheads_k = 8, 2
+    q = torch.randn(2, 64, nheads, d, device="cuda", dtype=dtypes.bf16)
+    k = torch.randn(2, 64, nheads_k, d, device="cuda", dtype=dtypes.bf16)
+    v = torch.randn(2, 64, nheads_k, d, device="cuda", dtype=dtypes.bf16)
+    sink = torch.full((nheads,), float("inf"), device="cuda", dtype=torch.float32)
+    with torch.no_grad():
+        out, lse = aiter.flash_attn_func(
+            q, k, v, causal=causal, return_lse=True, sink_ptr=sink
+        )
+        out_opus = fmha_fwd_bf16_opus_fwd(
+            q, k, v, softmax_scale=d**-0.5, causal=causal, sink=sink
+        )
+    assert torch.equal(out, out_opus), "did not route to the OPUS kernel"
+    assert torch.isposinf(
+        lse
+    ).all(), f"+inf sink must give LSE=+inf, got {lse.unique()}"
+    assert (out == 0).all(), "+inf sink must receive all probability"
+
+
+@pytest.mark.parametrize("grad_on", ["qkv", "sink"])
+@pytest.mark.parametrize("d", [64, 128])
+def test_flash_attn_func_sink_requires_grad_rejected(d, grad_on):
+    """The public dense API rejects sinks until its backward implements them."""
+    if not torch.cuda.is_available():
+        pytest.skip("needs a GPU to build q/k/v")
+    nheads, nheads_k = 8, 2
+    qkv_kw = {
+        "device": "cuda",
+        "dtype": dtypes.bf16,
+        "requires_grad": grad_on == "qkv",
+    }
+    q = torch.randn(2, 64, nheads, d, **qkv_kw)
+    k = torch.randn(2, 64, nheads_k, d, **qkv_kw)
+    v = torch.randn(2, 64, nheads_k, d, **qkv_kw)
+    sink = torch.randn(
+        nheads, device="cuda", dtype=torch.float32, requires_grad=grad_on == "sink"
+    )
+    with pytest.raises(NotImplementedError, match="sink"):
+        aiter.flash_attn_func(q, k, v, sink_ptr=sink)
+
+
+@pytest.mark.parametrize("grad_on", ["qkv", "sink"])
+@pytest.mark.parametrize("d", [64, 128])
+def test_flash_attn_varlen_func_sink_requires_grad_rejected(d, grad_on):
+    """The public varlen API applies the same forward-only sink guard."""
+    if not torch.cuda.is_available():
+        pytest.skip("needs a GPU to build q/k/v")
+    nheads, nheads_k = 8, 2
+    qkv_kw = {
+        "device": "cuda",
+        "dtype": dtypes.bf16,
+        "requires_grad": grad_on == "qkv",
+    }
+    q = torch.randn(80, nheads, d, **qkv_kw)
+    k = torch.randn(80, nheads_k, d, **qkv_kw)
+    v = torch.randn(80, nheads_k, d, **qkv_kw)
+    sink = torch.randn(
+        nheads, device="cuda", dtype=torch.float32, requires_grad=grad_on == "sink"
+    )
+    cu = torch.tensor([0, 32, 80], dtype=torch.int32, device="cuda")
+    with pytest.raises(NotImplementedError, match="varlen"):
+        aiter.flash_attn_varlen_func(q, k, v, cu, cu, 48, 48, sink_ptr=sink)
+
+
 # Single-sequence shapes for the varlen router (batch is always 1 here).
 #   (seqlen_q, seqlen_kv, nheads, nheads_k)
 _OPUS_VARLEN_CASES = [
@@ -1358,13 +1462,14 @@ def _run_opus_single_seq_varlen(
             sink_ptr=sink,
         )
         # The same single sequence sent straight to the dense OPUS op.
-        out_dense = fmha_fwd_bf16_opus_fwd(
+        out_dense, lse_dense = fmha_fwd_bf16_opus_fwd(
             q.unsqueeze(0),
             k.unsqueeze(0),
             v.unsqueeze(0),
             softmax_scale=d**-0.5,
             causal=causal,
             sink=sink,
+            return_lse=True,
         )
     tag = f"opus-varlen-d{d}" + ("-sink" if with_sink else "")
     assert tuple(out.shape) == (
@@ -1376,10 +1481,13 @@ def _run_opus_single_seq_varlen(
         nheads,
         seqlen_q,
     ), f"{tag}: lse shape {tuple(lse.shape)}"
-    # Routing + view correctness in one check: varlen must equal the dense path.
+    # Routing + view correctness: O and LSE must exactly equal the dense path.
     assert torch.equal(
         out, out_dense.squeeze(0)
     ), f"{tag}: single-seq varlen did not route to the dense OPUS kernel"
+    assert torch.equal(
+        lse, lse_dense.squeeze(0)
+    ), f"{tag}: single-seq varlen LSE differs from dense OPUS"
 
 
 @pytest.mark.parametrize("with_sink", [False, True])
@@ -1621,6 +1729,7 @@ _OPUS_GROUP_CASES = [
     ([96, 160, 32], [96, 512, 300]),
     ([64, 128], [512, 64]),  # group 1 has seqlen_q > seqlen_kv
     ([128, 0, 64], [256, 128, 300]),  # empty middle group -> short-circuit
+    ([64, 128], [0, 64]),  # no-key group -> O=0 and LSE=-inf (or sink)
 ]
 _OPUS_GROUP_IDS = [
     f"g{len(q)}_q{'-'.join(map(str, q))}_k{'-'.join(map(str, k))}"


### PR DESCRIPTION
## What

Extends the gfx950 OPUS bf16 flash-attention forward — already the fastest attention kernel on this part — to three cases it previously rejected, all behind the existing opt-in `AITER_ENABLE_FMHA_OPUS` (default `0`):

1. **Symmetric head dim 64** alongside 128.
2. **Attention sinks** (a learned per-head logit, as used by gpt-oss) on the symmetric kernel.
3. **Single-sequence varlen routing** — a one-sequence `flash_attn_varlen_func` call is dispatched to the batch-mode OPUS kernel instead of falling back to CK.

Motivation: `d=64` bf16 prefill (e.g. gpt-oss-120b: 64 q-heads / 8 kv-heads, `d=64`, sinks) currently runs on ck_tile at ~27% MFU on gfx950. With FLOPs and KV bytes held constant, the OPUS `d=128` kernel reaches ~49% MFU — the head dimension and the kernel are both worth real MFU — but OPUS had no `d=64` instance and three gates (head dim, varlen, sinks) kept `d=64` prefill out of it. This series opens all three.

## Commits (review bottom-up)

**#5223 original — d=64, sinks, single-seq varlen routing**

1. **head dim 64 alongside 128.** `D_TILE_SIZE` was already a template parameter and the kernel body has no literal head-dim constant; only a `static_assert(D_TILE_SIZE_ == 128)` plus host `D == 128` checks blocked it. Every derived count stays integral at 64; a `static_assert` per divisibility condition guards a future `D`. Tile shape `Q=32/KV=64/8 waves` is inherited from D=128 (not retuned). → **~34.9% MFU, 1.29× ck_tile** at `sq=4096 sk=32768 hq=64 hk=8`.
2. **single-sequence varlen → dense router.** A varlen batch with one sequence is a dense batch-1 problem. Detection is sync-free: `cu_seqlens.numel() == 2` means one sequence (metadata only) and `max_seqlen_*` are host ints, so no `cu_seqlens` value is read. → **1.359× through the varlen entry**.
3. **attention sinks.** A sink is one extra key that joins the softmax denominator but carries no value. Threaded through the torch-free launch layer, the torch validation, the pybind, and mha.py; the asymmetric d192/v128 kernel has no sink support and rejects it.
4. **oversized K/V buffer in the single-seq router.** vLLM's chunked-context path gathers into a fixed-size workspace then describes a shorter valid range, so an exact-match check silently rejected any chunk that wasn't workspace-sized. Accept `>= max_seqlen_k` and slice the valid prefix (a view); Q stays exact.
5. **tests** for the above.

**Follow-on — closing the two gates that made the gain non-deterministic**

6. **`out=` passthrough.** The router declined every call carrying `out=`, on the assumption that vLLM's extend path does not pass it. A gate-decision log says otherwise: **126 of 612 router decisions (21%)**, at two distinct shapes. `_flash_attn_forward` already threads `out` to all six backends and `flash_attn_varlen_func` has had it all along — only the dense public entry lacked it. Forwarded as a view, so no copy.
7. **group (varlen) mode for the symmetric kernel.** `GROUP_MODE` trait plus an `if constexpr` prologue resolving per-group seqlens and base row offsets from the seqstart prefix sums, following the d192/v128 group kernel already in tree. 11 sites move from `kargs.N`/`N_KV` to per-workgroup locals; batch mode assigns them from `kargs`, so its arithmetic and codegen are untouched. Instances 4 → 8.
8. **the varlen gate** that reaches it, so a multi-sequence batch no longer falls back to ck_tile. `cu_seqlens` stay device pointers, so this remains sync-free.
9. **two gates found by running on gfx950.** `fmha_fwd_bf16_opus_launch` had its own `if(is_group) return false;` for the symmetric branch, separate from the `TORCH_CHECK` removed in 7 — one line that broke 100% of group mode. And the new gate did not validate `out`, so a buffer the router had already declined tripped the launcher's check from deep inside instead of falling back.
10. **harden sink, out and group dispatch.** Sink finalization rebases onto `max(key_max, sink)` so a dominant or `+inf` sink cannot overflow `exp2` or produce `inf-inf`; when the sink does not dominate the scale factor is exactly 1.0 and the result is bit-identical to 3. Rejects sink-enabled autograd (every backward hard-codes `sink=None`), returns the twentieth gradient slot that `out=` requires, aligns the fake op schema with the real trailing `sink` argument, and tightens the sink and k/v shape gates.

## Evidence

**Kernel level**, `sq=4096 sk=32768 hq=64 hk=8 d=64 bf16`, one MI350X:

| | µs | MFU |
|---|---|---|
| ck_tile | 3452.9 | 27.05% |
| OPUS d=64 | 2735.8 | 34.95% |

**Correctness**: `op_tests/test_mha.py -k opus` on gfx950 with `AITER_ENABLE_FMHA_OPUS=1` — **208 passed, 0 failed**. Covers d=64/d=128, GQA/MQA/MHA, causal and non-causal, sinks swept over `linspace(-4,12)` plus dominant and `+inf` sinks, empty-key rows (`O=0, lse=sink`), and autograd rejection. The group-mode cases check ragged 2- and 3-sequence batches, non-tile-aligned tails, a group with `seqlen_q > seqlen_kv` (negative causal bottom-right offset) and an empty middle group, each **bit-equal to a dense OPUS call on that sequence alone for both O and the packed `[H, total_q]` LSE**, with every sequence's K/V scaled distinctly so cross-group leakage would be loud rather than a drift.

**Register cost: none.** All 8 symmetric instances build with VGPRs 249/248/167/166, occupancy 2/2/3/3 and zero spills — identical before and after group mode, the sink rescale and the accumulator fold.

**End to end** (internal vLLM serving benchmark, gpt-oss-120b, 64k context / 4k query, concurrency 2; arms differ only by `AITER_ENABLE_FMHA_OPUS`, 3 interleaved arms per condition on one card):

| | mean e2e | computed tok/s | sigma |
|---|---|---|---|
| OPUS on | 366.3 ms | 22,305 | 1.3–5.5 |
| OPUS off | 419.3 ms | 19,487 | 1.6–6.0 |

**−12.6% latency / +14.5% throughput**, with the three same-condition arms agreeing to 0.07%. A trace of the OPUS-on arm shows attention at 57.8% of GPU time and **full-attention launches 1877 OPUS / 0 ck_tile**, i.e. every full-attention call now takes OPUS.

Worth stating explicitly for reviewers: before commits 6–9 this same benchmark ranged 355–406 ms at sigma 21–33, because the two router gates made OPUS engagement depend on whether the scheduler happened to co-batch the two in-flight requests. The earlier `+13.7%` figure was a favourable draw from that bimodal distribution. The gain is the same size — what these commits add is that it is now deterministic. Not upstream-reproducible as-is; the op-level numbers and `op_tests` are.

## Blast radius

- **Opt-in**: the OPUS forward is behind `AITER_ENABLE_FMHA_OPUS` (default `0`); default dispatch is unchanged.
- **gfx942 codegen untouched**; d=128 path preserved (tile shape inherited unchanged) and its tests still pass.
- Anything the gate rejects falls back with correct output; multi-sequence batches are unchanged.
- New C++ parameters are trailing `std::optional`s (source-compatible; a rebuild is required since the mangled symbol changes — aiter JITs from source).

## Not done (noted for reviewers)

1. **Sliding-window layers stay on ck_tile, deliberately.** `window_size` is `(127, 0)` on those layers and both gates reject it. That is the correct dispatch, not a gap: SWA is ~1% of total GPU time and ck_tile is ~1.6× *faster* than OPUS on those shapes, so windowed masking here would be a regression. The reachable target is ~76% of attention calls (every full-attention call), which this series achieves.
2. No model-level accuracy eval — kernel-level allclose and op_tests only.
3. Gate polarity: the symmetric path is opt-**in** (`AITER_ENABLE_FMHA_OPUS`) while d192/v128 is opt-**out**; making `d=64` default-on once validated is worth deciding deliberately.
4. `sink_size` (the "first N keys are sinks" variant) is unsupported — a different feature from `sink_ptr`.
5. Caller-supplied KV padding (`cu_seqlens_*_padded`) is declined by the group gate. The kernel plumbs `seqstart_*_pad`, but that path is unvalidated against this kernel, so it routes to CK rather than guess.
