### PR TITLE
[FlyDSL] perf(mqa-logits): build the FP4 prefill schedule in one kernel, not 25 torch ops

### DIFF
--- a/aiter/ops/flydsl/kernels/mqa_logits/pa_mqa_logits_fp4_prefill.py
+++ b/aiter/ops/flydsl/kernels/mqa_logits/pa_mqa_logits_fp4_prefill.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 from functools import lru_cache
+from typing import NamedTuple
 
 import flydsl.compiler as flyc
 import flydsl.expr as fx
@@ -46,6 +47,15 @@ def compute_prefill_schedule(
     Pass `cta_info_out` (a fixed [parallel_unit_num, CTA_INFO_WIDTH] int32 buffer)
     to write the schedule into a stable address (CUDAGraph decode: the captured
     kernel replays from this pointer while `build()` refreshes its contents).
+
+    Returns `(safe, cta_info, parallel_unit_num)`, `safe` being the [1] int32
+    split factor the schedule was built with.
+
+    The row plan is every-lane work over one [T] vector, so up to
+    `_ROW_PLAN_MAX_ROWS` rows it is one block instead of the ~25 torch ops
+    `_row_plan_torch` spells it as. What that buys is HOST latency, not device
+    time -- the torch form hides its own kernels behind its own dispatch, and a
+    decode step calls this once per forward, in the host gap between two.
     """
     device = local_ends.device
     P = parallel_unit_num
@@ -57,15 +67,135 @@ def compute_prefill_schedule(
         f"pre-fill -> wrong top-k). Pass parallel_unit_num >= number of rows."
     )
 
-    rb = row_to_batch.to(torch.int32)
-    ls = local_starts.to(torch.int32)
-    le = local_ends.to(torch.int32)
+    # Asserted, not coerced. Every caller already holds int32, so the three
+    # `.to()` calls this replaces were no-ops -- but on a host-bound path a
+    # no-op still costs its dispatch, and a caller that stopped honouring this
+    # would silently change what the kernels below compile to.
+    assert (
+        row_to_batch.dtype == local_starts.dtype == local_ends.dtype == torch.int32
+    ), (
+        f"compute_prefill_schedule: row_to_batch/local_starts/local_ends must be "
+        f"int32, got {row_to_batch.dtype}/{local_starts.dtype}/{local_ends.dtype}."
+    )
 
+    s_max = max(1, (max_seq_len + block_k - 1) // block_k)
+    plan = _row_plan(local_ends, block_k, P, s_max)
+
+    # ── map each fixed slot → (row, split) + emit cta_info in ONE kernel ──
+    if cta_info_out is None:
+        cta_info = torch.empty(P, CTA_INFO_WIDTH, dtype=torch.int32, device=device)
+    else:
+        cta_info = cta_info_out
+    BLOCK_P = 256
+    grid = (triton.cdiv(P, BLOCK_P),)
+    _prefill_cta_info_kernel[grid](
+        plan.incl,
+        plan.excl,
+        plan.chunks,
+        row_to_batch,
+        local_starts,
+        local_ends,
+        plan.safe,
+        plan.total_splits,
+        cta_info,
+        T,
+        P,
+        BLOCK_P=BLOCK_P,
+    )
+    return plan.safe, cta_info, P
+
+
+class _RowPlan(NamedTuple):
+    """Everything the emit kernel needs about the rows, from either producer.
+
+    One carrier, so a field can only be added where both have to answer for it.
+    """
+
+    incl: torch.Tensor  # [T] inclusive prefix sum of per-row CTA counts
+    excl: torch.Tensor  # [T] exclusive prefix sum
+    chunks: torch.Tensor  # [T] ceil(local_end / block_k), 0 for an empty row
+    safe: torch.Tensor  # [1] chunk-splits merged into one CTA
+    total_splits: torch.Tensor  # [1] number of valid (row, split) slots
+
+
+# Rows the fused arm plans, and the only two widths it plans them in. A block
+# costs its WIDTH, not the rows that fill it -- 40.8us at 16384 lanes whether 300
+# rows or 16384 arrive -- so the choice is which shapes share a width, and every
+# distinct width is a kernel to compile:
+#
+#     block    device    cold compile   what reaches it
+#      4096    13.3us          0.84s    every decode forward
+#     16384    40.8us          1.86s    every prefill forward
+#
+# The FLOOR is what keeps decode off the wide block: `max_num_seqs * (1 + spec
+# steps)` = 512 x 8 fits in one width, so decode compiles once and pays 13.3us.
+# Sizing per shape below it saves 0.3us for nine more variants.
+#
+# NOTHING between them, though an 8192 rung measured 21.1us: on a 100k/10 conc-50
+# trace 534 of 541 prefill forwards ran 8193-16384 rows and four ran 4097-8192,
+# so that rung would cost a third of the ladder and a 1.13s compile to save 20us
+# on 0.7% of forwards -- and a variant nothing exercises is one discovered
+# mid-run.
+#
+# The CAP is where widening stops paying: 32768 is bit-exact and still beats the
+# torch arm on both axes (87.1us device against 338.8us), but takes 4.98s to
+# compile, and 65536 does not finish compiling at all.
+_ROW_PLAN_BLOCK_FLOOR = 4096
+_ROW_PLAN_MAX_ROWS = 16384
+
+# int32s per 16 bytes -- the granularity Triton's pointer-alignment
+# specialization works at.
+_I32_PER_16B = 4
+
+
+def _row_plan(le, block_k, P, s_max) -> _RowPlan:
+    T = le.shape[0]
+    if T > _ROW_PLAN_MAX_ROWS:
+        return _row_plan_torch(le, block_k, P, s_max)
+    # One allocation, sliced: five `torch.empty` calls would put four more
+    # dispatches back on the path this exists to shorten.
+    #
+    # Every region starts on a 16-byte boundary, which is not cosmetic: Triton
+    # specializes a kernel on whether each pointer is 16-byte aligned, so a
+    # stride of exactly T forks a variant per `T % 4` and the JIT never stops
+    # finding new ones mid-run. Rounding the stride up pins all six pointers to
+    # one alignment signature.
+    stride = (T + _I32_PER_16B - 1) // _I32_PER_16B * _I32_PER_16B
+    tail = 3 * stride
+    work = torch.empty(tail + 2 * _I32_PER_16B, dtype=torch.int32, device=le.device)
+    plan = _RowPlan(
+        incl=work[:T],
+        excl=work[stride : stride + T],
+        chunks=work[2 * stride : 2 * stride + T],
+        safe=work[tail : tail + 1],
+        total_splits=work[tail + _I32_PER_16B : tail + _I32_PER_16B + 1],
+    )
+    # Named, not `*plan`: field ORDER should not become load-bearing.
+    _prefill_row_plan_kernel[(1,)](
+        le,
+        plan.incl,
+        plan.excl,
+        plan.chunks,
+        plan.safe,
+        plan.total_splits,
+        T,
+        P,
+        block_k,
+        s_max,
+        BLOCK_T=(
+            _ROW_PLAN_BLOCK_FLOOR if T <= _ROW_PLAN_BLOCK_FLOOR else _ROW_PLAN_MAX_ROWS
+        ),
+        SEARCH_STEPS=max(1, (s_max - 1).bit_length() + 1),
+    )
+    return plan
+
+
+def _row_plan_torch(le, block_k, P, s_max) -> _RowPlan:
+    """The row plan as ~25 torch ops. Reference for `_prefill_row_plan_kernel`."""
     # chunk count per row = ceil(le / block_k); le<=0 → 0 chunks.
     chunks_per_row = torch.clamp((le + (block_k - 1)) // block_k, min=0)  # [T]
 
-    s_max = max(1, (max_seq_len + block_k - 1) // block_k)
-    s_cand = torch.arange(1, s_max + 1, device=device, dtype=torch.int32)  # [s_max]
+    s_cand = torch.arange(1, s_max + 1, device=le.device, dtype=torch.int32)  # [s_max]
     ctas_per_r_s = (chunks_per_row[None, :] + (s_cand[:, None] - 1)) // s_cand[
         :, None
     ]  # [s_max, T]
@@ -79,37 +209,90 @@ def compute_prefill_schedule(
     # ── per-row number of CTAs (chunk-splits); 0 for empty rows ──
     ctas_r = (chunks_per_row + (safe - 1)) // safe  # [T]
     incl = torch.cumsum(ctas_r, dim=0, dtype=torch.int32)  # [T] inclusive prefix sum
-    excl = incl - ctas_r  # exclusive prefix sum
-    total_splits = incl[-1]  # 0-dim; total valid (row, split) slots
-
-    # ── map each fixed slot → (row, split) + emit cta_info in ONE kernel ──
-    # (the ~25 per-slot torch ops below were the bulk of the ~50-launch cost).
-    if cta_info_out is None:
-        cta_info = torch.empty(P, CTA_INFO_WIDTH, dtype=torch.int32, device=device)
-    else:
-        cta_info = cta_info_out
-    safe_i32 = safe.reshape(1).to(torch.int32)
-    total_splits_i32 = total_splits.reshape(1).to(torch.int32)
-    BLOCK_P = 256
-    grid = (triton.cdiv(P, BLOCK_P),)
-    _prefill_cta_info_kernel[grid](
-        incl,
-        excl,
-        chunks_per_row.to(torch.int32),
-        rb,
-        ls,
-        le,
-        safe_i32,
-        total_splits_i32,
-        cta_info,
-        T,
-        P,
-        BLOCK_P=BLOCK_P,
+    return _RowPlan(
+        incl=incl,
+        excl=incl - ctas_r,  # exclusive prefix sum
+        chunks=chunks_per_row.to(torch.int32),
+        safe=safe.reshape(1).to(torch.int32),
+        total_splits=incl[-1].reshape(1).to(torch.int32),
     )
-    return safe, cta_info, P
 
 
-@triton.jit
+# `T` and `P` are batch shape, and a decode step's row count changes every
+# forward, so specializing on whether they divide 16 keeps finding new variants
+# to compile in the middle of a run. Both kernels here: over 17 shapes it takes
+# this pair from 9 and 6 variants down to 3 and 1, and what is left of the 3 is
+# exactly the BLOCK_T ladder -- a set small enough to be compiled through.
+#
+# `T` alone is the whole of that halving AND the whole of its cost: dropping it
+# gives up the divisibility hint the wide blocks vectorize on, 41.1us -> 52.0us
+# at 16384 lanes. That lands on prefill, one call per ~500ms forward; the widths
+# decode runs stay hidden behind the call's own dispatch either way.
+@triton.jit(do_not_specialize=["T", "P"])
+def _prefill_row_plan_kernel(
+    le_ptr,  # [T] int32 local_ends
+    incl_ptr,  # [T] int32 out
+    excl_ptr,  # [T] int32 out
+    chunks_ptr,  # [T] int32 out
+    safe_ptr,  # [1] int32 out
+    total_splits_ptr,  # [1] int32 out
+    T,
+    P,
+    block_k,
+    s_max,
+    BLOCK_T: tl.constexpr,
+    SEARCH_STEPS: tl.constexpr,
+):
+    """Single-block row plan: chunk counts, split factor, and its prefix sums.
+
+    `total_ctas(s) = sum ceil(chunks/s)` is non-increasing in s, so feasibility is
+    monotone and the smallest feasible s is a binary search. `_row_plan_torch`
+    instead materializes the whole [s_max, T] feasibility matrix and counts its
+    False entries -- same answer, and the matrix is why that path's cost also
+    tracks the model's context length.
+
+    Masked-out lanes carry `chunks = 0`, which contributes 0 CTAs at every s, so
+    no reduction below needs a second mask.
+
+    `SEARCH_STEPS` is derived from `s_max`, not a generous constant: the range
+    halves each step, so `(s_max - 1).bit_length()` converges it and the caller
+    passes one more. Every surplus step is another reduction over all BLOCK_T
+    lanes -- 0.74us each at 4096 rows -- and a fixed 32 was this kernel's ENTIRE
+    growth with block width, 28.7us against 12.8us. The one spare step is not
+    that: it is hidden behind the call's own dispatch, and coming up short
+    returns a schedule that is merely wrong, with nothing downstream to fault.
+    """
+    t = tl.arange(0, BLOCK_T)
+    mask = t < T
+    le = tl.load(le_ptr + t, mask=mask, other=0)
+    # The clamp puts `le <= 0` at 0 under either rounding, so this agrees with the
+    # torch path's floor division without asking which one Triton does.
+    chunks = tl.where(mask, tl.maximum((le + block_k - 1) // block_k, 0), 0)
+    max_chunks = tl.maximum(tl.max(chunks, axis=0), 1)
+
+    lo = 1
+    hi = s_max
+    for _ in tl.static_range(SEARCH_STEPS):
+        mid = (lo + hi) // 2
+        feasible = tl.sum((chunks + mid - 1) // mid, axis=0) <= P
+        active = lo < hi
+        hi = tl.where(active & feasible, mid, hi)
+        lo = tl.where(active & (feasible == 0), mid + 1, lo)
+    # No s in [1, s_max] fits: fall back to one CTA per row, as torch's
+    # `feasible.any()` arm does.
+    total_smax = tl.sum((chunks + s_max - 1) // s_max, axis=0)
+    safe = tl.where(total_smax <= P, lo, max_chunks)
+
+    ctas = tl.where(mask, (chunks + safe - 1) // safe, 0)
+    incl = tl.cumsum(ctas, axis=0)
+    tl.store(incl_ptr + t, incl, mask=mask)
+    tl.store(excl_ptr + t, incl - ctas, mask=mask)
+    tl.store(chunks_ptr + t, chunks, mask=mask)
+    tl.store(safe_ptr, safe)
+    tl.store(total_splits_ptr, tl.sum(ctas, axis=0))
+
+
+@triton.jit(do_not_specialize=["T", "P"])
 def _prefill_cta_info_kernel(
     incl_ptr,  # [T] int32 inclusive prefix sum of per-row CTA counts
     excl_ptr,  # [T] int32 exclusive prefix sum


### PR DESCRIPTION
## What

`compute_prefill_schedule` derived its row plan — chunk counts, split factor,
prefix sums — from ~25 small torch ops before launching
`_prefill_cta_info_kernel`. Each is a few thousand elements, so the preamble was
pure dispatch: **168 µs of host time per call**, with its own kernels hidden
behind it. A decode forward calls this once per forward, in the host gap between
two, and pays all of it.

The plan is a reduction and a scan over one `[T]` vector, so one block holds it.
`_row_plan_torch` keeps the torch spelling as the path for row counts past a
block, and as the reference the kernel's arithmetic is pinned against.

## Measured (MI355X, per call, against the torch arm at the same shapes)

| rows | host | device |
|---|---|---|
| 300 | **36.5 µs** ← 164.6 | **18.1 µs** ← 92.2 |
| 4096 | **37.1 µs** ← 163.7 | **22.6 µs** ← 139.9 |
| 16384 | **37.2 µs** ← 165.4 | **60.0 µs** ← 214.6 |

## Four choices that are not transcription

- **Binary search for the split factor.** `total_ctas(s) = Σ ceil(chunks/s)` is
  non-increasing in `s`, so feasibility is monotone. The torch form materializes
  the whole `[s_max, T]` matrix and counts its `False` entries — which is also
  why its cost tracks the model's context length.
- **Exact search trip count**, derived from `s_max`, not a fixed 32. Each
  surplus step is another reduction over every lane, and a fixed count was the
  whole of this kernel's growth with block width: 12.8 µs vs 28.7 µs at 4096
  rows, `s_max` 1024.
- **Two block widths, 4096 and 16384, nothing between.** A block costs its
  *width*, not the rows filling it. The floor keeps every decode forward
  (`max_num_seqs * (1 + spec steps)`) on one width; the cap is where widening
  stops paying — 32768 is bit-exact and still beats the torch arm on both axes
  but takes 4.98 s to compile, and 65536 does not finish compiling at all. An
  8192 rung measured 21.1 µs, but on a 100k/10 conc-50 trace **534 of 541**
  prefill forwards ran 8193–16384 rows and **four** ran 4097–8192.
- **No specialization on `T`/`P`, and 16-byte-aligned plan regions.** Both are
  about compile *count*: a stride of exactly `T` forks a variant per `T % 4`,
  and the divisibility hint forks one per `T % 16`. Over 17 shapes the pair
  compiled **9 and 6** kernels and kept finding more mid-run; it is now **2 and
  1**, and what remains is a pure function of the row bucket. Declining the hint
  costs the wide block its vectorization (41.1 → 52.0 µs), which lands on
  prefill; the width decode runs stays hidden behind the call's own dispatch.

`row_to_batch` / `local_starts` / `local_ends` are asserted `int32` rather than
coerced — every caller already holds `int32`, so the three `.to()` calls were
no-ops, and a no-op still costs its dispatch on this path.

## Test plan

- [x] `op_tests/test_flydsl_pa_mqa_logits_fp4_prefill.py` — passes, `cos_exact =
  1.000000` on both the prefill and variable-qlen cases
- [x] End to end on ATOM, DeepSeek-V4-Flash-DSpark tp2, fp8 KV, FP4 indexer
  confirmed active: GSM8K over 1319 questions, flexible **0.9522** / strict
  **0.9530** against a 0.948–0.950 baseline; MTP acceptance **65.43%** at 4.27
  toks/fwd against 65.2% / 4.26
- [x] Profiler trace of the same workload: `aten::any`, `aten::cumsum`,
  `aten::where`, `aten::arange` at **zero** occurrences, from 280 / 280 / 280 /
  560; `_prefill_row_plan_kernel` at 279, matching the schedule-build count
- [ ] **Not included here:** the bit-exact parity harness against
  `_row_plan_torch` (86 cases over row count, `block_k` and `max_seq_len`, plus
  a variant-count guard). Every field is compared bit for bit, and each of the
  choices above was verified by reverting it and confirming the harness fails.
  Happy to add it as a follow-up if wanted in-tree.
