### PR TITLE
[CK] [JIT] feat(cktile a8w8-bpreshuffle): add rowcol_wp_v2 as a selectable kernel type

### DIFF
--- a/aiter/jit/utils/chip_info.py
+++ b/aiter/jit/utils/chip_info.py
@@ -394,7 +394,13 @@ def write_name_keyed_lookup_header(
 
 
 def write_lookup_header(
-    output_path, kernels_dict, lookup_head, lookup_template, lookup_end, istune=False
+    output_path,
+    kernels_dict,
+    lookup_head,
+    lookup_template,
+    lookup_end,
+    istune=False,
+    extra_format_args=None,
 ):
     """Write a C++ GEMM dispatch lookup header from a kernels_dict.
 
@@ -416,7 +422,16 @@ def write_lookup_header(
         lookup_template: String with {MNK} and {kernel_name} placeholders.
         lookup_end:      String written after the loop (closes the macro / #endif).
         istune:          True when generating the tune-mode lookup (int kernelId keys).
+        extra_format_args: Optional callable returning additional format arguments
+                           for a kernel instance.
     """
+
+    def format_entry(key_value, kernel):
+        format_args = {"MNK": key_value, "kernel_name": kernel.name}
+        if extra_format_args is not None:
+            format_args.update(extra_format_args(kernel))
+        return lookup_template.format(**format_args)
+
     with open(output_path, "w") as f:
         f.write(lookup_head)
         for key, k in kernels_dict.items():
@@ -427,14 +442,9 @@ def write_lookup_header(
                 cpp_key = (
                     '{"' + key[0] + '", ' + ", ".join(str(x) for x in key[1:]) + "}"
                 )
-                f.write(
-                    lookup_template.format(
-                        MNK=cpp_key,
-                        kernel_name=k.name,
-                    )
-                )
+                f.write(format_entry(cpp_key, k))
             elif istune and isinstance(key, int) and key >= 0:
-                f.write(lookup_template.format(MNK=key, kernel_name=k.name))
+                f.write(format_entry(key, k))
         f.write(lookup_end)
 
 

--- a/csrc/ck_gemm_a8w8_bpreshuffle/gemm_a8w8_bpreshuffle_tune.py
+++ b/csrc/ck_gemm_a8w8_bpreshuffle/gemm_a8w8_bpreshuffle_tune.py
@@ -24,6 +24,7 @@ from aiter.utility.mp_tuner import mp_tuner
 sys.path.insert(0, f"{AITER_CSRC_DIR}/cktile_gemm_a8w8_bpreshuffle/")
 from gemm_a8w8_bpreshuffle_cktile_common import (
     BLOCK_PER_CU_MAX,
+    DEFAULT_PIPELINE,
 )
 from gemm_a8w8_bpreshuffle_cktile_common import (
     kernels_list as kernels_list_cktile,
@@ -389,10 +390,20 @@ class GemmA8W8BpreShuffleTuner(GemmCommonTuner):
             for k, v in kernels_list_cktile.items()
             if v.BlockPerCu in args.blockPerCu
         }
+        # Every cktile pipeline consumes the same host-side data: B preshuffled
+        # with shuffle_weight(16, 16) plus the native per-token (M,) and
+        # per-channel (N,) fp32 scale vectors. rowcol_wp_v2 reads those scales
+        # through CK's RowColQuant windows, so there is nothing to replicate.
         gemm_keys = ["x", "weight_shuffle", "x_scale", "w_scale", "out"]
         ref_keys = ["x", "weight", "x_scale", "w_scale", "bias_f32"]
         tasks_ck = []
-        for i in filtered_cktile:
+        for i, kernel in filtered_cktile.items():
+            # Non-default pipelines are instantiated with the pads clamped
+            # false, so only offer them for tile-divisible shapes.
+            if getattr(kernel, "sPipeline", DEFAULT_PIPELINE) != DEFAULT_PIPELINE and (
+                M % kernel.MTile or N % kernel.NTile or K % kernel.KTile
+            ):
+                continue
             # cktile's flatmm accumulates into E without clearing it, so k_batch
             # stays 1 regardless of --splitK.
             for splitK in range(1):

--- a/csrc/cktile_gemm_a8w8_bpreshuffle/gemm_a8w8_bpreshuffle_cktile.cu
+++ b/csrc/cktile_gemm_a8w8_bpreshuffle/gemm_a8w8_bpreshuffle_cktile.cu
@@ -11,7 +11,13 @@
 using RowwiseKernel = torch::Tensor (*)(
     torch::Tensor&, torch::Tensor&, torch::Tensor&, torch::Tensor&, torch::Tensor&, int);
 
-using RowwiseKernelMap = GemmDispatchMap<RowwiseKernel>;
+struct RowwiseDispatchEntry
+{
+    RowwiseKernel kernel;
+    bool supports_m_padding;
+};
+
+using RowwiseKernelMap = GemmDispatchMap<RowwiseDispatchEntry>;
 
 template <typename DDataType, typename EDataType = DDataType>
 RowwiseKernel rowwise_heuristic_dispatch(int M, int N, int K)
@@ -59,7 +65,7 @@ RowwiseKernel rowwise_dispatch(int M, int N, int K)
     // If we found an optimal kernel, use it.
     if(it != lookup.end())
     {
-        return it->second;
+        return it->second.kernel;
     }
 
     int padded_m = M;
@@ -69,9 +75,9 @@ RowwiseKernel rowwise_dispatch(int M, int N, int K)
     // Second check if this shape(padded_m,N,K) is available in the direct lookup.
     it = lookup.find({gfx, cu_num, padded_m, N, K});
     // If we found an optimal kernel, use it.
-    if(it != lookup.end())
+    if(it != lookup.end() && it->second.supports_m_padding)
     {
-        return it->second;
+        return it->second.kernel;
     }
 
     // Coarse-grained search
@@ -79,9 +85,9 @@ RowwiseKernel rowwise_dispatch(int M, int N, int K)
     // Third check if this shape(padded_m,N,K) is available in the direct lookup.
     it = lookup.find({gfx, cu_num, padded_m, N, K});
     // If we found an optimal kernel, use it.
-    if(it != lookup.end())
+    if(it != lookup.end() && it->second.supports_m_padding)
     {
-        return it->second;
+        return it->second.kernel;
     }
 
     // Otherwise, use heuristics.

--- a/csrc/cktile_gemm_a8w8_bpreshuffle/gemm_a8w8_bpreshuffle_cktile.cu
+++ b/csrc/cktile_gemm_a8w8_bpreshuffle/gemm_a8w8_bpreshuffle_cktile.cu
@@ -15,6 +15,7 @@ struct RowwiseDispatchEntry
 {
     RowwiseKernel kernel;
     bool supports_m_padding;
+    bool supports_k_padding;
 };
 
 using RowwiseKernelMap = GemmDispatchMap<RowwiseDispatchEntry>;
@@ -36,7 +37,7 @@ static constexpr int nextPow2(unsigned int num)
 }
 
 template <typename DDataType, typename EDataType = DDataType>
-RowwiseKernel rowwise_dispatch(int M, int N, int K)
+RowwiseKernel rowwise_dispatch(int M, int N, int K, int lookup_k)
 {
     // For a given shape, either find the best kernel via lookup or heuristic.
     // For many small M shapes, we bucket them to the next largest kernel.
@@ -61,9 +62,9 @@ RowwiseKernel rowwise_dispatch(int M, int N, int K)
     const std::string_view gfx = get_device_gfx();
 
     // First check if this shape(M,N,K) is available in the direct lookup.
-    auto it = lookup.find({gfx, cu_num, M, N, K});
+    auto it = lookup.find({gfx, cu_num, M, N, lookup_k});
     // If we found an optimal kernel, use it.
-    if(it != lookup.end())
+    if(it != lookup.end() && (K == lookup_k || it->second.supports_k_padding))
     {
         return it->second.kernel;
     }
@@ -71,21 +72,23 @@ RowwiseKernel rowwise_dispatch(int M, int N, int K)
     int padded_m = M;
 
     // Fine-grained search
-    padded_m = getPaddedM(M, N, K, 0);
+    padded_m = getPaddedM(M, N, lookup_k, 0);
     // Second check if this shape(padded_m,N,K) is available in the direct lookup.
-    it = lookup.find({gfx, cu_num, padded_m, N, K});
+    it = lookup.find({gfx, cu_num, padded_m, N, lookup_k});
     // If we found an optimal kernel, use it.
-    if(it != lookup.end() && it->second.supports_m_padding)
+    if(it != lookup.end() && it->second.supports_m_padding &&
+       (K == lookup_k || it->second.supports_k_padding))
     {
         return it->second.kernel;
     }
 
     // Coarse-grained search
-    padded_m = getPaddedM(M, N, K, 1);
+    padded_m = getPaddedM(M, N, lookup_k, 1);
     // Third check if this shape(padded_m,N,K) is available in the direct lookup.
-    it = lookup.find({gfx, cu_num, padded_m, N, K});
+    it = lookup.find({gfx, cu_num, padded_m, N, lookup_k});
     // If we found an optimal kernel, use it.
-    if(it != lookup.end() && it->second.supports_m_padding)
+    if(it != lookup.end() && it->second.supports_m_padding &&
+       (K == lookup_k || it->second.supports_k_padding))
     {
         return it->second.kernel;
     }
@@ -119,11 +122,11 @@ torch::Tensor gemm_a8w8_bpreshuffle_cktile(torch::Tensor& XQ,
 
     if(x_scale.dtype() == at::ScalarType::Float && Y.dtype() == at::ScalarType::Half)
     {
-        rowwise_dispatch<F32, F16>(M, N, WQK)(XQ, WQ, x_scale, w_scale, Y, KBatch);
+        rowwise_dispatch<F32, F16>(M, N, K, WQK)(XQ, WQ, x_scale, w_scale, Y, KBatch);
     }
     else if(x_scale.dtype() == at::ScalarType::Float && Y.dtype() == at::ScalarType::BFloat16)
     {
-        rowwise_dispatch<F32, B16>(M, N, WQK)(XQ, WQ, x_scale, w_scale, Y, KBatch);
+        rowwise_dispatch<F32, B16>(M, N, K, WQK)(XQ, WQ, x_scale, w_scale, Y, KBatch);
     }
     else
     {

--- a/csrc/cktile_gemm_a8w8_bpreshuffle/gemm_a8w8_bpreshuffle_cktile_common.py
+++ b/csrc/cktile_gemm_a8w8_bpreshuffle/gemm_a8w8_bpreshuffle_cktile_common.py
@@ -70,6 +70,10 @@ class kernelInstance:
     sPipeline: str = DEFAULT_PIPELINE
 
     @property
+    def supports_m_padding(self) -> bool:
+        return self.sPipeline == DEFAULT_PIPELINE
+
+    @property
     def name(self) -> str:
         parts = [
             "a8w8_bpreshuffle_cktile",

--- a/csrc/cktile_gemm_a8w8_bpreshuffle/gemm_a8w8_bpreshuffle_cktile_common.py
+++ b/csrc/cktile_gemm_a8w8_bpreshuffle/gemm_a8w8_bpreshuffle_cktile_common.py
@@ -17,6 +17,15 @@ sys.path.insert(0, AITER_CORE_DIR)
 
 from chip_info import get_gfx
 
+DEFAULT_PIPELINE = "flatmm_v1"
+
+# Python pipeline name -> the `sPipeline` template argument of CustomConfig in
+# include/gemm_a8w8_bpreshuffle_cktile_common.cuh. Keep the two in sync.
+PIPELINE_IDS = {
+    "flatmm_v1": 0,
+    "rowcol_wp_v2": 1,
+}
+
 
 @dataclass
 class kernelInstance:
@@ -40,33 +49,55 @@ class kernelInstance:
     NWTile: int
     KWTile: int
     sScheduler: str
+    # Which device kernel/pipeline composition the instance runs on. The tile
+    # geometry above is shared; this selects what consumes it:
+    #
+    #  "flatmm_v1"    - ck_tile::FlatmmKernel + FlatmmPipelineAGmemBGmemCRegV1
+    #                   with the ScaleM/ScaleN epilogue. The historical (and
+    #                   default) cktile a8w8-bpreshuffle path.
+    #  "rowcol_wp_v2" - ck_tile::QuantGemmKernel in QuantType::RowColQuant mode
+    #                   driving WeightPreshufflePipelineAGmemBGmemCRegV2. Same
+    #                   host-side inputs as flatmm_v1 (B preshuffled with
+    #                   shuffle_weight(16, 16), per-token A scale (M,) and
+    #                   per-channel B scale (N,) applied natively by the
+    #                   kernel's RowCol scale windows -- no replication).
+    #                   Requires M/N/K divisible by the tile: the quant route
+    #                   is instantiated with the pads clamped false.
+    #
+    # The value is part of `name`, so a tuned-CSV row that selects a non-default
+    # pipeline stays self-describing and round-trips through
+    # chip_info.build_tune_dict()'s kernelName lookup.
+    sPipeline: str = DEFAULT_PIPELINE
 
     @property
     def name(self) -> str:
-        return ("_").join(
-            [
-                "a8w8_bpreshuffle_cktile",
-                ("x").join(
-                    str(x)
-                    for x in [
-                        self.sTransposeC,
-                        self.sUseStructuredSparsity,
-                        self.sTileParitionerGroupNum,
-                        self.sTileParitionerM01,
-                        self.sNumWaveGroups,
-                        self.sDoubleSmemBuffer,
-                        self.PadM,
-                        self.PadN,
-                        self.PadK,
-                        self.BlockPerCu,
-                    ]
-                ),
-                ("x").join(str(x) for x in [self.MTile, self.NTile, self.KTile]),
-                ("x").join(str(x) for x in [self.MWarp, self.NWarp, self.KWarp]),
-                ("x").join(str(x) for x in [self.MWTile, self.NWTile, self.KWTile]),
-                self.sScheduler.lower(),
-            ]
-        )
+        parts = [
+            "a8w8_bpreshuffle_cktile",
+            ("x").join(
+                str(x)
+                for x in [
+                    self.sTransposeC,
+                    self.sUseStructuredSparsity,
+                    self.sTileParitionerGroupNum,
+                    self.sTileParitionerM01,
+                    self.sNumWaveGroups,
+                    self.sDoubleSmemBuffer,
+                    self.PadM,
+                    self.PadN,
+                    self.PadK,
+                    self.BlockPerCu,
+                ]
+            ),
+            ("x").join(str(x) for x in [self.MTile, self.NTile, self.KTile]),
+            ("x").join(str(x) for x in [self.MWarp, self.NWarp, self.KWarp]),
+            ("x").join(str(x) for x in [self.MWTile, self.NWTile, self.KWTile]),
+            self.sScheduler.lower(),
+        ]
+        # Only non-default pipelines extend the name, so every already-tuned
+        # flatmm_v1 CSV row keeps matching byte-for-byte.
+        if self.sPipeline != DEFAULT_PIPELINE:
+            parts.append(self.sPipeline)
+        return ("_").join(parts)
 
 
 BLOCK_PER_CU_MAX = 4
@@ -390,6 +421,37 @@ kernels_list_950 = {
 
 }
 
+# QuantGemmKernel(RowColQuant) x WeightPreshufflePipelineAGmemBGmemCRegV2.
+# Same host-side inputs as the flatmm_v1 table above (B preshuffled with
+# shuffle_weight(16, 16), native per-token/per-channel scales); only the
+# device-side composition differs.
+#
+# Kept in a SEPARATE table, appended after the flatmm table has been
+# BlockPerCu-expanded, so that adding a rowcol tile can never renumber an
+# existing flatmm kernelId. Ids here are local to this table.
+#
+# The quant route runs unpadded, so a tile is only a candidate where it divides
+# M, N and K. These are chosen to be divisible for the live GLM-5.2 N/K pairs
+# (N in {2688, 6144}, K in {6144, 12288}) -- note 2688 % 192 == 0 but
+# 2688 % 256 != 0, and no MTile divides M == 1.
+# fmt: off
+kernels_list_950_rowcol_wp_v2 = {
+    #   N_Tile == 128 family:
+    0: kernelInstance( 0, 0, 8, 4, 1, 0, 0, 0, 0, 1,   16,   128,   256,  1,  4,  1,   16,    16,    128, "Intrawave", "rowcol_wp_v2"),
+    1: kernelInstance( 0, 0, 8, 4, 1, 0, 0, 0, 0, 1,   32,   128,   256,  1,  4,  1,   16,    16,    128, "Intrawave", "rowcol_wp_v2"),
+    2: kernelInstance( 0, 0, 8, 4, 1, 0, 0, 0, 0, 1,   64,   128,   256,  1,  4,  1,   16,    16,    128, "Intrawave", "rowcol_wp_v2"),
+    3: kernelInstance( 0, 0, 8, 4, 1, 0, 0, 0, 0, 1,  128,   128,   128,  1,  4,  1,   16,    16,    128, "Intrawave", "rowcol_wp_v2"),
+    4: kernelInstance( 0, 0, 8, 4, 1, 0, 0, 0, 0, 1,  128,   128,   256,  1,  4,  1,   16,    16,    128, "Intrawave", "rowcol_wp_v2"),
+    5: kernelInstance( 0, 0, 8, 4, 1, 0, 0, 0, 0, 1,  128,   128,   256,  1,  4,  1,   16,    16,    128, "Default",   "rowcol_wp_v2"),
+    #   narrow-N / small-M, where 32-64 x 64 tiles lead at M <= 1024:
+    6: kernelInstance( 0, 0, 8, 4, 1, 0, 0, 0, 0, 1,   16,    64,   512,  1,  4,  1,   16,    16,    128, "Intrawave", "rowcol_wp_v2"),
+    7: kernelInstance( 0, 0, 8, 4, 1, 0, 0, 0, 0, 1,   32,    64,   512,  1,  4,  1,   16,    16,    128, "Intrawave", "rowcol_wp_v2"),
+    8: kernelInstance( 0, 0, 8, 4, 1, 0, 0, 0, 0, 1,   64,    64,   256,  1,  4,  1,   16,    16,    128, "Intrawave", "rowcol_wp_v2"),
+    #   wide-N / large-M, where 192-wide tiles lead at M >= 2048:
+    9: kernelInstance( 0, 0, 8, 4, 1, 0, 0, 0, 0, 1,  128,   192,   128,  1,  4,  1,   16,    16,    128, "Intrawave", "rowcol_wp_v2"),
+   10: kernelInstance( 0, 0, 8, 4, 1, 0, 0, 0, 0, 1,  256,   192,   128,  1,  4,  1,   16,    16,    128, "Intrawave", "rowcol_wp_v2"),
+}
+
 default_kernels_dict_950 = {
     (-1): kernelInstance( 0, 0, 8, 4, 1, 0, 0, 0, 0,1, 128,   256,   256,  1,  4,  1,   16,    16,    128, "Default"),
     (-2): kernelInstance( 0, 0, 8, 4, 1, 0, 0, 0, 0,1, 16,    64,    512,  1,  4,  1,   16,    16,    128, "Default"),
@@ -399,12 +461,31 @@ default_kernels_dict_950 = {
 
 # fmt: on
 
+def append_expanded(base_expanded, extra):
+    """Append BlockPerCu-expanded `extra` after `base_expanded`, renumbering
+    only the appended entries.
+
+    Kernel ids are positional, so inserting into a table shifts every id after
+    the insertion point -- including the ids `expand_blockpercu` hands out.
+    Growing a secondary table (e.g. the rowcol_wp_v2 candidates) must not
+    renumber the primary one, so it is expanded on its own and appended.
+    """
+    out = dict(base_expanded)
+    next_id = max(out.keys()) + 1
+    for inst in expand_blockpercu(extra).values():
+        out[next_id] = inst
+        next_id += 1
+    return out
+
+
 arch = get_gfx()
 if arch == "gfx942":
     kernels_list = expand_blockpercu(kernels_list_942)
     default_kernels_dict = default_kernels_dict_942
 else:
-    kernels_list = expand_blockpercu(kernels_list_950)
+    kernels_list = append_expanded(
+        expand_blockpercu(kernels_list_950), kernels_list_950_rowcol_wp_v2
+    )
     default_kernels_dict = default_kernels_dict_950
 
 # Name-based reverse lookup for get_tune_dict() — built once at import time

--- a/csrc/cktile_gemm_a8w8_bpreshuffle/gemm_a8w8_bpreshuffle_cktile_common.py
+++ b/csrc/cktile_gemm_a8w8_bpreshuffle/gemm_a8w8_bpreshuffle_cktile_common.py
@@ -469,6 +469,7 @@ default_kernels_dict_950 = {
 
 # fmt: on
 
+
 def append_expanded(base_expanded, extra):
     """Append BlockPerCu-expanded `extra` after `base_expanded`, renumbering
     only the appended entries.

--- a/csrc/cktile_gemm_a8w8_bpreshuffle/gemm_a8w8_bpreshuffle_cktile_common.py
+++ b/csrc/cktile_gemm_a8w8_bpreshuffle/gemm_a8w8_bpreshuffle_cktile_common.py
@@ -74,6 +74,10 @@ class kernelInstance:
         return self.sPipeline == DEFAULT_PIPELINE
 
     @property
+    def supports_k_padding(self) -> bool:
+        return self.sPipeline == DEFAULT_PIPELINE
+
+    @property
     def name(self) -> str:
         parts = [
             "a8w8_bpreshuffle_cktile",

--- a/csrc/cktile_gemm_a8w8_bpreshuffle/gen_instances.py
+++ b/csrc/cktile_gemm_a8w8_bpreshuffle/gen_instances.py
@@ -237,10 +237,13 @@ template torch::Tensor
         else:
             LOOKUP_template = """
        {{{MNK},                                                                                                       \\
-        RowwiseDispatchEntry{{{kernel_name}<DTYPE, ETYPE>, {supports_m_padding}}}}},                                  \\"""
+        RowwiseDispatchEntry{{{kernel_name}<DTYPE, ETYPE>, {supports_m_padding}, {supports_k_padding}}}}},            \\"""
 
             def extra_format_args(kernel):
-                return {"supports_m_padding": str(kernel.supports_m_padding).lower()}
+                return {
+                    "supports_m_padding": str(kernel.supports_m_padding).lower(),
+                    "supports_k_padding": str(kernel.supports_k_padding).lower(),
+                }
 
         LOOKUP_end = """
    }

--- a/csrc/cktile_gemm_a8w8_bpreshuffle/gen_instances.py
+++ b/csrc/cktile_gemm_a8w8_bpreshuffle/gen_instances.py
@@ -19,6 +19,8 @@ AITER_CORE_DIR = (
 sys.path.insert(0, AITER_CORE_DIR)
 from chip_info import build_tune_dict, write_lookup_header
 from gemm_a8w8_bpreshuffle_cktile_common import (
+    DEFAULT_PIPELINE,
+    PIPELINE_IDS,
     default_kernels_dict,
     kernelInstance,
     kernels_by_name,
@@ -40,6 +42,67 @@ class gemm_a8w8_bpreshuffle_cktile_codegen:
         self.istune = istune
 
     def gen_instance(self, k: kernelInstance):
+        pipeline = getattr(k, "sPipeline", DEFAULT_PIPELINE)
+        if pipeline not in PIPELINE_IDS:
+            raise ValueError(
+                f"{k.name}: unknown sPipeline {pipeline!r}, "
+                f"expected one of {sorted(PIPELINE_IDS)}"
+            )
+        pipeline_id = PIPELINE_IDS[pipeline]
+
+        def instance_content(pad_m: bool, pad_n: bool, pad_k: bool) -> str:
+            return f"""using FlatmmInstance = CustomConfig<
+            DDataType, EDataType,
+            {k.sTransposeC},{k.sUseStructuredSparsity}, {k.sTileParitionerGroupNum},
+            {k.sTileParitionerM01}, {k.sNumWaveGroups}, {k.sDoubleSmemBuffer},
+            {int(pad_m)},  {int(pad_n)},  {int(pad_k)},
+            {k.BlockPerCu},
+            {k.MTile}, {k.NTile}, {k.KTile},
+            {k.MWarp}, {k.NWarp}, {k.KWarp},
+            {k.MWTile}, {k.NWTile}, {k.KWTile},
+            ck_tile::GemmPipelineScheduler::{k.sScheduler},
+            {pipeline_id}>;
+        // Run kernel instance.
+        return gemm_a8w8_bpreshuffle_cktile_impl<DDataType, EDataType, FlatmmInstance>(XQ, WQ, x_scale, w_scale, Y, KBatch);
+"""
+
+        if pipeline != DEFAULT_PIPELINE:
+            # The quant route instantiates its traits with the pads clamped
+            # false (see gemm_calc_rowcol_wp_v2), so there is exactly one body
+            # and a non-divisible shape has to fail loudly instead of silently
+            # reading out of tile.
+            INSTANCE_IMPL_str = f"""// SPDX-License-Identifier: MIT
+// Copyright (c) 2024, Advanced Micro Devices, Inc. All rights reserved.
+
+#include "gemm_a8w8_bpreshuffle_cktile_common.cuh"
+
+template <typename DDataType, typename EDataType>
+torch::Tensor
+{k.name}(
+    torch::Tensor &XQ,
+    torch::Tensor &WQ,
+    torch::Tensor &x_scale,
+    torch::Tensor &w_scale,
+    torch::Tensor &Y,
+    int KBatch = 1
+    )
+{{
+    int M = size_to_dim_(XQ.dim() - 1, XQ.sizes());
+    int N = WQ.size(0);
+    int K = XQ.size(1);
+    TORCH_CHECK(M % {k.MTile} == 0 && N % {k.NTile} == 0 && K % {k.KTile} == 0,
+                "{k.name} runs unpadded: M/N/K must be divisible by the "
+                "tile ({k.MTile}, {k.NTile}, {k.KTile})");
+    {instance_content(False, False, False)}
+}}
+
+"""
+            Path(os.path.join(self.impl_path, f"{k.name}.cuh")).write_text(
+                INSTANCE_IMPL_str
+            )
+            self._gen_instance_registrations(k)
+            return
+
         INSTANCE_IMPL = f"""// SPDX-License-Identifier: MIT
 // Copyright (c) 2024, Advanced Micro Devices, Inc. All rights reserved.
 
@@ -101,21 +164,6 @@ torch::Tensor
 
 """
 
-        def instance_content(pad_m: bool, pad_n: bool, pad_k: bool) -> str:
-            return f"""using FlatmmInstance = CustomConfig<
-            DDataType, EDataType,
-            {k.sTransposeC},{k.sUseStructuredSparsity}, {k.sTileParitionerGroupNum},
-            {k.sTileParitionerM01}, {k.sNumWaveGroups}, {k.sDoubleSmemBuffer},
-            {int(pad_m)},  {int(pad_n)},  {int(pad_k)},
-            {k.BlockPerCu},
-            {k.MTile}, {k.NTile}, {k.KTile},
-            {k.MWarp}, {k.NWarp}, {k.KWarp},
-            {k.MWTile}, {k.NWTile}, {k.KWTile},
-            ck_tile::GemmPipelineScheduler::{k.sScheduler}>;
-        // Run kernel instance.
-        return gemm_a8w8_bpreshuffle_cktile_impl<DDataType, EDataType, FlatmmInstance>(XQ, WQ, x_scale, w_scale, Y, KBatch);
-"""
-
         INSTANCE_CONTENT_nopad = instance_content(k.PadM, k.PadN, k.PadK)
         instance_replacements = {
             "INSTANCE_CONTENT_nopad": INSTANCE_CONTENT_nopad,
@@ -136,6 +184,9 @@ torch::Tensor
             INSTANCE_IMPL_str
         )
 
+        self._gen_instance_registrations(k)
+
+    def _gen_instance_registrations(self, k: kernelInstance):
         INSTANCE_template = """// SPDX-License-Identifier: MIT
 // Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
 

--- a/csrc/cktile_gemm_a8w8_bpreshuffle/gen_instances.py
+++ b/csrc/cktile_gemm_a8w8_bpreshuffle/gen_instances.py
@@ -229,9 +229,18 @@ template torch::Tensor
 #define GENERATE_LOOKUP_TABLE(DTYPE, ETYPE)                                                                                      \\
    {                                                                                                                             \\"""
 
-        LOOKUP_template = """
+        if self.istune:
+            LOOKUP_template = """
        {{{MNK},                                                                                                       \\
-        {kernel_name}<DTYPE, ETYPE>}},                       \\"""
+        {kernel_name}<DTYPE, ETYPE>}},                                                                                \\"""
+            extra_format_args = None
+        else:
+            LOOKUP_template = """
+       {{{MNK},                                                                                                       \\
+        RowwiseDispatchEntry{{{kernel_name}<DTYPE, ETYPE>, {supports_m_padding}}}}},                                  \\"""
+
+            def extra_format_args(kernel):
+                return {"supports_m_padding": str(kernel.supports_m_padding).lower()}
 
         LOOKUP_end = """
    }
@@ -245,6 +254,7 @@ template torch::Tensor
             LOOKUP_template,
             LOOKUP_end,
             self.istune,
+            extra_format_args=extra_format_args,
         )
 
     def gen_manifest_head(self, kernels_dict):

--- a/csrc/cktile_gemm_a8w8_bpreshuffle/include/gemm_a8w8_bpreshuffle_cktile_common.cuh
+++ b/csrc/cktile_gemm_a8w8_bpreshuffle/include/gemm_a8w8_bpreshuffle_cktile_common.cuh
@@ -13,6 +13,9 @@
 #include <numeric>
 
 #include "flatmm_basic.hpp"
+// QuantGemmKernel and the RowColQuant scale windows used by the
+// "rowcol_wp_v2" pipeline below.
+#include "ck_tile/ops/gemm_quant.hpp"
 #include <ATen/ATen.h>
 #include <ATen/hip/impl/HIPGuardImplMasqueradingAsCUDA.h>
 #include <ATen/hip/impl/HIPStreamMasqueradingAsCUDA.h>
@@ -228,7 +231,8 @@ template <bool sTransposeC,
           int MWTile,
           int NWTile,
           int KWTile,
-          ck_tile::GemmPipelineScheduler sScheduler = ck_tile::GemmPipelineScheduler::Default>
+          ck_tile::GemmPipelineScheduler sScheduler = ck_tile::GemmPipelineScheduler::Default,
+          int sPipeline                             = 0>
 struct CreateTileConfig
 {
     static constexpr bool TransposeC                = sTransposeC;
@@ -251,6 +255,14 @@ struct CreateTileConfig
     static constexpr int N_Warp_Tile                = NWTile;
     static constexpr int K_Warp_Tile                = KWTile;
     static constexpr auto Scheduler                 = sScheduler;
+    // Which device composition consumes the tile geometry above.
+    // 0 = flatmm_v1    : ck_tile::FlatmmKernel + FlatmmPipelineAGmemBGmemCRegV1
+    //                    (the historical path; see flatmm_calc).
+    // 1 = rowcol_wp_v2 : ck_tile::QuantGemmKernel<QuantType::RowColQuant> +
+    //                    WeightPreshufflePipelineAGmemBGmemCRegV2
+    //                    (see gemm_calc_rowcol_wp_v2).
+    // Mirrors PIPELINE_IDS in gemm_a8w8_bpreshuffle_cktile_common.py.
+    static constexpr int PipelineId                 = sPipeline;
 };
 
 template <typename AccDataType,
@@ -274,7 +286,8 @@ template <typename AccDataType,
           int MWTile,
           int NWTile,
           int KWTile,
-          ck_tile::GemmPipelineScheduler Scheduler = ck_tile::GemmPipelineScheduler::Default>
+          ck_tile::GemmPipelineScheduler Scheduler = ck_tile::GemmPipelineScheduler::Default,
+          int sPipeline                            = 0>
 using CustomConfig = CreateTileConfig<sTransposeC,
                                       sUseStructuredSparsity,
                                       sTileParitionerGroupNum,
@@ -294,7 +307,161 @@ using CustomConfig = CreateTileConfig<sTransposeC,
                                       MWTile,
                                       NWTile,
                                       KWTile,
-                                      Scheduler>;
+                                      Scheduler,
+                                      sPipeline>;
+
+// ---------------------------------------------------------------------------
+// "rowcol_wp_v2": ck_tile::QuantGemmKernel in QuantType::RowColQuant mode
+// driving the plain weight-preshuffle pipeline.
+//
+// ptpc (per-token A x per-channel B) *is* CK's RowColQuant: the kernel builds
+// the aq window with strides (1, 0) and the bq window with strides (0, 1)
+// (gemm_quant_kernel.hpp), so the (M,) and (N,) scale vectors AITER already
+// hands the flatmm path are consumed natively -- no host-side replication.
+// The quant mode and the GEMM pipeline are orthogonal axes: RowColQuant calls
+// the pipeline with the plain (a, b, num_loop, smem) operator and applies the
+// scales in the epilogue, which is exactly what the weight-preshuffle
+// pipeline provides. That lets ptpc run on preshuffled B -- the same
+// shuffle_weight(16, 16) layout flatmm_v1 consumes.
+//
+// One bridge is required. QuantGemmKernel detects a preshuffled B by SFINAE on
+// `GemmPipeline::PreshuffleB`, and WeightPreshufflePipelineAGmemBGmemCRegV2
+// does not expose that member; without the alias the detection silently
+// defaults to false and the kernel reads shuffled B as if it were plain
+// (measured: ~39% of elements wrong). The alias is being added upstream in
+// ROCm/composable_kernel#3772; drop this wrapper once AITER's pinned CK
+// carries it and use the pipeline directly.
+// ---------------------------------------------------------------------------
+template <typename Problem>
+struct KtWp2RowcolPipeline : ck_tile::WeightPreshufflePipelineAGmemBGmemCRegV2<Problem>
+{
+    static constexpr bool PreshuffleB = true;
+};
+
+template <typename FlatmmConfig, typename CDataType_>
+float gemm_calc_rowcol_wp_v2(const ck_tile::QuantGemmHostArgs& args,
+                             const ck_tile::stream_config& s)
+{
+    using ADataType   = ck_tile::fp8_t;
+    using BDataType   = ck_tile::fp8_t;
+    using AccDataType = float;
+    using CDataType   = CDataType_;
+    using ALayout     = ck_tile::tensor_layout::gemm::RowMajor;
+    using BLayout     = ck_tile::tensor_layout::gemm::ColumnMajor;
+    using CLayout     = ck_tile::tensor_layout::gemm::RowMajor;
+
+    using GemmShape = ck_tile::TileGemmShape<
+        ck_tile::sequence<FlatmmConfig::M_Tile, FlatmmConfig::N_Tile, FlatmmConfig::K_Tile>,
+        ck_tile::sequence<FlatmmConfig::M_Warp, FlatmmConfig::N_Warp, FlatmmConfig::K_Warp>,
+        ck_tile::sequence<FlatmmConfig::M_Warp_Tile,
+                          FlatmmConfig::N_Warp_Tile,
+                          FlatmmConfig::K_Warp_Tile>>;
+
+    using TilePartitioner = ck_tile::GemmTile1DPartitioner<GemmShape>;
+
+    // Pads are clamped false: codegen emits a divisibility TORCH_CHECK for
+    // this pipeline and the tuner only issues tile-divisible shapes.
+    using UniversalTraits = ck_tile::TileGemmUniversalTraits<false, // kPadM
+                                                             false, // kPadN
+                                                             false, // kPadK
+                                                             true,  // DoubleSmemBuffer
+                                                                    // (required by WP2)
+                                                             ALayout,
+                                                             BLayout,
+                                                             CLayout,
+                                                             false, // TransposeC
+                                                             false, // UseStructuredSparsity
+                                                             false, // Persistent
+                                                             1,     // NumWaveGroups
+                                                             true>; // Preshuffle
+
+    using UniProblem = ck_tile::UniversalGemmPipelineProblem<ADataType,
+                                                             BDataType,
+                                                             AccDataType,
+                                                             GemmShape,
+                                                             UniversalTraits,
+                                                             FlatmmConfig::Scheduler,
+                                                             ck_tile::element_wise::PassThrough,
+                                                             ck_tile::element_wise::PassThrough>;
+
+    using GemmPipeline = KtWp2RowcolPipeline<UniProblem>;
+
+    using GemmEpilogue = ck_tile::CShuffleEpilogue<
+        ck_tile::CShuffleEpilogueProblem<typename UniProblem::AComputeDataType,
+                                         typename UniProblem::BComputeDataType,
+                                         ck_tile::tuple<>,
+                                         AccDataType,
+                                         CDataType,
+                                         ck_tile::tuple<>,
+                                         CLayout,
+                                         ck_tile::element_wise::PassThrough,
+                                         TilePartitioner::MPerBlock,
+                                         TilePartitioner::NPerBlock,
+                                         FlatmmConfig::M_Warp,
+                                         FlatmmConfig::N_Warp,
+                                         FlatmmConfig::M_Warp_Tile,
+                                         FlatmmConfig::N_Warp_Tile,
+                                         FlatmmConfig::K_Warp_Tile,
+                                         false>>;
+
+    using Kernel = ck_tile::QuantGemmKernel<TilePartitioner,
+                                            GemmPipeline,
+                                            GemmEpilogue,
+                                            ck_tile::QuantType::RowColQuant>;
+
+    auto kargs        = Kernel::MakeKernelArgs(args);
+    const dim3 grids  = Kernel::GridSize(args.M, args.N, args.k_batch);
+    const dim3 blocks = Kernel::BlockSize();
+
+    if(!Kernel::IsSupportedArgument(kargs))
+    {
+        throw std::runtime_error("Wrong! rowcol_wp_v2 arguments not supported! Skipping gemm!\n");
+    }
+
+    return ck_tile::launch_kernel(
+        s, ck_tile::make_kernel<FlatmmConfig::kBlockPerCu>(Kernel{}, grids, blocks, 0, kargs));
+}
+
+template <typename DDataType, typename EDataType, typename FlatmmInstance>
+__forceinline__ torch::Tensor
+gemm_a8w8_bpreshuffle_cktile_rowcol_wp_v2_impl(torch::Tensor& XQ,
+                                               torch::Tensor& WQ,
+                                               torch::Tensor& x_scale,
+                                               torch::Tensor& w_scale,
+                                               torch::Tensor& out,
+                                               int KBatch)
+{
+    int m = XQ.size(0);
+    int n = WQ.size(0);
+    int k = XQ.size(1);
+
+    // Native ptpc: x_scale is (M,) / (M,1) and w_scale is (N,) / (N,1), i.e.
+    // one quant group along K. QK_* == 1 is what puts the kernel on the
+    // stride-(1,0) / (0,1) RowCol scale windows.
+    ck_tile::QuantGemmHostArgs args;
+    args.a_ptr     = (void*)XQ.data_ptr();
+    args.aq_ptr    = (const void*)x_scale.data_ptr();
+    args.b_ptr     = (void*)WQ.data_ptr();
+    args.bq_ptr    = (const void*)w_scale.data_ptr();
+    args.c_ptr     = (void*)out.data_ptr();
+    args.k_batch   = KBatch;
+    args.M         = m;
+    args.N         = n;
+    args.K         = k;
+    args.QK_A      = 1;
+    args.QK_B      = 1;
+    args.stride_A  = XQ.stride(-2);
+    args.stride_B  = WQ.stride(-2);
+    args.stride_C  = n;
+    args.stride_AQ = 1;
+    args.stride_BQ = 1;
+
+    const c10::hip::OptionalHIPGuardMasqueradingAsCUDA device_guard(device_of(XQ));
+    const hipStream_t stream = at::hip::getCurrentHIPStream();
+    ck_tile::stream_config naive_config{stream};
+    gemm_calc_rowcol_wp_v2<FlatmmInstance, EDataType>(args, naive_config);
+    return out;
+}
 
 template <typename DDataType, typename EDataType, typename FlatmmInstance>
 __forceinline__ torch::Tensor
@@ -307,6 +474,15 @@ gemm_a8w8_bpreshuffle_cktile_impl(torch::Tensor& XQ,
 {
     TORCH_CHECK(XQ.dtype() == WQ.dtype(), "Weights and activations should have the same dtype!");
     TORCH_CHECK(x_scale.dtype() == w_scale.dtype(), "Scales should have the same dtype!");
+    // A real else-branch, so the flatmm kernel is never instantiated for a
+    // quant-route config (and vice versa).
+    if constexpr(FlatmmInstance::PipelineId == 1)
+    {
+        return gemm_a8w8_bpreshuffle_cktile_rowcol_wp_v2_impl<DDataType, EDataType, FlatmmInstance>(
+            XQ, WQ, x_scale, w_scale, out, KBatch);
+    }
+    else
+    {
     using ADataType      = typename GemmBasicTypeConfig<ck_tile::fp8_t>::ADataType;
     using BDataType      = typename GemmBasicTypeConfig<ck_tile::fp8_t>::BDataType;
     using CDataType      = EDataType;
@@ -361,6 +537,7 @@ gemm_a8w8_bpreshuffle_cktile_impl(torch::Tensor& XQ,
                 CDEElementWise>(args, naive_config);
 
     return out;
+    } // else (PipelineId == 0, flatmm_v1)
 }
 
 #endif // USE_ROCM

--- a/csrc/cktile_gemm_a8w8_bpreshuffle/include/gemm_a8w8_bpreshuffle_cktile_common.cuh
+++ b/csrc/cktile_gemm_a8w8_bpreshuffle/include/gemm_a8w8_bpreshuffle_cktile_common.cuh
@@ -329,7 +329,7 @@ using CustomConfig = CreateTileConfig<sTransposeC,
 // does not expose that member; without the alias the detection silently
 // defaults to false and the kernel reads shuffled B as if it were plain
 // (measured: ~39% of elements wrong). The alias is being added upstream in
-// ROCm/composable_kernel#3772; drop this wrapper once AITER's pinned CK
+// ROCm/rocm-libraries#11721; drop this wrapper once AITER's pinned CK
 // carries it and use the pipeline directly.
 // ---------------------------------------------------------------------------
 template <typename Problem>

--- a/op_tests/test_gemm_codegen.py
+++ b/op_tests/test_gemm_codegen.py
@@ -687,21 +687,25 @@ def test_write_lookup_header():
     from chip_info import write_lookup_header
 
     class _FakeKernel:
-        def __init__(self, name, supports_m_padding=True):
+        def __init__(self, name, supports_m_padding=True, supports_k_padding=True):
             self.name = name
             self.supports_m_padding = supports_m_padding
+            self.supports_k_padding = supports_k_padding
 
     kernels_dict = {
         ("gfx942", 304, 128, 4096, 4096): _FakeKernel("kernel_non_batched"),
         ("gfx942", 304, 2, 128, 4096, 4096): _FakeKernel(
-            "kernel_batched", supports_m_padding=False
+            "kernel_batched",
+            supports_m_padding=False,
+            supports_k_padding=False,
         ),
         -1: _FakeKernel("default_kernel"),  # default_dict entry — must be skipped
     }
 
     LOOKUP_head = "#ifdef USE_ROCM\n#define GENERATE_LOOKUP_TABLE(DTYPE, ETYPE) {\\\n"
     LOOKUP_template = (
-        "   {{{MNK}, {{{kernel_name}<DTYPE, ETYPE>, {supports_m_padding}}}}},\\\n"
+        "   {{{MNK}, {{{kernel_name}<DTYPE, ETYPE>, {supports_m_padding}, "
+        "{supports_k_padding}}}}},\\\n"
     )
     LOOKUP_end = "}\n#endif\n"
 
@@ -720,7 +724,8 @@ def test_write_lookup_header():
             LOOKUP_template,
             LOOKUP_end,
             extra_format_args=lambda kernel: {
-                "supports_m_padding": str(kernel.supports_m_padding).lower()
+                "supports_m_padding": str(kernel.supports_m_padding).lower(),
+                "supports_k_padding": str(kernel.supports_k_padding).lower(),
             },
         )
         with open(path) as fh:
@@ -743,7 +748,7 @@ def test_write_lookup_header():
         )
         _check(
             "per-kernel metadata is emitted in the lookup value",
-            "{kernel_batched<DTYPE, ETYPE>, false}" in content,
+            "{kernel_batched<DTYPE, ETYPE>, false, false}" in content,
             f"padding metadata not found in output:\n{content}",
         )
         _check(

--- a/op_tests/test_gemm_codegen.py
+++ b/op_tests/test_gemm_codegen.py
@@ -687,17 +687,22 @@ def test_write_lookup_header():
     from chip_info import write_lookup_header
 
     class _FakeKernel:
-        def __init__(self, name):
+        def __init__(self, name, supports_m_padding=True):
             self.name = name
+            self.supports_m_padding = supports_m_padding
 
     kernels_dict = {
         ("gfx942", 304, 128, 4096, 4096): _FakeKernel("kernel_non_batched"),
-        ("gfx942", 304, 2, 128, 4096, 4096): _FakeKernel("kernel_batched"),
+        ("gfx942", 304, 2, 128, 4096, 4096): _FakeKernel(
+            "kernel_batched", supports_m_padding=False
+        ),
         -1: _FakeKernel("default_kernel"),  # default_dict entry — must be skipped
     }
 
     LOOKUP_head = "#ifdef USE_ROCM\n#define GENERATE_LOOKUP_TABLE(DTYPE, ETYPE) {\\\n"
-    LOOKUP_template = "   {{{MNK}, {kernel_name}<DTYPE, ETYPE>}},\\\n"
+    LOOKUP_template = (
+        "   {{{MNK}, {{{kernel_name}<DTYPE, ETYPE>, {supports_m_padding}}}}},\\\n"
+    )
     LOOKUP_end = "}\n#endif\n"
 
     path = None
@@ -709,7 +714,14 @@ def test_write_lookup_header():
         path = f.name
         f.close()
         write_lookup_header(
-            path, kernels_dict, LOOKUP_head, LOOKUP_template, LOOKUP_end
+            path,
+            kernels_dict,
+            LOOKUP_head,
+            LOOKUP_template,
+            LOOKUP_end,
+            extra_format_args=lambda kernel: {
+                "supports_m_padding": str(kernel.supports_m_padding).lower()
+            },
         )
         with open(path) as fh:
             content = fh.read()
@@ -728,6 +740,11 @@ def test_write_lookup_header():
             "default_dict (-1) entry is skipped",
             "default_kernel" not in content,
             f"default_kernel unexpectedly in output:\n{content}",
+        )
+        _check(
+            "per-kernel metadata is emitted in the lookup value",
+            "{kernel_batched<DTYPE, ETYPE>, false}" in content,
+            f"padding metadata not found in output:\n{content}",
         )
         _check(
             "old-style key without gfx (regression guard): {304, 128, ...} absent",


### PR DESCRIPTION
Adds `rowcol_wp_v2` as a selectable kernel type in the cktile `a8w8_bpreshuffle` family: CK's `QuantGemmKernel` in **RowColQuant** mode driving the plain **weight-preshuffle pipeline** (WP2). Per-token × per-channel scales are exactly what this op already carries, so the tuner gains a genuinely different kernel to choose between per shape.

## Why

`a8w8_bpreshuffle` already hands the kernel a `shuffle_weight(16,16)`-preshuffled B and native `(M,)`/`(N,)` ptpc scales — which is precisely RowColQuant's contract. Until now the `cktile` libtype meant exactly one thing (`FlatmmPipelineAGmemBGmemCRegV1`), so a better pipeline could not be nominated by the tuner even where it wins.

## Results (gfx950 / MI350X)

**Correctness: `errRatio 0.0000` on every one of 1754 measurements**, including all 44 rowcol candidates.

**Performance, measured against the full candidate space** (single tune, `--libtype all`, 2804 candidates — not a cktile-only comparison):

| shape (M,N,K) | champion, all libtypes | best rowcol | rowcol rank |
|---|---|---|---|
| 2048, 6144, 12288 | **151.788 µs** — `ck a8w8_bpreshuffle_256x256x192x128` | 156.512 µs | **5 / 1624** |
| 16384, 6144, 12288 | **1018.110 µs** — `flydsl_bpreshuffle_8w_256x256x128` | 1186.285 µs | **30 / 1144** |

**On the shapes measured here, rowcol_wp_v2 is not selected.** A `ck` or `flydsl` kernel wins every one. Within the CK-Tile family it beats flatmm at large M (+9.8% / +7.4%), but that is a comparison against its own family's twin, not against the dispatched kernel, and it is not the basis for merging this.

The case for it is coverage:

- at M=2048 it is **5th of 1624 valid candidates**, ~3.1% off the champion — a credible candidate on a route that could not be expressed before this PR;
- it costs nothing when it loses: the tuner simply does not select it;
- `sPipeline` is a new **axis**, so future improvements to the weight-preshuffle pipeline reach this op without new plumbing.

## Padding safety

`rowcol_wp_v2` is instantiated without M or K padding and therefore requires exact tile divisibility. Serving lookup entries now carry `supports_m_padding` and `supports_k_padding` metadata:

- an exact-M rowcol winner dispatches normally;
- fine- and coarse-grained padded-M lookup skip unpadded rowcol entries;
- lookup retains the padded weight width as its dispatch key but also receives the activation's actual K, so a padded-K match skips rowcol unless that entry supports K padding;
- the search can continue to a padding-safe flatmm entry or the existing heuristic.

This prevents arbitrary shapes such as M=2000, or an activation K smaller than its padded weight K, from selecting a rowcol winner that would reject the real input shape.

## Compatibility

- **Existing flatmm instances are untouched.** All 259 keep byte-identical names and ids 0..258; rowcol occupies 259..302 via a secondary table expanded and appended after the primary one.
- The pipeline suffix is added to the kernel name **only for non-default pipelines**, so existing tuned CSVs keep resolving.
- Tune-mode codegen remains a plain function-pointer lookup; padding metadata is emitted only for serving dispatch.
- No tuner data-prep change: rowcol consumes the same preshuffled B and native scales flatmm already receives. The only tuner edit is a tile-divisibility skip.

## Verified

1. codegen — tune-mode and serving lookup generation both succeed;
2. regression test — `op_tests/test_gemm_codegen.py`: 40 passed;
3. lint/format checks pass for the changed code;
4. GPU compile, tuning, and serving validation were completed on gfx950 for the original implementation.

## Note on the CK bridge

`KtWp2RowcolPipeline` exists only because `WeightPreshufflePipelineAGmemBGmemCRegV2` does not expose `PreshuffleB`, and `QuantGemmKernel` detects preshuffle by SFINAE on that member — defaulting to **false** when absent, which silently makes it read preshuffled weights as a plain B. The upstream CK fix is ROCm/rocm-libraries#11721; the wrapper can be removed once the pinned CK contains it.
