### PR TITLE
[Triton/Gluon] Support per-query context lengths in paged MQA logits

### DIFF
--- a/aiter/ops/triton/_triton_kernels/attention/pa_mqa_logits.py
+++ b/aiter/ops/triton/_triton_kernels/attention/pa_mqa_logits.py
@@ -385,6 +385,7 @@ def _deepgemm_fp8_paged_mqa_logits(
     HiddenDim: tl.constexpr,
     KVBlockSize: tl.constexpr,
     SplitKV: tl.constexpr = 1,
+    PerQueryContext: tl.constexpr = False,
 ):
     pid = tl.program_id(0)
     num_block_q_head = tl.cdiv(heads_num, ChunkQ)
@@ -393,7 +394,12 @@ def _deepgemm_fp8_paged_mqa_logits(
     pid_next_n, remain_pid = remain_pid % next_n, remain_pid // next_n
     pid_batch, pid_split_kv = remain_pid % batch_size, remain_pid // batch_size
 
-    context_length = tl.load(context_len_ptr + pid_batch)
+    if PerQueryContext:
+        context_length = tl.load(context_len_ptr + pid_batch * next_n + pid_next_n)
+        context_end = context_length - 1
+    else:
+        context_length = tl.load(context_len_ptr + pid_batch)
+        context_end = context_length - next_n + pid_next_n
 
     context_chunk_num = tl.cdiv(context_length, ChunkK)
     split_context_chunk_num = tl.cdiv(context_chunk_num, SplitKV)
@@ -451,9 +457,7 @@ def _deepgemm_fp8_paged_mqa_logits(
         o = tl.maximum(o, 0.0)
         o = o * scale_weight[None, :].T
 
-        mask = (
-            context_idx + tl.arange(0, ChunkK) <= context_length - next_n + pid_next_n
-        )
+        mask = context_idx + tl.arange(0, ChunkK) <= context_end
         o = tl.where(mask[None, :], o, float("-inf"))
 
         logits = tl.reduce(o, axis=0, combine_fn=_sum_combine)
@@ -493,6 +497,7 @@ def _gluon_deepgemm_fp8_paged_mqa_logits(
     ChunkK: tl.constexpr,
     HiddenDim: tl.constexpr,
     KVBlockSize: tl.constexpr = 1,
+    PerQueryContext: tl.constexpr = False,
 ):
     # for AOT load use, only need kernel have the same signature as implementation side
     pass
@@ -525,6 +530,7 @@ def _gluon_deepgemm_fp8_paged_mqa_logits_preshuffle(
     ChunkK: tl.constexpr,
     HiddenDim: tl.constexpr,
     KVBlockSize: tl.constexpr = 16,
+    PerQueryContext: tl.constexpr = False,
 ):
     # for AOT load use, only need kernel have the same signature as implementation side
     pass
@@ -557,6 +563,7 @@ def _gluon_deepgemm_fp8_paged_mqa_logits_preshuffle_varctx(
     ChunkK: tl.constexpr,
     HiddenDim: tl.constexpr,
     KVBlockSize: tl.constexpr = 16,
+    PerQueryContext: tl.constexpr = False,
 ):
     # for AOT load use, only need kernel have the same signature as implementation side
     pass

--- a/aiter/ops/triton/attention/pa_mqa_logits.py
+++ b/aiter/ops/triton/attention/pa_mqa_logits.py
@@ -266,6 +266,7 @@ def _compile_deepgemm_fp8_paged_mqa_logits(
     is_padded_mode: bool,
     WavePerEU: int = 2,
     VarCtxOpt: bool = False,
+    PerQueryContext: bool = False,
 ):
     gfx_version = get_gfx()
     assert gfx_version in _GLUON_PA_MQA_LOGITS_ARCHS
@@ -327,6 +328,7 @@ def _compile_deepgemm_fp8_paged_mqa_logits(
     fn_signature["HiddenDim"] = "constexpr"
     fn_signature["CDNA_VERSION"] = "constexpr"
     fn_signature["ARCH"] = "constexpr"
+    fn_signature["PerQueryContext"] = "constexpr"
 
     effective_wave_per_eu = 1 if is_gfx1250 and not Preshuffle else WavePerEU
     effective_num_warps = 1 if is_gfx1250 and Preshuffle else 4
@@ -373,6 +375,7 @@ def _compile_deepgemm_fp8_paged_mqa_logits(
             "HiddenDim": HiddenDim,
             "CDNA_VERSION": cdna_version,
             "ARCH": gfx_version,
+            "PerQueryContext": PerQueryContext,
         },
         attrs={
             (2,): [["tt.divisibility", 16]],  # heads_num
@@ -409,7 +412,8 @@ def _compile_deepgemm_fp8_paged_mqa_logits(
         padded_str = "T" if is_padded_mode and not Preshuffle else "F"
         preshuffle_suffix = "_preshuffle" if Preshuffle else ""
         varctx_suffix = "_varctx" if VarCtxOpt else ""
-        kernel_str = f"paged_mqa_logits{preshuffle_suffix}{varctx_suffix}_{ChunkQ}x{ChunkK}x{HiddenDim}_B{KVBlockSize}P{padded_str}W{WavePerEU}"
+        per_query_suffix = "_per_query_ctx" if PerQueryContext else ""
+        kernel_str = f"paged_mqa_logits{preshuffle_suffix}{varctx_suffix}{per_query_suffix}_{ChunkQ}x{ChunkK}x{HiddenDim}_B{KVBlockSize}P{padded_str}W{WavePerEU}"
         metadata_pth = f"{AITER_TRITON_CONFIGS_PATH}/paged_mqa_logits/aot/{kernel_str}"
         with AOTMetadataContext(
             kernel_fn.fn.__name__,
@@ -478,6 +482,26 @@ def deepgemm_fp8_paged_mqa_logits(
     if TotalCuCount is None:
         TotalCuCount = get_num_sms()
     batch_size, next_n, heads, hidden_dim = q_fp8.size()
+    if context_lens.ndim == 1:
+        assert context_lens.shape[0] >= batch_size, (
+            context_lens.shape,
+            batch_size,
+        )
+        per_query_context = False
+    elif context_lens.ndim == 2:
+        assert context_lens.shape == (batch_size, next_n), (
+            context_lens.shape,
+            (batch_size, next_n),
+        )
+        assert (
+            context_lens.is_contiguous()
+        ), "Per-query context_lens must be contiguous [batch_size, next_n]"
+        per_query_context = True
+    else:
+        raise ValueError(
+            "context_lens must be [batch_size] or [batch_size, next_n], "
+            f"got shape={tuple(context_lens.shape)}"
+        )
     _, block_Size, _, index_dim = kv_cache.size()
     _, max_block_len = kv_indices.size()
 
@@ -522,6 +546,10 @@ def deepgemm_fp8_paged_mqa_logits(
         VarCtxSchedule = None
 
     VarCtxOpt = VarCtxSchedule is not None
+    if VarCtxOpt and per_query_context:
+        raise ValueError(
+            "VarCtxSchedule does not support per-query context_lens [B, N]"
+        )
     if VarCtxOpt:
         grid = (TotalCuCount * WavePerEU, 1, 1)
     else:
@@ -538,6 +566,7 @@ def deepgemm_fp8_paged_mqa_logits(
             is_padded_mode=is_padded_mode,
             WavePerEU=WavePerEU,
             VarCtxOpt=VarCtxOpt,
+            PerQueryContext=per_query_context,
         )
         if triton_version >= Version("3.5.0"):
             cdna_version = get_cdna_version()
@@ -570,6 +599,7 @@ def deepgemm_fp8_paged_mqa_logits(
                 hidden_dim,
                 cdna_version,
                 get_gfx(),
+                per_query_context,
             )
         else:  #  load AOT compiled gluon kernel
             assert triton_version < Version(
@@ -606,6 +636,7 @@ def deepgemm_fp8_paged_mqa_logits(
                 ChunkK,
                 KVBlockSize,
                 hidden_dim,
+                per_query_context,
             )
     else:
         assert not Preshuffle, "Preshuffle mode is only supported on gluon kernel."
@@ -639,5 +670,6 @@ def deepgemm_fp8_paged_mqa_logits(
             SplitKV=SplitKV,
             HiddenDim=hidden_dim,
             KVBlockSize=KVBlockSize,
+            PerQueryContext=per_query_context,
         )
     return triton.runtime.cache.get_cache_manager(kernel.hash).key

--- a/aiter/ops/triton/gluon/pa_mqa_logits.py
+++ b/aiter/ops/triton/gluon/pa_mqa_logits.py
@@ -85,6 +85,7 @@ def _gluon_deepgemm_fp8_paged_mqa_logits(
     KVBlockSize: tl.constexpr = 1,
     CDNA_VERSION: gl.constexpr = 3,
     ARCH: gl.constexpr = "gfx942",
+    PerQueryContext: gl.constexpr = False,
 ):
     IS_GFX1250: gl.constexpr = ARCH == "gfx1250"
     pid = tl.program_id(0)
@@ -94,7 +95,12 @@ def _gluon_deepgemm_fp8_paged_mqa_logits(
     pid_next_n, remain_pid = remain_pid % next_n, remain_pid // next_n
     pid_batch, pid_split_kv = remain_pid % batch_size, remain_pid // batch_size
 
-    context_length = gl.load(context_len_ptr + pid_batch)
+    if PerQueryContext:
+        context_length = gl.load(context_len_ptr + pid_batch * next_n + pid_next_n)
+        context_end = context_length - 1
+    else:
+        context_length = gl.load(context_len_ptr + pid_batch)
+        context_end = context_length - next_n + pid_next_n
 
     context_chunk_num = tl.cdiv(context_length, ChunkK)
     split_context_chunk_num = tl.cdiv(context_chunk_num, SplitKV)
@@ -296,7 +302,7 @@ def _gluon_deepgemm_fp8_paged_mqa_logits(
 
         mask = (
             context_idx + gl.arange(0, ChunkK, layout=gl.SliceLayout(0, mfma_layout))
-            <= context_length - next_n + pid_next_n
+            <= context_end
         )
         o = tl.where(mask[None, :], o, float("-inf"))
 
@@ -330,7 +336,7 @@ def _gluon_deepgemm_fp8_paged_mqa_logits(
 
     mask = (
         context_idx + gl.arange(0, ChunkK, layout=gl.SliceLayout(0, mfma_layout))
-        <= context_length - next_n + pid_next_n
+        <= context_end
     )
     o = tl.where(mask[None, :], o, float("-inf"))
 
@@ -376,6 +382,7 @@ def _gluon_deepgemm_fp8_paged_mqa_logits_preshuffle(
     KVBlockSize: gl.constexpr = 16,
     CDNA_VERSION: gl.constexpr = 3,
     ARCH: gl.constexpr = "gfx942",
+    PerQueryContext: gl.constexpr = False,
 ):
     IS_GFX1250: gl.constexpr = ARCH == "gfx1250"
     # ===---------------------------------------------------
@@ -464,7 +471,12 @@ def _gluon_deepgemm_fp8_paged_mqa_logits_preshuffle(
         pid = tl.program_id(0)
         pid_batch, remain_pid = pid % batch_size, pid // batch_size
         pid_next_n, pid_split_kv = remain_pid % next_n, remain_pid // next_n
-        context_length = gl.load(context_len_ptr + pid_batch)
+        if PerQueryContext:
+            context_length = gl.load(context_len_ptr + pid_batch * next_n + pid_next_n)
+            context_end = context_length - 1
+        else:
+            context_length = gl.load(context_len_ptr + pid_batch)
+            context_end = context_length - next_n + pid_next_n
 
         context_chunk_num = tl.cdiv(context_length, ChunkK)
         split_context_chunk_num = context_chunk_num // SplitKV
@@ -589,7 +601,7 @@ def _gluon_deepgemm_fp8_paged_mqa_logits_preshuffle(
             o = gl.maximum(o, 0.0)
             o = o * scale_weight[:, None]
 
-            valid = (context_idx + col) <= (context_length - next_n + pid_next_n)
+            valid = (context_idx + col) <= context_end
             o = tl.where(valid[None, :], o, float("-inf"))
             logits = gl.reduce(o, axis=0, combine_fn=_sum_combine)
 
@@ -623,7 +635,12 @@ def _gluon_deepgemm_fp8_paged_mqa_logits_preshuffle(
     pid_batch, remain_pid = pid % batch_size, pid // batch_size
     pid_next_n, pid_split_kv = remain_pid % next_n, remain_pid // next_n
     # ===---------------------------------------------------
-    context_length = gl.load(context_len_ptr + pid_batch)
+    if PerQueryContext:
+        context_length = gl.load(context_len_ptr + pid_batch * next_n + pid_next_n)
+        context_end = context_length - 1
+    else:
+        context_length = gl.load(context_len_ptr + pid_batch)
+        context_end = context_length - next_n + pid_next_n
 
     context_chunk_num = tl.cdiv(context_length, ChunkK)
     split_context_chunk_num = context_chunk_num // SplitKV
@@ -982,7 +999,7 @@ def _gluon_deepgemm_fp8_paged_mqa_logits_preshuffle(
             context_idx
             + ChunkKPerStage
             + gl.arange(0, ChunkKPerStage, layout=gl.SliceLayout(0, mfma_layout))
-            <= context_length - next_n + pid_next_n
+            <= context_end
         )
 
         logits = gl.reduce(o, axis=0, combine_fn=_sum_combine)
@@ -1139,7 +1156,7 @@ def _gluon_deepgemm_fp8_paged_mqa_logits_preshuffle(
         mask = (
             context_idx
             + gl.arange(0, ChunkKPerStage, layout=gl.SliceLayout(0, mfma_layout))
-            <= context_length - next_n + pid_next_n
+            <= context_end
         )
 
         logits = gl.reduce(o, axis=0, combine_fn=_sum_combine)
@@ -1298,7 +1315,7 @@ def _gluon_deepgemm_fp8_paged_mqa_logits_preshuffle(
                 context_idx_
                 + ChunkK
                 + gl.arange(0, ChunkKPerStage, layout=gl.SliceLayout(0, mfma_layout))
-                <= context_length - next_n + pid_next_n
+                <= context_end
             )
 
             logits = gl.reduce(o, axis=0, combine_fn=_sum_combine)
@@ -1341,7 +1358,7 @@ def _gluon_deepgemm_fp8_paged_mqa_logits_preshuffle(
             context_idx
             + ChunkKPerStage
             + gl.arange(0, ChunkKPerStage, layout=gl.SliceLayout(0, mfma_layout))
-            <= context_length - next_n + pid_next_n
+            <= context_end
         )
 
         logits = gl.reduce(o, axis=0, combine_fn=_sum_combine)
@@ -1393,6 +1410,7 @@ def _gluon_deepgemm_fp8_paged_mqa_logits_preshuffle_varctx(
     KVBlockSize: tl.constexpr = 16,
     CDNA_VERSION: gl.constexpr = 3,
     ARCH: gl.constexpr = "gfx942",
+    PerQueryContext: gl.constexpr = False,
 ):
     # ===---------------------------------------------------
     # Gluon Layout


### PR DESCRIPTION
## Motivation

`deepgemm_fp8_paged_mqa_logit`s assumed the `next_n` query tokens were always the last `next_n` positions of one sequence, hardcoding each token's visible range as` context_length - next_n + pid_next_n`. Accept a 2-D `context_lens [batch_size, next_n]` so every query token can carry its own context length, selected by tensor rank on the host and plumbed into the triton and gluon kernels as the PerQueryContext constexpr.

The varctx schedule path is explicitly rejected for per-query lens, and the AOT kernel cache name gains a `_per_query_ctx` suffix so the two modes do not share compiled artifacts.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
