### PR TITLE
fix(tune): default batch size silently disables the tuner's own checkpointing

### DIFF
--- a/aiter/utility/base_tuner.py
+++ b/aiter/utility/base_tuner.py
@@ -2,6 +2,7 @@
 # Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
 
 import argparse
+import math
 import os
 import shutil
 import sys
@@ -16,6 +17,11 @@ import torch
 
 from aiter import dtypes, logger
 from aiter.jit.utils.chip_info import get_gfx_runtime as _chip_get_gfx
+
+# How many checkpoints a run should have when the user did not pick a batch
+# size. Each batch writes the tuned CSV, and pre_process skips already-tuned
+# shapes on a rerun, so this bounds what an interrupted run loses.
+_DEFAULT_CHECKPOINTS = 8
 
 INVALID_TIME = -1
 
@@ -1420,6 +1426,20 @@ class TunerCommon:
             )
             return self.tunedf if self.tunedf is not None else pd.DataFrame()
         batch_size = min(args.batch, len(self.untunedf))
+        # A batch is this tuner's checkpoint: results are appended to the tuned
+        # CSV after every batch (see result_to_csv below), and pre_process skips
+        # shapes already present there, so a rerun resumes. The default batch
+        # (100) is larger than most tuning runs, which silently collapses a run
+        # into ONE batch -- an interruption then loses everything, including the
+        # shapes that had already finished. On a shared machine that is the
+        # difference between losing minutes and losing hours.
+        # When the user has not chosen a batch size, aim for a handful of
+        # checkpoints. This can only make batches smaller, never larger, and
+        # runs that already produce several batches are unaffected.
+        if args.batch == self.get_arg_defaults().get("batch"):
+            batch_size = max(
+                1, min(batch_size, math.ceil(len(self.untunedf) / _DEFAULT_CHECKPOINTS))
+            )
         total_batches = (len(self.untunedf) + batch_size - 1) // batch_size
         compare_report_file = self._init_compare_report(
             args, output_file, batch_size, total_batches

--- a/aiter/utility/base_tuner.py
+++ b/aiter/utility/base_tuner.py
@@ -26,6 +26,14 @@ _DEFAULT_CHECKPOINTS = 8
 INVALID_TIME = -1
 
 
+class _StoreBatchAction(argparse.Action):
+    """Store the batch size while remembering that the CLI supplied it."""
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        setattr(namespace, self.dest, values)
+        setattr(namespace, "_batch_was_explicit", True)
+
+
 def _read_csv(filepath, **kwargs):
     """Read CSV with automatic cleanup of common formatting issues:
     trailing tabs/spaces, extra unnamed columns, whitespace in headers/values.
@@ -114,6 +122,7 @@ class TunerCommon:
     def _setup_common_arguments(self):
         """set common arguments"""
         defaults = self.get_arg_defaults()
+        self.parser.set_defaults(_batch_was_explicit=False)
         self.parser.add_argument(
             "--verbose", "-v", action="store_true", help="more info"
         )
@@ -174,6 +183,7 @@ class TunerCommon:
         self.parser.add_argument(
             "--batch",
             type=int,
+            action=_StoreBatchAction,
             default=defaults["batch"],
             help="split untuned shapes to batches to tune",
         )
@@ -1436,7 +1446,7 @@ class TunerCommon:
         # When the user has not chosen a batch size, aim for a handful of
         # checkpoints. This can only make batches smaller, never larger, and
         # runs that already produce several batches are unaffected.
-        if args.batch == self.get_arg_defaults().get("batch"):
+        if not getattr(args, "_batch_was_explicit", True):
             batch_size = max(
                 1, min(batch_size, math.ceil(len(self.untunedf) / _DEFAULT_CHECKPOINTS))
             )

--- a/op_tests/tuning_tests/test_tuner_infra.py
+++ b/op_tests/tuning_tests/test_tuner_infra.py
@@ -80,6 +80,19 @@ class TestReadCSV(unittest.TestCase):
             os.unlink(path)
 
 
+class TestBatchArgument(unittest.TestCase):
+
+    def test_omitted_batch_is_marked_as_default(self):
+        args = _StubTuner.get().parser.parse_args([])
+        self.assertEqual(args.batch, 100)
+        self.assertFalse(args._batch_was_explicit)
+
+    def test_explicit_default_batch_is_honored(self):
+        args = _StubTuner.get().parser.parse_args(["--batch", "100"])
+        self.assertEqual(args.batch, 100)
+        self.assertTrue(args._batch_was_explicit)
+
+
 class TestUpdateTunedf(unittest.TestCase):
 
     def test_merges_existing_key(self):


### PR DESCRIPTION
Fixes #5263 — **and corrects it**: I claimed there that results are only written at the end. That was wrong, and I've said so on the issue. The mechanism is all there; it just doesn't engage at typical run sizes.

## What is actually true

- `run()` calls `result_to_csv(...)` **after every batch**.
- `pre_process()` builds a skip mask against the tuned file, so a rerun **already resumes**.
- `--batch` defaults to **100**.

Most tuning runs are much smaller than 100 shapes (ours were 42, 6, 5), so the entire run is a single batch, nothing is written until it finishes, and an interruption loses everything — including the shapes that had already completed. On a shared machine that is the difference between losing minutes and losing hours; we ended up wrapping the tuner in an external chunking driver purely to bound the loss, before noticing the tuner could already do it.

## Change

When the user has **not** chosen a batch size, aim for ~8 checkpoints:

```python
if args.batch == self.get_arg_defaults().get("batch"):
    batch_size = max(1, min(batch_size, math.ceil(len(self.untunedf) / _DEFAULT_CHECKPOINTS)))
```

| shapes | before | after |
|---|---|---|
| 42 | 1 batch | 7 batches (size 6) |
| 6 | 1 batch | 6 batches (size 1) |
| 174 | 2 batches | 8 batches (size 22) |
| 1000 | 10 batches | 10 batches (unchanged) |

This can only make batches **smaller, never larger**; an explicit `--batch` is honoured exactly as before; runs of ≥800 shapes are untouched.

If you would rather keep the default and simply document the trade-off, or pick a different checkpoint count, happy to adjust — the point is that the current default makes a working feature invisible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)