### PR TITLE
[HIP] fea: add LL, LL128 proto into gfx9

### DIFF
--- a/csrc/include/custom_all_reduce.cuh
+++ b/csrc/include/custom_all_reduce.cuh
@@ -3343,6 +3343,569 @@ __global__ void __launch_bounds__(1024, 1) allreduce_mhc_post_large_m_kernel(
     end_sync<ngpus, true>(sg, self_sg, rank);
 }
 
+// ===========================================================================
+// LL / LL128 low-latency small-message all-reduce (gfx9 POC kernels)
+// ===========================================================================
+// Two flag-in-data, zero-GPU-barrier all-reduce kernels for small messages:
+//   * ar_ll_gfx9       — LL, 16B lines carrying 8B payload + epoch flags.
+//   * ar_ll128_unroll2 — LL128, 128B/16-lane lines, 15 payload words + 1 flag.
+// Both stage into a per-rank scratch that peers write into and the owner polls
+// (spinning on a per-epoch flag), then reduce in fp32. On this port the scratch
+// is NOT independently allocated: it reuses the meta/Signal buffer's post-Signal
+// region (the same region the 2-stage kernel uses as tmp), which is already
+// IPC-exchanged at construction. A peer's scratch base is therefore
+// (char*)sg_.signals[peer] + sizeof(Signal). LL and 2-stage never run on the
+// same message concurrently, and the per-epoch flag + double-buffered banks keep
+// scratch reuse safe across CUDA-graph replay.
+
+constexpr int    kLLMaxRanks       = 8;      // gfx9 supports up to 8 ranks
+constexpr size_t kLLPocSlotCapPk   = 16384;  // per-rank slot cap in 8B packets (<=128KB msg)
+// LL sub-region size in the reused scratch: 2 banks * ngpus * slotCap * 16B.
+// Sized for the worst case (kLLMaxRanks) so the LL128 sub-region can start after
+// it at a fixed offset regardless of world size.
+constexpr size_t kLLPocRegionBytes =
+    (size_t)2 * kLLMaxRanks * kLLPocSlotCapPk * sizeof(uint4);
+// Max message (bytes) the LL128 fast path serves; bounds its dynamic scratch.
+constexpr size_t kLL128PocCapBytes = (size_t)4 * 1024 * 1024;
+
+// 16-byte LL line: two (4B data, 4B flag) pairs carrying 8B of payload.
+union LLPackedMsg
+{
+    struct
+    {
+        uint32_t data0;
+        uint32_t flag0;
+        uint32_t data1;
+        uint32_t flag1;
+    };
+    uint4 raw;
+};
+static_assert(sizeof(LLPackedMsg) == 16, "LLPackedMsg must be exactly 16 bytes");
+
+// gfx9 16B single-transaction store/load: a 16B vector via nontemporal
+// store/load lowers to a single global_store/load_dwordx4 (nt).
+using llx_v4u = __attribute__((__vector_size__(4 * sizeof(unsigned int)))) unsigned int;
+
+DINLINE void ll_store_b128(uint32_t* dst, uint32_t a0, uint32_t a1, uint32_t a2, uint32_t a3)
+{
+    union
+    {
+        llx_v4u  v;
+        uint32_t w[4];
+    } u;
+    u.w[0] = a0;
+    u.w[1] = a1;
+    u.w[2] = a2;
+    u.w[3] = a3;
+    __builtin_nontemporal_store(u.v, reinterpret_cast<llx_v4u*>(dst));
+    asm volatile("" ::: "memory");
+}
+
+template <typename T>
+DINLINE void remote_store_b128(uint32_t* dst, opus::vector_t<T, 16 / sizeof(T)> data)
+{
+  union
+  {
+    llx_v4u v;
+    T w[16 / sizeof(T)];
+  } u;
+#pragma unroll
+  for (int i = 0; i < 16 / sizeof(T); ++i)
+  {
+    u.w[i] = data[i];
+  }
+  __builtin_nontemporal_store(u.v, reinterpret_cast<llx_v4u*>(dst));
+  asm volatile("" ::: "memory");
+}
+
+template <typename T>
+DINLINE void remote_load_b128(const uint32_t* src, opus::vector_t<T, 16 / sizeof(T)>& data)
+{
+  asm volatile("" ::: "memory");
+  union
+  {
+    llx_v4u v;
+    T w[16 / sizeof(T)];
+  } u;
+  u.v = __builtin_nontemporal_load(reinterpret_cast<llx_v4u*>(const_cast<uint32_t*>(src)));
+#pragma unroll
+  for (int i = 0; i < 16 / sizeof(T); ++i)
+  {
+    data[i] = u.w[i];
+  }
+}
+
+DINLINE void ll_load_b128(
+    const uint32_t* src, uint32_t& o0, uint32_t& o1, uint32_t& o2, uint32_t& o3)
+{
+    asm volatile("" ::: "memory");
+    union
+    {
+        llx_v4u  v;
+        uint32_t w[4];
+    } u;
+    u.v = __builtin_nontemporal_load(reinterpret_cast<llx_v4u*>(const_cast<uint32_t*>(src)));
+    o0  = u.w[0];
+    o1  = u.w[1];
+    o2  = u.w[2];
+    o3  = u.w[3];
+}
+
+// LL flat all-reduce. 1D grid over 8-byte packets.
+//
+// Phase 1 (publish): rank writes its full sendbuff into every peer's scratch at
+// slot[rank], as LL lines carrying the epoch flag.
+// Phase 2 (reduce): rank polls its own scratch slots for the other ranks
+// (waiting on the flag), sums them with its own sendbuff (fp32 accumulation),
+// and writes recvbuff. Self is read directly from sendbuff.
+//
+// Graph-safe device epoch: each block owns a persistent device flag
+// block_flags[blockIdx.x] that the kernel itself bumps. Scratch is
+// double-buffered (bank = epoch & 1); the per-epoch flag disambiguates stale
+// lines, so no clearing is needed and it survives CUDA-graph replay.
+template <typename T, int ngpus, int BLOCK_SIZE = 256>
+__global__ void __launch_bounds__(BLOCK_SIZE) ar_ll_gfx9(
+    T* const* __restrict__ peer_scratch, // ngpus scratch bases (device table)
+    T* __restrict__ recvbuff,
+    const T* __restrict__ sendbuff,
+    size_t nPk,          // number of 8-byte packets = bytes / 8
+    int rank,
+    uint32_t* __restrict__ block_flags, // device array[gridDim.x], persisted
+    size_t slotStridePk = kLLPocSlotCapPk) // per-rank slot capacity in packets
+{
+    constexpr int LP = 8 / sizeof(T); // elements per 8-byte payload
+    using PL         = typename opus::vector_t<T, LP>;
+    using AL         = typename opus::vector_t<opus::fp32_t, LP>;
+    const size_t slot = slotStridePk;
+
+    __shared__ uint32_t s_flag;
+    if(threadIdx.x == 0)
+    {
+        uint32_t f = block_flags[blockIdx.x] + 1u;
+        if(f == 0u)
+            f = 1u; // flag is never 0 (0 == cleared scratch)
+        s_flag = f;
+    }
+    __syncthreads();
+    const uint32_t flag        = s_flag;
+    const size_t   bankOffPkts = (size_t)(flag & 1u) * (size_t)ngpus * slot;
+
+    const size_t gtid   = (size_t)blockIdx.x * blockDim.x + threadIdx.x;
+    const size_t stride = (size_t)gridDim.x * blockDim.x;
+
+    const uint32_t* in = reinterpret_cast<const uint32_t*>(sendbuff);
+
+    // Phase 1: publish my payload into every peer's slot[rank].
+    for(size_t pk = gtid; pk < nPk; pk += stride)
+    {
+        const uint32_t d0 = in[2 * pk];
+        const uint32_t d1 = in[2 * pk + 1];
+#pragma unroll
+        for(int r = 1; r < ngpus; ++r)
+        {
+            int          peer = (rank + r) % ngpus;
+            LLPackedMsg* dst  = reinterpret_cast<LLPackedMsg*>(peer_scratch[peer]) +
+                               bankOffPkts + (size_t)rank * slot;
+            ll_store_b128(reinterpret_cast<uint32_t*>(&dst[pk]), d0, flag, d1, flag);
+        }
+    }
+
+    // Phase 2: poll my slots for the other ranks, reduce with my own data.
+    LLPackedMsg* myBase =
+        reinterpret_cast<LLPackedMsg*>(peer_scratch[rank]) + bankOffPkts;
+    for(size_t pk = gtid; pk < nPk; pk += stride)
+    {
+        PL selfv = *reinterpret_cast<const PL*>(&in[2 * pk]);
+        AL acc;
+#pragma unroll
+        for(int j = 0; j < LP; ++j)
+            acc[j] = upcast_s(selfv[j]);
+
+        uint32_t load_reg[ngpus - 1][4];
+        volatile LLPackedMsg* src[ngpus - 1];
+#pragma unroll
+        for (int i = 1; i < ngpus; ++i)
+        {
+          int peer = (rank + i) % ngpus;
+          src[i - 1] = myBase + (size_t)peer * slot;
+        }
+        bool still_loop;
+        do
+        {
+          still_loop = false;
+#pragma unroll
+          for (int i = 0; i < ngpus - 1; ++i)
+          {
+            ll_load_b128(
+                reinterpret_cast<const uint32_t*>(const_cast<LLPackedMsg*>(&src[i][pk])),
+                load_reg[i][0], load_reg[i][1], load_reg[i][2], load_reg[i][3]
+            );
+          }
+#pragma unroll
+          for (int i = 0; i < ngpus - 1; ++i)
+          {
+            still_loop = still_loop || load_reg[i][1] != flag;
+            still_loop = still_loop || load_reg[i][3] != flag;
+          }
+        } while (still_loop);
+#pragma unroll
+        for (int i = 0; i < ngpus - 1; ++i)
+        {
+          const uint32_t w[2] = {load_reg[i][0], load_reg[i][2]};
+          PL pv = *reinterpret_cast<const PL*>(w);
+#pragma unroll
+          for (int j = 0; j < LP; ++j)
+          {
+            acc[j] += upcast_s(pv[j]);
+          }
+        }
+
+        PL ov;
+#pragma unroll
+        for(int j = 0; j < LP; ++j)
+            ov[j] = downcast_s<T>(acc[j]);
+        reinterpret_cast<PL*>(recvbuff)[pk] = ov;
+    }
+
+    if(threadIdx.x == 0)
+        block_flags[blockIdx.x] = flag;
+}
+
+// ---------------------------------------------------------------------------
+// LL128: 128B / 16-lane lines, 15 payload words + 1 flag word. Same
+// double-buffered scratch model as ar_ll_gfx9 above; only the line geometry
+// (128B / 16 lanes) and the paired-b128 access pattern differ.
+// ---------------------------------------------------------------------------
+
+constexpr int    kLL128MaxBlocks = 80;
+constexpr int    kLL128LineElems = 16;
+constexpr int    kLL128DataElems = 15;
+constexpr int    kLL128FlagElem  = 15;
+constexpr int    kLL128Lanes     = 16;
+
+struct LLLine128
+{
+    uint64_t w[kLL128LineElems];
+};
+static_assert(sizeof(LLLine128) == 128, "LLLine128 must be exactly 128 bytes");
+
+__host__ __device__ __forceinline__ size_t ll128NumLines(size_t nWords)
+{
+    return (nWords + (size_t)kLL128DataElems - 1) / (size_t)kLL128DataElems;
+}
+
+// Add two 8B payload words element-wise in fp32 (matches ar_ll_gfx9 accumulate).
+template <typename T>
+DINLINE uint64_t ll128_add_word(uint64_t a, uint64_t b)
+{
+    constexpr int LP = 8 / sizeof(T);
+    using PL         = typename opus::vector_t<T, LP>;
+    PL pa = *reinterpret_cast<const PL*>(&a);
+    PL pb = *reinterpret_cast<const PL*>(&b);
+    PL pr;
+#pragma unroll
+    for(int j = 0; j < LP; ++j)
+        pr[j] = downcast_s<T>(upcast_s(pa[j]) + upcast_s(pb[j]));
+    uint64_t r;
+    __builtin_memcpy(&r, &pr, 8);
+    return r;
+}
+
+// Per-block epoch (graph-safe).
+DINLINE uint32_t ll128EpochBegin(const uint32_t* __restrict__ epochDev,
+                                 int flatBlockId,
+                                 uint32_t& s_flag)
+{
+    if(threadIdx.x == 0)
+    {
+        uint32_t f = epochDev[flatBlockId] + 1u;
+        if(f == 0u)
+            f = 2u; // skip 0 sentinel; preserve bank parity
+        s_flag = f;
+    }
+    __syncthreads();
+    return s_flag;
+}
+
+DINLINE void ll128EpochEnd(uint32_t* __restrict__ epochDev,
+                           int flatBlockId,
+                           int total,
+                           int epochLen,
+                           uint32_t flag)
+{
+    if(threadIdx.x == 0)
+    {
+        for(int e = flatBlockId; e < epochLen; e += total)
+            epochDev[e] = flag;
+    }
+}
+template <typename T>
+__device__ void ll128_store_b128(opus::vector_t<T, 16 / sizeof(T)> data, uint32_t* dst)
+{
+  union
+  {
+    llx_v4u v;
+    opus::vector_t<T, 16 / sizeof(T)> vec;
+  } u;
+  u.vec = data;
+  __builtin_nontemporal_store(u.v, reinterpret_cast<llx_v4u*>(dst));
+  asm volatile("" ::: "memory");
+}
+
+template <typename T>
+__device__ void ll128_load_b128(opus::vector_t<T, 16 / sizeof(T)>& data, uint32_t* src)
+{
+  asm volatile("" ::: "memory");
+  union
+  {
+    llx_v4u v;
+    opus::vector_t<T, 16 / sizeof(T)> vec;
+  } u;
+  u.v = __builtin_nontemporal_load(reinterpret_cast<llx_v4u*>(const_cast<uint32_t*>(src)));
+  data = u.vec;
+}
+
+DINLINE void ll128_check_flag(uint32_t& flag0, uint32_t& flag1, uint32_t* src)
+{
+  asm volatile("" ::: "memory");
+  union
+  {
+    llx_v4u v;
+    uint32_t w[4];
+  } u;
+  u.v = __builtin_nontemporal_load(reinterpret_cast<llx_v4u*>(const_cast<uint32_t*>(src)));
+  flag0 = u.w[2];
+  flag1 = u.w[3];
+}
+
+template <typename T>
+__device__ void loadDataFromHBMToReg(
+    int group_index, int lane_index, int total_group, int last_group_pack_num, uint32_t flag,
+    const T* hbm_buffer, opus::vector_t<T, 16 / sizeof(T)> (&dst_reg)[2]
+)
+{
+  using P = opus::vector_t<T, 16 / sizeof(T)>;
+  constexpr int pack_per_group = 15;
+  if (group_index != total_group - 1)
+  {
+    dst_reg[0] = *(reinterpret_cast<const P*>(hbm_buffer) + group_index * pack_per_group + lane_index);
+    if (lane_index < 7)
+    {
+      dst_reg[1] = *(reinterpret_cast<const P*>(hbm_buffer) + group_index * pack_per_group + lane_index + 8);
+    }
+    else
+    {
+#pragma unroll
+      for (int i = 0; i < 4; ++i)
+      {
+        *(reinterpret_cast<uint32_t*>(&dst_reg[1]) + i) = flag;
+      }
+    }
+  }
+  else // last group
+  {
+    if (lane_index < last_group_pack_num)
+    {
+      dst_reg[0] = *(reinterpret_cast<const P*>(hbm_buffer) + group_index * pack_per_group + lane_index);
+    }
+    else
+    {
+#pragma unroll
+      for (int i = 0; i < 4; ++i)
+      {
+        *(reinterpret_cast<uint32_t*>(&dst_reg[0]) + i) = 0;
+      }
+    }
+
+    if (lane_index < last_group_pack_num - 8)
+    {
+      dst_reg[1] = *(reinterpret_cast<const P*>(hbm_buffer) + group_index * pack_per_group + 8 + lane_index);
+    }
+    else if (lane_index == 7)
+    {
+#pragma unroll
+      for (int i = 0; i < 4; ++i)
+      {
+        *(reinterpret_cast<uint32_t*>(&dst_reg[1]) + i) = flag;
+      }
+    }
+    else
+    {
+#pragma unroll
+      for (int i = 0; i < 4; ++i)
+      {
+        *(reinterpret_cast<uint32_t*>(&dst_reg[1]) + i) = 0;
+      }
+    }
+  }
+
+  if (lane_index == 7)
+  {
+#pragma unroll
+    for (int i = 0; i < 4; ++i)
+    {
+      dst_reg[1][i] = dst_reg[0][4 + i];
+      dst_reg[0][4 + i] = dst_reg[1][4 + i];
+    }
+  }
+}
+
+#define LL128_MAX_BLOCK_NUM 192
+
+// LL128 unroll2 1-shot all-reduce. 2B dtype only (fp16 / bf16). 8-lane groups,
+// 15-pack lines. Internally resets the per-block epoch up to LL128_MAX_BLOCK_NUM.
+template <typename T, int ngpus, int block_size>
+__global__ void __launch_bounds__(block_size) ar_ll128_unroll2(
+    const T* __restrict__ input, T* __restrict__ output,
+    T* const* __restrict__ peer_scratch, uint32_t* __restrict__ graph_safe_flag,
+    int self_rank, int size
+)
+{
+  constexpr int pack_size = 16 / sizeof(T);
+  using P = opus::vector_t<T, pack_size>;
+  using A = opus::vector_t<opus::fp32_t, pack_size>;
+
+  constexpr int group_per_block = block_size / 8;
+  constexpr int pack_per_group = 15;
+  constexpr int bytes_per_group = 240;
+  int total_bytes = size * sizeof(T);
+  int total_pack = total_bytes / 16;
+  int total_group = (total_bytes + bytes_per_group - 1) / bytes_per_group;
+  int lane_id = threadIdx.x % 8;
+  int group_id = threadIdx.x / 8;
+  int g_index = blockIdx.x * group_per_block + group_id;
+  int stride = gridDim.x * group_per_block;
+  int last_group_pack_num = total_pack % 15 == 0 ? 15 : total_pack % 15;
+
+  __shared__ uint32_t s_flag;
+  const uint32_t flag = ll128EpochBegin(graph_safe_flag, blockIdx.x, s_flag);
+  int bank_offset = (flag & 1u) * ngpus * (total_group * 128 * 2 / 4);
+
+  for (int idx = g_index; idx < total_group; idx += stride)
+  {
+    P inp_reg[2];
+    loadDataFromHBMToReg<T>(idx, lane_id, total_group, last_group_pack_num, flag, input, inp_reg);
+#pragma unroll
+    for (int i = 1; i < ngpus; ++i)
+    {
+      int peer = (self_rank + i) % ngpus;
+      uint32_t* scratch_dst = reinterpret_cast<uint32_t*>(peer_scratch[peer])
+                              + bank_offset
+                              + self_rank * (total_group * 128 * 2 / 4)
+                              + idx * 8 * 2 * 4 + lane_id * 4;
+      ll128_store_b128<T>(inp_reg[0], scratch_dst);
+      ll128_store_b128<T>(inp_reg[1], scratch_dst + 8 * 4);
+    }
+  }
+
+  uint32_t* self_scratch = reinterpret_cast<uint32_t*>(peer_scratch[self_rank]) + bank_offset;
+  for (int idx = g_index; idx < total_group; idx += stride)
+  {
+    P inp_reg[2];
+    loadDataFromHBMToReg<T>(idx, lane_id, total_group, last_group_pack_num, flag, input, inp_reg);
+    A reduce_rslt_f32[2];
+#pragma unroll
+    for (int i = 0; i < pack_size; ++i)
+    {
+      reduce_rslt_f32[0][i] = upcast_s(inp_reg[0][i]);
+      reduce_rslt_f32[1][i] = upcast_s(inp_reg[1][i]);
+    }
+    uint32_t* scratch_base[ngpus - 1];
+    uint32_t* scratch_flag_addr[2][ngpus - 1];
+#pragma unroll
+    for (int i = 1; i < ngpus; ++i)
+    {
+      scratch_base[i - 1] = self_scratch + ((self_rank + i) % ngpus) * (total_group * 128 * 2 / 4) + idx * 8 * 2 * 4;
+      scratch_flag_addr[0][i - 1] = scratch_base[i - 1] + 7 * 4;
+      scratch_flag_addr[1][i - 1] = scratch_flag_addr[0][i - 1] + 8 * 4;
+    }
+    uint32_t s_f[2][2 * (ngpus - 1)];
+    bool still_loop;
+    do
+    {
+      still_loop = false;
+#pragma unroll
+      for (int i = 0; i < ngpus - 1; ++i)
+      {
+        ll128_check_flag(s_f[0][2 * i], s_f[0][2 * i + 1], scratch_flag_addr[0][i]);
+      }
+#pragma unroll
+      for (int i = 0; i < ngpus - 1; ++i)
+      {
+        still_loop = still_loop || s_f[0][2 * i] != flag;
+        still_loop = still_loop || s_f[0][2 * i + 1] != flag;
+      }
+    } while (still_loop);
+    P reduce_elem[ngpus - 1];
+#pragma unroll
+    for (int i = 0; i < ngpus - 1; ++i)
+    {
+      ll128_load_b128<T>(reduce_elem[i], scratch_base[i] + lane_id * 4);
+#pragma unroll
+      for (int j = 0; j < pack_size; ++j)
+      {
+        reduce_rslt_f32[0][j] += upcast_s(reduce_elem[i][j]);
+      }
+    }
+
+    do
+    {
+      still_loop = false;
+#pragma unroll
+      for (int i = 0; i < ngpus - 1; ++i)
+      {
+        ll128_check_flag(s_f[1][2 * i], s_f[1][2 * i + 1], scratch_flag_addr[1][i]);
+      }
+#pragma unroll
+      for (int i = 0; i < ngpus - 1; ++i)
+      {
+        still_loop = still_loop || s_f[1][2 * i] != flag;
+        still_loop = still_loop || s_f[1][2 * i + 1] != flag;
+      }
+    } while (still_loop);
+#pragma unroll
+    for (int i = 0; i < ngpus - 1; ++i)
+    {
+      ll128_load_b128<T>(reduce_elem[i], scratch_base[i] + lane_id * 4 + 8 * 4);
+#pragma unroll
+      for (int j = 0; j < pack_size; ++j)
+      {
+        reduce_rslt_f32[1][j] += upcast_s(reduce_elem[i][j]);
+      }
+    }
+
+    // write output
+    P reduce_rslt[2];
+#pragma unroll
+    for (int i = 0; i < 2; ++i)
+    {
+#pragma unroll
+      for (int j = 0; j < pack_size; ++j)
+      {
+        reduce_rslt[i][j] = downcast_s<T>(reduce_rslt_f32[i][j]);
+      }
+    }
+    if (lane_id == 7)
+    {
+#pragma unroll
+      for (int i = 0; i < pack_size / 2; ++i)
+      {
+        reduce_rslt[0][pack_size / 2 + i] = reduce_rslt[1][i];
+      }
+    }
+    bool is_last_group = (idx == total_group - 1);
+    if (!is_last_group || lane_id < last_group_pack_num)
+    {
+      *(reinterpret_cast<P*>(output) + idx * pack_per_group + lane_id) = reduce_rslt[0];
+    }
+    if (lane_id != 7 && (!is_last_group || lane_id + 8 < last_group_pack_num))
+    {
+      *(reinterpret_cast<P*>(output) + idx * pack_per_group + lane_id + 8) = reduce_rslt[1];
+    }
+  }
+  ll128EpochEnd(graph_safe_flag, blockIdx.x, gridDim.x, LL128_MAX_BLOCK_NUM, flag);
+}
+
 class CustomAllreduce
 {
     public:
@@ -3362,6 +3925,17 @@ class CustomAllreduce
     std::vector<void*> graph_unreg_output_buffers_;
     // a map from IPC handles to opened IPC pointers
     std::map<IPC_KEY, char*> ipc_handles_;
+
+    // LL / LL128 fast-path staging (reuses the meta buffer's post-Signal region,
+    // already IPC-exchanged via sg_). Device table of per-rank scratch bases,
+    // computed in the constructor from sg_.signals[]; no second IPC exchange.
+    //   [0, world_size_)              -> LL   scratch bases (signals[i]+sizeof(Signal))
+    //   [world_size_, 2*world_size_)  -> LL128 scratch bases (+ kLLPocRegionBytes)
+    void**    d_ll_scratch_peers_    = nullptr;
+    // Rank-local per-block epoch arrays (not exchanged). Allocated at init time
+    // (not during graph capture) so the LL kernels are graph-capture safe.
+    uint32_t* d_ll_poc_block_flags_  = nullptr; // array[kMaxBlocks]
+    uint32_t* d_ll128_unroll2_epoch_ = nullptr; // array[LL128_MAX_BLOCK_NUM]
 
     template <typename T>
     T* local_tmp_reduced_ptr() const
@@ -3407,6 +3981,34 @@ class CustomAllreduce
             }
             sg_.signals[i] = rank_sg;
         }
