### PR TITLE
[HIP] [JIT] int4 a16w4 gemm kernel for gfx1201

### DIFF
--- a/aiter/__init__.py
+++ b/aiter/__init__.py
@@ -96,6 +96,7 @@ else:
     from .ops.quant import *
     from .ops.gemm_op_a8w8 import *
     from .ops.gemm_op_a16w16 import *
+    from .ops.gemm_op_a16w4 import *
     from .ops.gemm_op_a4w4 import *
     from .ops.gemm_op_a6w6 import *
     from .ops.gemm_op_a8w4 import *

--- a/aiter/jit/optCompilerConfig.json
+++ b/aiter/jit/optCompilerConfig.json
@@ -401,6 +401,26 @@
         "verbose": "False",
         "blob_gen_cmd": "f'{AITER_META_DIR}/hsa/codegen.py -m bf16gemm --output_dir {{}}'"
     },
+    "module_gemm_a16w4": {
+        "srcs": [
+            "f'{AITER_CSRC_DIR}/pybind/gemm_a16w4_pybind.cu'",
+            "f'{AITER_CSRC_DIR}/gemm_a16w4/gemm_a16w4.cu'",
+            "f'{AITER_CSRC_DIR}/gemm_a16w4/gemm_a16w4_prefill_bf16.cu'",
+            "f'{AITER_CSRC_DIR}/gemm_a16w4/gemm_a16w4_prefill_fp16.cu'",
+            "f'{AITER_CSRC_DIR}/gemm_a16w4/gemm_a16w4_decode_bf16.cu'",
+            "f'{AITER_CSRC_DIR}/gemm_a16w4/gemm_a16w4_decode_fp16.cu'"
+        ],
+        "flags_extra_cc": [],
+        "flags_extra_hip": [
+            "'-fno-slp-vectorize'"
+        ],
+        "extra_ldflags": "None",
+        "extra_include": [
+            "f'{AITER_CSRC_DIR}/gemm_a16w4/include'"
+        ],
+        "verbose": "False",
+        "blob_gen_cmd": "''"
+    },
     "module_gemm_a4w4_asm": {
         "srcs": [
             "f'{AITER_CSRC_DIR}/py_itfs_cu/asm_gemm_a4w4.cu'"

--- a/aiter/jit/utils/torch_guard.py
+++ b/aiter/jit/utils/torch_guard.py
@@ -89,6 +89,9 @@ NONE_WRAPPED_OP = [
     "fused_allreduce_rmsnorm",
     "fused_allreduce_rmsnorm_quant",
     "fused_qknorm_allreduce",
+    # Returns a str (the failing shape constraint, or ""), which is not a
+    # useful torch.library op -- and it is a pure host query anyway.
+    "gemm_a16w4_unsupported_reason",
 ]
 
 

--- a/aiter/ops/gemm_op_a16w4.py
+++ b/aiter/ops/gemm_op_a16w4.py
@@ -1,0 +1,240 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+"""Dense weight-only int4 GEMM (a16w4) for gfx1201 (Navi 48).
+
+    out = x @ dequant(weight)
+    dequant(weight)[k, n] = (nibble(k, n) - zeros[k // G, n]) * scales[k // G, n]
+
+Tensor layout, both dtypes:
+
+    x        [M, K]        bf16 or fp16
+    weight   [K/8, N]      int32, 8 nibbles of ONE column packed along K
+    scales   [K/G, N]      same dtype as x
+    zeros    [K/G, N]      same dtype as x
+    out      [M, N]        same dtype as x
+
+Note the weight packing is along **K**, whereas an AWQ/GPTQ checkpoint ships
+[K, N//8] packed along **N**. Use `pack_a16w4_weight()` on the raw nibbles, or
+repack at load time -- never per token.
+
+The fp16 path additionally needs MAGIC-permuted nibbles and +1024-biased
+zeros; `prepare_a16w4_weight()` applies both. The two weight layouts are NOT
+interchangeable and nothing downstream can detect a mix-up, so the dtype of
+`x` is the only switch.
+"""
+
+import functools
+
+import torch
+from torch import Tensor
+
+from ..jit.core import compile_ops
+from ..jit.utils.chip_info import get_gfx_runtime
+
+MD_NAME = "module_gemm_a16w4"
+
+SUPPORTED_GFX = ("gfx1201",)
+
+# int4 quantisation group along K. Mirrors a16w4::kGroupSize in
+# csrc/gemm_a16w4/include/gemm_a16w4_launch.h -- fixed by the checkpoint
+# format, not a tuning knob.
+GROUP_SIZE = 128
+# int4 nibbles packed per int32 of `weight`.
+PACK_K = 8
+
+# +1024 magic bias for the fp16 dequant path. NOT arbitrary: fp16 has a
+# 10-bit mantissa, so 0x6400 | n == 1024 + n exactly for any 4-bit n, and
+# 1024 + n and 1024 + z both lie in the binade [1024, 2048) where fp16
+# subtraction is exact by Sterbenz's lemma. The dequant therefore rounds ONCE
+# (the multiply by the scale), which is why the fp16 kernels measure ~15x
+# LOWER max error than the bf16 ones rather than higher.
+MAGIC_BIAS = 1024.0
+# k -> bit position, p(k) = 4*(k>>1) + 16*(k&1), so the kernel's four
+# extractions ((packed >> 4j) & 0x000F000F) | 0x64006400 yield k = 0..7 in
+# order.
+_MAGIC_SHIFTS = [4 * (j >> 1) + 16 * (j & 1) for j in range(8)]
+
+
+# develop=True is load-bearing, not a debug flag: it converts the torch.Tensor
+# arguments to the pybind aiter_tensor_t ABI the C++ side takes, AND calls
+# module._set_current_hip_stream(), which is what makes aiter::getCurrentHIPStream()
+# return the caller's stream instead of the null stream.
+@compile_ops(MD_NAME, fc_name="gemm_a16w4", develop=True)
+def _gemm_a16w4(
+    x: Tensor,
+    weight: Tensor,
+    scales: Tensor,
+    zeros: Tensor,
+    out: Tensor,
+    workspace: Tensor,
+) -> None: ...
+
+
+@compile_ops(MD_NAME)
+def gemm_a16w4_unsupported_reason(M: int, N: int, K: int, is_fp16: bool) -> str: ...
+
+
+@compile_ops(MD_NAME)
+def gemm_a16w4_workspace_elems(M: int, N: int, K: int, is_fp16: bool) -> int: ...
+
+
+def is_a16w4_available() -> bool:
+    """True when the running GPU is one this kernel was built and tuned for."""
+    try:
+        return get_gfx_runtime() in SUPPORTED_GFX
+    except Exception:  # noqa: BLE001 - no GPU / unknown arch is just "no"
+        return False
+
+
+@functools.lru_cache(maxsize=256)
+def _plan(m: int, n: int, k: int, is_fp16: bool) -> tuple[str, int]:
+    """(unsupported_reason, workspace_elems) for one shape.
+
+    Both are pure host arithmetic on the C++ side, but they still cross the
+    pybind boundary, so they are cached: a decode step is ~30 us end to end
+    and would otherwise pay for two module calls per linear layer.
+    """
+    reason = gemm_a16w4_unsupported_reason(m, n, k, is_fp16)
+    if reason:
+        return reason, 0
+    return "", gemm_a16w4_workspace_elems(m, n, k, is_fp16)
+
+
+def gemm_a16w4(
+    x: Tensor,
+    weight: Tensor,
+    scales: Tensor,
+    zeros: Tensor,
+    out: Tensor | None = None,
+    workspace: Tensor | None = None,
+) -> Tensor:
+    """Run the a16w4 GEMM, allocating `out` and the split-K scratch if needed.
+
+    Args:
+        x: [M, K] bf16 or fp16 activations, contiguous.
+        weight: [K/8, N] int32 int4 weights packed along K. For fp16 `x` these
+            must be MAGIC-permuted -- see `prepare_a16w4_weight()`.
+        scales: [K/128, N], same dtype as `x`.
+        zeros: [K/128, N], same dtype as `x`. For fp16 `x` these must already
+            carry the +1024 magic bias.
+        out: optional preallocated [M, N] output, same dtype as `x`.
+        workspace: optional fp32 scratch of at least
+            `gemm_a16w4_workspace_elems(M, N, K, is_fp16)` elements. Only the
+            decode path uses it; prefill needs none.
+
+    Returns:
+        [M, N] tensor, `out` when one was passed.
+
+    Raises:
+        RuntimeError: on a non-gfx1201 GPU, or for a shape no tile covers
+            (the reason names the failing constraint).
+
+    Note:
+        Pass both buffers on the decode path. The kernel itself is ~24 us at
+        M=1 N=K=5120, so allocating a fresh output and scratch per call --
+        even from the caching allocator -- measurably dominates it. A serving
+        stack should hoist them the way it hoists any other per-layer buffer.
+    """
+    if not is_a16w4_available():
+        raise RuntimeError(
+            f"gemm_a16w4 is {'/'.join(SUPPORTED_GFX)} only; "
+            f"running on {get_gfx_runtime()}"
+        )
+
+    m, k = x.shape
+    n = weight.shape[1]
+    is_fp16 = x.dtype == torch.float16
+
+    reason, ws_elems = _plan(m, n, k, is_fp16)
+    if reason:
+        raise RuntimeError(
+            f"gemm_a16w4 does not support M={m} N={n} K={k} ({x.dtype}): {reason}"
+        )
+
+    if out is None:
+        out = torch.empty((m, n), dtype=x.dtype, device=x.device)
+    if workspace is None:
+        # Sized by the C++ side so the split-K factor has exactly one
+        # definition. C++ re-checks numel(), so a short buffer raises rather
+        # than corrupting memory.
+        workspace = torch.empty(ws_elems, dtype=torch.float32, device=x.device)
+
+    _gemm_a16w4(x, weight, scales, zeros, out, workspace)
+    return out
+
+
+def pack_a16w4_weight(nibbles: Tensor) -> Tensor:
+    """[K, N] uint8 nibbles (0..15) -> [K/8, N] int32 packed along K.
+
+    Nibble for row k lands at bit 4*(k%8), which is what the bf16 kernels
+    read. One packed int32 is exactly the 8 elements a lane needs for a
+    16x16x16 B fragment.
+
+    One-off, at weight load. Not on the inference path.
+    """
+    k, n = nibbles.shape
+    if k % PACK_K:
+        raise ValueError(f"K must be a multiple of {PACK_K}, got {k}")
+    v = nibbles.to(torch.int64).view(k // PACK_K, PACK_K, n)
+    shifts = (torch.arange(PACK_K, device=nibbles.device, dtype=torch.int64) * 4).view(
+        1, PACK_K, 1
+    )
+    return (v << shifts).sum(dim=1).to(torch.int32)
+
+
+def repack_a16w4_weight_magic(weight: Tensor) -> Tensor:
+    """[K/8, N] int32 packed along K -> the same, in MAGIC bit order.
+
+    Pure bit shuffle inside each int32; no data movement between rows. Needed
+    only by the fp16 kernels, whose dequant extracts two nibbles at a time out
+    of the 16-bit halves of a dword.
+    """
+    src = weight.to(torch.int64) & 0xFFFFFFFF
+    out = torch.zeros_like(src)
+    for k in range(PACK_K):
+        out |= ((src >> (4 * k)) & 0xF) << _MAGIC_SHIFTS[k]
+    return out.to(torch.int32)
+
+
+def bias_a16w4_zeros_magic(zeros: Tensor) -> Tensor:
+    """zeros -> fp16(zeros + 1024), the form the fp16 kernels subtract.
+
+    Folding the bias into the scale instead -- w = h*s - (1024+z)*s as one
+    v_pk_fma_f16 -- is one instruction cheaper and WRONG: it subtracts two
+    ~1024*s quantities to make a ~15*s result, amplifying fp16's 2^-11
+    relative error by 1024/15 to about 3.3%. That measured cosine 0.99947,
+    which passes a loose tolerance. Do not "optimise" it back.
+    """
+    return (zeros.float() + MAGIC_BIAS).to(torch.float16)
+
+
+def prepare_a16w4_weight(
+    nibbles: Tensor, scales: Tensor, zeros: Tensor, dtype: torch.dtype
+) -> tuple[Tensor, Tensor, Tensor]:
+    """Turn raw int4 nibbles + scales + zeros into kernel-ready tensors.
+
+    This is the whole of `process_weights_after_loading()` for this op: it
+    runs once per checkpoint, never per token.
+
+    Args:
+        nibbles: [K, N] uint8, values 0..15.
+        scales: [K/128, N], any float dtype.
+        zeros: [K/128, N], any float dtype.
+        dtype: bf16 or fp16 -- must match the activations the GEMM will see.
+
+    Returns:
+        (weight, scales, zeros) in the layout `a16w4_gemm()` expects for
+        `dtype`. For fp16 the weight is MAGIC-permuted and the zeros carry
+        the +1024 bias; for bf16 neither transform is applied.
+    """
+    if dtype not in (torch.float16, torch.bfloat16):
+        raise ValueError(f"a16w4 activations must be fp16 or bf16, got {dtype}")
+
+    weight = pack_a16w4_weight(nibbles)
+    if dtype == torch.float16:
+        return (
+            repack_a16w4_weight_magic(weight),
+            scales.to(torch.float16),
+            bias_a16w4_zeros_magic(zeros),
+        )
+    return weight, scales.to(torch.bfloat16), zeros.to(torch.bfloat16)

--- a/csrc/gemm_a16w4/gemm_a16w4.cu
+++ b/csrc/gemm_a16w4/gemm_a16w4.cu
@@ -1,0 +1,280 @@
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+//
+// Host entry point and dispatch for the a16w4 GEMM. The kernels themselves
+// live in one translation unit each -- see gemm_a16w4_launch.h for why.
+
+#include "gemm_a16w4.h"
+
+#include "aiter_hip_common.h"
+#include "aiter_stream.h"
+#include "gemm_a16w4_launch.h"
+
+#include <array>
+#include <string>
+
+namespace {
+
+// ── Runtime architecture gate ──────────────────────────────────────────────
+// The device code is #if'd out on non-gfx1201 targets (see
+// gfx1201/gemm_a16w4_common_gfx1201.cuh), so on a mixed-arch build the
+// kernels exist but trap. This check turns that into a readable error before
+// anything is launched.
+//
+// Cached per device ordinal: hipGetDeviceProperties is far too slow to call
+// on the decode path, which is ~30 us end to end.
+constexpr int kMaxCachedDevices = 16;
+
+bool device_is_gfx1201()
+{
+    static std::array<int8_t, kMaxCachedDevices> cache = [] {
+        std::array<int8_t, kMaxCachedDevices> a{};
+        a.fill(-1);
+        return a;
+    }();
+
+    int dev = 0;
+    if(hipGetDevice(&dev) != hipSuccess)
+        return false;
+    if(dev < 0 || dev >= kMaxCachedDevices)
+        return false; // uncached ordinal: refuse rather than guess
+
+    if(cache[dev] < 0)
+    {
+        hipDeviceProp_t prop{};
+        if(hipGetDeviceProperties(&prop, dev) != hipSuccess)
+            return false;
+        // gcnArchName looks like "gfx1201:sramecc+:xnack-"; match the prefix.
+        cache[dev] = std::string(prop.gcnArchName).rfind("gfx1201", 0) == 0 ? 1 : 0;
+    }
+    return cache[dev] == 1;
+}
+
+enum class Path
+{
+    None,
+    Prefill,
+    Decode
+};
+
+// Smallest M at which the prefill tile is worth using.
+//
+// Prefill's grid is (M/128, N/512). At M=128 that is grid.x == 1, so on
+// N=5120 it launches 10 workgroups against 32 WGPs and leaves most of the
+// part idle -- and it costs the SAME as M=256, which is the tell. Decode's
+// grid is (ceil(M/16), N/128, SPLIT_K), which at M=128 is 640 workgroups.
+//
+// MEASURED, gfx1201, fp16, N=K=5120, preallocated buffers:
+//
+//     M     prefill    decode     winner
+//     128   171.9 us   130.9 us   decode   (1.31x)
+//     256   172.7 us   267.9 us   prefill  (1.55x)
+//     512   305.6 us   554.1 us   prefill
+//
+// Decode's cost grows linearly in M (BM=16), prefill's is flat until it
+// saturates, so the crossover is sharp and sits between 128 and 256. Only
+// multiples of 128 ever reach prefill, so this threshold moves exactly one
+// bucket -- M=128 -- and leaves every other shape on the path it was
+// measured on. Re-measure if the prefill tile or BN changes.
+constexpr int64_t kPrefillMinM = 256;
+
+// Decode is tried first only below kPrefillMinM. Above it, prefill wins and
+// its constraints are strictly tighter (M % 128 == 0), so a shape it accepts
+// is a shape it was tuned for.
+Path select_path(int64_t M, int64_t N, int64_t K, bool is_fp16, const char** why)
+{
+    const int m = (int)M, n = (int)N, k = (int)K;
+    const char* prefill_why = nullptr;
+    const char* decode_why  = nullptr;
+
+    const bool prefill_ok = is_fp16 ? aiter::a16w4::prefill_fp16_supported(m, n, k, &prefill_why)
+                                    : aiter::a16w4::prefill_bf16_supported(m, n, k, &prefill_why);
+    const bool decode_ok = is_fp16 ? aiter::a16w4::decode_fp16_supported(m, n, k, &decode_why)
+                                   : aiter::a16w4::decode_bf16_supported(m, n, k, &decode_why);
+
+    if(prefill_ok && (M >= kPrefillMinM || !decode_ok))
+        return Path::Prefill;
+    if(decode_ok)
+        return Path::Decode;
+
+    if(why)
+        *why = prefill_ok ? prefill_why : (decode_why ? decode_why : "unsupported shape");
+    return Path::None;
+}
+
+void check_2d(const aiter_tensor_t& t,
+              const char* name,
+              AiterDtype dtype,
+              int64_t d0,
+              int64_t d1)
+{
+    AITER_CHECK(t.is_gpu(), "`", name, "` must be a CUDA/HIP tensor.");
+    AITER_CHECK(t.is_contiguous(), "`", name, "` must be contiguous.");
+    AITER_CHECK(t.dtype() == dtype,
+                "`",
+                name,
+                "` must be ",
+                AiterDtype_to_str(dtype),
+                ", got ",
+                AiterDtype_to_str(t.dtype()));
+    AITER_CHECK(t.dim() == 2, "`", name, "` must be 2-D, got ", t.dim(), "-D.");
+    AITER_CHECK(t.size(0) == d0 && t.size(1) == d1,
+                "`",
+                name,
+                "` must be [",
+                d0,
+                ", ",
+                d1,
+                "], got [",
+                t.size(0),
+                ", ",
+                t.size(1),
+                "].");
+}
+
+} // namespace
+
+namespace aiter {
+
+std::string gemm_a16w4_unsupported_reason(int64_t M, int64_t N, int64_t K, bool is_fp16)
+{
+    const char* why = "unknown";
+    if(select_path(M, N, K, is_fp16, &why) != Path::None)
+        return "";
+    return why ? std::string(why) : std::string("unknown");
+}
+
+int64_t gemm_a16w4_workspace_elems(int64_t M, int64_t N, int64_t K, bool is_fp16)
+{
+    switch(select_path(M, N, K, is_fp16, nullptr))
+    {
+    case Path::Decode:
+        return is_fp16 ? a16w4::decode_fp16_workspace_elems(M, N)
+                       : a16w4::decode_bf16_workspace_elems(M, N);
+    case Path::Prefill:
+    case Path::None:
+    default: return 0;
+    }
+}
+
+void gemm_a16w4(aiter_tensor_t x,
+                aiter_tensor_t weight,
+                aiter_tensor_t scales,
+                aiter_tensor_t zeros,
+                aiter_tensor_t out,
+                aiter_tensor_t workspace)
+{
+    AITER_CHECK(device_is_gfx1201(),
+                "gemm_a16w4 is gfx1201 (Navi 48) only: it uses the RDNA4 "
+                "wmma_*_w32_gfx12 builtins and its tiles are tuned for that "
+                "part. There is no fallback path.");
+
+    AITER_CHECK(x.is_gpu(), "`x` must be a CUDA/HIP tensor.");
+    AITER_CHECK(x.is_contiguous(), "`x` must be contiguous.");
+    AITER_CHECK(x.dim() == 2, "`x` must be 2-D [M, K], got ", x.dim(), "-D.");
+    const AiterDtype dtype = x.dtype();
+    AITER_CHECK(dtype == AITER_DTYPE_bf16 || dtype == AITER_DTYPE_fp16,
+                "`x` must be bf16 or fp16, got ",
+                AiterDtype_to_str(dtype));
+    const bool is_fp16 = dtype == AITER_DTYPE_fp16;
+
+    const int64_t M = x.size(0);
+    const int64_t K = x.size(1);
+    AITER_CHECK(weight.dim() == 2, "`weight` must be 2-D [K/8, N].");
+    const int64_t N = weight.size(1);
+
+    const int64_t ngroups = K / a16w4::kGroupSize;
+    check_2d(weight, "weight", AITER_DTYPE_i32, K / a16w4::kPackK, N);
+    check_2d(scales, "scales", dtype, ngroups, N);
+    check_2d(zeros, "zeros", dtype, ngroups, N);
+    check_2d(out, "out", dtype, M, N);
+
+    const char* why      = "unknown";
+    const Path path      = select_path(M, N, K, is_fp16, &why);
+    AITER_CHECK(path != Path::None,
+                "gemm_a16w4 does not support M=",
+                M,
+                " N=",
+                N,
+                " K=",
+                K,
+                " (",
+                AiterDtype_to_str(dtype),
+                "): ",
+                why);
+
+    const hipStream_t stream = getCurrentHIPStream();
+
+    if(path == Path::Prefill)
+    {
+        if(is_fp16)
+            a16w4::launch_prefill_fp16(x.data_ptr(),
+                                       weight.data_ptr(),
+                                       scales.data_ptr(),
+                                       zeros.data_ptr(),
+                                       out.data_ptr(),
+                                       (int)M,
+                                       (int)N,
+                                       (int)K,
+                                       stream);
+        else
+            a16w4::launch_prefill_bf16(x.data_ptr(),
+                                       weight.data_ptr(),
+                                       scales.data_ptr(),
+                                       zeros.data_ptr(),
+                                       out.data_ptr(),
+                                       (int)M,
+                                       (int)N,
+                                       (int)K,
+                                       stream);
+        return;
+    }
+
+    // Decode: split-K writes SPLIT_K fp32 partials, then a second kernel sums
+    // them and narrows. The caller owns the scratch so the op signature stays
+    // allocation-free -- and so a mismatched allocation fails here rather than
+    // corrupting memory.
+    const int64_t need = is_fp16 ? a16w4::decode_fp16_workspace_elems(M, N)
+                                 : a16w4::decode_bf16_workspace_elems(M, N);
+    AITER_CHECK(workspace.is_gpu(), "`workspace` must be a CUDA/HIP tensor.");
+    AITER_CHECK(workspace.is_contiguous(), "`workspace` must be contiguous.");
+    AITER_CHECK(workspace.dtype() == AITER_DTYPE_fp32,
+                "`workspace` must be fp32, got ",
+                AiterDtype_to_str(workspace.dtype()));
+    AITER_CHECK((int64_t)workspace.numel() >= need,
+                "`workspace` needs at least ",
+                need,
+                " fp32 elements for M=",
+                M,
+                " N=",
+                N,
+                ", got ",
+                workspace.numel(),
+                ". Use aiter.gemm_a16w4_workspace_elems().");
+
+    float* ws = reinterpret_cast<float*>(workspace.data_ptr());
+    if(is_fp16)
+        a16w4::launch_decode_fp16(x.data_ptr(),
+                                  weight.data_ptr(),
+                                  scales.data_ptr(),
+                                  zeros.data_ptr(),
+                                  ws,
+                                  out.data_ptr(),
+                                  (int)M,
+                                  (int)N,
+                                  (int)K,
+                                  stream);
+    else
+        a16w4::launch_decode_bf16(x.data_ptr(),
+                                  weight.data_ptr(),
+                                  scales.data_ptr(),
+                                  zeros.data_ptr(),
+                                  ws,
+                                  out.data_ptr(),
+                                  (int)M,
+                                  (int)N,
+                                  (int)K,
+                                  stream);
+}
+
+} // namespace aiter

--- a/csrc/gemm_a16w4/gemm_a16w4_decode_bf16.cu
+++ b/csrc/gemm_a16w4/gemm_a16w4_decode_bf16.cu
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+#include "gemm_a16w4_launch.h"
+#include "gfx1201/gemm_a16w4_decode_bf16_gfx1201.cuh"
+
+namespace aiter {
+namespace a16w4 {
+
+namespace {
+// Threads per block of the split-K reduce. Not tuned: the reduce is launch
+// latency bound (constant ~3 us across SPLIT_K = 2/4/8 at M=1 N=5120), not
+// bandwidth bound.
+constexpr int kReduceBlock = 256;
+} // namespace
+
+bool decode_bf16_supported(int M, int N, int K, const char** why)
+{
+    (void)M; // the epilogue predicates rows, so ragged M is fine here
+    if(N % decode_bf16::kBlockN)
+    {
+        if(why)
+            *why = "N % 128 != 0";
+        return false;
+    }
+    if(K % decode_bf16::kBlockK)
+    {
+        if(why)
+            *why = "K % 64 != 0";
+        return false;
+    }
+    if(K % (decode_bf16::kSplitK * kGroupSize))
+    {
+        if(why)
+            *why = "K % (SPLIT_K*128) != 0: a split would start mid quant-group";
+        return false;
+    }
+    const int ks = K / decode_bf16::kSplitK / decode_bf16::kBlockK;
+    if(ks < 2)
+    {
+        if(why)
+            *why = "K/SPLIT_K/BK < 2: pipeline needs 2 K-steps";
+        return false;
+    }
+    if(ks % 2)
+    {
+        if(why)
+            *why = "K/SPLIT_K/BK is odd: main loop is unrolled x2";
+        return false;
+    }
+    return true;
+}
+
+int64_t decode_bf16_workspace_elems(int64_t M, int64_t N)
+{
+    return (int64_t)decode_bf16::kSplitK * M * N;
+}
+
+void launch_decode_bf16(const void* A,
+                        const void* W_q,
+                        const void* scales,
+                        const void* zeros,
+                        float* workspace,
+                        void* C,
+                        int M,
+                        int N,
+                        int K,
+                        hipStream_t stream)
+{
+    dim3 grid((M + decode_bf16::kBlockM - 1) / decode_bf16::kBlockM,
+              N / decode_bf16::kBlockN,
+              decode_bf16::kSplitK);
+    dim3 block(decode_bf16::kThreads);
+    hipLaunchKernelGGL(decode_bf16::gemm_a16w4_decode_bf16_kernel,
+                       grid,
+                       block,
+                       0,
+                       stream,
+                       reinterpret_cast<const bf16_raw_t*>(A),
+                       reinterpret_cast<const unsigned int*>(W_q),
+                       reinterpret_cast<const bf16_raw_t*>(scales),
+                       reinterpret_cast<const bf16_raw_t*>(zeros),
+                       workspace,
+                       M,
+                       N,
+                       K);
+
+    const int MN = M * N;
+    hipLaunchKernelGGL(decode_bf16::gemm_a16w4_decode_bf16_reduce_kernel,
+                       dim3((MN + kReduceBlock - 1) / kReduceBlock),
+                       dim3(kReduceBlock),
+                       0,
+                       stream,
+                       workspace,
+                       reinterpret_cast<bf16_raw_t*>(C),
+                       MN);
+}
+
+} // namespace a16w4
+} // namespace aiter

--- a/csrc/gemm_a16w4/gemm_a16w4_decode_fp16.cu
+++ b/csrc/gemm_a16w4/gemm_a16w4_decode_fp16.cu
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+#include "gemm_a16w4_launch.h"
+#include "gfx1201/gemm_a16w4_decode_fp16_gfx1201.cuh"
+
+namespace aiter {
+namespace a16w4 {
+
+namespace {
+constexpr int kReduceBlock = 256;
+} // namespace
+
+bool decode_fp16_supported(int M, int N, int K, const char** why)
+{
+    (void)M;
+    if(N % decode_fp16::kBlockN)
+    {
+        if(why)
+            *why = "N % 128 != 0";
+        return false;
+    }
+    if(K % decode_fp16::kBlockK)
+    {
+        if(why)
+            *why = "K % 64 != 0";
+        return false;
+    }
+    if(K % (decode_fp16::kSplitK * kGroupSize))
+    {
+        if(why)
+            *why = "K % (SPLIT_K*128) != 0: a split would start mid quant-group";
+        return false;
+    }
+    const int ks = K / decode_fp16::kSplitK / decode_fp16::kBlockK;
+    if(ks < 2)
+    {
+        if(why)
+            *why = "K/SPLIT_K/BK < 2: pipeline needs 2 K-steps";
+        return false;
+    }
+    if(ks % 2)
+    {
+        if(why)
+            *why = "K/SPLIT_K/BK is odd: main loop is unrolled x2";
+        return false;
+    }
+    return true;
+}
+
+int64_t decode_fp16_workspace_elems(int64_t M, int64_t N)
+{
+    return (int64_t)decode_fp16::kSplitK * M * N;
+}
+
+void launch_decode_fp16(const void* A,
+                        const void* W_q,
+                        const void* scales,
+                        const void* zeros_biased,
+                        float* workspace,
+                        void* C,
+                        int M,
+                        int N,
+                        int K,
+                        hipStream_t stream)
+{
+    dim3 grid((M + decode_fp16::kBlockM - 1) / decode_fp16::kBlockM,
+              N / decode_fp16::kBlockN,
+              decode_fp16::kSplitK);
+    dim3 block(decode_fp16::kThreads);
+    hipLaunchKernelGGL(decode_fp16::gemm_a16w4_decode_fp16_kernel,
+                       grid,
+                       block,
+                       0,
+                       stream,
+                       reinterpret_cast<const fp16_raw_t*>(A),
+                       reinterpret_cast<const unsigned int*>(W_q),
+                       reinterpret_cast<const fp16_raw_t*>(scales),
+                       reinterpret_cast<const fp16_raw_t*>(zeros_biased),
+                       workspace,
+                       M,
+                       N,
+                       K);
+
+    const int MN = M * N;
+    hipLaunchKernelGGL(decode_fp16::gemm_a16w4_decode_fp16_reduce_kernel,
+                       dim3((MN + kReduceBlock - 1) / kReduceBlock),
+                       dim3(kReduceBlock),
+                       0,
+                       stream,
+                       workspace,
+                       reinterpret_cast<fp16_raw_t*>(C),
+                       MN);
+}
+
+} // namespace a16w4
+} // namespace aiter

--- a/csrc/gemm_a16w4/gemm_a16w4_prefill_bf16.cu
+++ b/csrc/gemm_a16w4/gemm_a16w4_prefill_bf16.cu
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+#include "gemm_a16w4_launch.h"
+#include "gfx1201/gemm_a16w4_prefill_bf16_gfx1201.cuh"
+
+namespace aiter {
+namespace a16w4 {
+
+bool prefill_bf16_supported(int M, int N, int K, const char** why)
+{
+    // Fail loudly on an unsupported shape. Silently producing wrong numbers
+    // is the failure mode this guard exists to prevent -- the kernel has no
+    // ragged-M predicate and no partial-tile path.
+    if(M % prefill_bf16::kBlockM)
+    {
+        if(why)
+            *why = "M % 128 != 0";
+        return false;
+    }
+    if(N % prefill_bf16::kBlockN)
+    {
+        if(why)
+            *why = "N % 512 != 0";
+        return false;
+    }
+    if(K % prefill_bf16::kBlockK)
+    {
+        if(why)
+            *why = "K % 64 != 0";
+        return false;
+    }
+    if(K % kGroupSize)
+    {
+        if(why)
+            *why = "K % 128 != 0";
+        return false;
+    }
+    const int ks = K / prefill_bf16::kBlockK;
+    if(ks < 2 || (ks % 2))
+    {
+        if(why)
+            *why = "K/BK must be even and >= 2";
+        return false;
+    }
+    return true;
+}
+
+void launch_prefill_bf16(const void* A,
+                         const void* W_q,
+                         const void* scales,
+                         const void* zeros,
+                         void* C,
+                         int M,
+                         int N,
+                         int K,
+                         hipStream_t stream)
+{
+    dim3 grid(M / prefill_bf16::kBlockM, N / prefill_bf16::kBlockN);
+    dim3 block(prefill_bf16::kThreads);
+    hipLaunchKernelGGL(prefill_bf16::gemm_a16w4_prefill_bf16_kernel,
+                       grid,
+                       block,
+                       0,
+                       stream,
+                       reinterpret_cast<const bf16_raw_t*>(A),
+                       reinterpret_cast<const unsigned int*>(W_q),
+                       reinterpret_cast<const bf16_raw_t*>(scales),
+                       reinterpret_cast<const bf16_raw_t*>(zeros),
+                       reinterpret_cast<bf16_raw_t*>(C),
+                       M,
+                       N,
+                       K);
+}
+
+} // namespace a16w4
+} // namespace aiter

--- a/csrc/gemm_a16w4/gemm_a16w4_prefill_fp16.cu
+++ b/csrc/gemm_a16w4/gemm_a16w4_prefill_fp16.cu
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+#include "gemm_a16w4_launch.h"
+#include "gfx1201/gemm_a16w4_prefill_fp16_gfx1201.cuh"
+
+namespace aiter {
+namespace a16w4 {
+
+bool prefill_fp16_supported(int M, int N, int K, const char** why)
+{
+    if(M % prefill_fp16::kBlockM)
+    {
+        if(why)
+            *why = "M % 128 != 0";
+        return false;
+    }
+    if(N % prefill_fp16::kBlockN)
+    {
+        if(why)
+            *why = "N % 512 != 0";
+        return false;
+    }
+    if(K % prefill_fp16::kBlockK)
+    {
+        if(why)
+            *why = "K % 64 != 0";
+        return false;
+    }
+    if(K % kGroupSize)
+    {
+        if(why)
+            *why = "K % 128 != 0";
+        return false;
+    }
+    const int ks = K / prefill_fp16::kBlockK;
+    if(ks < 2 || (ks % 2))
+    {
+        if(why)
+            *why = "K/BK must be even and >= 2";
+        return false;
+    }
+    return true;
+}
+
+void launch_prefill_fp16(const void* A,
+                         const void* W_q,
+                         const void* scales,
+                         const void* zeros_biased,
+                         void* C,
+                         int M,
+                         int N,
+                         int K,
+                         hipStream_t stream)
+{
+    dim3 grid(M / prefill_fp16::kBlockM, N / prefill_fp16::kBlockN);
+    dim3 block(prefill_fp16::kThreads);
+    hipLaunchKernelGGL(prefill_fp16::gemm_a16w4_prefill_fp16_kernel,
+                       grid,
+                       block,
+                       0,
+                       stream,
+                       reinterpret_cast<const fp16_raw_t*>(A),
+                       reinterpret_cast<const unsigned int*>(W_q),
+                       reinterpret_cast<const fp16_raw_t*>(scales),
+                       reinterpret_cast<const fp16_raw_t*>(zeros_biased),
+                       reinterpret_cast<fp16_raw_t*>(C),
+                       M,
+                       N,
+                       K);
+}
+
+} // namespace a16w4
+} // namespace aiter

--- a/csrc/gemm_a16w4/include/gemm_a16w4_launch.h
+++ b/csrc/gemm_a16w4/include/gemm_a16w4_launch.h
@@ -1,0 +1,88 @@
+#pragma once
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+//
+// Internal launcher surface for the a16w4 GEMM kernels.
+//
+// Each variant lives in its OWN translation unit. That is not a style choice:
+// the four kernel headers under gfx1201/ define BM / BN / BK / THREADS /
+// PIPE_STEP and friends to different values, and although each header undefs
+// them on the way out, keeping one kernel per TU also keeps the four ninja
+// jobs parallel and stops a change to one tile from rebuilding the others.
+//
+// aiter::gemm_a16w4() in gemm_a16w4.cu is the only caller.
+
+#include <hip/hip_runtime.h>
+
+#include <cstdint>
+
+namespace aiter {
+namespace a16w4 {
+
+// int4 quantisation group along K. Fixed by the checkpoint format, not a
+// tuning knob: every kernel static_asserts that GROUP_SIZE % BK == 0 so that
+// one K-step never straddles two groups.
+constexpr int kGroupSize = 128;
+// int4 nibbles packed per uint32 of the weight tensor.
+constexpr int kPackK = 8;
+
+// Shape predicates. On failure `why` is set to a static string explaining
+// which constraint was violated; it is never freed. Each predicate is derived
+// from the constexpr tile geometry of its own kernel, so it cannot drift out
+// of sync with the kernel it guards.
+bool prefill_bf16_supported(int M, int N, int K, const char** why);
+bool prefill_fp16_supported(int M, int N, int K, const char** why);
+bool decode_bf16_supported(int M, int N, int K, const char** why);
+bool decode_fp16_supported(int M, int N, int K, const char** why);
+
+// fp32 workspace elements the decode path needs: SPLIT_K * M * N.
+int64_t decode_bf16_workspace_elems(int64_t M, int64_t N);
+int64_t decode_fp16_workspace_elems(int64_t M, int64_t N);
+
+// A/scales/zeros/C are bf16 or fp16 raw bit patterns (unsigned short), W_q is
+// packed int4. void* rather than the raw typedefs so this header does not
+// have to pull in the device-side common header.
+void launch_prefill_bf16(const void* A,
+                         const void* W_q,
+                         const void* scales,
+                         const void* zeros,
+                         void* C,
+                         int M,
+                         int N,
+                         int K,
+                         hipStream_t stream);
+
+void launch_prefill_fp16(const void* A,
+                         const void* W_q,
+                         const void* scales,
+                         const void* zeros_biased,
+                         void* C,
+                         int M,
+                         int N,
+                         int K,
+                         hipStream_t stream);
+
+void launch_decode_bf16(const void* A,
+                        const void* W_q,
+                        const void* scales,
+                        const void* zeros,
+                        float* workspace,
+                        void* C,
+                        int M,
+                        int N,
+                        int K,
+                        hipStream_t stream);
+
+void launch_decode_fp16(const void* A,
+                        const void* W_q,
+                        const void* scales,
+                        const void* zeros_biased,
+                        float* workspace,
+                        void* C,
+                        int M,
+                        int N,
+                        int K,
+                        hipStream_t stream);
+
+} // namespace a16w4
+} // namespace aiter

--- a/csrc/gemm_a16w4/include/gfx1201/gemm_a16w4_common_gfx1201.cuh
+++ b/csrc/gemm_a16w4/include/gfx1201/gemm_a16w4_common_gfx1201.cuh
@@ -1,0 +1,167 @@
+#pragma once
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+//
+// Shared scalar plumbing for the gfx1201 (Navi 48) a16w4 GEMM kernels.
+//
+// ── ARCHITECTURE GATE ──────────────────────────────────────────────────────
+// Every kernel under gfx1201/ calls __builtin_amdgcn_wmma_*_w32_gfx12, which
+// does not exist before RDNA4, and every tile, LDS stride and AGROUP value was
+// measured on gfx1201 specifically (see the header comment on each kernel).
+//
+// aiter builds ONE module for whatever GPU_ARCHS lists, so a hard #error here
+// would break any multi-arch build that merely happens to include this module.
+// Instead the device bodies compile to a trap on other targets and the host
+// entry point refuses to launch -- see aiter::gemm_a16w4() in gemm_a16w4.cu,
+// which checks gcnArchName before every dispatch. The two guards are
+// deliberately redundant: the host one produces a readable error, the device
+// one guarantees that a hole in the host gate cannot silently execute
+// whatever the compiler decided a missing builtin should mean.
+//
+// This mirrors csrc/kernels/chunk_gated_delta_rule_fwd_h.cu, which gates the
+// same way on __gfx1200__/__gfx1201__.
+
+#include "gemm_a16w4_launch.h"
+
+#include <hip/hip_runtime.h>
+
+#if defined(__HIP_DEVICE_COMPILE__) && !defined(__gfx1201__)
+#define AITER_A16W4_DEVICE_SUPPORTED 0
+#else
+#define AITER_A16W4_DEVICE_SUPPORTED 1
+#endif
+
+// Placed at the top of every a16w4 __global__ body. On a non-gfx1201 device
+// target it replaces the body outright, so the WMMA builtins are never parsed
+// for an architecture that lacks them.
+#if AITER_A16W4_DEVICE_SUPPORTED
+#define AITER_A16W4_REQUIRE_GFX1201()
+#else
+#define AITER_A16W4_REQUIRE_GFX1201() \
+    do                                \
+    {                                 \
+        __builtin_trap();             \
+        return;                       \
+    } while(0)
+#endif
+
+namespace aiter {
+namespace a16w4 {
+
+// kGroupSize / kPackK live in gemm_a16w4_launch.h so the host dispatcher can
+// see them without pulling in device code.
+
+// +1024 magic bias for the fp16 dequant path. NOT arbitrary: fp16 has a
+// 10-bit mantissa, so 0x6400 | n == 1024 + n exactly for any 4-bit n, and
+// 1024 + n and 1024 + z both lie in the binade [1024, 2048) where fp16
+// subtraction is exact by Sterbenz's lemma. See dequant8_magic() in the fp16
+// kernels for why the subtraction must not be folded into the scale.
+constexpr float kMagicBias = 1024.0f;
+constexpr unsigned kF16Magic = 0x64006400u; // two copies of fp16(1024.0)
+constexpr unsigned kNibMask = 0x000F000Fu;  // one nibble in each 16-bit half
+
+using bf16_raw_t = unsigned short;
+using fp16_raw_t = unsigned short;
+
+typedef unsigned short u16x4_t __attribute__((ext_vector_type(4)));
+typedef unsigned short u16x8_t __attribute__((ext_vector_type(8)));
+typedef unsigned int u32x4_t __attribute__((ext_vector_type(4)));
+typedef __bf16 frag_bf16x8 __attribute__((ext_vector_type(8)));
+typedef _Float16 f16x2 __attribute__((ext_vector_type(2)));
+typedef _Float16 f16x8 __attribute__((ext_vector_type(8)));
+typedef float frag_f32x8 __attribute__((ext_vector_type(8)));
+
+__device__ __host__ __forceinline__ float bf16_to_f32(bf16_raw_t x)
+{
+    union
+    {
+        unsigned u;
+        float f;
+    } v;
+    v.u = (unsigned)x << 16;
+    return v.f;
+}
+
+__device__ __host__ __forceinline__ bf16_raw_t f32_to_bf16(float x)
+{
+    union
+    {
+        float f;
+        unsigned u;
+    } v;
+    v.f = x;
+    return (bf16_raw_t)(v.u >> 16);
+}
+
+__device__ __host__ __forceinline__ float fp16_to_f32(fp16_raw_t x)
+{
+    _Float16 h;
+    __builtin_memcpy(&h, &x, 2);
+    return (float)h;
+}
+
+__device__ __host__ __forceinline__ fp16_raw_t f32_to_fp16(float x)
+{
+    _Float16 h = (_Float16)x;
+    fp16_raw_t r;
+    __builtin_memcpy(&r, &h, 2);
+    return r;
+}
+
+__device__ __forceinline__ frag_bf16x8 as_bf16x8(u16x8_t v)
+{
+    union
+    {
+        u16x8_t u;
+        frag_bf16x8 f;
+    } c;
+    c.u = v;
+    return c.f;
+}
+
+__device__ __forceinline__ f16x8 as_f16x8(u16x8_t v)
+{
+    union
+    {
+        u16x8_t u;
+        f16x8 f;
+    } c;
+    c.u = v;
+    return c.f;
+}
+
+__device__ __forceinline__ f16x8 as_f16x8_u32x4(u32x4_t v)
+{
+    union
+    {
+        u32x4_t u;
+        f16x8 f;
+    } c;
+    c.u = v;
+    return c.f;
+}
+
+__device__ __forceinline__ f16x2 as_f16x2(unsigned v)
+{
+    union
+    {
+        unsigned u;
+        f16x2 f;
+    } c;
+    c.u = v;
+    return c.f;
+}
+
+__device__ __forceinline__ unsigned as_u32(f16x2 v)
+{
+    union
+    {
+        f16x2 f;
+        unsigned u;
+    } c;
+    c.f = v;
+    return c.u;
+}
+
+} // namespace a16w4
+} // namespace aiter

--- a/csrc/gemm_a16w4/include/gfx1201/gemm_a16w4_decode_bf16_gfx1201.cuh
+++ b/csrc/gemm_a16w4/include/gfx1201/gemm_a16w4_decode_bf16_gfx1201.cuh
@@ -1,0 +1,309 @@
+#pragma once
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+//
+// a16w4 DECODE GEMM (bf16 x int4 -> bf16) for gfx1201 -- grid-level split-K.
+// Tile: BM=16, BN=128, BK=64, WM=16, WN=32 | 4 waves/WG | 128 threads
+// grid = (ceil(M/BM), N/BN, SPLIT_K)
+//
+// =====================================================================
+// WHY GRID-LEVEL SPLIT-K, AND WHY S=2 (not the "balanced" S=4)
+// =====================================================================
+// With BM = WM = 16 the wave count is fixed by N and WN alone:
+//
+//     total waves = (N/BN) x (BN/WN) = N/WN
+//
+// BN cancels. At N=5120, WN=32 that is 160 waves for ANY BN -- which is
+// exactly why BN=64, 128 and 256 all landed near 400 GB/s. K is the only
+// free variable left, and the split MUST be at grid level: splitting inside
+// the workgroup leaves the grid at 40 WGs and merely moves the problem
+// inside the WG.
+//
+// Cold GEMM at N=5120 K=5120:
+//
+//     S   waves/SIMD32   "balanced"   GEMM      GEMM+reduce
+//     1       1.25           no       37.36 us  37.27 us
+//     2       2.50           no       27.33 us  30.35 us   <-- BEST
+//     4       5.00          YES       28.51 us  31.51 us
+//     8      10.00          YES       29.17 us  32.08 us
+//
+// S=2 wins and BOTH "balanced" configs lose to it. The mechanism is
+// RESIDENCY, not divisibility:
+//
+//   - LDS is 39424 B/WG against 128 KB/WGP, so only floor(128/38.5) = 3 WGs
+//     fit per WGP = 3 waves/SIMD32. That is a hard cap.
+//   - S=4 asks for 5 waves/SIMD32 and S=8 asks for 10. Those surplus waves
+//     are QUEUED across dispatch rounds, not co-resident, so they hide no
+//     additional memory latency.
+//   - Meanwhile every WG pays ~2 K-steps of pipeline fill, and the WG count
+//     scales with S while useful work is fixed:
+//         fill = 2S/80 -> 2.5% / 5% / 10% / 20% for S = 1 / 2 / 4 / 8
+//     Measured degradation past S=2 is +4.3% and +6.7%, tracking that.
+//
+// So: occupancy benefit SATURATES at the resident cap, fill cost grows
+// LINEARLY with S. Pick the largest S still under the cap -- here, 2. THE
+// RIGHT S DEPENDS ON LDS_TOTAL, so changing the tile changes the best S.
+//
+// =====================================================================
+// OUTPUT PATH
+// =====================================================================
+// Each split writes an fp32 partial to workspace[split][M][N] with PLAIN
+// STORES -- no atomics, so the result is bit-deterministic run to run. A
+// second kernel sums the SPLIT_K partials and narrows to bf16.
+//
+// The reduce costs ~3.0 us at M=1 N=5120, and it cost the same ~3.0 us at
+// S=2, 4 and 8. Constant in S means it is LAUNCH LATENCY, not bandwidth --
+// it moves 170 KB against 13.95 MB of weights (1.2%). Fusing it into the
+// GEMM epilogue is the next ~10% and is left undone deliberately: it needs
+// a cross-workgroup completion protocol.
+//
+// =====================================================================
+// TWO THINGS THAT WERE MEASURED AND LOST -- DO NOT RETRY BLIND
+// =====================================================================
+//  - LDS-only barrier instead of __syncthreads: 30.40 us vs 28.45 us,
+//    spread 0.25 us. The barrier semantics were never the problem; the
+//    "memory" clobber on the inline asm is opaque to the scheduler, which
+//    then loses track of outstanding global loads and waits before every
+//    use (15 s_wait_loadcnt vs 1). Diff the codegen wait counts first.
+//  - Live dequant straight into the WMMA operand instead of staging through
+//    LDS: raised VALU per element from 3.875 to 4.48 and created WAR
+//    hazards against the 320-cycle WMMA latency.
+
+#include "gfx1201/gemm_a16w4_common_gfx1201.cuh"
+
+// FINAL. Measured best at N=5120 K=5120 (see the sweep above). This is NOT a
+// free knob: S changes the resident-WG count and the pipeline fill cost, and
+// the optimum moves with LDS_TOTAL. If you change the tile, re-sweep.
+#define SPLIT_K 2
+
+#define BM 16
+#define BN 128
+#define BK 64
+#define WM 16
+#define WN 32
+#define NUM_WAVES ((BM / WM) * (BN / WN)) // 4
+#define THREADS (NUM_WAVES * 32)          // 128
+#define GROUP_SIZE 128
+#define PACKS_PER_THR (BK / 8)          // 8
+#define A_PER_THR ((BM * BK) / THREADS) // 8
+
+#define LDS_A_STRIDE (BK + 8)  // 72 elems, b128 aligned
+#define LDS_WK_STRIDE (BK + 4) // 68 elems, b64 aligned
+
+#define LDS_BUF_A_ELEMS (BM * LDS_A_STRIDE)
+#define LDS_BUF_W_ELEMS (BN * LDS_WK_STRIDE)
+#define LDS_BUF_ELEMS (LDS_BUF_A_ELEMS + LDS_BUF_W_ELEMS)
+#define LDS_TOTAL (2 * LDS_BUF_ELEMS * 2) // 39424 B
+
+namespace aiter {
+namespace a16w4 {
+namespace decode_bf16 {
+
+static_assert(GROUP_SIZE % BK == 0, "GROUP_SIZE must be a multiple of BK");
+
+// ─── Pipeline stage macros ──────────────────────────────────────────────────
+
+// Nothing loaded here may be USED here -- touching a just-issued load forces
+// an s_waitcnt mid-prefetch and collapses the pipeline.
+#define PREFETCH_TILE(R, KS_LOAD)                                           \
+    {                                                                       \
+        const int nk_ = (KS_LOAD)*BK;                                       \
+        const int ng_ = nk_ / GROUP_SIZE;                                   \
+        rsc##R        = sc_base[(size_t)ng_ * N + my_col];                  \
+        rzr##R        = zr_base[(size_t)ng_ * N + my_col];                  \
+        if(a_ok)                                                            \
+            rA##R = *(const u16x8_t*)(a_src + nk_);                         \
+        const unsigned int* wsrc_ = W_col + (size_t)(nk_ / 8) * N;          \
+        _Pragma("unroll") for(int p = 0; p < PACKS_PER_THR; p++) rW##R[p] = \
+            wsrc_[(size_t)p * N];                                           \
+    }
+
+// Staged dequant: registers -> LDS.
+#define DEQUANT_TO_LDS(R, B)                                                    \
+    {                                                                           \
+        const float sc_ = bf16_to_f32(rsc##R);                                  \
+        const float zs_ = -bf16_to_f32(rzr##R) * sc_;                           \
+        *(u16x8_t*)(&lds_buf[B][a_lds_off]) = rA##R;                            \
+        bf16_raw_t* wcol_ = &lds_buf[B][LDS_BUF_A_ELEMS + tid * LDS_WK_STRIDE]; \
+        _Pragma("unroll") for(int p = 0; p < PACKS_PER_THR; p++)                \
+        {                                                                       \
+            const unsigned packed_ = rW##R[p];                                  \
+            u16x4_t lo_, hi_;                                                   \
+            _Pragma("unroll") for(int j = 0; j < 4; j++)                        \
+            {                                                                   \
+                lo_[j] = f32_to_bf16(                                           \
+                    fmaf((float)((packed_ >> (j * 4)) & 0xF), sc_, zs_));        \
+                hi_[j] = f32_to_bf16(                                           \
+                    fmaf((float)((packed_ >> ((j + 4) * 4)) & 0xF), sc_, zs_));  \
+            }                                                                   \
+            *(u16x4_t*)(wcol_ + p * 8)     = lo_;                               \
+            *(u16x4_t*)(wcol_ + p * 8 + 4) = hi_;                               \
+        }                                                                       \
+    }
+
+#define WMMA_FROM_LDS(B)                                                             \
+    {                                                                                \
+        const bf16_raw_t* srcA_ = &lds_buf[B][0];                                    \
+        const bf16_raw_t* srcW_ = &lds_buf[B][LDS_BUF_A_ELEMS];                      \
+        _Pragma("unroll") for(int s = 0; s < BK / 16; s++)                           \
+        {                                                                            \
+            const int koff_    = s * 16 + laneGroup * 8;                             \
+            frag_bf16x8 af_    = as_bf16x8(                                          \
+                *(const u16x8_t*)(srcA_ + laneWrapped * LDS_A_STRIDE + koff_));      \
+            const bf16_raw_t* w0_ = srcW_ + wcol0 * LDS_WK_STRIDE + koff_;           \
+            const bf16_raw_t* w1_ = srcW_ + wcol1 * LDS_WK_STRIDE + koff_;           \
+            frag_bf16x8 bf0_      = as_bf16x8(__builtin_shufflevector(               \
+                *(const u16x4_t*)(w0_), *(const u16x4_t*)(w0_ + 4), 0, 1, 2, 3, 4, 5, 6, 7)); \
+            frag_bf16x8 bf1_      = as_bf16x8(__builtin_shufflevector(               \
+                *(const u16x4_t*)(w1_), *(const u16x4_t*)(w1_ + 4), 0, 1, 2, 3, 4, 5, 6, 7)); \
+            acc0 = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(af_, bf0_, acc0); \
+            acc1 = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(af_, bf1_, acc1); \
+        }                                                                            \
+    }
+
+#define PIPE_STEP(RPF, RDQ, CURB, NXTB, KS) \
+    {                                       \
+        const int ks_ = (KS);               \
+        if(ks_ + 2 < k_steps)               \
+            PREFETCH_TILE(RPF, ks_ + 2)     \
+        WMMA_FROM_LDS(CURB)                 \
+        if(ks_ + 1 < k_steps)               \
+            DEQUANT_TO_LDS(RDQ, NXTB)       \
+        __syncthreads();                    \
+    }
+
+// ─── GEMM kernel ────────────────────────────────────────────────────────────
+
+__global__ __launch_bounds__(THREADS) void gemm_a16w4_decode_bf16_kernel(
+    const bf16_raw_t* __restrict__ A,      // [M, K] bf16
+    const unsigned int* __restrict__ W_q,  // [K/8, N] int32, packed along K
+    const bf16_raw_t* __restrict__ scales, // [K/G, N] bf16
+    const bf16_raw_t* __restrict__ zeros,  // [K/G, N] bf16
+    float* __restrict__ workspace,         // [SPLIT_K, M, N] fp32 partials
+    int M,
+    int N,
+    int K)
+{
+    AITER_A16W4_REQUIRE_GFX1201();
+#if AITER_A16W4_DEVICE_SUPPORTED
+    const int bm          = blockIdx.x * BM;
+    const int bn          = blockIdx.y * BN;
+    const int split       = blockIdx.z;
+    const int tid         = threadIdx.x;
+    const int wave_n      = tid / 32;
+    const int lane_id     = tid % 32;
+    const int laneWrapped = lane_id % 16;
+    const int laneGroup   = lane_id / 16;
+    const int wn_start    = wave_n * WN;
+    const int my_col      = bn + tid;
+
+    const int wcol0 = wn_start + laneWrapped;
+    const int wcol1 = wcol0 + 16;
+
+    // This WG owns K range [k_begin, k_begin + K/SPLIT_K). The bases are
+    // advanced once so the pipeline macros are identical to the SPLIT_K=1
+    // case -- the split costs nothing in the inner loop.
+    const int k_span  = K / SPLIT_K;
+    const int k_begin = split * k_span;
+    const int k_steps = k_span / BK;
+
+    __shared__ bf16_raw_t lds_buf[2][LDS_BUF_ELEMS];
+
+    frag_f32x8 acc0 = {0}, acc1 = {0};
+
+    const unsigned int* W_col = W_q + (size_t)(k_begin / 8) * N + bn + tid;
+    const bf16_raw_t* sc_base = scales + (size_t)(k_begin / GROUP_SIZE) * N;
+    const bf16_raw_t* zr_base = zeros + (size_t)(k_begin / GROUP_SIZE) * N;
+
+    // Activation addressing, hoisted out of the loop.
+    const int a_row            = (tid * A_PER_THR) / BK;
+    const int a_col            = (tid * A_PER_THR) % BK;
+    const bool a_ok            = (bm + a_row) < M;
+    const int a_row_clamped    = a_ok ? (bm + a_row) : 0;
+    const bf16_raw_t* a_src    = A + (long)a_row_clamped * K + k_begin + a_col;
+    const int a_lds_off        = a_row * LDS_A_STRIDE + a_col;
+
+    unsigned rW0[PACKS_PER_THR], rW1[PACKS_PER_THR];
+    u16x8_t rA0, rA1;
+    bf16_raw_t rsc0, rzr0, rsc1, rzr1;
+
+    rA0 = (u16x8_t)(bf16_raw_t)0;
+    rA1 = (u16x8_t)(bf16_raw_t)0;
+
+    PREFETCH_TILE(0, 0)
+    DEQUANT_TO_LDS(0, 0)
+    if(k_steps > 1)
+        PREFETCH_TILE(1, 1)
+    __syncthreads();
+
+    for(int ks = 0; ks < k_steps; ks += 2)
+    {
+        PIPE_STEP(0, 1, 0, 1, ks)
+        PIPE_STEP(1, 0, 1, 0, ks + 1)
+    }
+
+    // Epilogue: plain fp32 stores into this split's slice. No atomics, so
+    // the result is bit-deterministic run to run.
+    float* out = workspace + (size_t)split * M * N;
+#pragma unroll
+    for(int e = 0; e < 8; e++)
+    {
+        const int row = bm + e + laneGroup * 8;
+        if(row >= M)
+            continue;
+        const int c0 = bn + wcol0, c1 = bn + wcol1;
+        if(c0 < N)
+            out[(size_t)row * N + c0] = acc0[e];
+        if(c1 < N)
+            out[(size_t)row * N + c1] = acc1[e];
+    }
+#endif // AITER_A16W4_DEVICE_SUPPORTED
+}
+
+// Sum the SPLIT_K fp32 partials and narrow to bf16. SPLIT_K is a
+// compile-time constant so the loop fully unrolls.
+__global__ void gemm_a16w4_decode_bf16_reduce_kernel(const float* __restrict__ wsp,
+                                                     bf16_raw_t* __restrict__ C,
+                                                     int MN)
+{
+    const int i = blockIdx.x * blockDim.x + threadIdx.x;
+    if(i >= MN)
+        return;
+    float s = 0.f;
+#pragma unroll
+    for(int k = 0; k < SPLIT_K; k++)
+        s += wsp[(size_t)k * MN + i];
+    C[i] = f32_to_bf16(s);
+}
+
+constexpr int kBlockM  = BM;
+constexpr int kBlockN  = BN;
+constexpr int kBlockK  = BK;
+constexpr int kThreads = THREADS;
+constexpr int kSplitK  = SPLIT_K;
+
+} // namespace decode_bf16
+} // namespace a16w4
+} // namespace aiter
+
+#undef PIPE_STEP
+#undef WMMA_FROM_LDS
+#undef DEQUANT_TO_LDS
+#undef PREFETCH_TILE
+#undef LDS_TOTAL
+#undef LDS_BUF_ELEMS
+#undef LDS_BUF_W_ELEMS
+#undef LDS_BUF_A_ELEMS
+#undef LDS_WK_STRIDE
+#undef LDS_A_STRIDE
+#undef A_PER_THR
+#undef PACKS_PER_THR
+#undef GROUP_SIZE
+#undef THREADS
+#undef NUM_WAVES
+#undef WN
+#undef WM
+#undef BK
+#undef BN
+#undef BM
+#undef SPLIT_K

--- a/csrc/gemm_a16w4/include/gfx1201/gemm_a16w4_decode_fp16_gfx1201.cuh
+++ b/csrc/gemm_a16w4/include/gfx1201/gemm_a16w4_decode_fp16_gfx1201.cuh
@@ -1,0 +1,284 @@
+#pragma once
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+//
+// a16w4 DECODE GEMM (fp16 x int4 -> fp16) for gfx1201 -- grid-level split-K
+// with the fp16 bit-magic dequant.
+// Tile: BM=16, BN=128, BK=64, WM=16, WN=32 | 4 waves/WG | 128 threads
+// grid = (ceil(M/BM), N/BN, SPLIT_K)
+//
+// Same split-K structure as the bf16 decode kernel -- see that file for why
+// S=2 and why the dequant is staged through LDS rather than fed live into the
+// WMMA operand. Two things differ:
+//
+//   * the dequant is the fp16 bit-magic (see dequant8_magic below), which
+//     needs MAGIC-permuted nibbles and +1024-biased zeros from the host;
+//   * LDS_WK_STRIDE is 72, NOT the bf16 kernel's 68. See the note on the
+//     define -- it is a 2.4x difference and it is invisible to any
+//     numerical test.
+
+#include "gfx1201/gemm_a16w4_common_gfx1201.cuh"
+
+#define SPLIT_K 2
+
+#define BM 16
+#define BN 128
+#define BK 64
+#define WM 16
+#define WN 32
+#define NUM_WAVES ((BM / WM) * (BN / WN)) // 4
+#define THREADS (NUM_WAVES * 32)          // 128
+#define GROUP_SIZE 128
+#define PACKS_PER_THR (BK / 8)          // 8
+#define A_PER_THR ((BM * BK) / THREADS) // 8
+
+#define LDS_A_STRIDE (BK + 8) // 72 elems, b128 aligned
+// 72 elems = 144 B. MUST be a multiple of 8 fp16 (16 B), NOT the bf16
+// kernel's 68. This kernel reads and writes the W region with 16-byte LDS
+// accesses (ds_load_b128 / ds_store_b128) because the dequantised fragment
+// is a u32x4/f16x8. At stride 68 (136 B) those accesses are only 8-byte
+// aligned and the hardware serialises them:
+//     stride 68 -> 60.96 us / 183 GB/s
+//     stride 72 -> 25.05 us / 446 GB/s   <-- 2.4x, from alignment alone
+//     stride 80 -> 34.89 us / 320 GB/s   (aligned, but 8-way bank conflict)
+//     stride 88 -> 30.40 us / 367 GB/s   (aligned, 2-way conflict)
+// The bf16 kernel gets away with 68 only because clang splits its W accesses
+// into ds_load_2addr_b64, which needs just 8-byte alignment. Correctness is
+// IDENTICAL at every stride, so this is invisible to any numerical test.
+#define LDS_WK_STRIDE (BK + 8) // 72 elems, b128 aligned
+
+#define LDS_BUF_A_ELEMS (BM * LDS_A_STRIDE)
+#define LDS_BUF_W_ELEMS (BN * LDS_WK_STRIDE)
+#define LDS_BUF_ELEMS (LDS_BUF_A_ELEMS + LDS_BUF_W_ELEMS)
+#define LDS_TOTAL (2 * LDS_BUF_ELEMS * 2) // 41472 B
+
+namespace aiter {
+namespace a16w4 {
+namespace decode_fp16 {
+
+static_assert(GROUP_SIZE % BK == 0, "GROUP_SIZE must be a multiple of BK");
+
+// ─── The bit-magic ──────────────────────────────────────────────────────────
+// One packed int32 (8 pre-permuted nibbles) -> 8 dequantised fp16, written as
+// 4 dwords. sc2 is the scale and zm2 is the MAGIC-BIASED zero (1024 + z),
+// both broadcast into the two halves so each op handles two weights.
+//
+// SUBTRACT BEFORE SCALING. THIS ORDER IS NOT NEGOTIABLE.
+//   fused form   (1024+n)*s + (-(1024+z)*s)   -- ONE v_pk_fma_f16, BUT WRONG
+//   correct form ((1024+n) - (1024+z)) * s    -- pk_add + pk_mul
+// The fused form subtracts two quantities of magnitude ~1024*s to produce a
+// result of magnitude ~15*s, amplifying fp16's 2^-11 relative error by
+// 1024/15 ~= 68 to about 3.3%. Measured: cosine 0.99947, max_err 0.40,
+// 36% of elements over 5% error. It looks "almost right", which is the
+// worst way for a kernel to be wrong.
+//
+// The correct form is EXACT in the subtraction: both operands lie in the
+// binade [1024, 2048), so by Sterbenz's lemma their fp16 difference is
+// representable with no rounding at all. The integer n - z in [-15, 15]
+// comes out bit-exact, and the single multiply by s is the ONLY rounding in
+// the whole dequant.
+__device__ __forceinline__ u32x4_t dequant8_magic(unsigned packed, f16x2 sc2, f16x2 zm2)
+{
+    u32x4_t out;
+#pragma unroll
+    for(int j = 0; j < 4; j++)
+    {
+        // (1024 + n) for two nibbles, by OR alone -- no cvt instruction.
+        const unsigned bits = ((packed >> (4 * j)) & kNibMask) | kF16Magic;
+        // v_pk_add_f16 (exact) then v_pk_mul_f16. Written as (a-b)*c so that
+        // -ffp-contract=fast cannot refactor it back into the fused form.
+        out[j] = as_u32((as_f16x2(bits) - zm2) * sc2);
+    }
+    return out;
+}
+
+// ─── Pipeline stage macros ──────────────────────────────────────────────────
+
+// Nothing loaded here may be USED here -- touching a just-issued load forces
+// an s_waitcnt mid-prefetch and collapses the pipeline.
+#define PREFETCH_TILE(R, KS_LOAD)                                           \
+    {                                                                       \
+        const int nk_ = (KS_LOAD)*BK;                                       \
+        const int ng_ = nk_ / GROUP_SIZE;                                   \
+        rsc##R        = sc_base[(size_t)ng_ * N + my_col];                  \
+        rzr##R        = zr_base[(size_t)ng_ * N + my_col];                  \
+        if(a_ok)                                                            \
+            rA##R = *(const u16x8_t*)(a_src + nk_);                         \
+        const unsigned int* wsrc_ = W_col + (size_t)(nk_ / 8) * N;          \
+        _Pragma("unroll") for(int p = 0; p < PACKS_PER_THR; p++) rW##R[p] = \
+            wsrc_[(size_t)p * N];                                           \
+    }
+
+// Staged dequant: registers -> LDS, exactly as the bf16 kernel.
+//
+// The zero point arrives ALREADY BIASED by 1024 from the host, so it is used
+// as a raw fp16 broadcast: no unpack to f32, no folding into the scale.
+#define DEQUANT_TO_LDS(R, B)                                                    \
+    {                                                                           \
+        const f16x2 sc2_ = as_f16x2((unsigned)rsc##R * 0x00010001u);            \
+        const f16x2 zm2_ = as_f16x2((unsigned)rzr##R * 0x00010001u);            \
+        *(u16x8_t*)(&lds_buf[B][a_lds_off]) = rA##R;                            \
+        fp16_raw_t* wcol_ = &lds_buf[B][LDS_BUF_A_ELEMS + tid * LDS_WK_STRIDE]; \
+        _Pragma("unroll") for(int p = 0; p < PACKS_PER_THR; p++)                \
+        {                                                                       \
+            /* 8 fp16 in k order, because the host pre-permuted the nibbles */  \
+            *(u32x4_t*)(wcol_ + p * 8) = dequant8_magic(rW##R[p], sc2_, zm2_);  \
+        }                                                                       \
+    }
+
+#define WMMA_FROM_LDS(B)                                                              \
+    {                                                                                 \
+        const fp16_raw_t* srcA_ = &lds_buf[B][0];                                     \
+        const fp16_raw_t* srcW_ = &lds_buf[B][LDS_BUF_A_ELEMS];                       \
+        _Pragma("unroll") for(int s = 0; s < BK / 16; s++)                            \
+        {                                                                             \
+            const int koff_ = s * 16 + laneGroup * 8;                                 \
+            f16x8 af_       = as_f16x8(                                               \
+                *(const u16x8_t*)(srcA_ + laneWrapped * LDS_A_STRIDE + koff_));       \
+            f16x8 bf0_ =                                                              \
+                as_f16x8(*(const u16x8_t*)(srcW_ + wcol0 * LDS_WK_STRIDE + koff_));   \
+            f16x8 bf1_ =                                                              \
+                as_f16x8(*(const u16x8_t*)(srcW_ + wcol1 * LDS_WK_STRIDE + koff_));   \
+            acc0 = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32_gfx12(af_, bf0_, acc0); \
+            acc1 = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32_gfx12(af_, bf1_, acc1); \
+        }                                                                             \
+    }
+
+#define PIPE_STEP(RPF, RDQ, CURB, NXTB, KS) \
+    {                                       \
+        const int ks_ = (KS);               \
+        if(ks_ + 2 < k_steps)               \
+            PREFETCH_TILE(RPF, ks_ + 2)     \
+        WMMA_FROM_LDS(CURB)                 \
+        if(ks_ + 1 < k_steps)               \
+            DEQUANT_TO_LDS(RDQ, NXTB)       \
+        __syncthreads();                    \
+    }
+
+// ─── GEMM kernel ────────────────────────────────────────────────────────────
+
+__global__ __launch_bounds__(THREADS) void gemm_a16w4_decode_fp16_kernel(
+    const fp16_raw_t* __restrict__ A,      // [M, K] fp16
+    const unsigned int* __restrict__ W_q,  // [K/8, N] int32, MAGIC-permuted
+    const fp16_raw_t* __restrict__ scales, // [K/G, N] fp16
+    const fp16_raw_t* __restrict__ zeros,  // [K/G, N] fp16, BIASED by +1024
+    float* __restrict__ workspace,         // [SPLIT_K, M, N] fp32 partials
+    int M,
+    int N,
+    int K)
+{
+    AITER_A16W4_REQUIRE_GFX1201();
+#if AITER_A16W4_DEVICE_SUPPORTED
+    const int bm          = blockIdx.x * BM;
+    const int bn          = blockIdx.y * BN;
+    const int split       = blockIdx.z;
+    const int tid         = threadIdx.x;
+    const int wave_n      = tid / 32;
+    const int lane_id     = tid % 32;
+    const int laneWrapped = lane_id % 16;
+    const int laneGroup   = lane_id / 16;
+    const int wn_start    = wave_n * WN;
+    const int my_col      = bn + tid;
+
+    const int wcol0 = wn_start + laneWrapped;
+    const int wcol1 = wcol0 + 16;
+
+    const int k_span  = K / SPLIT_K;
+    const int k_begin = split * k_span;
+    const int k_steps = k_span / BK;
+
+    __shared__ fp16_raw_t lds_buf[2][LDS_BUF_ELEMS];
+
+    frag_f32x8 acc0 = {0}, acc1 = {0};
+
+    const unsigned int* W_col = W_q + (size_t)(k_begin / 8) * N + bn + tid;
+    const fp16_raw_t* sc_base = scales + (size_t)(k_begin / GROUP_SIZE) * N;
+    const fp16_raw_t* zr_base = zeros + (size_t)(k_begin / GROUP_SIZE) * N;
+
+    const int a_row         = (tid * A_PER_THR) / BK;
+    const int a_col         = (tid * A_PER_THR) % BK;
+    const bool a_ok         = (bm + a_row) < M;
+    const int a_row_clamped = a_ok ? (bm + a_row) : 0;
+    const fp16_raw_t* a_src = A + (long)a_row_clamped * K + k_begin + a_col;
+    const int a_lds_off     = a_row * LDS_A_STRIDE + a_col;
+
+    unsigned rW0[PACKS_PER_THR], rW1[PACKS_PER_THR];
+    u16x8_t rA0, rA1;
+    fp16_raw_t rsc0, rzr0, rsc1, rzr1;
+
+    rA0 = (u16x8_t)(fp16_raw_t)0;
+    rA1 = (u16x8_t)(fp16_raw_t)0;
+
+    PREFETCH_TILE(0, 0)
+    DEQUANT_TO_LDS(0, 0)
+    if(k_steps > 1)
+        PREFETCH_TILE(1, 1)
+    __syncthreads();
+
+    for(int ks = 0; ks < k_steps; ks += 2)
+    {
+        PIPE_STEP(0, 1, 0, 1, ks)
+        PIPE_STEP(1, 0, 1, 0, ks + 1)
+    }
+
+    float* out = workspace + (size_t)split * M * N;
+#pragma unroll
+    for(int e = 0; e < 8; e++)
+    {
+        const int row = bm + e + laneGroup * 8;
+        if(row >= M)
+            continue;
+        const int c0 = bn + wcol0, c1 = bn + wcol1;
+        if(c0 < N)
+            out[(size_t)row * N + c0] = acc0[e];
+        if(c1 < N)
+            out[(size_t)row * N + c1] = acc1[e];
+    }
+#endif // AITER_A16W4_DEVICE_SUPPORTED
+}
+
+__global__ void gemm_a16w4_decode_fp16_reduce_kernel(const float* __restrict__ wsp,
+                                                     fp16_raw_t* __restrict__ C,
+                                                     int MN)
+{
+    const int i = blockIdx.x * blockDim.x + threadIdx.x;
+    if(i >= MN)
+        return;
+    float s = 0.f;
+#pragma unroll
+    for(int k = 0; k < SPLIT_K; k++)
+        s += wsp[(size_t)k * MN + i];
+    C[i] = f32_to_fp16(s);
+}
+
+constexpr int kBlockM  = BM;
+constexpr int kBlockN  = BN;
+constexpr int kBlockK  = BK;
+constexpr int kThreads = THREADS;
+constexpr int kSplitK  = SPLIT_K;
+
+} // namespace decode_fp16
+} // namespace a16w4
+} // namespace aiter
+
+#undef PIPE_STEP
+#undef WMMA_FROM_LDS
+#undef DEQUANT_TO_LDS
+#undef PREFETCH_TILE
+#undef LDS_TOTAL
+#undef LDS_BUF_ELEMS
+#undef LDS_BUF_W_ELEMS
+#undef LDS_BUF_A_ELEMS
+#undef LDS_WK_STRIDE
+#undef LDS_A_STRIDE
+#undef A_PER_THR
+#undef PACKS_PER_THR
+#undef GROUP_SIZE
+#undef THREADS
+#undef NUM_WAVES
+#undef WN
+#undef WM
+#undef BK
+#undef BN
+#undef BM
+#undef SPLIT_K

--- a/csrc/gemm_a16w4/include/gfx1201/gemm_a16w4_prefill_bf16_gfx1201.cuh
+++ b/csrc/gemm_a16w4/include/gfx1201/gemm_a16w4_prefill_bf16_gfx1201.cuh
@@ -1,0 +1,386 @@
+#pragma once
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+//
+// a16w4 PREFILL GEMM (bf16 x int4 -> bf16) for gfx1201 -- 128x32 wave tile.
+// Tile: BM=128, BN=512, BK=64 | wave 128x32 | 16 waves | 512 threads
+// grid = (M/BM, N/BN)
+//
+// =====================================================================
+// WHY THE WAVE SHAPE IS 128x32 AND NOT 64x64
+// =====================================================================
+// Both shapes have a*b = 16, so both need 128 accumulator VGPRs and both
+// give the same WMMA pipe occupancy per K-step:
+//
+//     wmma_cy = a*b*BK = 16*64 = 1024   (identical for w64x64 and w128x32)
+//
+// What differs is DEQUANT, which scales with WN and with the number of
+// wave ROWS:
+//
+//   w64x64  : BM/WM = 2 wave rows x 8 wave cols. Both rows cover the SAME
+//             512 columns, so both dequantise the SAME B tile -- the work
+//             is done twice. WN=64 => 128 elem/lane => 496 VALU/K-step.
+//
+//   w128x32 : BM/WM = 1 wave row x 16 wave cols. WM == BM, so there is no
+//             second row to repeat anything, and each wave owns a
+//             distinct 32-column slice. WN=32 => 64 elem/lane
+//             => 248 VALU/K-step.
+//
+// Halving the live B fragments (NT 4 -> 2) also drops register pressure
+// below the cliff the 64x64 version fell off. MEASURED, ROCm 7.2 / clang 21:
+//
+//     w64x64 : VGPR 256, spill 17, private 40 B, 14 scratch insns
+//     w128x32: VGPR 210, spill  0, private  0 B,  0 scratch insns
+//
+// On the older ROCm 6.1 the 64x64 shape showed VGPR 239 spill 0 and looked
+// fine -- which is exactly how it shipped and then ran at 2.53x the floor.
+//
+// =====================================================================
+// RESIDENCY DEPENDS ON -fno-slp-vectorize
+// =====================================================================
+// Two WGs need VGPR <= 192 (8 waves/SIMD sharing 1536). This tile measured
+// 210 and missed by 18. But 30 of those registers were SLP splat copies of
+// the dequant scalars. Rebuilt with -fno-slp-vectorize:
+//
+//     w128x32:  VGPR 210 -> 180, spill 0 both ways
+//
+// 180 rounds to 184 by the allocation granule, and 8 * 184 = 1472 <= 1536,
+// so this reaches 2 WG/WGP. THE FLAG IS MANDATORY, NOT A TUNING CHOICE --
+// it is set in flags_extra_hip for module_gemm_a16w4. Dropping it is a
+// measured 12% regression.
+//
+// =====================================================================
+// REGISTER DISCIPLINE (load-bearing)
+// =====================================================================
+// The KSUB loop MUST stay rolled. Unrolled, clang 21/22 hoists every
+// substep's LDS loads and dequants and spills ~100 registers to scratch,
+// reloading the A fragment between WMMA groups at ~200 cy each -- 27% of
+// all stall in an ATT trace of the 64x64 version. ROCm 6.1 does NOT do
+// this, so a local 6.1 build proves nothing.
+//
+// ALWAYS CHECK ON THE TARGET TOOLCHAIN, AND CHECK ALL THREE:
+//   grep -E 'vgpr_count|vgpr_spill_count|private_segment_fixed_size' x.s
+//   grep -c 'scratch_' x.s
+// vgpr_spill_count alone reads 0 on a build that is spilling into
+// private_segment.
+
+#include "gfx1201/gemm_a16w4_common_gfx1201.cuh"
+
+#define BM 128
+#define BN 512
+#define BK 64
+#define WM 128
+#define WN 32
+
+#define WAVES_M (BM / WM)             // 1  <- the point: no repeated dequant
+#define WAVES_N (BN / WN)             // 16
+#define NUM_WAVES (WAVES_M * WAVES_N) // 16
+#define THREADS (NUM_WAVES * 32)      // 512
+#define GROUP_SIZE 128
+
+#define MT (WM / 16)  // 8 m-tiles per wave
+#define NT (WN / 16)  // 2 n-tiles per wave
+#define KSUB (BK / 16) // 4 k-substeps per K-step
+#define KPACK (BK / 8) // 8 int32 per column per K-step
+
+// Padded LDS strides, SINGLE buffered.
+//   A: stride 72 bf16 = 144 B = 9 x 16 B. gcd(9,8)=1 so the b128 fragment
+//      reads across the 16 lanes of a group hit distinct wide banks.
+//   W: stride 9 int32. 9n mod 32 is distinct for n = 0..15.
+#define LDS_A_STRIDE (BK + 8)           // 72 bf16
+#define LDS_W_STRIDE (KPACK + 1)        // 9 int32
+#define LDS_A_ELEMS (BM * LDS_A_STRIDE) // 9216 bf16 = 18432 B
+#define LDS_W_ELEMS (BN * LDS_W_STRIDE) // 4608 int32 = 18432 B
+// Total = 36864 B = 36 KB (double buffering would be 72 KB and NOT fit)
+
+#define A_PER_THR ((BM * BK) / THREADS) // 16 bf16 = 32 B = 2 x b128
+
+// AGROUP = how many A fragments are issued as a batch before their single
+// s_wait_dscnt drain. MEASURED, 4096x5120x5120, gfx1201:
+//
+//   AGROUP  VGPR  drains  WG/WGP     time     TFLOPS
+//     1      184      19       2   1752.2 us   122.6   <- DEFAULT, use this
+//     2      190      13       2   1737.9 us   123.6      +0.8%, inside spread
+//     4      206       9       1   1964.7 us   109.3      -12%
+//     8      214       3       1   1882.1 us   114.1      -7%
+//
+// GROUPING IS A SUBSTITUTE FOR OCCUPANCY, NOT AN ADDITION TO IT. The second
+// resident workgroup already runs through the drain stalls, so removing them
+// wins only where there is no second workgroup. THE BUDGET IS 8 REGISTERS,
+// NOT 72: AGROUP=2 at 190 leaves 2 registers of margin against the 192
+// ceiling, which will not survive a compiler update, for a gain inside the
+// measurement spread.
+#ifndef AGROUP
+#define AGROUP 1
+#endif
+
+namespace aiter {
+namespace a16w4 {
+namespace prefill_bf16 {
+
+static_assert(MT % AGROUP == 0, "AGROUP must divide MT");
+static_assert(GROUP_SIZE % BK == 0, "GROUP_SIZE must be a multiple of BK");
+
+// One packed int32 == 8 consecutive k for one column, which is EXACTLY the
+// 8 elements a lane needs for a 16x16x16 B fragment.
+__device__ __forceinline__ frag_bf16x8 dequant8(unsigned packed, float sc, float zs)
+{
+    u16x8_t o;
+#pragma unroll
+    for(int j = 0; j < 8; j++)
+        o[j] = f32_to_bf16(fmaf((float)((packed >> (j * 4)) & 0xF), sc, zs));
+    return as_bf16x8(o);
+}
+
+// ─── Pipeline stages ────────────────────────────────────────────────────────
+
+// Issued at the top of the read phase, consumed by STORE_LDS at the bottom
+// of the SAME iteration -- one whole WMMA phase later. Nothing loaded here
+// may be used here.
+#define PREFETCH(KS)                                             \
+    {                                                            \
+        const int k0_             = (KS)*BK;                     \
+        const bf16_raw_t* as_     = A + (size_t)a_row * K + k0_ + a_col; \
+        rA0                       = *(const u16x8_t*)(as_);      \
+        rA1                       = *(const u16x8_t*)(as_ + 8);  \
+        const unsigned* ws_       = W_q + (size_t)(k0_ / 8) * N + w_col; \
+        _Pragma("unroll") for(int p = 0; p < KPACK; p++) rW[p] = ws_[(size_t)p * N]; \
+    }
+
+// W lands in LDS STILL PACKED. Dequant happens per wave, in registers,
+// inside WMMA_STEP -- that is what keeps LDS at 36 KB.
+#define STORE_LDS()                                                     \
+    {                                                                   \
+        *(u16x8_t*)(&lds_a[a_lds_off])     = rA0;                       \
+        *(u16x8_t*)(&lds_a[a_lds_off + 8]) = rA1;                       \
+        unsigned* wd_                      = &lds_w[w_lds_off];         \
+        _Pragma("unroll") for(int p = 0; p < KPACK; p++) wd_[p] = rW[p]; \
+    }
+
+// At AGROUP = 1 the scheduling hints are pure cost: there is nothing to
+// group, but they still pin the schedule and measured +10 VGPR.
+// 0x100 = DS read, 0x008 = MFMA/WMMA.
+#if AGROUP > 1
+#define SCHED_A_GROUP()                                             \
+    do                                                              \
+    {                                                               \
+        __builtin_amdgcn_sched_group_barrier(0x100, AGROUP, 0);     \
+        __builtin_amdgcn_sched_group_barrier(0x008, AGROUP* NT, 0); \
+    } while(0)
+#else
+#define SCHED_A_GROUP() \
+    do                  \
+    {                   \
+    } while(0)
+#endif
+
+// THE KSUB LOOP MUST STAY ROLLED -- see the header. Rolled, only ONE
+// substep is live: NT B-fragments + AGROUP streamed A-fragments. B is the
+// hoisted operand because it is the one that costs a dequant; re-deriving
+// it per i would multiply VALU by MT = 8.
+#define WMMA_STEP(SC)                                                              \
+    {                                                                              \
+        _Pragma("unroll 1") for(int s = 0; s < KSUB; s++)                          \
+        {                                                                          \
+            frag_bf16x8 bf_[NT];                                                   \
+            _Pragma("unroll") for(int j = 0; j < NT; j++) bf_[j] = dequant8(       \
+                lds_w[(n_base + j * 16) * LDS_W_STRIDE + 2 * s + laneGroup],       \
+                sc_f[SC][j],                                                       \
+                zs_f[SC][j]);                                                      \
+            _Pragma("unroll") for(int g = 0; g < MT / AGROUP; g++)                 \
+            {                                                                      \
+                frag_bf16x8 af_[AGROUP];                                           \
+                _Pragma("unroll") for(int a = 0; a < AGROUP; a++) af_[a] =         \
+                    as_bf16x8(*(const u16x8_t*)(&lds_a[(m_base + (g * AGROUP + a) * 16) * \
+                                                           LDS_A_STRIDE +          \
+                                                       s * 16 + laneGroup * 8]));  \
+                _Pragma("unroll") for(int a = 0; a < AGROUP; a++)                  \
+                    _Pragma("unroll") for(int j = 0; j < NT; j++) acc[g * AGROUP + a][j] = \
+                        __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(         \
+                            af_[a], bf_[j], acc[g * AGROUP + a][j]);               \
+                SCHED_A_GROUP();                                                   \
+            }                                                                      \
+        }                                                                          \
+    }
+
+// SC is the buffer being FILLED, not the one consumed now. One base pointer
+// plus immediate offsets -- an address per n-tile costs ~16 VGPRs of pure
+// addressing, which shows up in a trace as v_add_co_u32 pairs before every
+// scale load.
+#define LOAD_SCALES(SC, KS)                                                     \
+    {                                                                           \
+        const size_t goff_     = (size_t)(((KS)*BK) / GROUP_SIZE) * N + n_col0; \
+        const bf16_raw_t* sp_  = scales + goff_;                                \
+        const bf16_raw_t* zp_  = zeros + goff_;                                 \
+        _Pragma("unroll") for(int j = 0; j < NT; j++)                           \
+        {                                                                       \
+            const float s_ = bf16_to_f32(sp_[j * 16]);                          \
+            sc_f[SC][j]    = s_;                                                \
+            zs_f[SC][j]    = -bf16_to_f32(zp_[j * 16]) * s_;                    \
+        }                                                                       \
+    }
+
+// Single-buffered step: read phase, drain readers, write phase, drain
+// writers. Both barriers are mandatory with one buffer.
+// NOTE both __syncthreads() are UNCONDITIONAL. STORE_LDS() expands to a
+// braced block, so `if(more_) STORE_LDS()` ends at the closing brace and the
+// barrier below it is reached by every thread. Making the second barrier
+// conditional would deadlock on the final K-step.
+#define PIPE_STEP(SC_CUR, SC_NXT, KS)                      \
+    {                                                      \
+        const int ks_    = (KS);                           \
+        const bool more_ = (ks_ + 1 < k_steps);            \
+        if(more_)                                          \
+        {                                                  \
+            PREFETCH(ks_ + 1) LOAD_SCALES(SC_NXT, ks_ + 1) \
+        }                                                  \
+        WMMA_STEP(SC_CUR)                                  \
+        __syncthreads();                                   \
+        if(more_)                                          \
+            STORE_LDS()                                    \
+        __syncthreads();                                   \
+    }
+
+// ─── Kernel ─────────────────────────────────────────────────────────────────
+
+__global__ __launch_bounds__(THREADS) void gemm_a16w4_prefill_bf16_kernel(
+    const bf16_raw_t* __restrict__ A,     // [M, K] bf16
+    const unsigned int* __restrict__ W_q, // [K/8, N] int32, packed along K
+    const bf16_raw_t* __restrict__ scales, // [K/G, N] bf16
+    const bf16_raw_t* __restrict__ zeros,  // [K/G, N] bf16
+    bf16_raw_t* __restrict__ C,            // [M, N] bf16
+    int M,
+    int N,
+    int K)
+{
+    AITER_A16W4_REQUIRE_GFX1201();
+#if AITER_A16W4_DEVICE_SUPPORTED
+    // M unused: supported() enforces M % BM == 0, so every row this workgroup
+    // writes is in range. A ragged-M path would need a predicate.
+    (void)M;
+    const int bm          = blockIdx.x * BM;
+    const int bn          = blockIdx.y * BN;
+    const int tid         = threadIdx.x;
+    const int wave        = tid / 32;
+    const int lane        = tid % 32;
+    const int laneWrapped = lane % 16;
+    const int laneGroup   = lane / 16;
+
+    // WAVES_M == 1, so wave_m is always 0 and every wave owns the full BM
+    // rows and a distinct 32-column slice.
+    const int wave_n = wave % WAVES_N; // 0..15
+
+    // BOTH bases carry laneWrapped. For wmma_*_w32 the lane's free index is
+    // lane%16 on BOTH operands: A gives lane A[m][k] with m = lane%16, B
+    // gives lane B[k][n] with n = lane%16, and laneGroup picks the k-half on
+    // both. Dropping it from B collapses the B tile to 16 identical columns
+    // and reads as cosine ~0.51 rather than as a crash.
+    const int m_base = laneWrapped;
+    const int n_base = wave_n * WN + laneWrapped;
+    // First global column this lane owns; the other n-tile is +16. Must
+    // agree with n_base, or the right scale lands on the wrong weights.
+    const int n_col0 = bn + n_base;
+
+    // ---- staging assignments, hoisted out of the loop ----
+    // A: 128 rows x 4 chunks of 16 bf16 = 512 threads, 2 x b128 each.
+    // LDS byte offset 144*a_m + 2*a_col is 16 B aligned since 144 = 9*16.
+    const int a_m       = tid / (BK / A_PER_THR);
+    const int a_col     = (tid % (BK / A_PER_THR)) * A_PER_THR;
+    const int a_row     = bm + a_m;
+    const int a_lds_off = a_m * LDS_A_STRIDE + a_col;
+    // W: BN == THREADS, so thread t owns exactly column t. Each of the KPACK
+    // loads is strided by N in global, which is coalesced ACROSS the wave
+    // (32 lanes x 4 B = one 128 B line).
+    const int w_col     = bn + tid;
+    const int w_lds_off = tid * LDS_W_STRIDE;
+
+    __shared__ bf16_raw_t lds_a[LDS_A_ELEMS];
+    __shared__ unsigned lds_w[LDS_W_ELEMS];
+
+    frag_f32x8 acc[MT][NT];
+#pragma unroll
+    for(int i = 0; i < MT; i++)
+#pragma unroll
+        for(int j = 0; j < NT; j++)
+            acc[i][j] = (frag_f32x8)0.f;
+
+    float sc_f[2][NT], zs_f[2][NT];
+    u16x8_t rA0, rA1;
+    unsigned rW[KPACK];
+
+    const int k_steps = K / BK;
+
+    PREFETCH(0)
+    STORE_LDS()
+    LOAD_SCALES(0, 0)
+    __syncthreads();
+
+    // Unrolled x2 only so the scale buffer index is a compile-time constant.
+    for(int ks = 0; ks < k_steps; ks += 2)
+    {
+        PIPE_STEP(0, 1, ks)
+        PIPE_STEP(1, 0, ks + 1)
+    }
+
+    // ---- epilogue ----
+    // For a 16x16 D tile in w32: lane holds D[m][n] with n = lane%16 and
+    // m = (lane/16)*8 + e. NOTE this INVERTS the input convention -- the m
+    // that came from lane%16 on the A operand arrives from lane/16 here.
+#pragma unroll
+    for(int i = 0; i < MT; i++)
+    {
+        const int row = bm + i * 16 + laneGroup * 8;
+#pragma unroll
+        for(int j = 0; j < NT; j++)
+        {
+            const int col = n_col0 + j * 16;
+#pragma unroll
+            for(int e = 0; e < 8; e++)
+                C[(size_t)(row + e) * N + col] = f32_to_bf16(acc[i][j][e]);
+        }
+    }
+#endif // AITER_A16W4_DEVICE_SUPPORTED
+}
+
+// Tile geometry, re-exported so the host side can keep using it after the
+// macros below are undefined.
+constexpr int kBlockM  = BM;
+constexpr int kBlockN  = BN;
+constexpr int kBlockK  = BK;
+constexpr int kThreads = THREADS;
+
+} // namespace prefill_bf16
+} // namespace a16w4
+} // namespace aiter
+
+// Undefined so several a16w4 kernel headers can coexist in one translation
+// unit: every one of these names is redefined with a different value by the
+// decode header.
+#undef PIPE_STEP
+#undef LOAD_SCALES
+#undef WMMA_STEP
+#undef SCHED_A_GROUP
+#undef STORE_LDS
+#undef PREFETCH
+// AGROUP is deliberately NOT undefined: it is an #ifndef override knob, and
+// dropping it here would silently ignore a -DAGROUP passed to the build for
+// every header included after this one.
+#undef A_PER_THR
+#undef LDS_W_ELEMS
+#undef LDS_A_ELEMS
+#undef LDS_W_STRIDE
+#undef LDS_A_STRIDE
+#undef KPACK
+#undef KSUB
+#undef NT
+#undef MT
+#undef GROUP_SIZE
+#undef THREADS
+#undef NUM_WAVES
+#undef WAVES_N
+#undef WAVES_M
+#undef WN
+#undef WM
+#undef BK
+#undef BN
+#undef BM

--- a/csrc/gemm_a16w4/include/gfx1201/gemm_a16w4_prefill_fp16_gfx1201.cuh
+++ b/csrc/gemm_a16w4/include/gfx1201/gemm_a16w4_prefill_fp16_gfx1201.cuh
@@ -1,0 +1,314 @@
+#pragma once
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+//
+// a16w4 PREFILL GEMM (fp16 x int4 -> fp16) for gfx1201 -- bit-magic dequant.
+// Tile: BM=128, BN=512, BK=64 | wave 128x32 | 16 waves | 512 threads
+// grid = (M/BM, N/BN)
+//
+// Same tile and same pipeline as the bf16 prefill kernel; the only change is
+// the dequant, which uses the fp16 bit-magic instead of an int->float convert
+// plus fma. gfx1201 has NO bf16 ALU (v_pk_add_bf16 / v_pk_mul_bf16 /
+// v_pk_fma_bf16 are all absent from the ISA), so the packed-math path only
+// exists for fp16 -- which is also what the AWQ checkpoints this targets
+// actually ship (Qwen3-32B-AWQ config.json says torch_dtype: float16).
+//
+// TWO HOST-SIDE INVARIANTS, BOTH OF WHICH FAIL SILENTLY IF VIOLATED:
+//   * the nibble for row k must sit at bit p(k) = 4*(k>>1) + 16*(k&1), so the
+//     four extractions j = 0..3 yield k = 0..7 in order. This is a DIFFERENT
+//     packing from the bf16 kernels and the two are NOT interchangeable;
+//   * `zeros` must arrive with +1024 already added.
+// aiter/ops/gemm_op_a16w4.py owns both conversions.
+//
+// BUILD FLAG: -fno-slp-vectorize is kept for parity with the bf16 prefill
+// build. It is less critical here -- the packed-fp16 dequant has no scalar
+// broadcast for SLP to splat -- but this kernel sits at 184 VGPR against a
+// 192 ceiling for 2 workgroups per WGP, so there is no headroom to gamble
+// with and the flag costs nothing.
+
+#include "gfx1201/gemm_a16w4_common_gfx1201.cuh"
+
+#define BM 128
+#define BN 512
+#define BK 64
+#define WM 128
+#define WN 32
+
+#define WAVES_M (BM / WM)             // 1  <- no repeated dequant
+#define WAVES_N (BN / WN)             // 16
+#define NUM_WAVES (WAVES_M * WAVES_N) // 16
+#define THREADS (NUM_WAVES * 32)      // 512
+#define GROUP_SIZE 128
+
+#define MT (WM / 16)   // 8 m-tiles per wave
+#define NT (WN / 16)   // 2 n-tiles per wave
+#define KSUB (BK / 16) // 4 k-substeps per K-step
+#define KPACK (BK / 8) // 8 int32 per column per K-step
+
+#define LDS_A_STRIDE (BK + 8)           // 72 fp16
+#define LDS_W_STRIDE (KPACK + 1)        // 9 int32
+#define LDS_A_ELEMS (BM * LDS_A_STRIDE) // 9216 fp16 = 18432 B
+#define LDS_W_ELEMS (BN * LDS_W_STRIDE) // 4608 int32 = 18432 B
+// Total = 36864 B = 36 KB
+
+#define A_PER_THR ((BM * BK) / THREADS) // 16 fp16 = 32 B = 2 x b128
+
+#ifndef AGROUP
+#define AGROUP 1
+#endif
+
+namespace aiter {
+namespace a16w4 {
+namespace prefill_fp16 {
+
+static_assert(MT % AGROUP == 0, "AGROUP must divide MT");
+// A K-step must lie inside one quantisation group, or one WMMA_STEP would
+// need two different scales for the same B fragment.
+static_assert(GROUP_SIZE % BK == 0, "GROUP_SIZE must be a multiple of BK");
+
+// One packed int32 (8 pre-permuted nibbles) -> 8 dequantised fp16, in k order.
+// No cvt, no perm: the OR with 0x6400 IS the int->float conversion.
+//
+// SUBTRACT BEFORE SCALING. THIS ORDER IS NOT NEGOTIABLE.
+//   fused form   (1024+n)*s + (-(1024+z)*s)   -- ONE v_pk_fma_f16, BUT WRONG
+//   correct form ((1024+n) - (1024+z)) * s    -- pk_add + pk_mul
+// The fused form subtracts two quantities of magnitude ~1024*s to produce a
+// result of magnitude ~15*s, amplifying fp16's 2^-11 relative error by
+// 1024/15 ~= 68 to about 3.3%. Measured: cosine 0.99944, max_err 0.53,
+// 37% of elements over 5% error. It looks "almost right", which is the
+// worst way for a kernel to be wrong.
+//
+// The correct form is EXACT in the subtraction: both operands lie in the
+// binade [1024, 2048), so by Sterbenz's lemma their fp16 difference is
+// representable with no rounding at all. The integer n - z in [-15, 15]
+// comes out bit-exact, and the single multiply by s is the ONLY rounding.
+__device__ __forceinline__ f16x8 dequant8_magic(unsigned packed, f16x2 sc2, f16x2 zm2)
+{
+    u32x4_t o;
+#pragma unroll
+    for(int j = 0; j < 4; j++)
+    {
+        const unsigned bits = ((packed >> (4 * j)) & kNibMask) | kF16Magic;
+        // v_pk_add_f16 (exact) then v_pk_mul_f16. Written as (a-b)*c so that
+        // -ffp-contract=fast cannot refactor it back into the fused form.
+        o[j] = as_u32((as_f16x2(bits) - zm2) * sc2);
+    }
+    return as_f16x8_u32x4(o);
+}
+
+// ─── Pipeline stages ────────────────────────────────────────────────────────
+
+#define PREFETCH(KS)                                                                 \
+    {                                                                                \
+        const int k0_         = (KS)*BK;                                             \
+        const fp16_raw_t* as_ = A + (size_t)a_row * K + k0_ + a_col;                 \
+        rA0                   = *(const u16x8_t*)(as_);                              \
+        rA1                   = *(const u16x8_t*)(as_ + 8);                          \
+        const unsigned* ws_   = W_q + (size_t)(k0_ / 8) * N + w_col;                 \
+        _Pragma("unroll") for(int p = 0; p < KPACK; p++) rW[p] = ws_[(size_t)p * N]; \
+    }
+
+// W lands in LDS STILL PACKED; dequant is per wave, in registers, inside
+// WMMA_STEP. That is what keeps LDS at 36 KB rather than 4x that.
+#define STORE_LDS()                                                     \
+    {                                                                   \
+        *(u16x8_t*)(&lds_a[a_lds_off])     = rA0;                       \
+        *(u16x8_t*)(&lds_a[a_lds_off + 8]) = rA1;                       \
+        unsigned* wd_                      = &lds_w[w_lds_off];         \
+        _Pragma("unroll") for(int p = 0; p < KPACK; p++) wd_[p] = rW[p]; \
+    }
+
+#if AGROUP > 1
+#define SCHED_A_GROUP()                                             \
+    do                                                              \
+    {                                                               \
+        __builtin_amdgcn_sched_group_barrier(0x100, AGROUP, 0);     \
+        __builtin_amdgcn_sched_group_barrier(0x008, AGROUP* NT, 0); \
+    } while(0)
+#else
+#define SCHED_A_GROUP() \
+    do                  \
+    {                   \
+    } while(0)
+#endif
+
+// THE KSUB LOOP MUST STAY ROLLED. Unrolled, clang 21/22 hoists every
+// substep's fragments and spills ~100 registers to scratch. ROCm 6.1 does
+// NOT reproduce this, so a 6.1 build proves nothing.
+#define WMMA_STEP(SC)                                                                      \
+    {                                                                                      \
+        _Pragma("unroll 1") for(int s = 0; s < KSUB; s++)                                  \
+        {                                                                                  \
+            f16x8 bf_[NT];                                                                 \
+            _Pragma("unroll") for(int j = 0; j < NT; j++) bf_[j] = dequant8_magic(         \
+                lds_w[(n_base + j * 16) * LDS_W_STRIDE + 2 * s + laneGroup],               \
+                sc2_f[SC][j],                                                              \
+                zm2_f[SC][j]);                                                             \
+            _Pragma("unroll") for(int g = 0; g < MT / AGROUP; g++)                         \
+            {                                                                              \
+                f16x8 af_[AGROUP];                                                         \
+                _Pragma("unroll") for(int a = 0; a < AGROUP; a++) af_[a] =                 \
+                    as_f16x8(*(const u16x8_t*)(&lds_a[(m_base + (g * AGROUP + a) * 16) *   \
+                                                          LDS_A_STRIDE +                   \
+                                                      s * 16 + laneGroup * 8]));           \
+                _Pragma("unroll") for(int a = 0; a < AGROUP; a++)                          \
+                    _Pragma("unroll") for(int j = 0; j < NT; j++) acc[g * AGROUP + a][j] = \
+                        __builtin_amdgcn_wmma_f32_16x16x16_f16_w32_gfx12(                  \
+                            af_[a], bf_[j], acc[g * AGROUP + a][j]);                       \
+                SCHED_A_GROUP();                                                           \
+            }                                                                              \
+        }                                                                                  \
+    }
+
+// SC is the buffer being FILLED, not the one consumed now. The scale and the
+// (already +1024-biased) zero are broadcast into both halves ONCE per K-step,
+// so the inner loop sees them as ready packed operands. Both are used as raw
+// fp16 -- no unpack to f32, no folding of the scale into the zero (see the
+// Sterbenz note on dequant8_magic for why that folding is forbidden).
+#define LOAD_SCALES(SC, KS)                                                            \
+    {                                                                                  \
+        const size_t goff_    = (size_t)(((KS)*BK) / GROUP_SIZE) * N + n_col0;         \
+        const fp16_raw_t* sp_ = scales + goff_;                                        \
+        const fp16_raw_t* zp_ = zeros + goff_;                                         \
+        _Pragma("unroll") for(int j = 0; j < NT; j++)                                  \
+        {                                                                              \
+            sc2_f[SC][j] = as_f16x2((unsigned)sp_[j * 16] * 0x00010001u);              \
+            zm2_f[SC][j] = as_f16x2((unsigned)zp_[j * 16] * 0x00010001u);              \
+        }                                                                              \
+    }
+
+// Both __syncthreads() are UNCONDITIONAL -- STORE_LDS() expands to a braced
+// block, so the barrier after it is reached by every thread.
+#define PIPE_STEP(SC_CUR, SC_NXT, KS)                      \
+    {                                                      \
+        const int ks_    = (KS);                           \
+        const bool more_ = (ks_ + 1 < k_steps);            \
+        if(more_)                                          \
+        {                                                  \
+            PREFETCH(ks_ + 1) LOAD_SCALES(SC_NXT, ks_ + 1) \
+        }                                                  \
+        WMMA_STEP(SC_CUR)                                  \
+        __syncthreads();                                   \
+        if(more_)                                          \
+            STORE_LDS()                                    \
+        __syncthreads();                                   \
+    }
+
+// ─── Kernel ─────────────────────────────────────────────────────────────────
+
+__global__ __launch_bounds__(THREADS) void gemm_a16w4_prefill_fp16_kernel(
+    const fp16_raw_t* __restrict__ A,      // [M, K] fp16
+    const unsigned int* __restrict__ W_q,  // [K/8, N] int32, MAGIC-permuted
+    const fp16_raw_t* __restrict__ scales, // [K/G, N] fp16
+    const fp16_raw_t* __restrict__ zeros,  // [K/G, N] fp16, BIASED by +1024
+    fp16_raw_t* __restrict__ C,            // [M, N] fp16
+    int M,
+    int N,
+    int K)
+{
+    AITER_A16W4_REQUIRE_GFX1201();
+#if AITER_A16W4_DEVICE_SUPPORTED
+    (void)M; // supported() enforces M % BM == 0
+    const int bm          = blockIdx.x * BM;
+    const int bn          = blockIdx.y * BN;
+    const int tid         = threadIdx.x;
+    const int wave        = tid / 32;
+    const int lane        = tid % 32;
+    const int laneWrapped = lane % 16;
+    const int laneGroup   = lane / 16;
+
+    const int wave_n = wave % WAVES_N;
+
+    // BOTH bases carry laneWrapped. For wmma_*_w32 the lane's free index is
+    // lane%16 on BOTH operands. Dropping it from B collapses the B tile to 16
+    // identical columns and reads as cosine ~0.51 rather than as a crash.
+    const int m_base = laneWrapped;
+    const int n_base = wave_n * WN + laneWrapped;
+    const int n_col0 = bn + n_base;
+
+    const int a_m       = tid / (BK / A_PER_THR);
+    const int a_col     = (tid % (BK / A_PER_THR)) * A_PER_THR;
+    const int a_row     = bm + a_m;
+    const int a_lds_off = a_m * LDS_A_STRIDE + a_col;
+    const int w_col     = bn + tid;
+    const int w_lds_off = tid * LDS_W_STRIDE;
+
+    __shared__ fp16_raw_t lds_a[LDS_A_ELEMS];
+    __shared__ unsigned lds_w[LDS_W_ELEMS];
+
+    frag_f32x8 acc[MT][NT];
+#pragma unroll
+    for(int i = 0; i < MT; i++)
+#pragma unroll
+        for(int j = 0; j < NT; j++)
+            acc[i][j] = (frag_f32x8)0.f;
+
+    f16x2 sc2_f[2][NT], zm2_f[2][NT];
+    u16x8_t rA0, rA1;
+    unsigned rW[KPACK];
+
+    const int k_steps = K / BK;
+
+    PREFETCH(0)
+    STORE_LDS()
+    LOAD_SCALES(0, 0)
+    __syncthreads();
+
+    for(int ks = 0; ks < k_steps; ks += 2)
+    {
+        PIPE_STEP(0, 1, ks)
+        PIPE_STEP(1, 0, ks + 1)
+    }
+
+    // For a 16x16 D tile in w32: lane holds D[m][n] with n = lane%16 and
+    // m = (lane/16)*8 + e. NOTE this INVERTS the input convention.
+#pragma unroll
+    for(int i = 0; i < MT; i++)
+    {
+        const int row = bm + i * 16 + laneGroup * 8;
+#pragma unroll
+        for(int j = 0; j < NT; j++)
+        {
+            const int col = n_col0 + j * 16;
+#pragma unroll
+            for(int e = 0; e < 8; e++)
+                C[(size_t)(row + e) * N + col] = f32_to_fp16(acc[i][j][e]);
+        }
+    }
+#endif // AITER_A16W4_DEVICE_SUPPORTED
+}
+
+constexpr int kBlockM  = BM;
+constexpr int kBlockN  = BN;
+constexpr int kBlockK  = BK;
+constexpr int kThreads = THREADS;
+
+} // namespace prefill_fp16
+} // namespace a16w4
+} // namespace aiter
+
+#undef PIPE_STEP
+#undef LOAD_SCALES
+#undef WMMA_STEP
+#undef SCHED_A_GROUP
+#undef STORE_LDS
+#undef PREFETCH
+#undef A_PER_THR
+#undef LDS_W_ELEMS
+#undef LDS_A_ELEMS
+#undef LDS_W_STRIDE
+#undef LDS_A_STRIDE
+#undef KPACK
+#undef KSUB
+#undef NT
+#undef MT
+#undef GROUP_SIZE
+#undef THREADS
+#undef NUM_WAVES
+#undef WAVES_N
+#undef WAVES_M
+#undef WN
+#undef WM
+#undef BK
+#undef BN
+#undef BM

--- a/csrc/include/gemm_a16w4.h
+++ b/csrc/include/gemm_a16w4.h
@@ -1,0 +1,45 @@
+#pragma once
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+#include "aiter_tensor.h"
+
+#include <cstdint>
+#include <string>
+
+namespace aiter {
+
+// Dense weight-only int4 GEMM:  out = x @ dequant(weight)
+//
+//   x          [M, K]        bf16 or fp16
+//   weight     [K/8, N]      i32, 8 int4 nibbles of ONE column packed along K
+//   scales     [K/128, N]    same dtype as x
+//   zeros      [K/128, N]    same dtype as x
+//   out        [M, N]        same dtype as x, preallocated by the caller
+//   workspace  [>= n]        fp32 scratch, n = gemm_a16w4_workspace_elems(...)
+//
+// dequant(weight)[k, n] = (nibble(k, n) - zeros[k/128, n]) * scales[k/128, n]
+//
+// The fp16 path uses a bit-magic dequant and needs a DIFFERENT weight
+// bit order plus zeros pre-biased by +1024; aiter/ops/gemm_op_a16w4.py owns
+// both conversions. The two weight layouts are not interchangeable and
+// nothing downstream can detect a mix-up, so the dtype of `x` is the only
+// switch.
+//
+// gfx1201 (Navi 48) only -- raises on any other architecture.
+void gemm_a16w4(aiter_tensor_t x,
+                aiter_tensor_t weight,
+                aiter_tensor_t scales,
+                aiter_tensor_t zeros,
+                aiter_tensor_t out,
+                aiter_tensor_t workspace);
+
+// "" when (M, N, K) is supported, otherwise the constraint that failed.
+// Pure host arithmetic; safe to cache on the Python side.
+std::string gemm_a16w4_unsupported_reason(int64_t M, int64_t N, int64_t K, bool is_fp16);
+
+// fp32 workspace elements gemm_a16w4() needs for this shape. 0 for shapes
+// that take the prefill path, which has no split-K and no scratch.
+int64_t gemm_a16w4_workspace_elems(int64_t M, int64_t N, int64_t K, bool is_fp16);
+
+} // namespace aiter

--- a/csrc/include/rocm_ops.hpp
+++ b/csrc/include/rocm_ops.hpp
@@ -749,6 +749,34 @@ namespace py = pybind11;
           py::arg("kernelName")  = std::nullopt, \
           py::arg("bpreshuffle") = false);
 
+#define GEMM_A16W4_PYBIND                                                          \
+    m.def("gemm_a16w4",                                                            \
+          &aiter::gemm_a16w4,                                                      \
+          "Dense weight-only int4 GEMM (bf16/fp16 x int4 -> bf16/fp16), gfx1201. " \
+          "`weight` is [K/8, N] int32 packed along K; `scales`/`zeros` are "       \
+          "[K/128, N]. The fp16 path expects MAGIC-permuted weights and "          \
+          "+1024-biased zeros -- see aiter/ops/gemm_op_a16w4.py.",                 \
+          py::arg("x"),                                                            \
+          py::arg("weight"),                                                       \
+          py::arg("scales"),                                                       \
+          py::arg("zeros"),                                                        \
+          py::arg("out"),                                                          \
+          py::arg("workspace"));                                                   \
+    m.def("gemm_a16w4_unsupported_reason",                                         \
+          &aiter::gemm_a16w4_unsupported_reason,                                   \
+          "Empty string if (M, N, K) is supported, else the failing constraint.",  \
+          py::arg("M"),                                                            \
+          py::arg("N"),                                                            \
+          py::arg("K"),                                                            \
+          py::arg("is_fp16"));                                                     \
+    m.def("gemm_a16w4_workspace_elems",                                            \
+          &aiter::gemm_a16w4_workspace_elems,                                      \
+          "fp32 workspace elements gemm_a16w4 needs; 0 on the prefill path.",      \
+          py::arg("M"),                                                            \
+          py::arg("N"),                                                            \
+          py::arg("K"),                                                            \
+          py::arg("is_fp16"));
+
 #define GEMM_A4W4_BLOCKSCALE_PYBIND  \
     m.def("gemm_a4w4_blockscale",    \
           &gemm_a4w4_blockscale,     \

--- a/csrc/pybind/gemm_a16w4_pybind.cu
+++ b/csrc/pybind/gemm_a16w4_pybind.cu
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+#include "rocm_ops.hpp"
+
+#include "aiter_stream.h"
+#include "gemm_a16w4.h"
+
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, m)
+{
+    AITER_SET_STREAM_PYBIND
+    GEMM_A16W4_PYBIND;
+}

--- a/op_tests/test_gemm_a16w4.py
+++ b/op_tests/test_gemm_a16w4.py
@@ -1,0 +1,524 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+"""
+Dense a16w4 GEMM benchmarks on gfx1201 (Radeon AI PRO R9700).
+
+TWO SWEEPS, TWO TABLES
+======================
+The op has two tiles with opposite characters, so they get separate sweeps
+rather than one table that averages them into nonsense:
+
+    prefill   M >= 512   compute bound, BM128 BN512 BK64, no split-K
+    decode    M <=  64   memory bound,  BM16 BN128 BK64, grid split-K=2
+
+M in [65, 511] is DELIBERATELY NOT SWEPT. Neither tile covers it: prefill's
+grid is (M/128, N/512), so below M=512 it runs too few workgroups to fill the
+part, and decode's cost grows linearly in M because BM=16. The C++ dispatch
+splits the range at M=256 (kPrefillMinM) as damage control, but both halves
+are off their tuned regime -- at M=128 the vLLM Triton W4A16 kernel is still
+1.25x faster. A third tile is the fix; until it lands, benchmarking that range
+would only publish a number nobody has optimised.
+
+WHAT THE CANDIDATES MEAN
+========================
+    a16w4                  the op under test
+    vllm_triton_w4a16      THE COMPARISON THAT MATTERS -- vLLM's Triton W4A16
+                           kernel, the thing gemm_a16w4 replaces in
+                           production. Vendored verbatim (see the attribution
+                           block below); same nibbles, same symmetric zero
+                           point, same output dtype, so the only differences
+                           are the weight packing and the kernel itself.
+    torch_a16w16_ceiling   F.linear on the SAME weights, dequantized to 16-bit
+                           beforehand -> hipBLASLt. A CEILING, NOT A
+                           COMPETITOR: it reads 4x the weight bytes and does
+                           no dequant at all, so at large M -- where the GEMM
+                           is compute bound -- matching it is the best a
+                           weight-only kernel can do, since it is doing
+                           strictly more work for the same FLOPs. Kept only to
+                           bound the remaining headroom.
+    triton_a16w16          aiter's Triton dense GEMM, when a tuned config for
+                           the running arch exists (there is none for gfx1201
+                           today, so it is normally skipped)
+
+`TB/s` is reported per candidate against its own byte count: 16-bit weights
+for the ceiling, 4-bit + scales for Triton (HAS_ZP=False folds the zero point
+into a constant), 4-bit + scales + zeros for a16w4.
+
+The whole file is gated on gfx1201 and exits early elsewhere: the op is
+RDNA4-only, and a table of just the baselines on another card would say
+nothing about it.
+
+QUANTIZATION MODEL (identical for every candidate and the reference)
+====================================================================
+    nibbles [K, N]        uint8, values 0..15
+    scales  [K/G, N]      fp16/bf16
+    zeros   [K/G, N]      fp16/bf16, constant ZP=8 (symmetric), matching what
+                          an AWQ checkpoint with a symmetric zero point ships
+    W_deq[k, n] = (nibbles[k, n] - zeros[k//G, n]) * scales[k//G, n]
+
+WEIGHT PREPARATION
+==================
+Goes through aiter.prepare_a16w4_weight(), the same call a serving stack makes
+in process_weights_after_loading() -- packing [K, N] nibbles into [K/8, N]
+int32 along K, plus the MAGIC nibble permutation and +1024 zero bias on the
+fp16 path. It runs once per shape here, outside the timed region, exactly as
+it would in production.
+
+RUN
+===
+    python3 op_tests/test_gemm_a16w4.py                    # both tables
+    python3 op_tests/test_gemm_a16w4.py -d fp16 bf16
+    python3 op_tests/test_gemm_a16w4.py -s 1,5120,5120     # decode table only
+"""
+
+import argparse
+import functools
+
+import pandas as pd
+import torch
+import torch.nn.functional as F
+import triton
+import triton.language as tl
+
+import aiter
+from aiter import dtypes
+from aiter.jit.utils.chip_info import get_gfx
+from aiter.ops.gemm_op_a16w4 import (
+    GROUP_SIZE,
+    PACK_K,
+    SUPPORTED_GFX,
+    gemm_a16w4,
+    gemm_a16w4_workspace_elems,
+    prepare_a16w4_weight,
+)
+from aiter.ops.triton.gemm.basic.gemm_a16w16 import gemm_a16w16
+from aiter.ops.triton.utils.gemm_config_utils import get_gemm_config
+from aiter.test_common import (
+    benchmark,
+    checkAllclose,
+    run_perftest,
+)
+
+torch.set_default_device("cuda")
+
+# Symmetric zero point, the common AWQ case. The vLLM Triton kernel below
+# folds exactly this value in as a compile-time constant when HAS_ZP=False,
+# so both candidates compute bit-for-bit the same C = A @ ((W - 8) * scale).
+ZP = 8
+
+# Sweep bounds. These are NOT the C++ dispatch threshold (kPrefillMinM = 256 in
+# csrc/gemm_a16w4/gemm_a16w4.cu) -- they are deliberately narrower, so that
+# each table only contains shapes the corresponding tile was actually tuned
+# for. M in [65, 511] is skipped: prefill runs too few workgroups there
+# (its grid is (M/128, N/512)) and decode's cost grows linearly in M because
+# BM=16, so neither number would say anything useful until a third tile lands.
+PREFILL_MIN_M = 512
+DECODE_MAX_M = 64
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Reference baseline: vLLM's Triton W4A16 kernel
+# ──────────────────────────────────────────────────────────────────────
+#
+# THIRD-PARTY CODE. Reproduced verbatim from vLLM 0.21.0,
+#   vllm/model_executor/kernels/linear/mixed_precision/triton_w4a16.py
+# which is Apache-2.0. It is vendored rather than imported so the benchmark
+# does not require vLLM to be installed, and it is NOT part of the aiter
+# library -- it lives here only so `gemm_a16w4` is measured against the
+# kernel it actually replaces in production rather than against a
+# dequantized-fp16 upper bound.
+#
+# Kept byte-identical on purpose: the point is to measure what a user gets
+# today, so it is not autotuned, not re-tiled, and not given num_warps /
+# num_stages overrides that vLLM does not pass either.
+
+
+@triton.jit
+def _vllm_triton_w4a16_kernel(
+    a_ptr, b_ptr, scales_ptr, zeros_ptr, c_ptr,
+    M, N, K,
+    stride_am, stride_ak, stride_bk, stride_bn, stride_cm, stride_cn,
+    group_size,
+    HAS_ZP: tl.constexpr,
+    ZP_BIAS: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+
+    offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+    offs_bn = pid_n * (BLOCK_N // 8) + tl.arange(0, BLOCK_N // 8)
+
+    shifts_row = tl.arange(0, 8) * 4
+    shifts_1d_2d = tl.broadcast_to(shifts_row[None, :], (BLOCK_N // 8, 8))
+    shifts_1d = tl.reshape(shifts_1d_2d, (BLOCK_N,))
+    shifts = tl.broadcast_to(shifts_1d[None, :], (BLOCK_K, BLOCK_N))
+
+    offs_sn = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+
+    accumulator = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float32)
+
+    for k_start in range(0, tl.cdiv(K, BLOCK_K)):
+        offs_k = k_start * BLOCK_K + tl.arange(0, BLOCK_K)
+        mask_k = offs_k < K
+
+        a_ptrs = a_ptr + offs_m[:, None] * stride_am + offs_k[None, :] * stride_ak
+        mask_a = (offs_m[:, None] < M) & mask_k[None, :]
+        a = tl.load(a_ptrs, mask=mask_a, other=0.0)
+
+        b_ptrs = b_ptr + offs_k[:, None] * stride_bk + offs_bn[None, :] * stride_bn
+        mask_b = mask_k[:, None] & (offs_bn[None, :] < N // 8)
+        b_packed = tl.load(b_ptrs, mask=mask_b, other=0)
+
+        b = tl.interleave(b_packed, b_packed)
+        b = tl.interleave(b, b)
+        b = tl.interleave(b, b)
+        b = (b >> shifts) & 0xF
+
+        g_idx = (k_start * BLOCK_K) // group_size
+
+        scale_offset = g_idx * N + offs_sn
+        scale_mask = offs_sn < N
+        scales = tl.load(scales_ptr + scale_offset, mask=scale_mask, other=1.0)
+        scales = tl.broadcast_to(scales[None, :], (BLOCK_K, BLOCK_N))
+
+        if HAS_ZP:
+            zero_offset = g_idx * (N // 8) + offs_bn
+            zero_mask = offs_bn < N // 8
+            z_packed = tl.load(zeros_ptr + zero_offset, mask=zero_mask, other=0)
+            z = tl.interleave(z_packed, z_packed)
+            z = tl.interleave(z, z)
+            z = tl.interleave(z, z)
+            z = (z >> shifts_1d) & 0xF
+            z = tl.broadcast_to(z[None, :], (BLOCK_K, BLOCK_N))
+        else:
+            z = tl.full((BLOCK_K, BLOCK_N), ZP_BIAS, dtype=tl.int32)
+
+        b_fp = (b - z).to(a.dtype) * scales
+        accumulator += tl.dot(a, b_fp, out_dtype=tl.float32)
+
+    c = accumulator.to(c_ptr.type.element_ty)
+    c_ptrs = c_ptr + offs_m[:, None] * stride_cm + offs_n[None, :] * stride_cn
+    mask_c = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+    tl.store(c_ptrs, c, mask=mask_c)
+
+
+def vllm_triton_config(m, group_size=GROUP_SIZE):
+    """vLLM's production tile table, verbatim.
+
+    gfx1201 takes the _ON_GFX1X branch because vllm.platforms.rocm sets
+        _ON_GFX1X = any(arch in _GCN_ARCH for arch in ["gfx11", "gfx12"])
+    so RDNA4 inherits a table whose own comment says it was tuned for gfx1151.
+    There is no RDNA4 entry. That is what production runs today, so that is
+    what is measured -- these numbers are a statement about vLLM's current
+    defaults on this card, not about Triton as a compiler.
+    """
+    if m <= 32:
+        block_m, block_n, block_k = 32, 32, 64
+    elif m <= 64:
+        block_m, block_n, block_k = 64, 64, 32
+    else:
+        block_m, block_n, block_k = 128, 32, 64
+    if group_size < block_k:
+        block_k = group_size
+    return block_m, block_n, block_k
+
+
+def pack_int4_along_n(nibbles):
+    """[K, N] uint8 nibbles -> [K, N/8] int32, nibble n%8 at bit 4*(n%8).
+
+    The AWQ/GPTQ checkpoint layout, which is what the Triton kernel consumes
+    directly. `prepare_a16w4_weight()` produces the other packing (along K)
+    for gemm_a16w4; both are derived from the same nibbles here, so the two
+    candidates are fed identical numbers.
+
+    Worth noting for integration: gemm_a16w4 cannot read the checkpoint
+    layout natively and Triton can, so adopting it costs one repack in
+    process_weights_after_loading(). That is a one-off, not per token, and is
+    outside the timed region here.
+    """
+    k, n = nibbles.shape
+    v = nibbles.to(torch.int64).view(k, n // PACK_K, PACK_K)
+    shifts = (torch.arange(PACK_K, device=nibbles.device, dtype=torch.int64) * 4).view(
+        1, 1, PACK_K
+    )
+    return (v << shifts).sum(dim=-1).to(torch.int32)
+
+
+def generate_gemm_a16w4_inputs(m, n, k, gsize, dtype):
+    """Build one int4 weight set plus every layout the candidates need.
+
+    Magnitudes are chosen so the fp32 reference and the 16-bit kernels agree
+    to ~1e-2 over K up to 16k; plain randn weights would make the comparison
+    dominated by fp16 accumulation error rather than by kernel bugs.
+    """
+    torch.manual_seed(0)
+    x = (torch.randn((m, k), dtype=dtypes.fp32) * 0.1).to(dtype)
+
+    nibbles = torch.randint(0, 16, (k, n), dtype=torch.uint8)
+    scales = (torch.rand((k // gsize, n), dtype=dtypes.fp32) * 0.01 + 0.005).to(dtype)
+    zeros = torch.full((k // gsize, n), float(ZP), dtype=dtype)
+
+    # [K, N] fp32 dequantized weights, then [N, K] for the 16-bit GEMM APIs.
+    w_deq = (
+        nibbles.to(dtypes.fp32) - zeros.to(dtypes.fp32).repeat_interleave(gsize, dim=0)
+    ) * scales.to(dtypes.fp32).repeat_interleave(gsize, dim=0)
+    w_nk = w_deq.T.contiguous().to(dtype)
+
+    # Two packings of the SAME nibbles: [K, N/8] along N is the checkpoint
+    # layout the Triton kernel reads; prepare_a16w4_weight() gives [K/8, N]
+    # along K (plus the MAGIC permutation and +1024 zero bias on fp16).
+    # Both are load-time work, timed nowhere.
+    b_tri = pack_int4_along_n(nibbles)
+    w_q, s_q, z_q = prepare_a16w4_weight(nibbles, scales, zeros, dtype)
+
+    return x, b_tri, w_q, s_q, z_q, w_deq, w_nk
+
+
+def run_torch(x, w_deq, dtype):
+    """Reference only: fp32 dequant + matmul. Not timed, not in the table."""
+    return (x.to(dtypes.fp32) @ w_deq).to(dtype)
+
+
+@functools.lru_cache(maxsize=None)
+def triton_a16w16_available(m, n, k):
+    """True when aiter ships a tuned GEMM-A16W16 config for this arch.
+
+    As of writing there is none for gfx1201 -- configs/gfx1201/triton/gemm/
+    has a8w8 and conv families only -- so get_gemm_config() raises and the
+    Triton baseline is simply unavailable on this card. Probing through the
+    resolver rather than stat()ing a hand-built path keeps this working if the
+    family migrates between the legacy and nested config layouts.
+    """
+    try:
+        get_gemm_config("GEMM-A16W16", m, n, k)
+        return True
+    except AssertionError:
+        return False
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Benchmarks
+# ──────────────────────────────────────────────────────────────────────
+
+
+def run_candidates(m, n, k, gsize, dtype):
+    """Time every candidate for one shape and return the table row.
+
+    Shared by both sweeps: prefill and decode differ only in which shapes
+    reach them, not in how a shape is measured.
+    """
+    x, b_tri, w_q, s_q, z_q, w_deq, w_nk = generate_gemm_a16w4_inputs(
+        m, n, k, gsize, dtype
+    )
+    ref = run_torch(x, w_deq, dtype)
+
+    esize = x.element_size()
+    flops = 2 * m * n * k
+    # Per-candidate byte counts. The 16-bit path reads N*K 2-byte weights; the
+    # two 4-bit paths read N*K/2 bytes plus per-group metadata -- Triton takes
+    # scales only (HAS_ZP=False folds the zero point into a constant), a16w4
+    # takes scales and zeros.
+    bytes_a16w16 = (m * k + n * k + m * n) * esize
+    bytes_meta = (k // gsize) * n * esize
+    bytes_triton = (m * k + m * n) * esize + n * k // 2 + bytes_meta
+    bytes_a16w4 = (m * k + m * n) * esize + n * k // 2 + 2 * bytes_meta
+
+    # Preallocated outputs, as a linear layer would pass them. One buffer per
+    # candidate so a kernel is never timed writing into another's cache lines.
+    y = torch.empty((m, n), dtype=dtype)
+    y_q = torch.empty((m, n), dtype=dtype)
+    y_tri = torch.empty((m, n), dtype=dtype)
+
+    block_m, block_n, block_k = vllm_triton_config(m)
+    tri_grid = (triton.cdiv(m, block_m), triton.cdiv(n, block_n))
+    # Triton reads scales in the activation dtype, which is what
+    # prepare_a16w4_weight() returns; on the fp16 path it only casts them,
+    # the MAGIC permutation and +1024 bias touch the weights and zeros only.
+    scales_arg = s_q
+
+    def run_vllm_triton():
+        _vllm_triton_w4a16_kernel[tri_grid](
+            x, b_tri, scales_arg, b_tri, y_tri, m, n, k,
+            x.stride(0), x.stride(1), b_tri.stride(0), b_tri.stride(1),
+            y_tri.stride(0), y_tri.stride(1),
+            gsize, HAS_ZP=False, ZP_BIAS=ZP,
+            BLOCK_M=block_m, BLOCK_N=block_n, BLOCK_K=block_k,
+        )
+        # run_perftest hands the return value to checkAllclose, and a raw
+        # Triton launch returns None.
+        return y_tri
+
+    candidates = {
+        # THE COMPARISON THAT MATTERS: the kernel gemm_a16w4 replaces in
+        # production. Same nibbles, same symmetric zero point, same output
+        # dtype -- only the weight packing and the kernel differ.
+        "vllm_triton_w4a16": (run_vllm_triton, bytes_triton),
+        # CEILING, NOT A COMPETITOR: same weights, dequantized to 16-bit
+        # beforehand, so it reads 4x the weight bytes and does no dequant.
+        # Kept because it bounds how much of the gap to dense fp16 is left,
+        # but it is not what a16w4 is competing against.
+        "torch_a16w16_ceiling": (lambda: F.linear(x, w_nk), bytes_a16w16),
+    }
+    if triton_a16w16_available(m, n, k):
+        candidates["triton_a16w16"] = (
+            lambda: gemm_a16w16(x, w_nk, None, dtype, y),
+            bytes_a16w16,
+        )
+    else:
+        aiter.logger.info(
+            "triton_a16w16 skipped: no tuned GEMM-A16W16 config for %s", get_gfx()
+        )
+
+    reason = aiter.gemm_a16w4_unsupported_reason(m, n, k, dtype == dtypes.fp16)
+    if reason:
+        # Not a failure: prefill wants M % 128 == 0 and N % 512 == 0, decode
+        # wants K % 256 == 0, so some shapes land outside both tiles. Leaving
+        # the cells nan is more honest than silently reshaping the case.
+        aiter.logger.info("a16w4 skipped for m=%d n=%d k=%d: %s", m, n, k, reason)
+    else:
+        # BOTH buffers are hoisted, which is what a serving stack does and what
+        # the numbers depend on: at M=1 the kernel is ~24 us, so allocating a
+        # fresh output and split-K scratch per call adds ~45 us and would show
+        # a 1.4x win where the kernel actually delivers 3.2x.
+        ws = torch.empty(
+            gemm_a16w4_workspace_elems(m, n, k, dtype == dtypes.fp16),
+            dtype=dtypes.fp32,
+        )
+        candidates["a16w4"] = (
+            lambda: gemm_a16w4(x, w_q, s_q, z_q, out=y_q, workspace=ws),
+            bytes_a16w4,
+        )
+
+    ret = {"gfx": get_gfx()}
+    for name, (fn, nbytes) in candidates.items():
+        # use_cuda_event=True, not the default torch-profiler path. On gfx1201
+        # (ROCm 7.2.2) the profiler records no CUDA device events -- roctracer
+        # logs "produced duplicate flow start" and every kernel is attributed
+        # to the CPU -- so get_trace_perf() drops every row and reports
+        # "no valida data after post process!" with us=0. That happens for a
+        # bare torch.matmul too, so it is the harness on this arch rather than
+        # any candidate here. cuda.Event timing does not depend on roctracer.
+        out, us = run_perftest(fn, use_cuda_event=True)
+        err = checkAllclose(
+            ref.to(dtypes.fp32),
+            out.to(dtypes.fp32),
+            rtol=1e-2,
+            atol=1e-2,
+            msg=f"{name}: a16w4 gemm m={m} n={n} k={k}",
+        )
+        ret[f"{name} us"] = us
+        ret[f"{name} TFLOPS"] = flops / us / 1e6
+        ret[f"{name} TB/s"] = nbytes / us / 1e6
+        ret[f"{name} err"] = err
+    return ret
+
+
+@benchmark()
+def test_gemm_a16w4_prefill(m, n, k, gsize, dtype):
+    """Compute-bound sweep, M >= 512. Takes the BM128 BN512 BK64 tile."""
+    return run_candidates(m, n, k, gsize, dtype)
+
+
+@benchmark()
+def test_gemm_a16w4_decode(m, n, k, gsize, dtype):
+    """Memory-bound sweep, M <= 64. Takes the BM16 BN128 BK64 split-K tile."""
+    return run_candidates(m, n, k, gsize, dtype)
+
+
+def summarize(name, rows, dtype):
+    if not rows:
+        return
+    aiter.logger.info(
+        "a16w4 %s summary (dtype=%s):\n%s",
+        name,
+        dtype,
+        pd.DataFrame(rows).to_markdown(index=False),
+    )
+
+
+def main():
+    # Whole-op arch gate lives here, not inside the @benchmark fns: @benchmark
+    # always returns the call-args dict, so an in-fn return would still emit a
+    # meaningless args-only row.
+    if get_gfx() not in SUPPORTED_GFX:
+        aiter.logger.warning(
+            "a16w4 gemm is %s only; skipping on %s",
+            "/".join(SUPPORTED_GFX),
+            get_gfx(),
+        )
+        return
+
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.RawTextHelpFormatter,
+        description="config input of test",
+    )
+    parser.add_argument(
+        "-d",
+        "--dtype",
+        type=dtypes.str2Dtype,
+        choices=[dtypes.d_dtypes["fp16"], dtypes.d_dtypes["bf16"]],
+        nargs="*",
+        # A string default is passed through `type`, a list default is not.
+        default="fp16,",
+        metavar="{fp16,bf16}",
+        help="""Data type of activations, scales and output.
+        e.g.: -d fp16 bf16""",
+    )
+    parser.add_argument(
+        "-s",
+        "--mnk",
+        type=dtypes.str2tuple,
+        nargs="*",
+        default=[
+            # Qwen3-32B linear layers as deployed (hidden 5120, intermediate
+            # 25600). Every (N, K) here satisfies both tiles: prefill needs
+            # N % 512 and K % 128, decode needs N % 128 and K % 256.
+            #   5120 x  4096   o_proj
+            #   5120 x  5120   qkv / o_proj
+            #   5120 x 12800   down_proj
+            #  25600 x  5120   gate / up_proj
+            # Each M is routed to the prefill or decode table by the bounds
+            # above; nothing in [65, 511] is listed, because no tile is tuned
+            # for it yet.
+            *[(m, 5120, 4096) for m in (1, 8, 32, 64, 512, 1024, 4096)],
+            *[(m, 5120, 5120) for m in (1, 8, 32, 64, 512, 1024, 4096)],
+            *[(m, 5120, 12800) for m in (1, 8, 32, 64, 512, 1024, 4096)],
+            *[(m, 25600, 5120) for m in (1, 8, 32, 64, 512, 1024, 4096)],
+        ],
+        help="""Shape of mnk. Routed to the prefill table when m >= 512 and to
+        the decode table when m <= 64; anything between is skipped.
+        e.g.:   -s 1,5120,5120
+                --mnk 4096,25600,5120""",
+    )
+    args = parser.parse_args()
+
+    # GROUP_SIZE is fixed by the kernel, not a sweep axis: it is baked into the
+    # LDS layout and the K-step, so there is no -g flag to vary it.
+    for dtype in args.dtype:
+        prefill_rows, decode_rows = [], []
+        for m, n, k in args.mnk:
+            if m >= PREFILL_MIN_M:
+                prefill_rows.append(
+                    test_gemm_a16w4_prefill(m, n, k, GROUP_SIZE, dtype)
+                )
+            elif m <= DECODE_MAX_M:
+                decode_rows.append(test_gemm_a16w4_decode(m, n, k, GROUP_SIZE, dtype))
+            else:
+                aiter.logger.warning(
+                    "m=%d skipped: [%d, %d] has no tuned tile yet, so a number "
+                    "there would not mean anything",
+                    m,
+                    DECODE_MAX_M + 1,
+                    PREFILL_MIN_M - 1,
+                )
+        summarize("prefill", prefill_rows, dtype)
+        summarize("decode", decode_rows, dtype)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
##Motivations:

Adding fused int4 a16w4 gemm kernels for Navi48(gfx1201), including
1. FP16 prefill & decoding kernels
2. BF16 prefill &decoding kernels

## Test Plan
1. Kernel performance benchmark with vLLM's OOB w4a16 triton kernel.
3. vLLM E2E performance test.

## Test Result
Kernel level benchmark with vLLM's out-of-box w4a16 triton kernel:

Using the Qwen3 32B TP2 shape:

Prefill — fp16
|    M |     N |     K | triton us | triton TFLOPS | triton TB/s | a16w4 us | a16w4 TFLOPS | a16w4 TB/s | **a16w4 vs triton** | spread |
|-----:|------:|------:|----------:|--------------:|------------:|---------:|-------------:|-----------:|--------------------:|-------:|
|  512 |  5120 |  4096 |     409.2 |          52.5 |       0.049 |    288.0 |         74.6 |      0.071 | **1.42x** |   2.2% |
| 1024 |  5120 |  4096 |     772.2 |          55.6 |       0.038 |    458.0 |         93.8 |      0.066 | **1.69x** |   1.9% |
| 2048 |  5120 |  4096 |    1714.4 |          50.1 |       0.028 |    775.3 |        110.8 |      0.063 | **2.21x** |   2.4% |
| 4096 |  5120 |  4096 |    3657.4 |          47.0 |       0.024 |   1527.2 |        112.5 |      0.057 | **2.39x** |   2.0% |
|  512 |  5120 |  5120 |     503.8 |          53.3 |       0.048 |    352.7 |         76.1 |      0.069 | **1.43x** |   2.9% |
| 1024 |  5120 |  5120 |     975.1 |          55.1 |       0.035 |    572.1 |         93.8 |      0.061 | **1.70x** |   3.1% |
| 2048 |  5120 |  5120 |    1935.6 |          55.5 |       0.029 |    962.0 |        111.6 |      0.058 | **2.01x** |   2.6% |
| 4096 |  5120 |  5120 |    4051.4 |          53.0 |       0.024 |   1886.8 |        113.8 |      0.052 | **2.15x** |   2.4% |
|  512 |  5120 | 12800 |    1185.5 |          56.6 |       0.044 |    839.8 |         79.9 |      0.063 | **1.41x** |   1.1% |
| 1024 |  5120 | 12800 |    2392.5 |          56.1 |       0.029 |   1389.1 |         96.6 |      0.051 | **1.72x** |   2.1% |
| 2048 |  5120 | 12800 |    4759.5 |          56.4 |       0.023 |   2371.5 |        113.2 |      0.046 | **2.01x** |   2.5% |
| 4096 |  5120 | 12800 |   11715.4 |          45.8 |       0.015 |   4796.8 |        111.9 |      0.038 | **2.44x** |   2.1% |
|  512 | 25600 |  5120 |    2372.8 |          56.6 |       0.042 |   1300.0 |        103.2 |      0.078 | **1.83x** |   2.3% |
| 1024 | 25600 |  5120 |    4726.4 |          56.8 |       0.028 |   2421.6 |        110.8 |      0.055 | **1.95x** |   2.5% |
| 2048 | 25600 |  5120 |    9487.8 |          56.6 |       0.020 |   4681.2 |        114.7 |      0.042 | **2.03x** |   2.1% |
| 4096 | 25600 |  5120 |   20004.9 |          53.7 |       0.016 |   9283.3 |        115.7 |      0.035 | **2.15x** |   1.8% |

Decode — fp16

|    M |     N |     K | triton us | triton TFLOPS | triton TB/s | a16w4 us | a16w4 TFLOPS | a16w4 TB/s | **a16w4 vs triton** | spread |
|-----:|------:|------:|----------:|--------------:|------------:|---------:|-------------:|-----------:|--------------------:|-------:|
|    1 |  5120 |  4096 |     106.7 |           0.4 |       0.101 |     51.0 |          0.8 |      0.219 | **2.09x** |   0.2% |
|    4 |  5120 |  4096 |      98.0 |           1.7 |       0.111 |     46.6 |          3.6 |      0.241 | **2.11x** |  10.7% |
|    8 |  5120 |  4096 |      96.8 |           3.5 |       0.113 |     50.9 |          6.6 |      0.222 | **1.90x** |   1.7% |
|   16 |  5120 |  4096 |      99.2 |           6.8 |       0.112 |     49.4 |         13.6 |      0.231 | **2.01x** |   5.0% |
|   32 |  5120 |  4096 |      98.2 |          13.7 |       0.116 |     63.8 |         21.0 |      0.184 | **1.54x** |   5.2% |
|   64 |  5120 |  4096 |     133.2 |          20.2 |       0.090 |     92.3 |         29.1 |      0.134 | **1.44x** |   4.5% |
|    1 |  5120 |  5120 |     107.7 |           0.5 |       0.126 |     52.3 |          1.0 |      0.267 | **2.06x** |   4.0% |
|    4 |  5120 |  5120 |     108.6 |           1.9 |       0.125 |     52.0 |          4.0 |      0.269 | **2.09x** |   2.6% |
|    8 |  5120 |  5120 |     109.2 |           3.8 |       0.125 |     53.1 |          7.9 |      0.265 | **2.06x** |   3.9% |
|   16 |  5120 |  5120 |     109.2 |           7.7 |       0.127 |     53.4 |         15.7 |      0.267 | **2.04x** |   1.5% |
|   32 |  5120 |  5120 |     110.1 |          15.2 |       0.129 |     68.6 |         24.4 |      0.212 | **1.60x** |   2.2% |
|   64 |  5120 |  5120 |     155.2 |          21.6 |       0.096 |    105.9 |         31.7 |      0.144 | **1.47x** |   2.7% |
|    1 |  5120 | 12800 |     197.1 |           0.7 |       0.172 |     79.4 |          1.7 |      0.439 | **2.48x** |   1.2% |
|    4 |  5120 | 12800 |     199.7 |           2.6 |       0.170 |     79.9 |          6.6 |      0.438 | **2.50x** |   2.6% |
|    8 |  5120 | 12800 |     198.8 |           5.3 |       0.171 |     79.9 |         13.1 |      0.439 | **2.49x** |   1.6% |
|   16 |  5120 | 12800 |     200.5 |          10.5 |       0.171 |     81.5 |         25.7 |      0.434 | **2.46x** |   2.8% |
|   32 |  5120 | 12800 |     203.1 |          20.7 |       0.172 |    118.5 |         35.4 |      0.303 | **1.71x** |   1.8% |
|   64 |  5120 | 12800 |     314.7 |          26.7 |       0.115 |    203.3 |         41.3 |      0.183 | **1.55x** |   1.7% |
|    1 | 25600 |  5120 |     320.8 |           0.8 |       0.211 |    121.3 |          2.2 |      0.575 | **2.65x** |   1.5% |
|    4 | 25600 |  5120 |     323.1 |           3.2 |       0.210 |    122.7 |          8.5 |      0.569 | **2.63x** |   1.3% |
|    8 | 25600 |  5120 |     324.9 |           6.5 |       0.210 |    141.0 |         14.9 |      0.497 | **2.31x** |   0.9% |
|   16 | 25600 |  5120 |     327.3 |          12.8 |       0.210 |    156.0 |         26.9 |      0.453 | **2.10x** |   1.8% |
|   32 | 25600 |  5120 |     333.1 |          25.2 |       0.209 |    215.6 |         38.9 |      0.332 | **1.55x** |   1.3% |
|   64 | 25600 |  5120 |     388.2 |          43.2 |       0.184 |    382.9 |         43.8 |      0.192 | **1.01x** |   2.1% |

vLLM E2E benchmark:

workload:
Dataset: vllm bench random
ISL/OSL: 1024/128
Concurrency: 16
Num of prompts: 320
Request rate: inf

Benchmark model AWQ:

Qwen/Qwen3-32B-AWQ, TP2
Qwen/Qwen3-14B-AWQ, TP2
Qwen/Qwen3-8B-AWQ, TP1
Qwen/Qwen3-4B-AWQ, TP1
QuantTrio/Qwen3.5-9B-AWQ, TP1
QuantTrio/Qwen3.6-27B-AWQ, TP2
QuantTrio/Qwen3.5-4B-AWQ, TP1

Mean TTFT:

| Model | TP | HIP (ms) | Triton (ms) | × | cut | median TTFT HIP / Triton (ms) | |---|---:|---:|---:|---:|---:|---:|
| `Qwen3-32B-AWQ`   | 2 | **2206.45** | 5985.35 | **2.71×** | −63.1% | 2257 / 7163 |
| `Qwen3.6-27B-AWQ` | 2 | **2249.84** | 4189.30 | **1.86×** | −46.3% | 1968 / 4386 |
| `Qwen3-14B-AWQ`   | 2 | **1439.74** | 2604.83 | **1.81×** | −44.7% | 1296 / 2694 |
| `Qwen3-8B-AWQ`    | 1 | **1541.20** | 2634.91 | **1.71×** | −41.5% | 1584 / 2677 |
| `Qwen3.5-4B-AWQ`  | 1 |  **981.90** | 1675.45 | **1.71×** | −41.4% |  924 / 1679 |
| `Qwen3.5-9B-AWQ`  | 1 | **1639.68** | 2625.60 | **1.60×** | −37.6% | 1505 / 2689 |
| `Qwen3-4B-AWQ`    | 1 |  **663.27** | 1054.11 | **1.59×** | −37.1% |  599 /  999 |

Mean TPOT:

| Model | TP | HIP (ms) | Triton (ms) | × | cut |
|---|---:|---:|---:|---:|---:|
| `Qwen3-32B-AWQ`   | 2 | **57.65** | 100.38 | **1.74×** | −42.6% |
| `Qwen3-14B-AWQ`   | 2 | **24.99** |  40.65 | **1.63×** | −38.5% |
| `Qwen3-8B-AWQ`    | 1 | **31.94** |  50.44 | **1.58×** | −36.7% |
| `Qwen3.6-27B-AWQ` | 2 | **61.68** |  86.62 | **1.40×** | −28.8% |
| `Qwen3-4B-AWQ`    | 1 | **24.35** |  33.41 | **1.37×** | −27.1% |
| `Qwen3.5-9B-AWQ`  | 1 | **46.37** |  53.21 | **1.15×** | −12.9% |
| `Qwen3.5-4B-AWQ`  | 1 | **31.30** |  34.27 | **1.10×** |  −8.7% |
