### PR TITLE
fix(mega_moe): stop the reference clamping SwiGLU at swiglu_limit=0

### DIFF
--- a/op_tests/multigpu_tests/test_mega_moe_v2.py
+++ b/op_tests/multigpu_tests/test_mega_moe_v2.py
@@ -22,6 +22,14 @@ from aiter.ops.shuffle import shuffle_scale_a16w4, shuffle_weight_a16w4
 from aiter.utility import fp4_utils
 
 NETWORKS = {
+    # swiglu_limit 0.0 exercises the operator's default, unclamped SwiGLU.
+    "glm52": {
+        "model_dim": 6144,
+        "inter_dim": 2048,
+        "experts": 256,
+        "topk": 8,
+        "swiglu_limit": 0.0,
+    },
     "v4_pro": {
         "model_dim": 7168,
         "inter_dim": 3072,
@@ -178,8 +186,14 @@ def _reference(
         )
         w2 = _dequant_expert(w2_q[local_id], w2_scale[local_id], model_dim, inter_dim)
         inp = x_all[rows].float()
-        gate = (inp @ w1[:inter_dim].T).clamp(max=swiglu_limit)
-        up = (inp @ w1[inter_dim:].T).clamp(-swiglu_limit, swiglu_limit)
+        gate = inp @ w1[:inter_dim].T
+        up = inp @ w1[inter_dim:].T
+        # MegaMoEV2 treats swiglu_limit <= 0 as "no clamp"; clamping here
+        # unconditionally turns up into zeros at the operator's own default of
+        # 0.0, so the reference is all-zero and relL2 divides by zero.
+        if swiglu_limit > 0:
+            gate = gate.clamp(max=swiglu_limit)
+            up = up.clamp(-swiglu_limit, swiglu_limit)
         hidden = F.silu(gate) * up
         out = (hidden @ w2.T) * weights_all[rows, slots, None]
         partial.index_add_(0, rows, out)


### PR DESCRIPTION
## What

`MegaMoEV2` reads `swiglu_limit <= 0` as "no clamp" (`gemm_util.py`), but the test's reference clamped unconditionally:

```python
gate = (inp @ w1[:inter_dim].T).clamp(max=swiglu_limit)
up = (inp @ w1[inter_dim:].T).clamp(-swiglu_limit, swiglu_limit)
```

At the operator's own default of `0.0`, `up = x.clamp(-0.0, 0.0)` is all zeros, so the reference is all zeros and `relL2 = ||output - 0|| / 0 = inf`.

The kernel is correct throughout. Diagnostics at `bs=8`, EP4:

```
kernel output: finite=True  n_nonfinite=0/49152  norm=30484.1  absmax=672
reference:     finite=True  n_nonfinite=0/49152  norm=0        absmax=0
```

## Why it was never seen

`NETWORKS` has one entry, `v4_pro`, which clamps at `10.0`. Any network whose activation is a plain SiLU takes the `0.0` default and cannot be validated — it reports `relL2=inf` and reads as a broken kernel. This PR adds an unclamped entry so the default path stays covered.

## Measured

MI355X gfx950, EP4, `model_dim=6144 inter_dim=2048 experts=256 topk=8`, unclamped:

| bs | before | after |
|---:|---|---|
| 8 | `relL2=inf` | **0.046365** |
| 32 | `relL2=inf` | **0.046631** |
| 128 | `relL2=inf` | **0.046395** |

`v4_pro` unchanged, EP8: `relL2` 0.053443 at bs=8, 0.053064 at bs=128. The clamp still runs whenever `swiglu_limit > 0`.

## Follow-up, not in this PR

`num_dispatch_cu` looks over-provisioned for the shapes measured here. Forcing 64 against the bucket table's pick, `mega_e2e` against the mori path:

| shape | EP | tokens | table default | forced 64 |
|---|---:|---:|---:|---:|
| 6144x2048, 256e, topk 8 | 4 | 128 | +13.8% | **+14.0%** |
| 6144x2048, 256e, topk 8 | 4 | 512 | −3.8% | **0.0%** |
| 6144x2048, 256e, topk 8 | 4 | 2048 | −1.2% | **−3.3%** |
| 7168x3072, 384e, topk 6 | 8 | 128 | +61.7% | **+64.2%** |
| 7168x3072, 384e, topk 6 | 8 | 512 | +28.9% | **+31.0%** |

It is not a uniform win — at `tokens=8` the table's pick beats 64 (+9.8% vs +9.0%) — so retuning it needs a full sweep across the fixed/compact/large paths and every bucket rather than a blanket default change. Filing the data here so it is not lost.

## Test plan

- [x] `test_mega_moe_v2.py --network glm52` (unclamped) on 4x MI355X — was `inf`, now passes
- [x] `test_mega_moe_v2.py --network v4_pro` on 8x MI355X — unchanged
- [x] `ruff==0.16.0` and `black` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