+        init_ll_fast_path_();
+    }
+
+    // LL / LL128 fast-path init. Builds the device scratch-base table from the
+    // already-exchanged sg_.signals[] (peer scratch = post-Signal region of each
+    // peer's meta buffer) and allocates the rank-local per-block epoch arrays.
+    // Runs at construction (never during graph capture) so replays never malloc.
+    void init_ll_fast_path_()
+    {
+        std::vector<void*> peers(2 * world_size_);
+        for(int i = 0; i < world_size_; ++i)
+        {
+            char* base =
+                reinterpret_cast<char*>(const_cast<Signal*>(sg_.signals[i])) + sizeof(Signal);
+            peers[i]               = base;                       // LL scratch base
+            peers[world_size_ + i] = base + kLLPocRegionBytes;   // LL128 scratch base
+        }
+        HIP_CALL(hipMalloc(&d_ll_scratch_peers_, sizeof(void*) * 2 * world_size_));
+        HIP_CALL(hipMemcpy(d_ll_scratch_peers_, peers.data(),
+                           sizeof(void*) * 2 * world_size_, hipMemcpyHostToDevice));
+
+        HIP_CALL(hipMalloc((void**)&d_ll_poc_block_flags_, sizeof(uint32_t) * kMaxBlocks));
+        HIP_CALL(hipMemset(d_ll_poc_block_flags_, 0, sizeof(uint32_t) * kMaxBlocks));
+
+        HIP_CALL(hipMalloc((void**)&d_ll128_unroll2_epoch_,
+                           sizeof(uint32_t) * LL128_MAX_BLOCK_NUM));
+        HIP_CALL(hipMemset(d_ll128_unroll2_epoch_, 0,
+                           sizeof(uint32_t) * LL128_MAX_BLOCK_NUM));
     }
 
     char* open_ipc_handle(const void* ipc_handle)
@@ -3723,6 +4325,132 @@ class CustomAllreduce
      * Not quite sure the underlying reason, but my guess is that too many SMs
      * will cause contention on NVLink bus.
      */
+
+    // -----------------------------------------------------------------------
+    // LL / LL128 small-message fast paths (gfx9 POC). Staging scratch reuses the
+    // meta buffer's post-Signal region (peer bases in d_ll_scratch_peers_, built
+    // at construction from sg_.signals[]); no separate alloc / IPC exchange. NOT
+    // wired into the size-based dispatch below yet — that lands in step 2 once
+    // the bench thresholds are in. The caller must keep the message within the
+    // LL / LL128 caps (kLLPocSlotCapPk / kLL128PocCapBytes) so the scratch fits
+    // the reused tmp region (2 * max_size).
+    // -----------------------------------------------------------------------
+    template <typename T>
+    void allreduce_ll_poc(hipStream_t stream, const T* input, T* output,
+                          int numel, int threads_per_block = 256)
+    {
+        const size_t bytes = (size_t)numel * sizeof(T);
+        if(bytes % 8 != 0)
+            throw std::runtime_error(
+                "allreduce_ll_poc: byte count must be a multiple of 8");
+        const size_t nPk     = bytes >> 3;
+        const size_t slotCap = kLLPocSlotCapPk;
+        if(nPk > slotCap)
+            throw std::runtime_error(
+                "allreduce_ll_poc: packet count exceeds scratch slot capacity");
+
+        int blocks = std::min<int>(
+            kMaxBlocks, (int)((nPk + threads_per_block - 1) / threads_per_block));
+        if(blocks < 1)
+            blocks = 1;
+
+        T* const* peers = reinterpret_cast<T* const*>(d_ll_scratch_peers_);
+
+#define LAUNCH_LL_POC(NGPUS, BS)                                             \
+    ar_ll_gfx9<T, NGPUS, BS><<<blocks, BS, 0, stream>>>(                     \
+        peers, output, input, nPk, rank_, d_ll_poc_block_flags_, slotCap)
+
+#define DISPATCH_LL_POC_BS(NGPUS)                                            \
+    switch(threads_per_block)                                               \
+    {                                                                        \
+    case 256: LAUNCH_LL_POC(NGPUS, 256); break;                             \
+    case 512: LAUNCH_LL_POC(NGPUS, 512); break;                             \
+    case 1024: LAUNCH_LL_POC(NGPUS, 1024); break;                           \
+    default:                                                                 \
+        throw std::invalid_argument(                                        \
+            "allreduce_ll_poc: threads_per_block must be 256, 512 or 1024"); \
+    }
+
+        switch(world_size_)
+        {
+        case 2: DISPATCH_LL_POC_BS(2); break;
+        case 4: DISPATCH_LL_POC_BS(4); break;
+        case 8: DISPATCH_LL_POC_BS(8); break;
+        default:
+            throw std::runtime_error(
+                "allreduce_ll_poc only supports world_size in (2,4,8). Actual = " +
+                std::to_string(world_size_));
+        }
+
+#undef DISPATCH_LL_POC_BS
+#undef LAUNCH_LL_POC
+    }
+
+    // LL128 unroll2 1-shot all-reduce. 2-byte dtype only (fp16 / bf16). The
+    // kernel sizes its scratch from the message internally (per total_group);
+    // the cap bounds it to the LL128 sub-region of the reused tmp buffer.
+    template <typename T>
+    void allreduce_ll128_unroll2(hipStream_t stream, const T* input, T* output,
+                                 int numel, int threads_per_block = 512)
+    {
+        static_assert(sizeof(T) == 2,
+                      "allreduce_ll128_unroll2 only supports 2-byte dtypes");
+        const size_t bytes = (size_t)numel * sizeof(T);
+        if(bytes % 16 != 0)
+            throw std::runtime_error(
+                "allreduce_ll128_unroll2: byte count must be a multiple of 16");
+        if(bytes > kLL128PocCapBytes)
+            throw std::runtime_error(
+                "allreduce_ll128_unroll2: message " + std::to_string(bytes) +
+                "B exceeds LL128 fast-path cap " +
+                std::to_string(kLL128PocCapBytes) + "B");
+
+        constexpr int bytesPerGroup = 240; // 15 packs * 16B
+        const int     totalGroup = (int)((bytes + bytesPerGroup - 1) / bytesPerGroup);
+
+        T* const* peers =
+            reinterpret_cast<T* const*>(d_ll_scratch_peers_ + world_size_);
+
+#define LAUNCH_LL128_UNROLL2(NGPUS, BS)                                          \
+    do                                                                          \
+    {                                                                           \
+        constexpr int groupsPerBlock = (BS) / 8;                                \
+        int           blocks         = std::min<int>(                           \
+            LL128_MAX_BLOCK_NUM, (totalGroup + groupsPerBlock - 1) / groupsPerBlock); \
+        if(blocks < 1)                                                          \
+            blocks = 1;                                                         \
+        ar_ll128_unroll2<T, NGPUS, BS><<<blocks, (BS), 0, stream>>>(            \
+            input, output, peers, d_ll128_unroll2_epoch_, rank_, numel);        \
+    } while(0)
+
+#define DISPATCH_LL128_UNROLL2_BS(NGPUS)                                        \
+    switch(threads_per_block)                                                   \
+    {                                                                           \
+    case 256: LAUNCH_LL128_UNROLL2(NGPUS, 256); break;                          \
+    case 512: LAUNCH_LL128_UNROLL2(NGPUS, 512); break;                          \
+    case 1024: LAUNCH_LL128_UNROLL2(NGPUS, 1024); break;                        \
+    default:                                                                    \
+        throw std::invalid_argument(                                            \
+            "allreduce_ll128_unroll2: threads_per_block must be 256, 512 or "   \
+            "1024");                                                            \
+    }
+
+        switch(world_size_)
+        {
+        case 2: DISPATCH_LL128_UNROLL2_BS(2); break;
+        case 4: DISPATCH_LL128_UNROLL2_BS(4); break;
+        case 8: DISPATCH_LL128_UNROLL2_BS(8); break;
+        default:
+            throw std::runtime_error(
+                "allreduce_ll128_unroll2 only supports world_size in (2,4,8). "
+                "Actual = " +
+                std::to_string(world_size_));
+        }
+
+#undef DISPATCH_LL128_UNROLL2_BS
+#undef LAUNCH_LL128_UNROLL2
+    }
+
     template <typename T>
     void allreduce(hipStream_t stream,
                    T* input,
@@ -3746,6 +4474,65 @@ class CustomAllreduce
     if(block_limit > kMaxBlocks)
         throw std::runtime_error("max supported block limit is " + std::to_string(kMaxBlocks) +
                                  ". Got " + std::to_string(block_limit));
+
+    // -----------------------------------------------------------------------
+    // LL / LL128 small-message fast path (gfx9). Routes small messages to the
+    // ar_ll_gfx9 / ar_ll128_unroll2 kernels per measured thresholds; anything
+    // larger falls through to the existing 1-/2-stage dispatch below. Staging
+    // scratch reuses the meta buffer's post-Signal region (see
+    // allreduce_ll_poc / allreduce_ll128_unroll2), which assumes the tmp region
+    // (2 * max_size) comfortably exceeds the fast-path scratch (worst case
+    // ~18 MiB at tp2); true for the default max_size (1 GiB).
+    //
+    // `size` here is still the element count (numel); it is divided down to
+    // 16-byte packs only after this block. Thresholds were measured on bf16, so
+    // the path is gated to 2-byte dtypes (if constexpr also keeps the LL128
+    // 2-byte static_assert out of the fp32 instantiation). numel notation a*b
+    // mirrors the (tokens, hidden) bench shapes.
+    if constexpr(sizeof(T) == 2)
+    {
+        if(use_new && !is_broadcast_reg_outptr)
+        {
+            const int numel    = size;
+            int       ll_bs    = 0; // >0 -> LL    with this block size
+            int       ll128_bs = 0; // >0 -> LL128 with this block size
+            if(world_size_ == 8)
+            {
+                if(numel <= 4 * 8192)
+                    ll_bs = 256;
+            }
+            else if(world_size_ == 4)
+            {
+                if(numel <= 4 * 7168)
+                    ll_bs = 256;
+                else if(numel <= 8 * 8192)
+                    ll128_bs = 256;
+                else if(numel <= 16 * 8192)
+                    ll128_bs = 512;
+            }
+            else if(world_size_ == 2)
+            {
+                if(numel <= 4 * 8192)
+                    ll_bs = 256;
+                else if(numel <= 16 * 8192)
+                    ll128_bs = 256;
+                else if(numel <= 128 * 7168)
+                    ll128_bs = 512;
+                else if(numel <= 256 * 8192)
+                    ll128_bs = 1024;
+            }
+            if(ll_bs)
+            {
+                allreduce_ll_poc<T>(stream, input, output, numel, ll_bs);
+                return;
+            }
+            if(ll128_bs)
+            {
+                allreduce_ll128_unroll2<T>(stream, input, output, numel, ll128_bs);
+                return;
+            }
+        }
+    }
 
     RankData* input_ptrs  = get_buffer_RD(stream, input);
     RankData* output_ptrs = nullptr;
@@ -4888,6 +5675,12 @@ void dispatchAllReduceMhcPostSplit(hipStream_t stream,
 
 ~CustomAllreduce()
 {
+    if(d_ll_scratch_peers_)
+        (void)hipFree(d_ll_scratch_peers_);
+    if(d_ll_poc_block_flags_)
+        (void)hipFree(d_ll_poc_block_flags_);
+    if(d_ll128_unroll2_epoch_)
+        (void)hipFree(d_ll128_unroll2_epoch_);
     for(auto [_, ptr] : ipc_handles_)
     {
         HIP_CALL(hipIpcCloseMemHandle(ptr));

--- a/csrc/include/custom_all_reduce.cuh
+++ b/csrc/include/custom_all_reduce.cuh
@@ -4505,10 +4505,8 @@ class CustomAllreduce
             {
                 if(numel <= 4 * 7168)
                     ll_bs = 256;
-                else if(numel <= 8 * 8192)
+                else if(numel <= 4 * 8192)
                     ll128_bs = 256;
-                else if(numel <= 16 * 8192)
-                    ll128_bs = 512;
             }
             else if(world_size_ == 2)
             {
@@ -4516,10 +4514,8 @@ class CustomAllreduce
                     ll_bs = 256;
                 else if(numel <= 16 * 8192)
                     ll128_bs = 256;
-                else if(numel <= 128 * 7168)
+                else if(numel <= 64 * 7168)
                     ll128_bs = 512;
-                else if(numel <= 256 * 8192)
-                    ll128_bs = 1024;
             }
             if(ll_bs)
             {

--- a/op_tests/multigpu_tests/test_custom_allreduce.py
+++ b/op_tests/multigpu_tests/test_custom_allreduce.py
@@ -123,8 +123,45 @@ def test_allreduce_custom(
     }
 
 
-l_dtype = ["fp16", "bf16"]
-l_shape = [(2, 7168), (128, 8192)]
+# Custom-AR size cutoff (bytes). Mirrors _DEFAULT_CAR_MAX_SIZE in
+# aiter/dist/device_communicators/custom_all_reduce.py and honors the same
+# AITER_CUSTOM_AR_MAX_SIZE override. Inputs at or below this run on the custom
+# kernels (larger ones fall back to RCCL), so the swept size list stops here.
+_DEFAULT_CAR_MAX_BYTES = 8192 * 8192
+
+
+def _car_max_bytes() -> int:
+    e = os.environ.get("AITER_CUSTOM_AR_MAX_SIZE", "")
+    try:
+        v = int(e)
+        if v > 0:
+            return v
+    except ValueError:
+        pass
+    return _DEFAULT_CAR_MAX_BYTES
+
+
+def gen_sizes(dtype) -> list[int]:
+    """Element counts to sweep: [1024, 2048, 4096] then 7168*k / 8192*k for
+    k = 1, 2, 4, 8, ... up to the largest size custom_all_reduce serves."""
+    itemsize = torch.empty(0, dtype=dtype).element_size()
+    max_numel = _car_max_bytes() // itemsize
+    sizes = [n for n in (1024, 2048, 4096) if n <= max_numel]
+    k = 1
+    while True:
+        added = False
+        for base in (7168, 8192):
+            n = base * k
+            if n <= max_numel:
+                sizes.append(n)
+                added = True
+        if not added:
+            break
+        k *= 2
+    return sizes
+
+
+l_dtype = ["bf16", "fp16", "fp32"]
 
 parser = argparse.ArgumentParser(description="config input of test")
 parser.add_argument(
@@ -132,10 +169,24 @@ parser.add_argument(
     "--dtype",
     type=str,
     choices=l_dtype,
-    nargs="?",
-    const=None,
-    default=None,
-    help="data type",
+    default="bf16",
+    help="data type (default: bf16)",
+)
+parser.add_argument(
+    "-t",
+    "--tp-size",
+    type=int,
+    choices=[2, 4, 6, 8],
+    default=8,
+    help="number of GPUs / tensor-parallel size (default: 8)",
+)
+parser.add_argument(
+    "-m",
+    "--mode",
+    type=str,
+    choices=["graph", "eager"],
+    default="graph",
+    help="execution mode (default: graph)",
 )
 parser.add_argument(
     "-s",
@@ -144,40 +195,32 @@ parser.add_argument(
     nargs="?",
     const=None,
     default=None,
-    help="shape. e.g. -s 128,8192",
-)
-parser.add_argument(
-    "-g",
-    "--with-graph",
-    type=lambda x: str(x).lower() in ["true", "1", "yes"],
-    default=True,
-    help="use CUDA graph (default: True). e.g. -g true or -g false",
+    help="single shape override, e.g. -s 128,8192 (default: swept size list)",
 )
 
 
 if __name__ == "__main__":
     freeze_support()
     args = parser.parse_args()
-    if args.dtype is None:
-        l_dtype = [dtypes.d_dtypes[key] for key in l_dtype]
-    else:
-        l_dtype = [dtypes.d_dtypes[args.dtype]]
+    dtype = dtypes.d_dtypes[args.dtype]
+    with_graph = args.mode == "graph"
     if args.shape is not None:
         l_shape = [args.shape]
+    else:
+        l_shape = gen_sizes(dtype)
     df = []
-    for dtype in l_dtype:
-        for shape in l_shape:
-            ret = test_allreduce_custom(
-                8,
-                1,
-                shape,
-                dtype,
-                withGraph=args.with_graph,
-                distributed_init_method=get_distributed_init_method(
-                    get_ip(), get_open_port()
-                ),
-            )
-            df.append(ret)
+    for shape in l_shape:
+        ret = test_allreduce_custom(
+            args.tp_size,
+            1,
+            shape,
+            dtype,
+            withGraph=with_graph,
+            distributed_init_method=get_distributed_init_method(
+                get_ip(), get_open_port()
+            ),
+        )
+        df.append(ret)
     df = pd.DataFrame(df)
     show_cols = [
         "tp_size",


### PR DESCRIPTION
## Motivation

add LL proto and LL128 proto for optimization of small size case

## Technical Details

remove rank level sync and replace by LL,LL128 proto

## Test Plan


## Test Result

MI308 tp2

  | baseline | ll | ll128 b256 | ll128 b512 | ll128 b1024
-- | -- | -- | -- | -- | --
1024 | 12.98 | 5.49 | 10.6 | 10.77 | 10.65
2048 | 13.12 | 5.46 | 11 | 11.07 | 10.77
4096 | 13.43 | 5.42 | 8.4 | 11.33 | 11.55
7168 | 13.86 | 5.32 | 7.89 | 11.35 | 11.31
8192 | 13.62 | 5.43 | 7.12 | 8.49 | 11.7
2*7168 | 13.98 | 5.36 | 6.83 | 8.59 | 12.5
2*8192 | 14 | 5.19 | 6.3 | 7.47 | 9.07
4*7168 | 14.3 | 5.9 | 6.12 | 7.2 | 9.34
4*8192 | 14.83 | 6.14 | 6.45 | 7 | 8.36
8*7168 | 16.3 | 8.02 | 7.59 | 7.99 | 8.57
8*8192 | 16.55 | 8.72 | 9 | 8.02 | 8.81
16*7168 | 18.65 | 12.88 | 9.62 | 10.31 | 10.23
16*8192 | 19.78 | 14.51 | 10.72 | 10.84 | 11.03
32*7168 | 24.42 | 24.27 | 15.24 | 15.09 | 15.19
32*8192 | 25.04 | 26.7 | 16.8 | 16.7 | 16.78
64*7168 | 33.69 | 43.95 | 25.34 | 26.05 | 25.85
64*8192 | 36.95 | 50.2 | 28.29 | 28.23 | 28.28
128*7168 | 54.11 | 85.7 | 49.61 | 45.87 | 47.09
128*8192 | 59.92 | 96.95 | 53.2 | 51.71 | 52.21
256*7168 | 99.15 | 168.54 | 91.16 | 89.16 | 87.02
256*8192 | 108.75 | 192.03 | 104.37 | 100.74 | 98.63
512*7168 | 175.89 | 335.19 | 178.62 | 175.76 | 171.33
512*8192 | 197.63 | 382.96 | 204.01 | 200.04 | 194.6
1024*7168 | 331.55 | 668.5 | 354.64 | 348.02 | 340.17
1024*8192 | 377.44 | 762.34 | 405.3 | 398.45 | 389.39
2048*7168 | 649.77 | 1332.35 | 707.04 | 698.71 | 687.44
2048*8192 | 737.73 | 1521.82 | 807.99 | 801.23 | 787.31
4096*7168 | 1277.77 | 2664.31 | 1417.07 | 1409.67 | 1382.22
4096*8192 | 1460.21 | 3042.05 | 1621.97 | 1611.16 | 1581.16

MI308 tp4
  | baseline | ll | ll128 b256 | ll128 b512 | ll128 b1024
-- | -- | -- | -- | -- | --
1024 | 14.63 | 5.22 | 11.69 | 11.3 | 11.52
2048 | 14.02 | 5.22 | 12.09 | 11.84 | 12.7
4096 | 13.88 | 5.25 | 9.42 | 13.06 | 13.21
7168 | 14.14 | 5.4 | 9.36 | 13.74 | 13.15
8192 | 13.99 | 5.81 | 8.57 | 10.11 | 13.26
2*7168 | 14.28 | 5.34 | 7.58 | 10.02 | 15.51
2*8192 | 14.56 | 5.54 | 7.6 | 9.07 | 12.71
4*7168 | 15.74 | 7.08 | 7.6 | 8.44 | 12.43
4*8192 | 15.87 | 8.35 | 7.54 | 8.26 | 11.77
8*7168 | 16.94 | 10.56 | 8.48 | 8.95 | 11.77
8*8192 | 17.75 | 11.65 | 8.54 | 9.39 | 12.22
16*7168 | 14.78 | 17.49 | 12.03 | 11.19 | 13.57
16*8192 | 15.31 | 19.47 | 13.55 | 13.14 | 15.17
32*7168 | 18.83 | 29.48 | 20.55 | 18.58 | 18.54
32*8192 | 20.29 | 35.35 | 22.63 | 21.08 | 20.52
64*7168 | 26.36 | 52.79 | 34.18 | 32.27 | 32.24
64*8192 | 26.58 | 60.97 | 36.7 | 35.88 | 36.51
128*7168 | 38.28 | 100.34 | 58.33 | 59.18 | 58.72
128*8192 | 41.42 | 112.2 | 64.55 | 66.8 | 67.2
256*7168 | 62.55 | 195.04 | 106.26 | 103.63 | 105.27
256*8192 | 68.61 | 223.2 | 121.48 | 118.07 | 117.67
512*7168 | 111.51 | 384.31 | 198.86 | 198.67 | 191.34
512*8192 | 127.55 | 440.33 | 224.16 | 228.35 | 229.35
1024*7168 | 205.78 | 765.6 | 384.17 | 387.57 | 390.17
1024*8192 | 232.06 | 872.02 | 438.62 | 440.95 | 435.88
2048*7168 | 397.46 | 1522.59 | 756 | 754.92 | 741.23
2048*8192 | 451.74 | 1740.29 | 861.29 | 850.53 | 847.44
4096*7168 | 780.58 | 3048.46 | 1501.88 | 1474.57 | 1461.8
4096*8192 | 886.44 | 3483.03 | 1715.62 | 1676.47 | 1665.9

MI308 tp8

  | baseline | ll | ll128 b256 | ll128 b512 | ll128 b1024
-- | -- | -- | -- | -- | --
1024 | 14.21 | 7.95 | 16.44 | 16.41 | 16.93
2048 | 14.83 | 7.59 | 17.18 | 17.23 | 17.45
4096 | 15.51 | 8.42 | 15.39 | 18.42 | 18.2
7168 | 14.91 | 8.15 | 15.5 | 19.98 | 19.68
8192 | 14.98 | 7.36 | 14.02 | 16.26 | 20.06
2*7168 | 15.74 | 8.06 | 12.68 | 16.26 | 25.59
2*8192 | 15.12 | 8.25 | 12.64 | 15.25 | 22.01
4*7168 | 16.28 | 10.54 | 12.92 | 14.92 | 22.03
4*8192 | 16.51 | 11.21 | 13.31 | 15.93 | 21.91
8*7168 | 14.43 | 15.12 | 15.43 | 17.2 | 22.58
8*8192 | 14.46 | 16.35 | 16.15 | 16.75 | 22.21
16*7168 | 15.56 | 26.27 | 20.26 | 20.06 | 24.33
16*8192 | 15.71 | 27.97 | 22.31 | 20.58 | 24.41
32*7168 | 18.37 | 41.73 | 34.53 | 28.77 | 30.66
32*8192 | 19.21 | 48.28 | 40.44 | 30.88 | 31.34
64*7168 | 22.99 | 71.7 | 59.95 | 53.61 | 43.7
64*8192 | 23.71 | 82.51 | 67.89 | 60.59 | 49.52
128*7168 | 30.31 | 134.09 | 96.43 | 90.67 | 82.73
128*8192 | 32.96 | 150.1 | 108.65 | 100.01 | 94.45
256*7168 | 43.29 | 254.68 | 168.85 | 145.58 | 156.88
256*8192 | 47.99 | 292.44 | 190.07 | 182.98 | 173.89
512*7168 | 71.54 | 493.37 | 304.45 | 306.17 | 261.04
512*8192 | 78.35 | 563.18 | 335.17 | 331.09 | 326.77
1024*7168 | 121.54 | 981.78 | 529.93 | 518.31 | 521.05
1024*8192 | 135.52 | 1122.52 | 595.95 | 580.46 | 592.65
2048*7168 | 218.98 | 1955.59 | 968.83 | 954.82 | 964.47
2048*8192 | 245.71 | 2244.52 | 1089.31 | 1080.69 | 1084.06
4096*7168 | 434.35 | 3944.21 | 1837.5 | 1793.19 | 1851.19
4096*8192 | 489.97 | 4512.78 | 2088.8 | 2031.16 | 2087.35

MI355 tp2

baseline | ll | ll128 b256 | ll128 b512 | ll128 b1024
-- | -- | -- | -- | --
10.37 | 5.74 | 7.68 | 7.42 | 8.64
10.19 | 6.14 | 7.49 | 7.95 | 7.53
10.28 | 8.15 | 7.6 | 7.55 | 7.66
10.15 | 3.89 | 9.1 | 7.65 | 7.5
10.21 | 7.11 | 8.83 | 6.71 | 7.77
10.08 | 8.66 | 9.54 | 8.11 | 8.21
10.03 | 6.62 | 8.2 | 7.42 | 6.78
10.36 | 8.11 | 9.04 | 5.64 | 7.24
10.47 | 8.47 | 9.52 | 8.29 | 9.93
11.35 | 8.68 | 7.1 | 8.01 | 7.26
11.75 | 7.06 | 8.85 | 7.42 | 6.72
13.94 | 11.11 | 7.96 | 7.96 | 8.21
13.98 | 12.02 | 8.83 | 8.84 | 11.32
18.29 | 19.61 | 12.6 | 12.73 | 12.67
19.41 | 22.59 | 14.04 | 14.06 | 14.1
26.11 | 37.65 | 21.54 | 21.56 | 21.52
29.12 | 42.84 | 24.11 | 24.23 | 24.05
42.64 | 73.88 | 40.88 | 39.75 | 39.51
47.52 | 83.72 | 46.18 | 45.07 | 44.65
74.9 | 144.9 | 78.66 | 77.19 | 76.06
84.36 | 165.37 | 88.46 | 87.73 | 87.33
141.07 | 287.9 | 153.25 | 150.9 | 153.5
158.63 | 328.72 | 175.13 | 171.62 | 175.03
271.8 | 572.92 | 305.69 | 301.33 | 307.37
309.01 | 654.96 | 349.45 | 344.62 | 350.08
532.09 | 1145.88 | 610 | 604.81 | 617.43
607.24 | 1309.49 | 697.37 | 692.29 | 705.45
1054.53 | 2298.98 | 1215.34 | 1215.03 | 1238.87
1205.55 | 2628 | 1389.22 | 1389.33 | 1417.86

MI355 tp4

  | baseline | ll | ll128 b256 | ll128 b512 | ll128 b1024
-- | -- | -- | -- | -- | --
1024 | 10.75 | 10.29 | 8.66 | 8.35 | 8.83
2048 | 10.92 | 8.1 | 8.85 | 10.66 | 8.77
4096 | 10.78 | 7.4 | 11.06 | 10.71 | 12.96
7168 | 10.88 | 7.34 | 7.15 | 9.65 | 11.19
8192 | 10.87 | 9.44 | 6.73 | 9.79 | 9.98
2*7168 | 10.86 | 10.07 | 9.5 | 11.33 | 11.97
2*8192 | 11.18 | 8.31 | 10.27 | 7.49 | 10.74
4*7168 | 10.94 | 11.1 | 7.38 | 21.69 | 10.45
4*8192 | 11.17 | 10.63 | 7.28 | 7.43 | 10.23
8*7168 | 22.25 | 9.04 | 8.39 | 11.93 | 10.52
8*8192 | 12.94 | 9.68 | 8.25 | 8.52 | 10.74
16*7168 | 10.82 | 14.5 | 11.24 | 10.64 | 12.15
16*8192 | 11.23 | 15.49 | 12.19 | 11.82 | 12.65
32*7168 | 12.85 | 23.93 | 17.7 | 16.75 | 16.41
32*8192 | 13.24 | 27.57 | 19.59 | 18.43 | 17.86
64*7168 | 16.92 | 43.78 | 32.23 | 28.45 | 27.89
64*8192 | 17.61 | 49.43 | 36.3 | 32.46 | 30.66
128*7168 | 25.31 | 82.45 | 61.54 | 51.53 | 51.1
128*8192 | 28.27 | 92.98 | 66.95 | 58.22 | 57.79
256*7168 | 42.74 | 160.32 | 102.63 | 99.35 | 95.41
256*8192 | 47.1 | 182.38 | 115.06 | 110.77 | 108.05
512*7168 | 77.92 | 315.78 | 184.81 | 180.97 | 185.14
512*8192 | 86.42 | 360.92 | 208.57 | 201.87 | 206.1
1024*7168 | 147.2 | 627.19 | 346.23 | 336.14 | 344.9
1024*8192 | 161.35 | 716.09 | 395.58 | 385.49 | 407.5
2048*7168 | 277.91 | 1249.78 | 678.02 | 663.24 | 685.51
2048*8192 | 316.22 | 1428.54 | 775.52 | 756.39 | 771.32
4096*7168 | 549.05 | 2509.65 | 1347.79 | 1315.01 | 1334.74
4096*8192 | 626.56 | 2870.92 | 1541.67 | 1500.51 | 1519.02

MI355 tp8

  | LL | LL128-256 | LL28-512 | LL28-1024 | baseline
-- | -- | -- | -- | -- | --
1024 | 10.29 | 18.19 | 13.47 | 13.46 | 14.05
2048 | 6.9 | 21.92 | 11.51 | 18.46 | 12.66
4096 | 10.52 | 10.61 | 10.66 | 12.6 | 13.29
8192 | 10.18 | 10.07 | 10.04 | 11.87 | 13.11
2*8192 | 8.58 | 10.27 | 10.28 | 11.31 | 13.19
4*8192 | 9.5 | 10.19 | 10.34 | 11.43 | 13.54
8*8192 | 14.36 | 12.34 | 11.6 | 12.24 | 11.44
16*8192 | 23.03 | 17.26 | 15.67 | 15.31 | 11.52
32*8192 | 40.07 | 32.66 | 23.78 | 21.86 | 18.76
64*8192 | 69.55 | 48.63 | 45.34 | 35.54 | 15.31
128*8192 | 126.39 | 80.2 | 73.03 | 67.15 | 20.73
256*8192 | 244.69 | 142.83 | 126.59 | 121.16 | 30.33
512*8192 | 482.01 | 270.33 | 244.76 | 222.9 | 49.38
1024*8192 | 952.44 | 529.65 | 453.7 | 426.72 | 87.76
2048*8192 | 1916.78 | 1054.89 | 901.28 | 836.36 | 164.78
4096*8192 | 3872.92 | 2097.16 | 1813.57 | 1652.76 | 319.12


## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
