### PR TITLE
[FlyDSL][DSv4] Prototype FP4 MQA streaming TopK

### DIFF
--- a/aiter/ops/flydsl/__init__.py
+++ b/aiter/ops/flydsl/__init__.py
@@ -25,6 +25,14 @@ if _base_version < _MIN_FLYDSL_VERSION:
     )
 
 _LAZY_IMPORTS = {
+    "FP4PrefillTopKResult": (
+        ".kernels.mqa_logits.pa_mqa_logits_fp4_prefill",
+        "FP4PrefillTopKResult",
+    ),
+    "FP4PrefillTopKWorkspace": (
+        ".kernels.mqa_logits.pa_mqa_logits_fp4_prefill",
+        "FP4PrefillTopKWorkspace",
+    ),
     "FP8_MQA_LOGITS_DEFAULT_VARIANT": (
         ".kernels.mqa_logits.fp8_mqa_logits",
         "DEFAULT_VARIANT",
@@ -36,6 +44,10 @@ _LAZY_IMPORTS = {
     "compute_varqlen_windows": (
         ".kernels.mqa_logits.pa_mqa_logits_fp4_prefill",
         "compute_varqlen_windows",
+    ),
+    "allocate_fp4_prefill_topk_workspace": (
+        ".kernels.mqa_logits.pa_mqa_logits_fp4_prefill",
+        "allocate_fp4_prefill_topk_workspace",
     ),
     "flydsl_flash_attn_func": (".fmha_kernels", "flydsl_flash_attn_func"),
     "flydsl_fp8_mqa_logits": (
@@ -54,6 +66,10 @@ _LAZY_IMPORTS = {
         ".kernels.mqa_logits.pa_mqa_logits_fp4_prefill",
         "flydsl_pa_mqa_logits_fp4_prefill",
     ),
+    "flydsl_pa_mqa_topk_fp4_prefill": (
+        ".kernels.mqa_logits.pa_mqa_logits_fp4_prefill",
+        "flydsl_pa_mqa_topk_fp4_prefill",
+    ),
     "flydsl_pa_mqa_logits_fp4_varqlen": (
         ".kernels.mqa_logits.pa_mqa_logits_fp4_prefill",
         "flydsl_pa_mqa_logits_fp4_varqlen",
@@ -71,7 +87,10 @@ _LAZY_IMPORTS = {
 __all__ = [
     "FP8_MQA_LOGITS_DEFAULT_VARIANT",
     "FP8_MQA_LOGITS_VARIANTS",
+    "FP4PrefillTopKResult",
+    "FP4PrefillTopKWorkspace",
     "GateMode",
+    "allocate_fp4_prefill_topk_workspace",
     "compute_varqlen_windows",
     "flydsl_flash_attn_func",
     "flydsl_fp8_mqa_logits",
@@ -82,6 +101,7 @@ __all__ = [
     "flydsl_pa_mqa_logits_fp4",
     "flydsl_pa_mqa_logits_fp4_prefill",
     "flydsl_pa_mqa_logits_fp4_varqlen",
+    "flydsl_pa_mqa_topk_fp4_prefill",
     "flydsl_preshuffle_gemm_a8",
     "flydsl_qk_norm_rope_quant",
 ]

--- a/aiter/ops/flydsl/candidate_topk_merge.py
+++ b/aiter/ops/flydsl/candidate_topk_merge.py
@@ -1,0 +1,234 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+"""Public interface for exact split-candidate TopK merge."""
+
+from functools import cache, lru_cache
+
+import torch
+
+from .kernels.candidate_topk_merge import build_candidate_topk_merge_module
+from .kernels.kernels_common import get_warp_size
+from .kernels.tensor_shim import _run_compiled
+
+
+@cache
+def _get_launcher(topk: int, page_size: int, map_physical_indices: bool = True):
+    return build_candidate_topk_merge_module(
+        topk,
+        page_size,
+        map_physical_indices=map_physical_indices,
+    )
+
+
+@lru_cache(maxsize=128)
+def _validate(
+    candidate_values_shape,
+    candidate_values_stride,
+    candidate_values_dtype,
+    candidate_indices_shape,
+    candidate_indices_stride,
+    candidate_indices_dtype,
+    candidate_counts_shape,
+    candidate_counts_dtype,
+    row_offsets_shape,
+    row_offsets_dtype,
+    row_to_batch_shape,
+    row_to_batch_dtype,
+    block_table_shape,
+    block_table_dtype,
+    out_values_shape,
+    out_values_dtype,
+    out_raw_shape,
+    out_raw_dtype,
+    out_physical_shape,
+    out_physical_dtype,
+    out_counts_shape,
+    out_counts_dtype,
+    page_size,
+    wave_size,
+):
+    if len(candidate_values_shape) != 2 or candidate_values_dtype != torch.float32:
+        raise ValueError("candidate_values must be float32 [ctas, topk]")
+    ctas, topk = candidate_values_shape
+    if candidate_values_stride != (topk, 1):
+        raise ValueError("candidate_values must be contiguous")
+    if (
+        candidate_indices_shape != candidate_values_shape
+        or candidate_indices_stride != (topk, 1)
+        or candidate_indices_dtype != torch.int32
+    ):
+        raise ValueError(
+            "candidate_indices must be contiguous int32 with candidate_values shape"
+        )
+    if candidate_counts_shape != (ctas,) or candidate_counts_dtype != torch.int32:
+        raise ValueError("candidate_counts must be int32 [ctas]")
+    if len(row_to_batch_shape) != 1 or row_to_batch_dtype != torch.int32:
+        raise ValueError("row_to_batch must be int32 [rows]")
+    rows = row_to_batch_shape[0]
+    if row_offsets_shape != (rows + 1,) or row_offsets_dtype != torch.int32:
+        raise ValueError("row_offsets must be int32 [rows + 1]")
+    if len(block_table_shape) != 2 or block_table_dtype != torch.int32:
+        raise ValueError("block_table must be a 2D int32 tensor")
+    expected_output = (rows, topk)
+    if out_values_shape != expected_output or out_values_dtype != torch.float32:
+        raise ValueError("out_values must be float32 [rows, topk]")
+    if out_raw_shape != expected_output or out_raw_dtype != torch.int32:
+        raise ValueError("out_raw_indices must be int32 [rows, topk]")
+    if out_physical_shape != expected_output or out_physical_dtype != torch.int32:
+        raise ValueError("out_physical_indices must be int32 [rows, topk]")
+    if out_counts_shape != (rows,) or out_counts_dtype != torch.int32:
+        raise ValueError("out_counts must be int32 [rows]")
+    if page_size <= 0:
+        raise ValueError("page_size must be positive")
+    if wave_size != 64:
+        raise ValueError("candidate TopK merge requires a wave64 GPU")
+
+
+def flydsl_candidate_topk_merge(
+    candidate_values: torch.Tensor,
+    candidate_indices: torch.Tensor,
+    candidate_counts: torch.Tensor,
+    row_offsets: torch.Tensor,
+    row_to_batch: torch.Tensor,
+    block_table: torch.Tensor,
+    out_values: torch.Tensor,
+    out_raw_indices: torch.Tensor,
+    out_physical_indices: torch.Tensor,
+    out_counts: torch.Tensor,
+    page_size: int,
+    *,
+    stream: torch.cuda.Stream | None = None,
+) -> None:
+    """Merge CTA candidate planes and map logical indices through a page table.
+
+    The winning set is exact under ``score descending, raw index ascending``.
+    NaNs sort below every numeric value and ``+0`` sorts above ``-0``. Candidate
+    planes are grouped by row through ``row_offsets``; only the first
+    ``candidate_counts[cta]`` entries of each plane are read.
+
+    Output slots are compact but not score-sorted. Unused slots are written as
+    ``(-inf, -1, -1)``. The op allocates no device memory and can be captured
+    after its shape-specialized first-call compilation.
+    """
+
+    tensors = (
+        candidate_values,
+        candidate_indices,
+        candidate_counts,
+        row_offsets,
+        row_to_batch,
+        block_table,
+        out_values,
+        out_raw_indices,
+        out_physical_indices,
+        out_counts,
+    )
+    device = candidate_values.device
+    if device.type != "cuda":
+        raise ValueError("candidate tensors must be CUDA tensors")
+    if any(t.device != device for t in tensors):
+        raise ValueError("all candidate merge tensors must be on one device")
+    if any(not t.is_contiguous() for t in tensors):
+        raise ValueError("all candidate merge tensors must be contiguous")
+
+    _validate(
+        tuple(candidate_values.shape),
+        tuple(candidate_values.stride()),
+        candidate_values.dtype,
+        tuple(candidate_indices.shape),
+        tuple(candidate_indices.stride()),
+        candidate_indices.dtype,
+        tuple(candidate_counts.shape),
+        candidate_counts.dtype,
+        tuple(row_offsets.shape),
+        row_offsets.dtype,
+        tuple(row_to_batch.shape),
+        row_to_batch.dtype,
+        tuple(block_table.shape),
+        block_table.dtype,
+        tuple(out_values.shape),
+        out_values.dtype,
+        tuple(out_raw_indices.shape),
+        out_raw_indices.dtype,
+        tuple(out_physical_indices.shape),
+        out_physical_indices.dtype,
+        tuple(out_counts.shape),
+        out_counts.dtype,
+        page_size,
+        get_warp_size(torch.cuda.get_device_properties(device).gcnArchName),
+    )
+
+    topk = candidate_values.shape[1]
+    launcher = _get_launcher(topk, page_size)
+    if stream is None:
+        stream = torch.cuda.current_stream(device)
+    elif stream.device != device:
+        raise ValueError("stream must belong to the candidate tensor device")
+    _run_compiled(
+        launcher,
+        *tensors,
+        row_to_batch.shape[0],
+        stream,
+    )
+
+
+def _flydsl_candidate_topk_merge_raw(
+    candidate_values: torch.Tensor,
+    candidate_indices: torch.Tensor,
+    candidate_counts: torch.Tensor,
+    row_offsets: torch.Tensor,
+    row_to_batch: torch.Tensor,
+    block_table: torch.Tensor,
+    out_values: torch.Tensor,
+    out_raw_indices: torch.Tensor,
+    out_counts: torch.Tensor,
+    page_size: int,
+    *,
+    stream: torch.cuda.Stream,
+) -> None:
+    """Merge raw candidates and leave physical mapping to the finalizer."""
+
+    tensors = (
+        candidate_values,
+        candidate_indices,
+        candidate_counts,
+        row_offsets,
+        row_to_batch,
+        block_table,
+        out_values,
+        out_raw_indices,
+        out_counts,
+    )
+    device = candidate_values.device
+    rows = row_offsets.shape[0] - 1
+    topk = candidate_values.shape[1]
+    if device.type != "cuda" or any(t.device != device for t in tensors):
+        raise ValueError("all raw candidate merge tensors must be on one CUDA device")
+    if any(not t.is_contiguous() for t in tensors):
+        raise ValueError("all raw candidate merge tensors must be contiguous")
+    if candidate_indices.shape != candidate_values.shape:
+        raise ValueError("candidate indices must match candidate values")
+    if candidate_counts.shape != (candidate_values.shape[0],):
+        raise ValueError("candidate counts must match the CTA count")
+    if out_values.shape != (rows, topk) or out_raw_indices.shape != (rows, topk):
+        raise ValueError("raw merge outputs must have shape [rows, topk]")
+    if out_counts.shape != (rows,):
+        raise ValueError("raw merge counts must have shape [rows]")
+
+    launcher = _get_launcher(topk, page_size, map_physical_indices=False)
+    _run_compiled(
+        launcher,
+        candidate_values,
+        candidate_indices,
+        candidate_counts,
+        row_offsets,
+        row_to_batch,
+        block_table,
+        out_values,
+        out_raw_indices,
+        out_raw_indices,
+        out_counts,
+        rows,
+        stream,
+    )

--- a/aiter/ops/flydsl/kernels/candidate_topk_common.py
+++ b/aiter/ops/flydsl/kernels/candidate_topk_common.py
@@ -1,0 +1,156 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+"""Wave64 helpers shared by experimental exact candidate TopK kernels."""
+
+import flydsl.compiler as flyc
+import flydsl.expr as fx
+from flydsl.expr import arith, gpu
+from flydsl.expr import rocdl as fly_rocdl
+from flydsl.expr.typing import T
+
+from .kernels_common import uint32_to_int32
+
+BLOCK_THREADS = 256
+WAVE_SIZE = 64
+NUM_WAVES = BLOCK_THREADS // WAVE_SIZE
+RADIX_BITS = 8
+RADIX_MASK = (1 << RADIX_BITS) - 1
+RADIX_SIGN_BIT = 1 << (RADIX_BITS - 1)
+NUM_SCORE_BYTES = 4
+NUM_KEY_BYTES = 2 * NUM_SCORE_BYTES  # score descending, then index ascending
+NUM_HIST_BINS = 1 << RADIX_BITS
+INT32_MIN = -(1 << 31)
+
+_DPP_ROW_SHR_1 = 0x111
+_DPP_ROW_SHR_2 = 0x112
+_DPP_ROW_SHR_4 = 0x114
+_DPP_ROW_SHR_8 = 0x118
+_DPP_ROW_MASK = 0xF
+_DPP_BANK_MASK = 0xF
+
+
+def make_streaming_topk_storage(pool_capacity, state_size):
+    """Create a statically sized LDS carrier outside postponed annotations."""
+
+    @fx.struct
+    class StreamingTopKStorage:
+        pool_values: fx.Array[fx.Float32, pool_capacity, 16]
+        pool_indices: fx.Array[fx.Int32, pool_capacity, 16]
+        histogram: fx.Array[fx.Int32, NUM_HIST_BINS, 16]
+        scan: fx.Array[fx.Int32, NUM_WAVES + 1, 16]
+        state: fx.Array[fx.Int32, state_size, 16]
+
+    return StreamingTopKStorage
+
+
+def f32_to_ordered_i32(value):
+    """Map float32 to signed-order int32; NaNs tie at the very bottom.
+
+    The normal sign-fold also keeps ``+0`` one ordinal above ``-0``.  Raw index
+    is the secondary key, so all NaNs are ordered by increasing index.
+    """
+
+    bits = value.bitcast(fx.Int32)
+    ordered = bits ^ ((bits >> fx.Int32(31)) & fx.Int32(0x7FFFFFFF))
+    abs_bits = bits & fx.Int32(0x7FFFFFFF)
+    is_nan = arith.cmpi(
+        arith.CmpIPredicate.ugt,
+        abs_bits,
+        fx.Int32(0x7F800000),
+    )
+    return arith.select(is_nan, fx.Int32(INT32_MIN), ordered)
+
+
+def key_is_better(score_ord, raw_index, threshold_score, threshold_index):
+    """Whether ``(score desc, index asc)`` precedes the threshold key."""
+
+    return (score_ord > threshold_score) | (
+        (score_ord == threshold_score) & (raw_index < threshold_index)
+    )
+
+
+def key_matches_prefix(
+    score_ord,
+    raw_index,
+    score_prefix,
+    score_mask,
+    index_prefix,
+    index_mask,
+):
+    return ((score_ord & score_mask) == score_prefix) & (
+        (raw_index & index_mask) == index_prefix
+    )
+
+
+def radix_byte(key, byte_position):
+    shift = (3 - byte_position) * RADIX_BITS
+    return (key >> fx.Int32(shift)) & fx.Int32(RADIX_MASK)
+
+
+def prefix_byte_mask(byte_position):
+    shift = (3 - byte_position) * RADIX_BITS
+    return fx.Int32(uint32_to_int32(RADIX_MASK << shift)), shift
+
+
+def _unwrap(value):
+    return value.ir_value() if hasattr(value, "ir_value") else arith.unwrap(value)
+
+
+def warp_inclusive_prefix_i32(value, lane):
+    value_raw = _unwrap(value)
+    zero_raw = _unwrap(0)
+    for dpp_op, threshold in (
+        (_DPP_ROW_SHR_1, 1),
+        (_DPP_ROW_SHR_2, 2),
+        (_DPP_ROW_SHR_4, 4),
+        (_DPP_ROW_SHR_8, 8),
+    ):
+        remote = fly_rocdl.update_dpp(
+            T.i32,
+            zero_raw,
+            value_raw,
+            dpp_op,
+            _DPP_ROW_MASK,
+            _DPP_BANK_MASK,
+            True,
+        )
+        value = (lane >= fx.Int32(threshold)).select(
+            value + fx.Int32(remote),
+            value,
+        )
+        value_raw = _unwrap(value)
+
+    src16 = (lane & fx.Int32(0x30)) - fx.Int32(1)
+    remote16 = fly_rocdl.ds_bpermute(T.i32, src16 * fx.Int32(4), value)
+    value = (lane >= fx.Int32(16)).select(value + fx.Int32(remote16), value)
+    src32 = (lane & fx.Int32(0x30)) - fx.Int32(17)
+    remote32 = fly_rocdl.ds_bpermute(T.i32, src32 * fx.Int32(4), value)
+    return (lane >= fx.Int32(32)).select(value + fx.Int32(remote32), value)
+
+
+@flyc.jit
+def block_exclusive_prefix_i32(tid, value, scan):
+    """Return ``(exclusive_prefix, block_total)`` for one i32 per thread."""
+
+    lane = tid % fx.Int32(WAVE_SIZE)
+    wave = tid // fx.Int32(WAVE_SIZE)
+    inclusive = warp_inclusive_prefix_i32(value, lane)
+    exclusive = inclusive - value
+    if lane == fx.Int32(WAVE_SIZE - 1):
+        scan[wave] = inclusive
+    gpu.barrier()
+
+    cross_wave = fx.Int32(0)
+    total = fx.Int32(0)
+    for wave_index in range(NUM_WAVES):
+        wave_total = scan[wave_index]
+        cross_wave = (wave > fx.Int32(wave_index)).select(
+            cross_wave + wave_total,
+            cross_wave,
+        )
+        total = total + wave_total
+    result = cross_wave + exclusive
+    # The next scan may reuse ``scan`` immediately.
+    gpu.barrier()
+    return result, total

--- a/aiter/ops/flydsl/kernels/candidate_topk_merge.py
+++ b/aiter/ops/flydsl/kernels/candidate_topk_merge.py
@@ -1,0 +1,303 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+"""Exact split-candidate TopK merge with optional paged-index mapping."""
+
+from functools import cache
+
+import flydsl.compiler as flyc
+import flydsl.expr as fx
+from flydsl.expr import const_expr, gpu, range_constexpr
+
+from .candidate_topk_common import (
+    BLOCK_THREADS,
+    NUM_HIST_BINS,
+    NUM_KEY_BYTES,
+    NUM_WAVES,
+    RADIX_SIGN_BIT,
+    block_exclusive_prefix_i32,
+    f32_to_ordered_i32,
+    key_is_better,
+    key_matches_prefix,
+    prefix_byte_mask,
+    radix_byte,
+)
+from .kernels_common import atomic_add_i32
+
+_SCORE_PREFIX = 0
+_SCORE_MASK = 1
+_INDEX_PREFIX = 2
+_INDEX_MASK = 3
+_REMAINING = 4
+_WRITE_CURSOR = 5
+_EQUAL_SEEN = 6
+_TARGET = 7
+_STATE_SIZE = 8
+
+# A scan processes at most 256 predicates, so its low 16-bit count cannot carry
+# into the packed high count.
+_PACK_SHIFT = 16
+_PACK_MASK = (1 << _PACK_SHIFT) - 1
+
+
+def _make_storage():
+    @fx.struct
+    class Storage:
+        histogram: fx.Array[fx.Int32, NUM_HIST_BINS, 16]
+        scan: fx.Array[fx.Int32, NUM_WAVES + 1, 16]
+        state: fx.Array[fx.Int32, _STATE_SIZE, 16]
+
+    return Storage
+
+
+@cache
+def build_candidate_topk_merge_module(
+    topk: int,
+    page_size: int,
+    *,
+    map_physical_indices: bool = True,
+):
+    """Build one-block-per-row exact merge for fixed-width CTA planes.
+
+    Candidate planes in ``[row_offsets[r], row_offsets[r + 1])`` may contain up
+    to ``topk`` live entries each. Selection is lexicographic
+    ``(score descending, raw index ascending)`` over the union.  Output order is
+    stable plane/slot order; membership, including the cutoff tie, follows the
+    total order exactly.
+    """
+
+    if topk <= 0:
+        raise ValueError("topk must be positive")
+    if page_size <= 0:
+        raise ValueError("page_size must be positive")
+    candidate_steps = (topk + BLOCK_THREADS - 1) // BLOCK_THREADS
+
+    @flyc.kernel(known_block_size=[BLOCK_THREADS, 1, 1])
+    def merge_kernel(
+        candidate_values: fx.Tensor,
+        candidate_indices: fx.Tensor,
+        candidate_counts: fx.Tensor,
+        row_offsets: fx.Tensor,
+        row_to_batch: fx.Tensor,
+        block_table: fx.Tensor,
+        out_values: fx.Tensor,
+        out_raw_indices: fx.Tensor,
+        out_physical_indices: fx.Tensor,
+        out_counts: fx.Tensor,
+    ):
+        row = fx.block_idx.x
+        tid = fx.thread_idx.x
+        cta_begin = row_offsets[row]
+        cta_end = row_offsets[row + fx.Int32(1)]
+
+        storage = fx.SharedAllocator().allocate(_make_storage())
+        histogram = storage.histogram.peek().view(fx.make_layout(NUM_HIST_BINS, 1))
+        scan = storage.scan.peek().view(fx.make_layout(NUM_WAVES + 1, 1))
+        state = storage.state.peek().view(fx.make_layout(_STATE_SIZE, 1))
+
+        if tid == 0:
+            total = fx.Int32(0)
+            for cta in range(cta_begin, cta_end, fx.Int32(1)):
+                count = candidate_counts[cta]
+                count = (count < 0).select(fx.Int32(0), count)
+                count = (count > fx.Int32(topk)).select(fx.Int32(topk), count)
+                total = total + count
+            target = (total < fx.Int32(topk)).select(total, fx.Int32(topk))
+            state[_SCORE_PREFIX] = 0
+            state[_SCORE_MASK] = 0
+            state[_INDEX_PREFIX] = 0
+            state[_INDEX_MASK] = 0
+            state[_REMAINING] = target
+            state[_TARGET] = target
+        gpu.barrier()
+
+        # Eight stable radix decisions: four score bytes in descending signed
+        # ordinal order, then four non-negative raw-index bytes ascending.
+        for key_byte in range_constexpr(NUM_KEY_BYTES):
+            histogram[tid] = 0
+            gpu.barrier()
+
+            score_prefix = state[_SCORE_PREFIX]
+            score_mask = state[_SCORE_MASK]
+            index_prefix = state[_INDEX_PREFIX]
+            index_mask = state[_INDEX_MASK]
+            if const_expr(key_byte < 4):
+                byte_position = key_byte
+                xor_value = RADIX_SIGN_BIT if key_byte == 0 else 0
+            else:
+                byte_position = key_byte - 4
+                xor_value = 0
+
+            for cta in range(cta_begin, cta_end, fx.Int32(1)):
+                count = candidate_counts[cta]
+                count = (count < 0).select(fx.Int32(0), count)
+                count = (count > fx.Int32(topk)).select(fx.Int32(topk), count)
+                for step in range_constexpr(candidate_steps):
+                    slot = fx.Int32(step * BLOCK_THREADS) + tid
+                    live = slot < count
+                    safe_slot = live.select(slot, fx.Int32(0))
+                    score_ord = f32_to_ordered_i32(candidate_values[cta, safe_slot])
+                    raw_index = candidate_indices[cta, safe_slot]
+                    prefix_match = live & key_matches_prefix(
+                        score_ord,
+                        raw_index,
+                        score_prefix,
+                        score_mask,
+                        index_prefix,
+                        index_mask,
+                    )
+                    if prefix_match:
+                        key = score_ord if const_expr(key_byte < 4) else raw_index
+                        bucket = radix_byte(key, byte_position) ^ fx.Int32(xor_value)
+                        atomic_add_i32(histogram, 1, bucket, "workgroup")
+            gpu.barrier()
+
+            selected_bucket = (
+                fx.Int32(NUM_HIST_BINS - 1) - tid if const_expr(key_byte < 4) else tid
+            )
+            count = histogram[selected_bucket]
+            before, _ = block_exclusive_prefix_i32(tid, count, scan)
+            remaining = state[_REMAINING]
+            # Keep every lane on the old remaining value before the unique hit
+            # lane publishes the next prefix.
+            gpu.barrier()
+            if (before < remaining) & (before + count >= remaining):
+                actual_bucket = selected_bucket ^ fx.Int32(xor_value)
+                byte_mask, shift = prefix_byte_mask(byte_position)
+                if const_expr(key_byte < 4):
+                    state[_SCORE_PREFIX] = score_prefix | (
+                        actual_bucket << fx.Int32(shift)
+                    )
+                    state[_SCORE_MASK] = score_mask | byte_mask
+                else:
+                    state[_INDEX_PREFIX] = index_prefix | (
+                        actual_bucket << fx.Int32(shift)
+                    )
+                    state[_INDEX_MASK] = index_mask | byte_mask
+                state[_REMAINING] = remaining - before
+            gpu.barrier()
+
+        threshold_score = state[_SCORE_PREFIX]
+        threshold_index = state[_INDEX_PREFIX]
+        threshold_equal_needed = state[_REMAINING]
+        target = state[_TARGET]
+
+        row_values = fx.slice(out_values, (row, None))
+        row_raw = fx.slice(out_raw_indices, (row, None))
+        row_physical = fx.slice(out_physical_indices, (row, None))
+        for step in range_constexpr(candidate_steps):
+            out_pos = fx.Int32(step * BLOCK_THREADS) + tid
+            if out_pos < fx.Int32(topk):
+                row_values[out_pos] = fx.Float32(float("-inf"))
+                row_raw[out_pos] = fx.Int32(-1)
+                if const_expr(map_physical_indices):
+                    row_physical[out_pos] = fx.Int32(-1)
+        if tid == 0:
+            state[_WRITE_CURSOR] = 0
+            state[_EQUAL_SEEN] = 0
+            out_counts[row] = target
+        gpu.barrier()
+
+        batch = row_to_batch[row]
+        row_blocks = fx.slice(block_table, (batch, None))
+        for cta in range(cta_begin, cta_end, fx.Int32(1)):
+            count = candidate_counts[cta]
+            count = (count < 0).select(fx.Int32(0), count)
+            count = (count > fx.Int32(topk)).select(fx.Int32(topk), count)
+            for step in range_constexpr(candidate_steps):
+                slot = fx.Int32(step * BLOCK_THREADS) + tid
+                live = slot < count
+                safe_slot = live.select(slot, fx.Int32(0))
+                value = candidate_values[cta, safe_slot]
+                score_ord = f32_to_ordered_i32(value)
+                raw_index = candidate_indices[cta, safe_slot]
+                better = live & key_is_better(
+                    score_ord,
+                    raw_index,
+                    threshold_score,
+                    threshold_index,
+                )
+                equal = (
+                    live
+                    & (score_ord == threshold_score)
+                    & (raw_index == threshold_index)
+                )
+                better_i32 = better.select(fx.Int32(1), fx.Int32(0))
+                equal_i32 = equal.select(fx.Int32(1), fx.Int32(0))
+                packed = (better_i32 << fx.Int32(_PACK_SHIFT)) + equal_i32
+                packed_before, packed_total = block_exclusive_prefix_i32(
+                    tid,
+                    packed,
+                    scan,
+                )
+                better_before = packed_before >> fx.Int32(_PACK_SHIFT)
+                equal_before = packed_before & fx.Int32(_PACK_MASK)
+                better_total = packed_total >> fx.Int32(_PACK_SHIFT)
+                equal_total = packed_total & fx.Int32(_PACK_MASK)
+
+                equal_seen = state[_EQUAL_SEEN]
+                room = threshold_equal_needed - equal_seen
+                room = (room < 0).select(fx.Int32(0), room)
+                admit_equal = equal & (equal_before < room)
+                keep = better | admit_equal
+                admitted_equal_before = (equal_before < room).select(
+                    equal_before,
+                    room,
+                )
+                destination = (
+                    state[_WRITE_CURSOR] + better_before + admitted_equal_before
+                )
+                if keep:
+                    row_values[destination] = value
+                    row_raw[destination] = raw_index
+                    if const_expr(map_physical_indices):
+                        physical = row_blocks[
+                            raw_index // fx.Int32(page_size)
+                        ] * fx.Int32(page_size) + raw_index % fx.Int32(page_size)
+                        row_physical[destination] = physical
+                gpu.barrier()
+
+                if tid == 0:
+                    admitted_equal_total = (equal_total < room).select(
+                        equal_total,
+                        room,
+                    )
+                    state[_WRITE_CURSOR] = (
+                        state[_WRITE_CURSOR] + better_total + admitted_equal_total
+                    )
+                    state[_EQUAL_SEEN] = state[_EQUAL_SEEN] + equal_total
+                gpu.barrier()
+
+    @flyc.jit
+    def launch(
+        candidate_values: fx.Tensor,
+        candidate_indices: fx.Tensor,
+        candidate_counts: fx.Tensor,
+        row_offsets: fx.Tensor,
+        row_to_batch: fx.Tensor,
+        block_table: fx.Tensor,
+        out_values: fx.Tensor,
+        out_raw_indices: fx.Tensor,
+        out_physical_indices: fx.Tensor,
+        out_counts: fx.Tensor,
+        rows: fx.Int32,
+        stream: fx.Stream,
+    ):
+        merge_kernel(
+            candidate_values,
+            candidate_indices,
+            candidate_counts,
+            row_offsets,
+            row_to_batch,
+            block_table,
+            out_values,
+            out_raw_indices,
+            out_physical_indices,
+            out_counts,
+        ).launch(
+            grid=(rows, 1, 1),
+            block=(BLOCK_THREADS, 1, 1),
+            stream=stream,
+        )
+
+    return launch

--- a/aiter/ops/flydsl/kernels/mqa_logits/pa_mqa_logits_fp4_prefill.py
+++ b/aiter/ops/flydsl/kernels/mqa_logits/pa_mqa_logits_fp4_prefill.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from functools import lru_cache
+from functools import cache
 from typing import NamedTuple
 
 import flydsl.compiler as flyc
@@ -12,10 +12,26 @@ import flydsl.expr as fx
 import torch
 import triton
 import triton.language as tl
-from flydsl.expr import gpu, rocdl
+from flydsl.expr import const_expr, gpu, rocdl
 from flydsl.expr.primitive import range_constexpr
 from flydsl.expr.typing import Float4E2M1FN, Int32, T
 
+from ..candidate_topk_common import (
+    BLOCK_THREADS as TOPK_BLOCK_THREADS,
+)
+from ..candidate_topk_common import (
+    NUM_HIST_BINS,
+    NUM_SCORE_BYTES,
+    NUM_WAVES,
+    RADIX_SIGN_BIT,
+    block_exclusive_prefix_i32,
+    f32_to_ordered_i32,
+    make_streaming_topk_storage,
+    prefix_byte_mask,
+    radix_byte,
+    warp_inclusive_prefix_i32,
+)
+from ..kernels_common import atomic_add_i32
 from .pa_mqa_logits_fp4_common import (
     _i32_buffer,
     _load_vec4_i32,
@@ -28,9 +44,44 @@ MFMA_M = 16
 MFMA_N = 16
 WARP_SIZE = 64
 DEFAULT_BLOCK_THREADS = DEFAULT_NUM_WARPS * WARP_SIZE  # 256
+# Reduce once per 5K produced scores instead of once per 1K. In-place
+# compaction keeps both TopK variants below gfx950's 64-KiB workgroup limit.
+DEFAULT_SCORE_BATCH_CHUNKS = 20
+SUPPORTED_SCORE_BATCH_CHUNKS = (1, 2, 4, 8, 16, 20, 24)
+_LDS_ALIGNMENT_BYTES = 16
+_GFX950_MAX_WORKGROUP_LDS_BYTES = 64 * 1024
 
 # cta_info packed fields per CTA.
 CTA_INFO_WIDTH = 6
+
+_STREAM_RETAINED = 0
+_STREAM_SCORE_PREFIX = 1
+_STREAM_SCORE_MASK = 2
+_STREAM_REMAINING = 3
+_STREAM_STATE_SIZE = 4
+_PACK_SHIFT = 16
+_PACK_MASK = (1 << _PACK_SHIFT) - 1
+
+
+def _align_up(value: int, alignment: int) -> int:
+    return (value + alignment - 1) // alignment * alignment
+
+
+def _streaming_topk_lds_bytes(candidate_topk: int, score_batch_chunks: int) -> int:
+    """Exact LDS footprint of ``make_streaming_topk_storage``."""
+
+    pool_capacity = candidate_topk + score_batch_chunks * DEFAULT_BLOCK_THREADS
+    field_bytes = (
+        pool_capacity * 4,  # pool_values
+        pool_capacity * 4,  # pool_indices
+        NUM_HIST_BINS * 4,
+        (NUM_WAVES + 1) * 4,
+        _STREAM_STATE_SIZE * 4,
+    )
+    offset = 0
+    for size in field_bytes:
+        offset = _align_up(offset, _LDS_ALIGNMENT_BYTES) + size
+    return _align_up(offset, _LDS_ALIGNMENT_BYTES)
 
 
 def compute_prefill_schedule(
@@ -41,12 +92,17 @@ def compute_prefill_schedule(
     parallel_unit_num,
     max_seq_len,
     cta_info_out=None,
+    row_offsets_out=None,
+    *,
+    single_cta_per_row=False,
 ):
     """Compute the persistent-grid schedule for ragged-prefill MQA logits.
 
     Pass `cta_info_out` (a fixed [parallel_unit_num, CTA_INFO_WIDTH] int32 buffer)
     to write the schedule into a stable address (CUDAGraph decode: the captured
     kernel replays from this pointer while `build()` refreshes its contents).
+    ``single_cta_per_row`` coalesces every nonempty row into one slot; this is
+    used when the launch has exactly one available slot per row.
 
     Returns `(safe, cta_info, parallel_unit_num)`, `safe` being the [1] int32
     split factor the schedule was built with.
@@ -77,9 +133,28 @@ def compute_prefill_schedule(
         f"compute_prefill_schedule: row_to_batch/local_starts/local_ends must be "
         f"int32, got {row_to_batch.dtype}/{local_starts.dtype}/{local_ends.dtype}."
     )
+    if row_offsets_out is not None and (
+        row_offsets_out.dtype != torch.int32
+        or row_offsets_out.ndim != 1
+        or row_offsets_out.shape[0] < T + 1
+        or row_offsets_out.device != device
+        or not row_offsets_out.is_contiguous()
+    ):
+        raise ValueError(
+            "row_offsets_out must be a contiguous one-dimensional int32 buffer "
+            "with at least rows + 1 entries on the schedule device"
+        )
 
     s_max = max(1, (max_seq_len + block_k - 1) // block_k)
-    plan = _row_plan(local_ends, block_k, P, s_max)
+    plan = _row_plan(
+        local_starts,
+        local_ends,
+        block_k,
+        P,
+        s_max,
+        max_seq_len,
+        single_cta_per_row=single_cta_per_row,
+    )
 
     # ── map each fixed slot → (row, split) + emit cta_info in ONE kernel ──
     if cta_info_out is None:
@@ -92,6 +167,7 @@ def compute_prefill_schedule(
         plan.incl,
         plan.excl,
         plan.chunks,
+        plan.first_chunks,
         row_to_batch,
         local_starts,
         local_ends,
@@ -100,8 +176,16 @@ def compute_prefill_schedule(
         cta_info,
         T,
         P,
+        max_seq_len,
         BLOCK_P=BLOCK_P,
     )
+    if row_offsets_out is not None:
+        _prefill_row_offsets_kernel[(triton.cdiv(T + 1, BLOCK_P),)](
+            plan.incl,
+            row_offsets_out,
+            T,
+            BLOCK=BLOCK_P,
+        )
     return plan.safe, cta_info, P
 
 
@@ -113,9 +197,73 @@ class _RowPlan(NamedTuple):
 
     incl: torch.Tensor  # [T] inclusive prefix sum of per-row CTA counts
     excl: torch.Tensor  # [T] exclusive prefix sum
-    chunks: torch.Tensor  # [T] ceil(local_end / block_k), 0 for an empty row
+    chunks: torch.Tensor  # [T] chunks intersecting [local_start, local_end)
+    first_chunks: torch.Tensor  # [T] floor(max(local_start, 0) / block_k)
     safe: torch.Tensor  # [1] chunk-splits merged into one CTA
     total_splits: torch.Tensor  # [1] number of valid (row, split) slots
+
+
+class FP4PrefillTopKWorkspace(NamedTuple):
+    """Caller-owned scratch for fused FP4 prefill TopK."""
+
+    cta_info: torch.Tensor
+    row_offsets: torch.Tensor
+    candidate_values: torch.Tensor
+    candidate_indices: torch.Tensor
+    candidate_counts: torch.Tensor
+    merge_values: torch.Tensor
+    merge_indices: torch.Tensor
+
+
+class FP4PrefillTopKResult(NamedTuple):
+    values: torch.Tensor
+    raw_indices: torch.Tensor
+    physical_indices: torch.Tensor
+    counts: torch.Tensor
+
+
+def allocate_fp4_prefill_topk_workspace(
+    rows: int,
+    parallel_unit_num: int,
+    topk: int,
+    device: torch.device | str,
+) -> FP4PrefillTopKWorkspace:
+    """Allocate all scratch needed by the no-logits fused path."""
+
+    if rows <= 0:
+        raise ValueError("rows must be positive")
+    if parallel_unit_num < rows:
+        raise ValueError("parallel_unit_num must be at least rows")
+    if topk not in (512, 1024):
+        raise ValueError("topk must be 512 or 1024")
+    return FP4PrefillTopKWorkspace(
+        cta_info=torch.empty(
+            parallel_unit_num,
+            CTA_INFO_WIDTH,
+            dtype=torch.int32,
+            device=device,
+        ),
+        row_offsets=torch.empty(rows + 1, dtype=torch.int32, device=device),
+        candidate_values=torch.empty(
+            parallel_unit_num,
+            topk,
+            dtype=torch.float32,
+            device=device,
+        ),
+        candidate_indices=torch.empty(
+            parallel_unit_num,
+            topk,
+            dtype=torch.int32,
+            device=device,
+        ),
+        candidate_counts=torch.empty(
+            parallel_unit_num,
+            dtype=torch.int32,
+            device=device,
+        ),
+        merge_values=torch.empty(rows, topk, dtype=torch.float32, device=device),
+        merge_indices=torch.empty(rows, topk, dtype=torch.int32, device=device),
+    )
 
 
 # Rows the fused arm plans, and the only two widths it plans them in. A block
@@ -148,63 +296,113 @@ _ROW_PLAN_MAX_ROWS = 16384
 _I32_PER_16B = 4
 
 
-def _row_plan(le, block_k, P, s_max) -> _RowPlan:
+def _row_plan(
+    ls,
+    le,
+    block_k,
+    P,
+    s_max,
+    max_seq_len,
+    *,
+    single_cta_per_row=False,
+) -> _RowPlan:
     T = le.shape[0]
     if T > _ROW_PLAN_MAX_ROWS:
-        return _row_plan_torch(le, block_k, P, s_max)
-    # One allocation, sliced: five `torch.empty` calls would put four more
+        return _row_plan_torch(
+            ls,
+            le,
+            block_k,
+            P,
+            s_max,
+            max_seq_len,
+            single_cta_per_row=single_cta_per_row,
+        )
+    # One allocation, sliced: separate `torch.empty` calls would add dispatches
     # dispatches back on the path this exists to shorten.
     #
     # Every region starts on a 16-byte boundary, which is not cosmetic: Triton
     # specializes a kernel on whether each pointer is 16-byte aligned, so a
     # stride of exactly T forks a variant per `T % 4` and the JIT never stops
-    # finding new ones mid-run. Rounding the stride up pins all six pointers to
+    # finding new ones mid-run. Rounding the stride up pins every pointer to
     # one alignment signature.
     stride = (T + _I32_PER_16B - 1) // _I32_PER_16B * _I32_PER_16B
-    tail = 3 * stride
+    tail = 4 * stride
     work = torch.empty(tail + 2 * _I32_PER_16B, dtype=torch.int32, device=le.device)
     plan = _RowPlan(
         incl=work[:T],
         excl=work[stride : stride + T],
         chunks=work[2 * stride : 2 * stride + T],
+        first_chunks=work[3 * stride : 3 * stride + T],
         safe=work[tail : tail + 1],
         total_splits=work[tail + _I32_PER_16B : tail + _I32_PER_16B + 1],
     )
     # Named, not `*plan`: field ORDER should not become load-bearing.
     _prefill_row_plan_kernel[(1,)](
+        ls,
         le,
         plan.incl,
         plan.excl,
         plan.chunks,
+        plan.first_chunks,
         plan.safe,
         plan.total_splits,
         T,
         P,
         block_k,
         s_max,
+        max_seq_len,
         BLOCK_T=(
             _ROW_PLAN_BLOCK_FLOOR if T <= _ROW_PLAN_BLOCK_FLOOR else _ROW_PLAN_MAX_ROWS
         ),
         SEARCH_STEPS=max(1, (s_max - 1).bit_length() + 1),
+        SINGLE_CTA_PER_ROW=single_cta_per_row,
     )
     return plan
 
 
-def _row_plan_torch(le, block_k, P, s_max) -> _RowPlan:
+def _row_plan_torch(
+    ls,
+    le,
+    block_k,
+    P,
+    s_max,
+    max_seq_len,
+    *,
+    single_cta_per_row=False,
+) -> _RowPlan:
     """The row plan as ~25 torch ops. Reference for `_prefill_row_plan_kernel`."""
-    # chunk count per row = ceil(le / block_k); le<=0 → 0 chunks.
-    chunks_per_row = torch.clamp((le + (block_k - 1)) // block_k, min=0)  # [T]
+    window_starts = torch.clamp(ls, min=0, max=max_seq_len)
+    window_ends = torch.clamp(le, min=0, max=max_seq_len)
+    window_ends = torch.maximum(window_ends, window_starts)
+    first_chunks = window_starts // block_k
+    end_chunks = (window_ends + (block_k - 1)) // block_k
+    chunks_per_row = torch.where(
+        window_ends > window_starts,
+        torch.clamp(end_chunks - first_chunks, min=0),
+        0,
+    )
 
-    s_cand = torch.arange(1, s_max + 1, device=le.device, dtype=torch.int32)  # [s_max]
-    ctas_per_r_s = (chunks_per_row[None, :] + (s_cand[:, None] - 1)) // s_cand[
-        :, None
-    ]  # [s_max, T]
-    total_ctas_s = ctas_per_r_s.sum(dim=1)  # [s_max]
-    feasible = total_ctas_s <= P  # [s_max] bool, monotonic False..True
     max_chunks = torch.clamp(chunks_per_row.max(), min=1).to(torch.int32)
-    # smallest feasible s, via arithmetic (no tensor gather → no capture sync).
-    first_feasible_s = torch.clamp((~feasible).to(torch.int32).sum() + 1, max=s_max)
-    safe = torch.where(feasible.any(), first_feasible_s, max_chunks).to(torch.int32)
+    if single_cta_per_row:
+        safe = max_chunks
+    else:
+        s_cand = torch.arange(
+            1,
+            s_max + 1,
+            device=le.device,
+            dtype=torch.int32,
+        )  # [s_max]
+        ctas_per_r_s = (chunks_per_row[None, :] + (s_cand[:, None] - 1)) // (
+            s_cand[:, None]
+        )  # [s_max, T]
+        total_ctas_s = ctas_per_r_s.sum(dim=1)  # [s_max]
+        feasible = total_ctas_s <= P  # [s_max] bool, monotonic False..True
+        # smallest feasible s, via arithmetic (no tensor gather → no capture sync).
+        first_feasible_s = torch.clamp(
+            (~feasible).to(torch.int32).sum() + 1,
+            max=s_max,
+        )
+        safe = torch.where(feasible.any(), first_feasible_s, max_chunks).to(torch.int32)
 
     # ── per-row number of CTAs (chunk-splits); 0 for empty rows ──
     ctas_r = (chunks_per_row + (safe - 1)) // safe  # [T]
@@ -213,6 +411,7 @@ def _row_plan_torch(le, block_k, P, s_max) -> _RowPlan:
         incl=incl,
         excl=incl - ctas_r,  # exclusive prefix sum
         chunks=chunks_per_row.to(torch.int32),
+        first_chunks=first_chunks.to(torch.int32),
         safe=safe.reshape(1).to(torch.int32),
         total_splits=incl[-1].reshape(1).to(torch.int32),
     )
@@ -228,20 +427,24 @@ def _row_plan_torch(le, block_k, P, s_max) -> _RowPlan:
 # gives up the divisibility hint the wide blocks vectorize on, 41.1us -> 52.0us
 # at 16384 lanes. That lands on prefill, one call per ~500ms forward; the widths
 # decode runs stay hidden behind the call's own dispatch either way.
-@triton.jit(do_not_specialize=["T", "P"])
+@triton.jit(do_not_specialize=["T", "P", "max_seq_len"])
 def _prefill_row_plan_kernel(
+    ls_ptr,  # [T] int32 local_starts
     le_ptr,  # [T] int32 local_ends
     incl_ptr,  # [T] int32 out
     excl_ptr,  # [T] int32 out
     chunks_ptr,  # [T] int32 out
+    first_chunks_ptr,  # [T] int32 out
     safe_ptr,  # [1] int32 out
     total_splits_ptr,  # [1] int32 out
     T,
     P,
     block_k,
     s_max,
+    max_seq_len,
     BLOCK_T: tl.constexpr,
     SEARCH_STEPS: tl.constexpr,
+    SINGLE_CTA_PER_ROW: tl.constexpr,
 ):
     """Single-block row plan: chunk counts, split factor, and its prefix sums.
 
@@ -264,39 +467,54 @@ def _prefill_row_plan_kernel(
     """
     t = tl.arange(0, BLOCK_T)
     mask = t < T
+    ls = tl.load(ls_ptr + t, mask=mask, other=0)
     le = tl.load(le_ptr + t, mask=mask, other=0)
-    # The clamp puts `le <= 0` at 0 under either rounding, so this agrees with the
-    # torch path's floor division without asking which one Triton does.
-    chunks = tl.where(mask, tl.maximum((le + block_k - 1) // block_k, 0), 0)
+    window_starts = tl.minimum(tl.maximum(ls, 0), max_seq_len)
+    window_ends = tl.maximum(
+        window_starts,
+        tl.minimum(tl.maximum(le, 0), max_seq_len),
+    )
+    first_chunks = tl.where(mask, window_starts // block_k, 0)
+    end_chunks = (window_ends + block_k - 1) // block_k
+    chunks = tl.where(
+        mask & (window_ends > window_starts),
+        tl.maximum(end_chunks - first_chunks, 0),
+        0,
+    )
     max_chunks = tl.maximum(tl.max(chunks, axis=0), 1)
 
-    lo = 1
-    hi = s_max
-    for _ in tl.static_range(SEARCH_STEPS):
-        mid = (lo + hi) // 2
-        feasible = tl.sum((chunks + mid - 1) // mid, axis=0) <= P
-        active = lo < hi
-        hi = tl.where(active & feasible, mid, hi)
-        lo = tl.where(active & (feasible == 0), mid + 1, lo)
-    # No s in [1, s_max] fits: fall back to one CTA per row, as torch's
-    # `feasible.any()` arm does.
-    total_smax = tl.sum((chunks + s_max - 1) // s_max, axis=0)
-    safe = tl.where(total_smax <= P, lo, max_chunks)
+    if SINGLE_CTA_PER_ROW:
+        safe = max_chunks
+    else:
+        lo = 1
+        hi = s_max
+        for _ in tl.static_range(SEARCH_STEPS):
+            mid = (lo + hi) // 2
+            feasible = tl.sum((chunks + mid - 1) // mid, axis=0) <= P
+            active = lo < hi
+            hi = tl.where(active & feasible, mid, hi)
+            lo = tl.where(active & (feasible == 0), mid + 1, lo)
+        # No s in [1, s_max] fits: fall back to one CTA per row, as torch's
+        # `feasible.any()` arm does.
+        total_smax = tl.sum((chunks + s_max - 1) // s_max, axis=0)
+        safe = tl.where(total_smax <= P, lo, max_chunks)
 
     ctas = tl.where(mask, (chunks + safe - 1) // safe, 0)
     incl = tl.cumsum(ctas, axis=0)
     tl.store(incl_ptr + t, incl, mask=mask)
     tl.store(excl_ptr + t, incl - ctas, mask=mask)
     tl.store(chunks_ptr + t, chunks, mask=mask)
+    tl.store(first_chunks_ptr + t, first_chunks, mask=mask)
     tl.store(safe_ptr, safe)
     tl.store(total_splits_ptr, tl.sum(ctas, axis=0))
 
 
-@triton.jit(do_not_specialize=["T", "P"])
+@triton.jit(do_not_specialize=["T", "P", "max_seq_len"])
 def _prefill_cta_info_kernel(
     incl_ptr,  # [T] int32 inclusive prefix sum of per-row CTA counts
     excl_ptr,  # [T] int32 exclusive prefix sum
     chunks_ptr,  # [T] int32 chunks_per_row
+    first_chunks_ptr,  # [T] first logical chunk
     rb_ptr,  # [T] int32 row_to_batch
     ls_ptr,  # [T] int32 local_starts
     le_ptr,  # [T] int32 local_ends
@@ -305,6 +523,7 @@ def _prefill_cta_info_kernel(
     cta_info_ptr,  # [P, 6] int32
     T,
     P,
+    max_seq_len,
     BLOCK_P: tl.constexpr,
 ):
     """Single-kernel slot->row mapping + cta_info emit for ragged prefill."""
@@ -331,18 +550,24 @@ def _prefill_cta_info_kernel(
 
     excl_r = tl.load(excl_ptr + safe_row, mask=smask, other=0)
     chunks_r = tl.load(chunks_ptr + safe_row, mask=smask, other=0)
+    first_chunk_r = tl.load(first_chunks_ptr + safe_row, mask=smask, other=0)
     rb_r = tl.load(rb_ptr + safe_row, mask=smask, other=0)
     ls_r = tl.load(ls_ptr + safe_row, mask=smask, other=0)
     le_r = tl.load(le_ptr + safe_row, mask=smask, other=0)
 
     vi = valid.to(tl.int32)
     split_within = slot - excl_r
-    start = split_within * safe  # pre-mask (count uses this)
-    count = tl.maximum(tl.minimum(safe, chunks_r - start), 0)
+    relative_start = split_within * safe  # pre-mask (count uses this)
+    count = tl.maximum(tl.minimum(safe, chunks_r - relative_start), 0)
     row_id = safe_row * vi
     batch_id = rb_r * vi
-    start = start * vi
-    count = tl.where(valid, count, 1)
+    start = (first_chunk_r + relative_start) * vi
+    # Zero is an inactive-CTA sentinel consumed uniformly by the score kernel.
+    # In particular, padded schedule slots must not manufacture a chunk zero:
+    # its page-table entry may legitimately be -1 for an empty request.
+    count = tl.where(valid, count, 0)
+    ls_r = tl.minimum(tl.maximum(ls_r, 0), max_seq_len)
+    le_r = tl.maximum(ls_r, tl.minimum(tl.maximum(le_r, 0), max_seq_len))
     ls_out = ls_r * vi
     le_out = le_r * vi
 
@@ -355,6 +580,86 @@ def _prefill_cta_info_kernel(
     tl.store(cta_info_ptr + base + 5, le_out, mask=smask)
 
 
+@triton.jit(do_not_specialize=["T"])
+def _prefill_row_offsets_kernel(
+    incl_ptr,  # [T] inclusive prefix sum
+    row_offsets_ptr,  # [T + 1] output
+    T,
+    BLOCK: tl.constexpr,
+):
+    offset = tl.program_id(0) * BLOCK + tl.arange(0, BLOCK)
+    mask = offset <= T
+    previous_row = tl.maximum(offset - 1, 0)
+    value = tl.load(incl_ptr + previous_row, mask=mask & (offset > 0), other=0)
+    tl.store(row_offsets_ptr + offset, value, mask=mask)
+
+
+@triton.jit(do_not_specialize=["rows"])
+def _copy_single_cta_topk_candidates_kernel(
+    candidate_values,
+    candidate_indices,
+    candidate_counts,
+    row_offsets,
+    out_values,
+    out_indices,
+    out_counts,
+    rows,
+    TOPK: tl.constexpr,
+    BLOCK: tl.constexpr,
+):
+    """Copy one exact CTA plane per row without repeating radix selection."""
+
+    row = tl.program_id(0)
+    lane = tl.arange(0, BLOCK)
+    cta_begin = tl.load(row_offsets + row)
+    cta_end = tl.load(row_offsets + row + 1)
+    has_cta = cta_end > cta_begin
+    count = tl.load(candidate_counts + cta_begin, mask=has_cta, other=0)
+    count = tl.minimum(tl.maximum(count, 0), TOPK)
+
+    for step in tl.static_range(0, TOPK, BLOCK):
+        slot = step + lane
+        live = has_cta & (slot < count)
+        source = cta_begin * TOPK + slot
+        values = tl.load(
+            candidate_values + source,
+            mask=live,
+            other=-float("inf"),
+        )
+        indices = tl.load(candidate_indices + source, mask=live, other=-1)
+        destination = row * TOPK + slot
+        tl.store(out_values + destination, values)
+        tl.store(out_indices + destination, indices)
+    tl.store(out_counts + row + lane, count, mask=lane == 0)
+
+
+def _copy_single_cta_topk_candidates(
+    candidate_values: torch.Tensor,
+    candidate_indices: torch.Tensor,
+    candidate_counts: torch.Tensor,
+    row_offsets: torch.Tensor,
+    out_values: torch.Tensor,
+    out_indices: torch.Tensor,
+    out_counts: torch.Tensor,
+) -> None:
+    """Launch the no-radix merge for a schedule with at most one CTA per row."""
+
+    rows, topk = out_values.shape
+    block = 256
+    _copy_single_cta_topk_candidates_kernel[(rows,)](
+        candidate_values,
+        candidate_indices,
+        candidate_counts,
+        row_offsets,
+        out_values,
+        out_indices,
+        out_counts,
+        rows,
+        TOPK=topk,
+        BLOCK=block,
+    )
+
+
 def build_pa_mqa_logits_fp4_prefill_module(
     block_k=256,
     kv_block_size=64,
@@ -363,9 +668,38 @@ def build_pa_mqa_logits_fp4_prefill_module(
     num_warps=DEFAULT_NUM_WARPS,
     heads=DEFAULT_HEADS,
     head_dim=DEFAULT_HEAD_DIM,
+    candidate_topk=None,
+    score_batch_chunks=DEFAULT_SCORE_BATCH_CHUNKS,
 ):
-    """Build the ragged-prefill FP4 MQA logits kernel."""
+    """Build the ragged-prefill FP4 scorer.
+
+    With ``candidate_topk=None`` the score callback writes the legacy logits
+    matrix. With 512 or 1024 it instead streams bounded score batches through
+    LDS and keeps an exact per-CTA candidate set.
+    """
     block_threads_k = num_warps * WARP_SIZE
+    emit_candidates = candidate_topk is not None
+    if emit_candidates:
+        assert candidate_topk in (512, 1024), "candidate_topk must be 512 or 1024"
+        assert block_k == 256, "streaming TopK currently requires block_k=256"
+        assert (
+            block_threads_k == TOPK_BLOCK_THREADS
+        ), "streaming TopK requires the 256-thread/4-wave score body"
+        assert score_batch_chunks in SUPPORTED_SCORE_BATCH_CHUNKS, (
+            "score_batch_chunks must be one of " f"{SUPPORTED_SCORE_BATCH_CHUNKS}"
+        )
+        pool_capacity = candidate_topk + score_batch_chunks * block_k
+        lds_bytes = _streaming_topk_lds_bytes(candidate_topk, score_batch_chunks)
+        assert lds_bytes <= _GFX950_MAX_WORKGROUP_LDS_BYTES, (
+            f"streaming TopK requires {lds_bytes} LDS bytes, exceeding the "
+            f"gfx950 workgroup limit of {_GFX950_MAX_WORKGROUP_LDS_BYTES}"
+        )
+        pool_steps = (pool_capacity + TOPK_BLOCK_THREADS - 1) // TOPK_BLOCK_THREADS
+        output_steps = (candidate_topk + TOPK_BLOCK_THREADS - 1) // TOPK_BLOCK_THREADS
+        streaming_storage_type = make_streaming_topk_storage(
+            pool_capacity,
+            _STREAM_STATE_SIZE,
+        )
     m_tiles = heads // MFMA_M
     k_tiles = head_dim // 128  # outer K-loop iters (MFMA K=128)
     assert (
@@ -442,6 +776,9 @@ def build_pa_mqa_logits_fp4_prefill_module(
     @flyc.kernel
     def pa_mqa_logits_fp4_prefill_kernel(
         out_logits_ptr: fx.Tensor,
+        candidate_values_ptr: fx.Tensor,
+        candidate_indices_ptr: fx.Tensor,
+        candidate_counts_ptr: fx.Tensor,
         q_ptr: fx.Tensor,
         q_scale_ptr: fx.Tensor,
         kv_cache_ptr: fx.Tensor,
@@ -450,6 +787,7 @@ def build_pa_mqa_logits_fp4_prefill_module(
         weights_ptr: fx.Tensor,
         cta_info_ptr: fx.Tensor,  # [n_ctas, 6] i32
         stride_out_row: Int32,
+        output_token_base: Int32,
         weight_scale: fx.Float32,
     ):
         tid = gpu.thread_idx.x
@@ -474,6 +812,11 @@ def build_pa_mqa_logits_fp4_prefill_module(
         cta_info_vec = fx.Vector(_load_vec4_i32(cta_info_bt, fx.Int32(0)))
         local_start = cta_info_bt[(fx.Int32(1), fx.Int32(0))]
         local_end = cta_info_bt[(fx.Int32(1), fx.Int32(1))]
+        table_capacity = fx.Int32(max_blocks_per_seq * kv_block_size)
+        local_start = (local_start > fx.Int32(0)).select(local_start, fx.Int32(0))
+        local_start = (local_start < table_capacity).select(local_start, table_capacity)
+        local_end = (local_end > fx.Int32(0)).select(local_end, fx.Int32(0))
+        local_end = (local_end < table_capacity).select(local_end, table_capacity)
 
         kv_bt = _i32_buffer(kv_cache_ptr, width=4)
         kvs_bt = _i32_buffer(kv_scale_ptr, width=1)
@@ -487,10 +830,36 @@ def build_pa_mqa_logits_fp4_prefill_module(
         chunk_start = cta_info_vec[2]
         chunk_count = cta_info_vec[3]
 
-        # out row base folded into an f32 global pointer (sizeof(f32)=4); the
-        # per-token store offset below stays small (no i32 overflow).
-        _row_elems = fx.Int64(row_id) * fx.Int64(stride_out_row)
-        out_base = fx.add_offset(fx.get_iter(out_logits_ptr), _row_elems)
+        if const_expr(emit_candidates):
+            # Inactive padded CTAs skip the page-dependent pipeline below. Their
+            # candidate planes are ignored, but the merge still needs an
+            # explicit zero count instead of stale workspace contents.
+            if tid == 0:
+                candidate_counts_ptr[pid] = 0
+            topk_storage = fx.SharedAllocator().allocate(streaming_storage_type)
+            pool_values = topk_storage.pool_values.peek().view(
+                fx.make_layout(pool_capacity, 1)
+            )
+            pool_indices = topk_storage.pool_indices.peek().view(
+                fx.make_layout(pool_capacity, 1)
+            )
+            topk_histogram = topk_storage.histogram.peek().view(
+                fx.make_layout(NUM_HIST_BINS, 1)
+            )
+            topk_scan = topk_storage.scan.peek().view(fx.make_layout(NUM_WAVES + 1, 1))
+            topk_state = topk_storage.state.peek().view(
+                fx.make_layout(_STREAM_STATE_SIZE, 1)
+            )
+            candidate_values_row = fx.slice(candidate_values_ptr, (pid, None))
+            candidate_indices_row = fx.slice(candidate_indices_ptr, (pid, None))
+            if tid == 0:
+                topk_state[_STREAM_RETAINED] = 0
+            gpu.barrier()
+        else:
+            # Fold the row into the f32 global base pointer; the per-token store
+            # offset below stays small (no i32 overflow).
+            _row_elems = fx.Int64(row_id) * fx.Int64(stride_out_row)
+            out_base = fx.add_offset(fx.get_iter(out_logits_ptr), _row_elems)
 
         # Q load (hoisted): per (k_tile, mi_idx) a thread loads its 16-byte FP4
         # chunk for head row mi_idx*16+lane_mod_16. Q: [total_tokens, H, D/2] uint8.
@@ -572,12 +941,26 @@ def build_pa_mqa_logits_fp4_prefill_module(
 
         def _load_phys(c_i32_arg):
             ni_base = warp_id * fx.Int32(N_TILES_PER_WARP)
-            token_local_base = (
+            lookup_token = (
                 (chunk_start + c_i32_arg) * fx.Int32(block_k)
                 + ni_base * fx.Int32(MFMA_N)
                 + lane_mod_16
             )
-            bi_base = _floordiv_kb(token_local_base)
+            lookup_token = (lookup_token > local_start).select(
+                lookup_token, local_start
+            )
+            window_last = local_end - fx.Int32(1)
+            lookup_token = (lookup_token < window_last).select(
+                lookup_token, window_last
+            )
+            bi_base = _floordiv_kb(lookup_token)
+            # The software pipeline intentionally asks for one chunk beyond the
+            # epilogue. Clamp that speculative page-table lookup to the exact
+            # inclusive table bounds so an unpadded table remains safe.
+            bi_base = (bi_base < fx.Int32(0)).select(fx.Int32(0), bi_base)
+            bi_base = (bi_base < fx.Int32(max_blocks_per_seq)).select(
+                bi_base, fx.Int32(max_blocks_per_seq - 1)
+            )
             phys_vec = bt_bt[batch_id * _stride_bt + bi_base]
             return _phys_to_list(phys_vec)
 
@@ -646,8 +1029,216 @@ def build_pa_mqa_logits_fp4_prefill_module(
                     accs[mi_idx] = c_frag.load()
             return accs
 
-        def _post_process_nt(accs, nt, c_i32_arg):
-            """relu + per-head weight + per-thread sum + bperm + windowed store."""
+        def _select_score_pool(
+            pool_count,
+            topk_state,
+            topk_histogram,
+            topk_scan,
+            pool_values,
+            pool_indices,
+        ):
+            """Reduce ``pool[0:pool_count]`` to exact ``candidate_topk`` in LDS."""
+            if tid == 0:
+                topk_state[_STREAM_SCORE_PREFIX] = 0
+                topk_state[_STREAM_SCORE_MASK] = 0
+                topk_state[_STREAM_REMAINING] = fx.Int32(candidate_topk)
+            gpu.barrier()
+
+            # The pool is a stable, raw-index-ordered stream. Select the score
+            # threshold in four radix passes, then admit threshold ties in pool
+            # order to preserve the total key (score desc, raw index asc).
+            for score_byte in range_constexpr(NUM_SCORE_BYTES):
+                topk_histogram[tid] = 0
+                gpu.barrier()
+
+                score_prefix = topk_state[_STREAM_SCORE_PREFIX]
+                score_mask = topk_state[_STREAM_SCORE_MASK]
+                xor_value = RADIX_SIGN_BIT if score_byte == 0 else 0
+
+                for step in range_constexpr(pool_steps):
+                    pool_pos = fx.Int32(step * TOPK_BLOCK_THREADS) + tid
+                    live = pool_pos < pool_count
+                    safe_pos = live.select(pool_pos, fx.Int32(0))
+                    value = pool_values[safe_pos]
+                    score_ord = f32_to_ordered_i32(value)
+                    prefix_match = live & ((score_ord & score_mask) == score_prefix)
+                    if prefix_match:
+                        bucket = radix_byte(score_ord, score_byte) ^ fx.Int32(xor_value)
+                        atomic_add_i32(topk_histogram, 1, bucket, "workgroup")
+                gpu.barrier()
+
+                if warp_id == 0:
+                    bucket0 = fx.Int32(NUM_HIST_BINS - 1) - lane_id * fx.Int32(4)
+                    count0 = topk_histogram[bucket0]
+                    count1 = topk_histogram[bucket0 - fx.Int32(1)]
+                    count2 = topk_histogram[bucket0 - fx.Int32(2)]
+                    count3 = topk_histogram[bucket0 - fx.Int32(3)]
+                    group_count = count0 + count1 + count2 + count3
+                    group_inclusive = warp_inclusive_prefix_i32(
+                        group_count,
+                        lane_id,
+                    )
+                    group_before = group_inclusive - group_count
+                    remaining = topk_state[_STREAM_REMAINING]
+                    if (group_before < remaining) & (group_inclusive >= remaining):
+                        within_group = remaining - group_before
+                        selected_bucket = bucket0
+                        selected_bucket = (within_group > count0).select(
+                            bucket0 - fx.Int32(1),
+                            selected_bucket,
+                        )
+                        selected_bucket = (within_group > count0 + count1).select(
+                            bucket0 - fx.Int32(2),
+                            selected_bucket,
+                        )
+                        selected_bucket = (
+                            within_group > count0 + count1 + count2
+                        ).select(
+                            bucket0 - fx.Int32(3),
+                            selected_bucket,
+                        )
+                        before = group_before
+                        before = (selected_bucket < bucket0).select(
+                            before + count0,
+                            before,
+                        )
+                        before = (selected_bucket < bucket0 - fx.Int32(1)).select(
+                            before + count1,
+                            before,
+                        )
+                        before = (selected_bucket < bucket0 - fx.Int32(2)).select(
+                            before + count2,
+                            before,
+                        )
+                        actual_bucket = selected_bucket ^ fx.Int32(xor_value)
+                        byte_mask, shift = prefix_byte_mask(score_byte)
+                        topk_state[_STREAM_SCORE_PREFIX] = score_prefix | (
+                            actual_bucket << fx.Int32(shift)
+                        )
+                        topk_state[_STREAM_SCORE_MASK] = score_mask | byte_mask
+                        topk_state[_STREAM_REMAINING] = remaining - before
+                gpu.barrier()
+
+            threshold_score = topk_state[_STREAM_SCORE_PREFIX]
+            threshold_equal_needed = topk_state[_STREAM_REMAINING]
+            write_cursor = fx.Int32(0)
+            equal_seen = fx.Int32(0)
+
+            for step in range_constexpr(pool_steps):
+                pool_pos = fx.Int32(step * TOPK_BLOCK_THREADS) + tid
+                live = pool_pos < pool_count
+                safe_pos = live.select(pool_pos, fx.Int32(0))
+                value = pool_values[safe_pos]
+                score_ord = f32_to_ordered_i32(value)
+                raw_index = pool_indices[safe_pos]
+                better = live & (score_ord > threshold_score)
+                equal = live & (score_ord == threshold_score)
+                better_i32 = better.select(fx.Int32(1), fx.Int32(0))
+                equal_i32 = equal.select(fx.Int32(1), fx.Int32(0))
+                packed = (better_i32 << fx.Int32(_PACK_SHIFT)) + equal_i32
+                packed_before, packed_total = block_exclusive_prefix_i32(
+                    tid,
+                    packed,
+                    topk_scan,
+                )
+                better_before = packed_before >> fx.Int32(_PACK_SHIFT)
+                equal_before = packed_before & fx.Int32(_PACK_MASK)
+                better_total = packed_total >> fx.Int32(_PACK_SHIFT)
+                equal_total = packed_total & fx.Int32(_PACK_MASK)
+
+                room = threshold_equal_needed - equal_seen
+                room = (room < 0).select(fx.Int32(0), room)
+                admit_equal = equal & (equal_before < room)
+                keep = better | admit_equal
+                admitted_equal_before = (equal_before < room).select(
+                    equal_before,
+                    room,
+                )
+                destination = write_cursor + better_before + admitted_equal_before
+                if keep:
+                    pool_values[destination] = value
+                    pool_indices[destination] = raw_index
+                admitted_equal_total = (equal_total < room).select(
+                    equal_total,
+                    room,
+                )
+                write_cursor = write_cursor + better_total + admitted_equal_total
+                equal_seen = equal_seen + equal_total
+
+            if tid == 0:
+                topk_state[_STREAM_RETAINED] = fx.Int32(candidate_topk)
+            gpu.barrier()
+
+        def _commit_score_chunk(
+            c_i32_arg,
+            topk_state,
+            topk_histogram,
+            topk_scan,
+            pool_values,
+            pool_indices,
+        ):
+            """Publish one score chunk and periodically reduce the bounded pool."""
+            batch_offset = c_i32_arg % fx.Int32(score_batch_chunks)
+            batch_first = (chunk_start + c_i32_arg - batch_offset) * fx.Int32(block_k)
+            batch_live_first = (batch_first > local_start).select(
+                batch_first,
+                local_start,
+            )
+            batch_boundary = (
+                (c_i32_arg + fx.Int32(1)) % fx.Int32(score_batch_chunks)
+            ) == 0
+            final_chunk = c_i32_arg == chunk_count - fx.Int32(1)
+            if batch_boundary | final_chunk:
+                gpu.barrier()
+                chunk_last = (chunk_start + c_i32_arg + fx.Int32(1)) * fx.Int32(block_k)
+                batch_live_last = (chunk_last < local_end).select(
+                    chunk_last,
+                    local_end,
+                )
+                pending = batch_live_last - batch_live_first
+                pending = (pending < 0).select(fx.Int32(0), pending)
+                pool_count = topk_state[_STREAM_RETAINED] + pending
+                if pool_count > fx.Int32(candidate_topk):
+                    _select_score_pool(
+                        pool_count,
+                        topk_state,
+                        topk_histogram,
+                        topk_scan,
+                        pool_values,
+                        pool_indices,
+                    )
+                else:
+                    if tid == 0:
+                        topk_state[_STREAM_RETAINED] = pool_count
+                    gpu.barrier()
+
+        def _finish_score_candidates(
+            topk_state,
+            pool_values,
+            pool_indices,
+            candidate_values_row,
+            candidate_indices_row,
+            candidate_counts_ptr,
+        ):
+            retained = topk_state[_STREAM_RETAINED]
+            for step in range_constexpr(output_steps):
+                out_pos = fx.Int32(step * TOPK_BLOCK_THREADS) + tid
+                if out_pos < fx.Int32(candidate_topk):
+                    live = out_pos < retained
+                    safe_pos = live.select(out_pos, fx.Int32(0))
+                    candidate_values_row[out_pos] = live.select(
+                        pool_values[safe_pos],
+                        fx.Float32(float("-inf")),
+                    )
+                    candidate_indices_row[out_pos] = live.select(
+                        pool_indices[safe_pos],
+                        fx.Int32(-1),
+                    )
+            if tid == 0:
+                candidate_counts_ptr[pid] = retained
+
+        def _post_process_nt(accs, nt, c_i32_arg, batch_live_first):
+            """relu + weighted reduction + score callback."""
             zero = fx.Vector.filled(4, 0.0, fx.Float32)
             ni_warp = warp_id * fx.Int32(N_TILES_PER_WARP) + fx.Int32(nt)
             token_base = (chunk_start + c_i32_arg) * fx.Int32(
@@ -675,14 +1266,46 @@ def build_pa_mqa_logits_fp4_prefill_module(
             # `weight_scale` already folded into `w_per_lane` (hoisted, once/wave).
 
             # Only [local_start, local_end) is written (one writer lane per token);
-            # the rest stays at the caller's -inf pre-fill. Sparse 1-writer
-            # scatter: guard the plain store instead of a V# OOB sentinel. Row base
-            # is folded into out_base, so the store offset is the token index.
+            # the rest stays at the caller's -inf pre-fill. output_token_base is
+            # normally zero. The bounded score+top-k operator sets it to its
+            # aligned tile start, allowing this same score kernel to target a
+            # fixed [rows, tile_tokens] buffer instead of context-sized logits.
+            # Sparse 1-writer scatter: guard the plain store instead of a V# OOB
+            # sentinel. Row base is folded into out_base.
             is_writer = lane_div_16 < fx.Int32(1)
             out_token = token_base + lane_mod_16
             in_window = (out_token >= local_start) & (out_token < local_end)
-            if is_writer & in_window:
-                fx.ptr_store(thread_sum, fx.add_offset(out_base, out_token))
+            should_write = is_writer & in_window
+            if const_expr(emit_candidates):
+                destination = (
+                    topk_state[_STREAM_RETAINED] + out_token - batch_live_first
+                )
+
+                def _write_candidate(
+                    _values=pool_values,
+                    _indices=pool_indices,
+                    _dst=destination,
+                    _value=thread_sum,
+                    _index=out_token,
+                ):
+                    _values[_dst] = _value
+                    _indices[_dst] = _index
+
+                @flyc.jit
+                def _guarded_candidate_write(
+                    _pred=should_write,
+                    _write=_write_candidate,
+                ):
+                    if _pred:
+                        _write()
+
+                _guarded_candidate_write()
+            else:
+                if should_write:
+                    fx.ptr_store(
+                        thread_sum,
+                        fx.add_offset(out_base, out_token - output_token_base),
+                    )
 
         def _compute_chunk(kv_list_in, kvs_packed_list_in, c_i32_arg, nt0_accs_in=None):
             assert (
@@ -694,92 +1317,141 @@ def build_pa_mqa_logits_fp4_prefill_module(
                 if nt0_accs_in is None
                 else list(nt0_accs_in)
             )
+            batch_offset = c_i32_arg % fx.Int32(score_batch_chunks)
+            batch_first = (chunk_start + c_i32_arg - batch_offset) * fx.Int32(block_k)
+            batch_live_first = (batch_first > local_start).select(
+                batch_first,
+                local_start,
+            )
 
             accs_nt1 = _issue_nt_mfmas(kv_list_in, kvs_packed_list_in, 1)
-            _post_process_nt(accs_nt0, 0, c_i32_arg)
+            _post_process_nt(accs_nt0, 0, c_i32_arg, batch_live_first)
 
             accs_nt2 = _issue_nt_mfmas(kv_list_in, kvs_packed_list_in, 2)
-            _post_process_nt(accs_nt1, 1, c_i32_arg)
+            _post_process_nt(accs_nt1, 1, c_i32_arg, batch_live_first)
 
             accs_nt3 = _issue_nt_mfmas(kv_list_in, kvs_packed_list_in, 3)
-            _post_process_nt(accs_nt2, 2, c_i32_arg)
+            _post_process_nt(accs_nt2, 2, c_i32_arg, batch_live_first)
 
-            _post_process_nt(accs_nt3, 3, c_i32_arg)
+            _post_process_nt(accs_nt3, 3, c_i32_arg, batch_live_first)
 
-        # === Prologue ===
-        N_KV = k_tiles * N_TILES_PER_WARP
-        last_c_i32 = chunk_count - fx.Int32(1)
+        # A bare ``if inactive: return`` is not an early exit under FlyDSL's
+        # kernel rewriter. Keep the complete page-dependent pipeline in a
+        # closure invoked by a block-uniform dynamic guard instead. This makes
+        # padded schedule slots and empty windows perform no block-table or KV
+        # access, even when every page-table entry is -1.
+        def _process_chunks():
+            # === Prologue ===
+            N_KV = k_tiles * N_TILES_PER_WARP
+            last_c_i32 = chunk_count - fx.Int32(1)
 
-        phys_pre = _load_phys(c0_i32)
-        kv_pre, kvs_pre = _prefetch_chunk(c0_i32, phys_pre)
-        phys_next_pre = _load_phys(fx.Int32(1))
+            phys_pre = _load_phys(c0_i32)
+            kv_pre, kvs_pre = _prefetch_chunk(c0_i32, phys_pre)
+            phys_next_pre = _load_phys(fx.Int32(1))
 
-        nt0_accs_init = _issue_nt_mfmas(list(kv_pre), list(kvs_pre), 0)
-        nt0_init_scalars = []
-        for v in nt0_accs_init:
-            vv = fx.Vector(v)
-            for i in range(4):
-                nt0_init_scalars.append(vv[i])
+            nt0_accs_init = _issue_nt_mfmas(list(kv_pre), list(kvs_pre), 0)
+            nt0_init_scalars = []
+            for v in nt0_accs_init:
+                vv = fx.Vector(v)
+                for i in range(4):
+                    nt0_init_scalars.append(vv[i])
 
-        # === Main loop: chunk_count - 1 iterations ===
-        N_KVS = k_tiles
-        chunk_count_minus_1_i32 = chunk_count - fx.Int32(1)
-        chunk_count_minus_1_idx = fx.Int64(chunk_count_minus_1_i32)
-        init_args = (
-            list(kv_pre) + list(kvs_pre) + list(phys_next_pre) + nt0_init_scalars
-        )
-        for c_idx, state in range(0, chunk_count_minus_1_idx, 1, init=init_args):
-            kv_cur_list = [state[i] for i in range(N_KV)]
-            kvs_cur_list = [state[N_KV + i] for i in range(N_KVS)]
-            phys_next_list = [state[N_KV + N_KVS + i] for i in range(N_TILES_PER_WARP)]
+            # === Main loop: chunk_count - 1 iterations ===
+            N_KVS = k_tiles
+            chunk_count_minus_1_i32 = chunk_count - fx.Int32(1)
+            chunk_count_minus_1_idx = fx.Int64(chunk_count_minus_1_i32)
+            init_args = (
+                list(kv_pre) + list(kvs_pre) + list(phys_next_pre) + nt0_init_scalars
+            )
+            for c_idx, state in range(0, chunk_count_minus_1_idx, 1, init=init_args):
+                kv_cur_list = [state[i] for i in range(N_KV)]
+                kvs_cur_list = [state[N_KV + i] for i in range(N_KVS)]
+                phys_next_list = [
+                    state[N_KV + N_KVS + i] for i in range(N_TILES_PER_WARP)
+                ]
+                nt0_acc_base = N_KV + N_KVS + N_TILES_PER_WARP
+                nt0_accs_cur = [
+                    fx.Vector.from_elements(
+                        [state[nt0_acc_base + mi * 4 + i] for i in range(4)],
+                        dtype=fx.Float32,
+                    )
+                    for mi in range(m_tiles)
+                ]
+                c_idx_i32 = fx.Int32(c_idx)
+                c_next_i32 = c_idx_i32 + fx.Int32(1)
+                c_next_next_i32 = c_next_i32 + fx.Int32(1)
+
+                _compute_chunk(
+                    kv_cur_list,
+                    kvs_cur_list,
+                    c_idx_i32,
+                    nt0_accs_in=nt0_accs_cur,
+                )
+                if const_expr(emit_candidates):
+                    _commit_score_chunk(
+                        c_idx_i32,
+                        topk_state,
+                        topk_histogram,
+                        topk_scan,
+                        pool_values,
+                        pool_indices,
+                    )
+
+                kv_next, kvs_next = _prefetch_chunk(c_next_i32, phys_next_list)
+
+                phys_next_next_list = _load_phys(c_next_next_i32)
+
+                nt0_accs_next = _issue_nt_mfmas(list(kv_next), list(kvs_next), 0)
+                nt0_next_scalars = []
+                for v in nt0_accs_next:
+                    vv = fx.Vector(v)
+                    for i in range(4):
+                        nt0_next_scalars.append(vv[i])
+
+                results = yield (
+                    list(kv_next)
+                    + list(kvs_next)
+                    + list(phys_next_next_list)
+                    + nt0_next_scalars
+                )
+
+            # === Epilogue: process last chunk (chunk_count - 1) ===
+            kv_last_list = [results[i] for i in range(N_KV)]
+            kvs_last_list = [results[N_KV + i] for i in range(N_KVS)]
             nt0_acc_base = N_KV + N_KVS + N_TILES_PER_WARP
-            nt0_accs_cur = [
+            nt0_accs_last = [
                 fx.Vector.from_elements(
-                    [state[nt0_acc_base + mi * 4 + i] for i in range(4)],
+                    [results[nt0_acc_base + mi * 4 + i] for i in range(4)],
                     dtype=fx.Float32,
                 )
                 for mi in range(m_tiles)
             ]
-            c_idx_i32 = fx.Int32(c_idx)
-            c_next_i32 = c_idx_i32 + fx.Int32(1)
-            c_next_next_i32 = c_next_i32 + fx.Int32(1)
-
             _compute_chunk(
-                kv_cur_list, kvs_cur_list, c_idx_i32, nt0_accs_in=nt0_accs_cur
+                kv_last_list,
+                kvs_last_list,
+                last_c_i32,
+                nt0_accs_in=nt0_accs_last,
             )
+            if const_expr(emit_candidates):
+                _commit_score_chunk(
+                    last_c_i32,
+                    topk_state,
+                    topk_histogram,
+                    topk_scan,
+                    pool_values,
+                    pool_indices,
+                )
+                _finish_score_candidates(
+                    topk_state,
+                    pool_values,
+                    pool_indices,
+                    candidate_values_row,
+                    candidate_indices_row,
+                    candidate_counts_ptr,
+                )
 
-            kv_next, kvs_next = _prefetch_chunk(c_next_i32, phys_next_list)
-
-            phys_next_next_list = _load_phys(c_next_next_i32)
-
-            nt0_accs_next = _issue_nt_mfmas(list(kv_next), list(kvs_next), 0)
-            nt0_next_scalars = []
-            for v in nt0_accs_next:
-                vv = fx.Vector(v)
-                for i in range(4):
-                    nt0_next_scalars.append(vv[i])
-
-            results = yield (
-                list(kv_next)
-                + list(kvs_next)
-                + list(phys_next_next_list)
-                + nt0_next_scalars
-            )
-
-        # === Epilogue: process last chunk (chunk_count - 1) ===
-        kv_last_list = [results[i] for i in range(N_KV)]
-        kvs_last_list = [results[N_KV + i] for i in range(N_KVS)]
-        nt0_acc_base = N_KV + N_KVS + N_TILES_PER_WARP
-        nt0_accs_last = [
-            fx.Vector.from_elements(
-                [results[nt0_acc_base + mi * 4 + i] for i in range(4)],
-                dtype=fx.Float32,
-            )
-            for mi in range(m_tiles)
-        ]
-        _compute_chunk(
-            kv_last_list, kvs_last_list, last_c_i32, nt0_accs_in=nt0_accs_last
-        )
+        if chunk_count > fx.Int32(0):
+            _process_chunks()
 
     return pa_mqa_logits_fp4_prefill_kernel, block_threads_k
 
@@ -789,7 +1461,7 @@ def build_pa_mqa_logits_fp4_prefill_module(
 # ============================================================================
 
 
-@lru_cache(maxsize=32)
+@cache
 def compile_pa_mqa_logits_fp4_prefill(
     *,
     block_k: int = 256,
@@ -819,16 +1491,96 @@ def compile_pa_mqa_logits_fp4_prefill(
         w,
         cta_info_,
         stride_out: fx.Int32,
+        output_token_base: fx.Int32,
         weight_scale: fx.Float32,
         gx: fx.Int32,
         stream: fx.Stream,
     ):
         gxi = fx.Int64(gx)
-        kfn(out, q, qs, kv, kvs, bt, w, cta_info_, stride_out, weight_scale).launch(
-            grid=(gxi,), block=(block_threads, 1, 1), stream=stream
-        )
+        kfn(
+            out,
+            out,
+            out,
+            out,
+            q,
+            qs,
+            kv,
+            kvs,
+            bt,
+            w,
+            cta_info_,
+            stride_out,
+            output_token_base,
+            weight_scale,
+        ).launch(grid=(gxi,), block=(block_threads, 1, 1), stream=stream)
 
     return launch_pa_mqa_logits_fp4_prefill, block_threads
+
+
+@cache
+def compile_pa_mqa_logits_fp4_prefill_topk(
+    *,
+    topk: int,
+    block_k: int = 256,
+    kv_block_size: int = 64,
+    max_blocks_per_seq: int = 256,
+    num_warps: int = DEFAULT_NUM_WARPS,
+    heads: int = DEFAULT_HEADS,
+    head_dim: int = DEFAULT_HEAD_DIM,
+    score_batch_chunks: int = DEFAULT_SCORE_BATCH_CHUNKS,
+):
+    """Compile the score callback that emits bounded per-CTA TopK planes."""
+
+    kfn, block_threads = build_pa_mqa_logits_fp4_prefill_module(
+        block_k=block_k,
+        kv_block_size=kv_block_size,
+        max_blocks_per_seq=max_blocks_per_seq,
+        num_warps=num_warps,
+        heads=heads,
+        head_dim=head_dim,
+        candidate_topk=topk,
+        score_batch_chunks=score_batch_chunks,
+    )
+
+    @flyc.jit
+    def launch_pa_mqa_logits_fp4_prefill_topk(
+        candidate_values,
+        candidate_indices,
+        candidate_counts,
+        q,
+        qs,
+        kv,
+        kvs,
+        bt,
+        w,
+        cta_info_,
+        weight_scale: fx.Float32,
+        gx: fx.Int32,
+        stream: fx.Stream,
+    ):
+        gxi = fx.Int64(gx)
+        kfn(
+            candidate_values,
+            candidate_values,
+            candidate_indices,
+            candidate_counts,
+            q,
+            qs,
+            kv,
+            kvs,
+            bt,
+            w,
+            cta_info_,
+            fx.Int32(0),
+            fx.Int32(0),
+            weight_scale,
+        ).launch(
+            grid=(gxi,),
+            block=(block_threads, 1, 1),
+            stream=stream,
+        )
+
+    return launch_pa_mqa_logits_fp4_prefill_topk, block_threads
 
 
 def flydsl_pa_mqa_logits_fp4_prefill(
@@ -851,9 +1603,15 @@ def flydsl_pa_mqa_logits_fp4_prefill(
     out: torch.Tensor | None = None,
     cta_info: torch.Tensor | None = None,
     n_ctas: int | None = None,
+    output_token_base: int = 0,
     stream: torch.cuda.Stream | None = None,
 ) -> torch.Tensor:
-    """Ragged-prefill FP4 paged MQA logits (gfx950)."""
+    """Ragged-prefill FP4 paged MQA logits (gfx950).
+
+    ``output_token_base`` is an internal tiling hook: logical token ``j`` is
+    stored at output column ``j - output_token_base``. Public full-logit calls
+    leave it at zero.
+    """
     total_tokens, heads, head_dim_packed = q_fp4.shape
     head_dim = head_dim_packed * 2
     max_blocks_per_seq = block_tables.shape[1]
@@ -903,6 +1661,7 @@ def flydsl_pa_mqa_logits_fp4_prefill(
         weights,
         cta_info,
         out.stride(0),
+        output_token_base,
         float(weight_scale),
         n_ctas,
         stream,
@@ -910,6 +1669,303 @@ def flydsl_pa_mqa_logits_fp4_prefill(
     return out
 
 
+def flydsl_pa_mqa_topk_fp4_prefill(
+    q_fp4: torch.Tensor,
+    q_scale: torch.Tensor,
+    kv_cache: torch.Tensor,
+    kv_scale: torch.Tensor,
+    block_tables: torch.Tensor,
+    weights: torch.Tensor,
+    row_to_batch: torch.Tensor,
+    local_starts: torch.Tensor,
+    local_ends: torch.Tensor,
+    max_seq_len: int,
+    *,
+    topk: int = 512,
+    weight_scale: float = 1.0,
+    block_k: int = 256,
+    kv_block_size: int = 64,
+    num_warps: int = DEFAULT_NUM_WARPS,
+    parallel_unit_num: int | None = None,
+    score_batch_chunks: int = DEFAULT_SCORE_BATCH_CHUNKS,
+    workspace: FP4PrefillTopKWorkspace | None = None,
+    out: FP4PrefillTopKResult | None = None,
+    stream: torch.cuda.Stream | None = None,
+) -> FP4PrefillTopKResult:
+    """True kernel-fused FP4 paged-MQA scoring and exact TopK for gfx950.
+
+    The MFMA kernel never materializes ``[rows, max_seq_len]`` logits. Each CTA
+    streams up to ``score_batch_chunks * block_k`` new scores through LDS,
+    repeatedly retaining its exact ``topk`` under score-descending/index-
+    ascending order. When the launch has one slot per row, a no-radix copier
+    forwards that CTA's exact set using the schedule offsets and candidate
+    count. Other geometries retain the exact split-candidate radix merge. A
+    bounded finalizer returns long rows in total order and maps logical sequence
+    indices through ``block_tables``. Rows no longer than ``topk`` preserve
+    sequential logical-index order.
+
+    ``workspace`` exposes the per-CTA values, raw indices, and counts for
+    callers that need to exchange or inspect local candidates. Reuse both the
+    workspace and output buffers to avoid allocations. HIP/CUDA graph capture
+    is intentionally rejected: the row-plan scratch and first-call compiles
+    have not been made capture-owned/preflighted.
+    """
+
+    if topk not in (512, 1024):
+        raise ValueError("topk must be 512 or 1024")
+    if block_k != 256 or num_warps != 4:
+        raise ValueError("the fused TopK path requires block_k=256 and num_warps=4")
+    if kv_block_size != 64:
+        raise ValueError("the fused TopK path requires kv_block_size=64")
+    if score_batch_chunks not in SUPPORTED_SCORE_BATCH_CHUNKS:
+        raise ValueError(
+            "score_batch_chunks must be one of " f"{SUPPORTED_SCORE_BATCH_CHUNKS}"
+        )
+
+    if q_fp4.ndim != 3:
+        raise ValueError("q_fp4 must have shape [rows, 64, 64]")
+    rows, heads, head_dim_packed = q_fp4.shape
+    if rows <= 0:
+        raise ValueError("the fused TopK path requires at least one query row")
+    if parallel_unit_num is None:
+        parallel_unit_num = max(512, rows)
+    head_dim = head_dim_packed * 2
+    if heads != 64 or head_dim != 128:
+        raise ValueError("the fused TopK path requires production H=64 and D=128")
+    if q_fp4.dtype != torch.uint8 or q_scale.dtype != torch.uint8:
+        raise ValueError("q_fp4 and q_scale must use the packed uint8 FP4 ABI")
+    if q_scale.shape != (rows, 1, 4, 16, 4):
+        raise ValueError("q_scale must have shape [rows, 1, 4, 16, 4]")
+    if weights.shape != (rows, 64) or weights.dtype != torch.bfloat16:
+        raise ValueError("weights must be contiguous bfloat16 [rows, 64]")
+    if kv_cache.dtype != torch.uint8 or tuple(kv_cache.shape[1:]) != (
+        1,
+        4,
+        64,
+        16,
+    ):
+        raise ValueError("kv_cache must be uint8 [blocks, 1, 4, 64, 16]")
+    if kv_scale.dtype != torch.uint8 or tuple(kv_scale.shape[1:]) != (
+        1,
+        4,
+        64,
+    ):
+        raise ValueError("kv_scale must be uint8 [blocks, 1, 4, 64]")
+    device = q_fp4.device
+    if device.type != "cuda":
+        raise ValueError("q_fp4 must be a CUDA tensor")
+    arch = str(torch.cuda.get_device_properties(device).gcnArchName).split(":")[0]
+    if arch != "gfx950":
+        raise ValueError(f"the fused TopK path requires gfx950, got {arch}")
+    metadata = (row_to_batch, local_starts, local_ends)
+    if any(t.dtype != torch.int32 or t.shape != (rows,) for t in metadata):
+        raise ValueError("row_to_batch/local_starts/local_ends must be int32 [rows]")
+    if block_tables.dtype != torch.int32 or block_tables.ndim != 2:
+        raise ValueError("block_tables must be a 2D int32 tensor")
+    if max_seq_len < 0:
+        raise ValueError("max_seq_len must be non-negative")
+    if max_seq_len > block_tables.shape[1] * kv_block_size:
+        raise ValueError("max_seq_len exceeds block_tables capacity")
+    inputs = (
+        q_fp4,
+        q_scale,
+        kv_cache,
+        kv_scale,
+        block_tables,
+        weights,
+        *metadata,
+    )
+    if any(t.device != device for t in inputs):
+        raise ValueError("all fused FP4 TopK inputs must be on one device")
+    if any(not t.is_contiguous() for t in inputs):
+        raise ValueError("all fused FP4 TopK inputs must be contiguous")
+
+    if stream is None:
+        stream = torch.cuda.current_stream(device)
+    else:
+        try:
+            stream_device = torch.device(stream.device)
+        except (AttributeError, TypeError) as exc:
+            raise TypeError("stream must be a torch.cuda.Stream") from exc
+        if stream_device != device:
+            raise ValueError("stream must belong to the FP4 input device")
+
+    # Resolve the launch stream before any allocation. Besides providing the
+    # expected allocation-stream affinity for internally owned scratch, making
+    # it current here lets capture detection cover an explicitly supplied
+    # non-current stream.
+    with torch.cuda.stream(stream):
+        if torch.cuda.is_current_stream_capturing():
+            raise RuntimeError(
+                "fused FP4 prefill TopK does not support HIP/CUDA graph capture"
+            )
+        if workspace is None:
+            workspace = allocate_fp4_prefill_topk_workspace(
+                rows,
+                parallel_unit_num,
+                topk,
+                device,
+            )
+    expected_workspace = (
+        ((parallel_unit_num, CTA_INFO_WIDTH), torch.int32, workspace.cta_info),
+        ((rows + 1,), torch.int32, workspace.row_offsets),
+        (
+            (parallel_unit_num, topk),
+            torch.float32,
+            workspace.candidate_values,
+        ),
+        (
+            (parallel_unit_num, topk),
+            torch.int32,
+            workspace.candidate_indices,
+        ),
+        ((parallel_unit_num,), torch.int32, workspace.candidate_counts),
+        ((rows, topk), torch.float32, workspace.merge_values),
+        ((rows, topk), torch.int32, workspace.merge_indices),
+    )
+    for expected_shape, expected_dtype, tensor in expected_workspace:
+        if (
+            tuple(tensor.shape) != expected_shape
+            or tensor.dtype != expected_dtype
+            or tensor.device != device
+            or not tensor.is_contiguous()
+        ):
+            raise ValueError(
+                "workspace tensor mismatch: expected "
+                f"{expected_shape} {expected_dtype} contiguous on {device}"
+            )
+
+    with torch.cuda.stream(stream):
+        if out is None:
+            out = FP4PrefillTopKResult(
+                values=torch.empty(rows, topk, dtype=torch.float32, device=device),
+                raw_indices=torch.empty(rows, topk, dtype=torch.int32, device=device),
+                physical_indices=torch.empty(
+                    rows,
+                    topk,
+                    dtype=torch.int32,
+                    device=device,
+                ),
+                counts=torch.empty(rows, dtype=torch.int32, device=device),
+            )
+    expected_outputs = (
+        ((rows, topk), torch.float32, out.values),
+        ((rows, topk), torch.int32, out.raw_indices),
+        ((rows, topk), torch.int32, out.physical_indices),
+        ((rows,), torch.int32, out.counts),
+    )
+    for expected_shape, expected_dtype, tensor in expected_outputs:
+        if (
+            tuple(tensor.shape) != expected_shape
+            or tensor.dtype != expected_dtype
+            or tensor.device != device
+            or not tensor.is_contiguous()
+        ):
+            raise ValueError(
+                "output tensor mismatch: expected "
+                f"{expected_shape} {expected_dtype} contiguous on {device}"
+            )
+
+    if max_seq_len == 0:
+        with torch.cuda.stream(stream):
+            workspace.row_offsets.zero_()
+            workspace.candidate_counts.zero_()
+            out.values.fill_(float("-inf"))
+            out.raw_indices.fill_(-1)
+            out.physical_indices.fill_(-1)
+            out.counts.zero_()
+        return out
+
+    single_cta_per_row = parallel_unit_num == rows
+    with torch.cuda.stream(stream):
+        compute_prefill_schedule(
+            row_to_batch,
+            local_starts,
+            local_ends,
+            block_k,
+            parallel_unit_num,
+            max_seq_len,
+            cta_info_out=workspace.cta_info,
+            row_offsets_out=workspace.row_offsets,
+            single_cta_per_row=single_cta_per_row,
+        )
+    max_blocks_per_seq = block_tables.shape[1]
+    launcher, _ = compile_pa_mqa_logits_fp4_prefill_topk(
+        topk=topk,
+        block_k=block_k,
+        kv_block_size=kv_block_size,
+        max_blocks_per_seq=max_blocks_per_seq,
+        num_warps=num_warps,
+        heads=heads,
+        head_dim=head_dim,
+        score_batch_chunks=score_batch_chunks,
+    )
+    launcher(
+        workspace.candidate_values,
+        workspace.candidate_indices,
+        workspace.candidate_counts,
+        q_fp4,
+        q_scale,
+        kv_cache,
+        kv_scale,
+        block_tables,
+        weights,
+        workspace.cta_info,
+        float(weight_scale),
+        parallel_unit_num,
+        stream,
+    )
+
+    if single_cta_per_row:
+        with torch.cuda.stream(stream):
+            _copy_single_cta_topk_candidates(
+                workspace.candidate_values,
+                workspace.candidate_indices,
+                workspace.candidate_counts,
+                workspace.row_offsets,
+                workspace.merge_values,
+                workspace.merge_indices,
+                out.counts,
+            )
+    else:
+        from ...candidate_topk_merge import _flydsl_candidate_topk_merge_raw
+
+        _flydsl_candidate_topk_merge_raw(
+            workspace.candidate_values,
+            workspace.candidate_indices,
+            workspace.candidate_counts,
+            workspace.row_offsets,
+            row_to_batch,
+            block_tables,
+            workspace.merge_values,
+            workspace.merge_indices,
+            out.counts,
+            kv_block_size,
+            stream=stream,
+        )
+    from ...mqa_topk_finalize import order_and_map_mqa_topk
+
+    with torch.cuda.stream(stream):
+        order_and_map_mqa_topk(
+            workspace.merge_values,
+            workspace.merge_indices,
+            out.counts,
+            local_starts,
+            local_ends,
+            row_to_batch,
+            block_tables,
+            out.values,
+            out.raw_indices,
+            out.physical_indices,
+            max_seq_len,
+            topk,
+            kv_block_size,
+        )
+    return out
+
+
+# Keep the logits-prefixed spelling as a compatibility alias for the original
+# prototype branch.
 @triton.jit
 def _varqlen_windows_kernel(
     cu_ptr,  # [B+1] int32, prefix-sum of per-batch qlen

--- a/aiter/ops/flydsl/kernels/mqa_logits/pa_mqa_logits_fp4_prefill.py
+++ b/aiter/ops/flydsl/kernels/mqa_logits/pa_mqa_logits_fp4_prefill.py
@@ -354,7 +354,9 @@ def _row_plan(
         BLOCK_T=(
             _ROW_PLAN_BLOCK_FLOOR if T <= _ROW_PLAN_BLOCK_FLOOR else _ROW_PLAN_MAX_ROWS
         ),
-        SEARCH_STEPS=max(1, (s_max - 1).bit_length() + 1),
+        SEARCH_STEPS=(
+            1 if single_cta_per_row else max(1, (s_max - 1).bit_length() + 1)
+        ),
         SINGLE_CTA_PER_ROW=single_cta_per_row,
     )
     return plan
@@ -663,7 +665,6 @@ def _copy_single_cta_topk_candidates(
 def build_pa_mqa_logits_fp4_prefill_module(
     block_k=256,
     kv_block_size=64,
-    max_blocks_per_seq=256,
     max_chunks_per_cta=16,
     num_warps=DEFAULT_NUM_WARPS,
     heads=DEFAULT_HEADS,
@@ -721,9 +722,6 @@ def build_pa_mqa_logits_fp4_prefill_module(
     ), f"block_k={block_k} must be a multiple of kv_block_size={kv_block_size}"
     TILES_PER_BLOCK = kv_block_size // MFMA_N
     N_PHYS = (N_TILES_PER_WARP + TILES_PER_BLOCK - 1) // TILES_PER_BLOCK
-
-    # block_tables row stride (i32 elements).
-    _stride_bt = max_blocks_per_seq
 
     # KV preshuffle layout: [block_id, K_TILES, K_chunk=4, kv_block_size, 16] uint8.
     _kv_chunk_bytes = 16
@@ -786,6 +784,8 @@ def build_pa_mqa_logits_fp4_prefill_module(
         kv_indices_ptr: fx.Tensor,
         weights_ptr: fx.Tensor,
         cta_info_ptr: fx.Tensor,  # [n_ctas, 6] i32
+        block_table_stride: Int32,
+        block_table_capacity: Int32,
         stride_out_row: Int32,
         output_token_base: Int32,
         weight_scale: fx.Float32,
@@ -812,7 +812,7 @@ def build_pa_mqa_logits_fp4_prefill_module(
         cta_info_vec = fx.Vector(_load_vec4_i32(cta_info_bt, fx.Int32(0)))
         local_start = cta_info_bt[(fx.Int32(1), fx.Int32(0))]
         local_end = cta_info_bt[(fx.Int32(1), fx.Int32(1))]
-        table_capacity = fx.Int32(max_blocks_per_seq * kv_block_size)
+        table_capacity = block_table_capacity * fx.Int32(kv_block_size)
         local_start = (local_start > fx.Int32(0)).select(local_start, fx.Int32(0))
         local_start = (local_start < table_capacity).select(local_start, table_capacity)
         local_end = (local_end > fx.Int32(0)).select(local_end, fx.Int32(0))
@@ -958,10 +958,9 @@ def build_pa_mqa_logits_fp4_prefill_module(
             # epilogue. Clamp that speculative page-table lookup to the exact
             # inclusive table bounds so an unpadded table remains safe.
             bi_base = (bi_base < fx.Int32(0)).select(fx.Int32(0), bi_base)
-            bi_base = (bi_base < fx.Int32(max_blocks_per_seq)).select(
-                bi_base, fx.Int32(max_blocks_per_seq - 1)
-            )
-            phys_vec = bt_bt[batch_id * _stride_bt + bi_base]
+            last_block = block_table_capacity - fx.Int32(1)
+            bi_base = (bi_base < block_table_capacity).select(bi_base, last_block)
+            phys_vec = bt_bt[batch_id * block_table_stride + bi_base]
             return _phys_to_list(phys_vec)
 
         def _prefetch_chunk(c_i32_arg, phys_list):
@@ -1474,7 +1473,6 @@ def compile_pa_mqa_logits_fp4_prefill(
     kfn, block_threads = build_pa_mqa_logits_fp4_prefill_module(
         block_k=block_k,
         kv_block_size=kv_block_size,
-        max_blocks_per_seq=max_blocks_per_seq,
         num_warps=num_warps,
         heads=heads,
         head_dim=head_dim,
@@ -1509,6 +1507,8 @@ def compile_pa_mqa_logits_fp4_prefill(
             bt,
             w,
             cta_info_,
+            fx.Int32(max_blocks_per_seq),
+            fx.Int32(max_blocks_per_seq),
             stride_out,
             output_token_base,
             weight_scale,
@@ -1523,7 +1523,6 @@ def compile_pa_mqa_logits_fp4_prefill_topk(
     topk: int,
     block_k: int = 256,
     kv_block_size: int = 64,
-    max_blocks_per_seq: int = 256,
     num_warps: int = DEFAULT_NUM_WARPS,
     heads: int = DEFAULT_HEADS,
     head_dim: int = DEFAULT_HEAD_DIM,
@@ -1534,7 +1533,6 @@ def compile_pa_mqa_logits_fp4_prefill_topk(
     kfn, block_threads = build_pa_mqa_logits_fp4_prefill_module(
         block_k=block_k,
         kv_block_size=kv_block_size,
-        max_blocks_per_seq=max_blocks_per_seq,
         num_warps=num_warps,
         heads=heads,
         head_dim=head_dim,
@@ -1554,6 +1552,8 @@ def compile_pa_mqa_logits_fp4_prefill_topk(
         bt,
         w,
         cta_info_,
+        block_table_stride: fx.Int32,
+        block_table_capacity: fx.Int32,
         weight_scale: fx.Float32,
         gx: fx.Int32,
         stream: fx.Stream,
@@ -1571,6 +1571,8 @@ def compile_pa_mqa_logits_fp4_prefill_topk(
             bt,
             w,
             cta_info_,
+            block_table_stride,
+            block_table_capacity,
             fx.Int32(0),
             fx.Int32(0),
             weight_scale,
@@ -1889,12 +1891,10 @@ def flydsl_pa_mqa_topk_fp4_prefill(
             row_offsets_out=workspace.row_offsets,
             single_cta_per_row=single_cta_per_row,
         )
-    max_blocks_per_seq = block_tables.shape[1]
     launcher, _ = compile_pa_mqa_logits_fp4_prefill_topk(
         topk=topk,
         block_k=block_k,
         kv_block_size=kv_block_size,
-        max_blocks_per_seq=max_blocks_per_seq,
         num_warps=num_warps,
         heads=heads,
         head_dim=head_dim,
@@ -1911,6 +1911,8 @@ def flydsl_pa_mqa_topk_fp4_prefill(
         block_tables,
         weights,
         workspace.cta_info,
+        int(block_tables.stride(0)),
+        int(block_tables.shape[1]),
         float(weight_scale),
         parallel_unit_num,
         stream,

--- a/aiter/ops/flydsl/mqa_topk_finalize.py
+++ b/aiter/ops/flydsl/mqa_topk_finalize.py
@@ -1,0 +1,145 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+"""Final ordering and paged-slot mapping for FP4 MQA TopK candidates."""
+
+import torch
+import triton
+import triton.language as tl
+
+from aiter.ops.triton._triton_kernels.topk import argsort as triton_argsort
+
+
+@triton.jit
+def _order_and_map_topk_kernel(
+    source_values,
+    source_raw_indices,
+    valid_counts,
+    local_starts,
+    local_ends,
+    row_to_batch,
+    block_tables,
+    output_values,
+    output_raw_indices,
+    output_page_slots,
+    rows,
+    max_seq_len,
+    block_table_stride,
+    TOPK: tl.constexpr,
+    PAGE_SIZE: tl.constexpr,
+):
+    row = tl.program_id(0)
+    offsets = tl.arange(0, TOPK)
+    count = tl.minimum(tl.maximum(tl.load(valid_counts + row), 0), TOPK)
+    valid = offsets < count
+    row_offset = row * TOPK
+    values = tl.load(
+        source_values + row_offset + offsets,
+        mask=valid,
+        other=-float("inf"),
+    )
+    raw_indices = tl.load(
+        source_raw_indices + row_offset + offsets,
+        mask=valid,
+        other=-1,
+    ).to(tl.int32)
+
+    # Signed ordinal comparison preserves +0 > -0. Every NaN maps below every
+    # numeric value; raw logical index is the exact secondary key.
+    bits = values.to(tl.int32, bitcast=True)
+    absolute_bits = bits & 0x7FFFFFFF
+    is_nan = absolute_bits > 0x7F800000
+    score_ordinal = bits ^ ((bits >> 31) & 0x7FFFFFFF)
+    score_ordinal = tl.where(is_nan, -2147483648, score_ordinal)
+    raw_i64 = raw_indices.to(tl.int64)
+    score_key = score_ordinal.to(tl.int64) * 4294967296 + (2147483647 - raw_i64)
+
+    start = tl.maximum(
+        0,
+        tl.minimum(tl.load(local_starts + row), max_seq_len),
+    )
+    end = tl.maximum(
+        start,
+        tl.minimum(tl.load(local_ends + row), max_seq_len),
+    )
+    # Preserve the serving contract for a short row: return its complete
+    # logical window sequentially. Long rows use score-desc/index-asc order.
+    sequential_key = 2147483647 - raw_i64
+    key = tl.where(end - start > TOPK, score_key, sequential_key)
+    key = tl.where(valid, key, -9223372036854775808)
+    positions = offsets.to(tl.int32)
+    _, sorted_positions = triton_argsort(key, positions, 0, descending=True)
+
+    selected_values = tl.load(
+        source_values + row_offset + sorted_positions,
+        mask=valid,
+        other=-float("inf"),
+    )
+    selected_raw = tl.load(
+        source_raw_indices + row_offset + sorted_positions,
+        mask=valid,
+        other=-1,
+    ).to(tl.int32)
+    safe_raw = tl.maximum(selected_raw, 0)
+    batch = tl.load(row_to_batch + row)
+    logical_page = safe_raw // PAGE_SIZE
+    page_offset = safe_raw % PAGE_SIZE
+    physical_page = tl.load(
+        block_tables + batch * block_table_stride + logical_page,
+        mask=valid,
+        other=-1,
+    ).to(tl.int32)
+    page_slot = physical_page * PAGE_SIZE + page_offset
+
+    tl.store(
+        output_values + row_offset + offsets,
+        tl.where(valid, selected_values, -float("inf")),
+    )
+    tl.store(
+        output_raw_indices + row_offset + offsets,
+        tl.where(valid, selected_raw, -1),
+    )
+    tl.store(
+        output_page_slots + row_offset + offsets,
+        tl.where(valid, page_slot, -1),
+    )
+
+
+def order_and_map_mqa_topk(
+    source_values: torch.Tensor,
+    source_raw_indices: torch.Tensor,
+    valid_counts: torch.Tensor,
+    local_starts: torch.Tensor,
+    local_ends: torch.Tensor,
+    row_to_batch: torch.Tensor,
+    block_tables: torch.Tensor,
+    output_values: torch.Tensor,
+    output_raw_indices: torch.Tensor,
+    output_page_slots: torch.Tensor,
+    max_seq_len: int,
+    topk: int,
+    page_size: int,
+) -> None:
+    """Order an exact winning set and map logical indices to physical slots."""
+    rows = source_values.shape[0]
+    _order_and_map_topk_kernel[(rows,)](
+        source_values,
+        source_raw_indices,
+        valid_counts,
+        local_starts,
+        local_ends,
+        row_to_batch,
+        block_tables,
+        output_values,
+        output_raw_indices,
+        output_page_slots,
+        rows,
+        max_seq_len,
+        block_tables.stride(0),
+        TOPK=topk,
+        PAGE_SIZE=page_size,
+        num_warps=8,
+    )
+
+
+__all__ = ["order_and_map_mqa_topk"]

--- a/aiter/ops/flydsl/mqa_topk_finalize.py
+++ b/aiter/ops/flydsl/mqa_topk_finalize.py
@@ -10,7 +10,7 @@ import triton.language as tl
 from aiter.ops.triton._triton_kernels.topk import argsort as triton_argsort
 
 
-@triton.jit
+@triton.jit(do_not_specialize=["rows", "max_seq_len", "block_table_stride"])
 def _order_and_map_topk_kernel(
     source_values,
     source_raw_indices,

--- a/op_tests/op_benchmarks/bench_flydsl_pa_mqa_fp4_prefill_topk.py
+++ b/op_tests/op_benchmarks/bench_flydsl_pa_mqa_fp4_prefill_topk.py
@@ -1,0 +1,387 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+"""Benchmark legacy full-logits TopK against fused FP4 paged-MQA TopK."""
+
+from __future__ import annotations
+
+import argparse
+import math
+import statistics
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass
+
+import torch
+
+from aiter.ops.flydsl.kernels.mqa_logits.pa_mqa_logits_fp4_prefill import (
+    DEFAULT_SCORE_BATCH_CHUNKS,
+    SUPPORTED_SCORE_BATCH_CHUNKS,
+)
+
+HEADS = 64
+HEAD_DIM = 128
+KV_BLOCK_SIZE = 64
+BLOCK_K = 256
+WEIGHT_SCALE = 1.25
+WIDTHS = (65536, 196608, 262144)
+TOPKS = (512, 1024)
+
+
+@dataclass(frozen=True)
+class PackedCase:
+    q_fp4: torch.Tensor
+    q_scale: torch.Tensor
+    kv_cache: torch.Tensor
+    kv_scale: torch.Tensor
+    block_tables: torch.Tensor
+    weights: torch.Tensor
+    row_to_batch: torch.Tensor
+    local_starts: torch.Tensor
+    local_ends: torch.Tensor
+    width: int
+
+    @property
+    def operands(self) -> tuple[object, ...]:
+        return (*self.tensors, self.width)
+
+    @property
+    def tensors(self) -> tuple[torch.Tensor, ...]:
+        return tuple(v for v in vars(self).values() if torch.is_tensor(v))
+
+
+def _positive(value: str) -> int:
+    parsed = int(value)
+    if parsed <= 0:
+        raise argparse.ArgumentTypeError(f"expected a positive integer, got {value}")
+    return parsed
+
+
+def _tensor_bytes(tensors: Iterable[torch.Tensor]) -> int:
+    return sum(tensor.numel() * tensor.element_size() for tensor in tensors)
+
+
+def _preflight(rows: int, width: int, topks: Iterable[int], device) -> None:
+    from aiter.ops import topk as topk_ops
+
+    pages = math.ceil(width / KV_BLOCK_SIZE)
+    input_bytes = rows * (HEADS * HEAD_DIM // 2 + 256 + HEADS * 2 + 12)
+    input_bytes += pages * (4096 + 256 + 4)
+    parallel_units = max(512, rows)
+    required = 0
+    for topk in topks:
+        output_bytes = rows * (topk * 12 + 4)
+        topk_scratch = max(
+            1, int(topk_ops.topk_ob_workspace_size(rows, width, topk, False))
+        )
+        legacy_scratch = rows * width * 4 + topk_scratch
+        fused_scratch = (
+            parallel_units * (28 + topk * 8) + (rows + 1) * 4 + rows * topk * 8
+        )
+        required = max(
+            required, input_bytes + legacy_scratch + fused_scratch + 2 * output_bytes
+        )
+    free_bytes, _ = torch.cuda.mem_get_info(device)
+    if required > free_bytes:
+        raise SystemExit(
+            "Insufficient free GPU memory for explicit inputs, "
+            "scratch, and outputs: "
+            f"required={required} bytes, free={free_bytes} bytes."
+        )
+
+
+def _require_gfx950() -> torch.device:
+    if not torch.cuda.is_available() or torch.version.hip is None:
+        raise SystemExit("This benchmark requires ROCm on a gfx950 GPU.")
+    device = torch.device("cuda", torch.cuda.current_device())
+    arch = str(torch.cuda.get_device_properties(device).gcnArchName).split(":")[0]
+    if arch != "gfx950":
+        raise SystemExit(f"This benchmark requires gfx950; current device is {arch}.")
+    return device
+
+
+def _random_u8(shape, device, generator, low=0, high=256) -> torch.Tensor:
+    return torch.empty(shape, dtype=torch.uint8, device=device).random_(
+        low, high, generator=generator
+    )
+
+
+def _make_case(rows: int, width: int, device: torch.device, seed: int) -> PackedCase:
+    generator = torch.Generator(device=device).manual_seed(seed)
+    pages = math.ceil(width / KV_BLOCK_SIZE)
+    q_fp4 = _random_u8((rows, HEADS, HEAD_DIM // 2), device, generator)
+    q_scale = _random_u8((rows, 1, 4, 16, 4), device, generator, 124, 131)
+    kv_cache = _random_u8((pages, 1, 4, 64, 16), device, generator)
+    kv_scale = _random_u8((pages, 1, 4, 64), device, generator, 124, 131)
+    block_tables = torch.randperm(
+        pages, dtype=torch.int32, device=device, generator=generator
+    )[None]
+    weights = torch.empty((rows, HEADS), dtype=torch.bfloat16, device=device)
+    weights.normal_(0.0, 0.1, generator=generator)
+    row_to_batch = torch.zeros(rows, dtype=torch.int32, device=device)
+    local_starts = torch.zeros(rows, dtype=torch.int32, device=device)
+    local_ends = torch.full((rows,), width, dtype=torch.int32, device=device)
+    return PackedCase(
+        q_fp4,
+        q_scale,
+        kv_cache,
+        kv_scale,
+        block_tables.contiguous(),
+        weights.contiguous(),
+        row_to_batch,
+        local_starts,
+        local_ends,
+        width,
+    )
+
+
+def _prepare_legacy(case: PackedCase, topk: int, parallel_units: int):
+    from aiter.ops import topk as topk_ops
+    from aiter.ops.flydsl import flydsl_pa_mqa_logits_fp4_prefill
+    from aiter.ops.flydsl.mqa_topk_finalize import order_and_map_mqa_topk
+
+    rows = case.q_fp4.shape[0]
+    device = case.q_fp4.device
+    logits = torch.empty((rows, case.width), dtype=torch.float32, device=device)
+    selected_raw = torch.empty((rows, topk), dtype=torch.int32, device=device)
+    selected_values = torch.empty((rows, topk), dtype=torch.float32, device=device)
+    values = torch.empty_like(selected_values)
+    raw_indices = torch.empty_like(selected_raw)
+    physical_indices = torch.empty_like(selected_raw)
+    counts = torch.full((rows,), topk, dtype=torch.int32, device=device)
+    scratch_size = topk_ops.topk_ob_workspace_size(rows, case.width, topk, False)
+    scratch = topk_ops.get_topk_scratch_workspace(device, scratch_size)
+    allocate_scratch = topk_ops.get_topk_scratch_workspace
+
+    def supplied_scratch(request_device, requested_size):
+        assert torch.device(request_device) == device
+        assert requested_size <= scratch.numel()
+        return scratch
+
+    def run() -> None:
+        flydsl_pa_mqa_logits_fp4_prefill(
+            *case.operands,
+            weight_scale=WEIGHT_SCALE,
+            block_k=BLOCK_K,
+            kv_block_size=KV_BLOCK_SIZE,
+            parallel_unit_num=parallel_units,
+            out=logits,
+        )
+        # Public TopK has no scratch argument; this benchmark is isolated-process.
+        assert topk_ops.get_topk_scratch_workspace is allocate_scratch
+        topk_ops.get_topk_scratch_workspace = supplied_scratch
+        try:
+            topk_ops.top_k_per_row_prefill(
+                logits,
+                case.local_starts,
+                case.local_ends,
+                selected_raw,
+                selected_values,
+                rows,
+                logits.stride(0),
+                logits.stride(1),
+                topk,
+                stable=True,
+            )
+        finally:
+            unchanged = topk_ops.get_topk_scratch_workspace is supplied_scratch
+            topk_ops.get_topk_scratch_workspace = allocate_scratch
+            assert unchanged, "TopK scratch allocator changed during benchmark"
+        order_and_map_mqa_topk(
+            selected_values,
+            selected_raw,
+            counts,
+            case.local_starts,
+            case.local_ends,
+            case.row_to_batch,
+            case.block_tables,
+            values,
+            raw_indices,
+            physical_indices,
+            case.width,
+            topk,
+            KV_BLOCK_SIZE,
+        )
+
+    output = (values, raw_indices, physical_indices, counts)
+    scratch_bytes = _tensor_bytes((logits, selected_values, selected_raw, scratch))
+    return run, output, scratch_bytes, _tensor_bytes(output)
+
+
+def _prepare_fused(case: PackedCase, topk: int, parallel_units: int, chunks: int):
+    from aiter.ops.flydsl import (
+        FP4PrefillTopKResult,
+        allocate_fp4_prefill_topk_workspace,
+        flydsl_pa_mqa_topk_fp4_prefill,
+    )
+
+    rows = case.q_fp4.shape[0]
+    workspace = allocate_fp4_prefill_topk_workspace(
+        rows, parallel_units, topk, case.q_fp4.device
+    )
+    device = case.q_fp4.device
+    out = FP4PrefillTopKResult(
+        torch.empty((rows, topk), dtype=torch.float32, device=device),
+        torch.empty((rows, topk), dtype=torch.int32, device=device),
+        torch.empty((rows, topk), dtype=torch.int32, device=device),
+        torch.empty(rows, dtype=torch.int32, device=device),
+    )
+
+    def run() -> None:
+        flydsl_pa_mqa_topk_fp4_prefill(
+            *case.operands,
+            topk=topk,
+            weight_scale=WEIGHT_SCALE,
+            block_k=BLOCK_K,
+            kv_block_size=KV_BLOCK_SIZE,
+            parallel_unit_num=parallel_units,
+            score_batch_chunks=chunks,
+            workspace=workspace,
+            out=out,
+        )
+
+    return run, out, _tensor_bytes(workspace), _tensor_bytes(out)
+
+
+def _time(run: Callable[[], None], warmup: int, iterations: int) -> float:
+    for _ in range(warmup):
+        run()
+    torch.cuda.synchronize()
+    pairs = [
+        (torch.cuda.Event(enable_timing=True), torch.cuda.Event(enable_timing=True))
+        for _ in range(iterations)
+    ]
+    for start, end in pairs:
+        start.record()
+        run()
+        end.record()
+    torch.cuda.synchronize()
+    return statistics.median(start.elapsed_time(end) * 1000.0 for start, end in pairs)
+
+
+def _check_exact(case: PackedCase, topk: int, legacy, fused) -> None:
+    names = ("values", "raw_indices", "physical_indices", "counts")
+    for name, wanted, actual in zip(names, legacy, fused, strict=True):
+        expected = wanted.view(torch.int32) if wanted.is_floating_point() else wanted
+        observed = actual.view(torch.int32) if actual.is_floating_point() else actual
+        if not torch.equal(expected, observed):
+            mismatch = torch.nonzero(expected != observed)[0].tolist()
+            index = tuple(mismatch)
+            detail = ""
+            if name == "physical_indices":
+                row, slot = index
+                raw = int(legacy[1][row, slot])
+                batch = int(case.row_to_batch[row])
+                logical_page = raw // KV_BLOCK_SIZE
+                physical_page = int(case.block_tables[batch, logical_page])
+                detail = (
+                    f", raw={raw}, batch={batch}, logical_page={logical_page}, "
+                    f"physical_page={physical_page}"
+                )
+            raise AssertionError(
+                f"exact {name} mismatch for topk={topk} at {index}: "
+                f"expected={int(expected[index])}, actual={int(observed[index])}"
+                f"{detail}"
+            )
+
+
+def _result(
+    provider, region, args, latency, legacy, scratch, output, baseline_scratch
+) -> None:
+    rows, width, topk, chunks, parallel_units = args
+    reduction = 100.0 * (baseline_scratch - scratch) / baseline_scratch
+    print(
+        f"RESULT,provider={provider},rows={rows},context_width={width},topk={topk},"
+        f"score_batch_chunks={chunks},parallel_unit_num={parallel_units},"
+        f"timed_region={region},"
+        f"latency_p50_us={latency:.3f},speedup_vs_legacy={legacy / latency:.4f},"
+        f"scratch_bytes={scratch},output_bytes={output},"
+        f"workspace_reduction_pct={reduction:.3f}"
+    )
+
+
+def _benchmark(case, topk, chunks, warmup, iterations) -> None:
+    rows = case.q_fp4.shape[0]
+    parallel_units = max(512, rows)
+    legacy_run, legacy, legacy_scratch, legacy_output = _prepare_legacy(
+        case, topk, parallel_units
+    )
+    fused_run, fused, fused_scratch, fused_output = _prepare_fused(
+        case, topk, parallel_units, chunks
+    )
+    legacy_run()
+    fused_run()
+    torch.cuda.synchronize()
+    _check_exact(case, topk, legacy, fused)
+    legacy_us = _time(legacy_run, warmup, iterations)
+    fused_us = _time(fused_run, warmup, iterations)
+    config = (rows, case.width, topk, chunks, parallel_units)
+    _result(
+        "legacy",
+        "scorer+stable_topk+ordering+physical_mapping",
+        config,
+        legacy_us,
+        legacy_us,
+        legacy_scratch,
+        legacy_output,
+        legacy_scratch,
+    )
+    _result(
+        "fused",
+        "public_scorer+selection+ordering+physical_mapping",
+        config,
+        fused_us,
+        legacy_us,
+        fused_scratch,
+        fused_output,
+        legacy_scratch,
+    )
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--rows", type=_positive, nargs="+", default=[1024])
+    parser.add_argument("--widths", type=_positive, nargs="+", default=list(WIDTHS))
+    parser.add_argument(
+        "--topks", type=int, nargs="+", choices=TOPKS, default=list(TOPKS)
+    )
+    parser.add_argument(
+        "--score-batch-chunks",
+        type=int,
+        nargs="+",
+        choices=SUPPORTED_SCORE_BATCH_CHUNKS,
+        default=[DEFAULT_SCORE_BATCH_CHUNKS],
+    )
+    parser.add_argument("--warmup", type=int, default=5)
+    parser.add_argument("--iterations", type=_positive, default=20)
+    parser.add_argument("--seed", type=int, default=2026)
+    args = parser.parse_args()
+    if args.warmup < 0:
+        parser.error("--warmup must be non-negative")
+    if min(args.widths) < max(args.topks):
+        parser.error("every --widths value must be at least max(--topks)")
+    return args
+
+
+def main() -> None:
+    args = _parse_args()
+    device = _require_gfx950()
+    print(
+        "TIMING,process_model=isolated-only,"
+        "legacy=scorer+stable_topk+ordering+physical_mapping,"
+        "fused=public_scorer+selection+ordering+physical_mapping,"
+        "equivalent_postprocessing=true"
+    )
+    with torch.inference_mode():
+        case_number = 0
+        for rows in dict.fromkeys(args.rows):
+            for width in dict.fromkeys(args.widths):
+                _preflight(rows, width, dict.fromkeys(args.topks), device)
+                case = _make_case(rows, width, device, args.seed + case_number)
+                case_number += 1
+                for topk in dict.fromkeys(args.topks):
+                    for chunks in dict.fromkeys(args.score_batch_chunks):
+                        _benchmark(case, topk, chunks, args.warmup, args.iterations)
+
+
+if __name__ == "__main__":
+    main()

--- a/op_tests/test_flydsl_candidate_topk_merge.py
+++ b/op_tests/test_flydsl_candidate_topk_merge.py
@@ -1,0 +1,154 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+"""Focused correctness test for the reusable prefill candidate merger."""
+
+import math
+import struct
+
+import pytest
+import torch
+
+
+def _ordered_i32(value: float) -> int:
+    bits = struct.unpack("<I", struct.pack("<f", value))[0]
+    if math.isnan(value):
+        return -(1 << 31)
+    ordered = bits ^ (0x7FFFFFFF if bits & 0x80000000 else 0)
+    return ordered - (1 << 32) if ordered & 0x80000000 else ordered
+
+
+def _reference(values, indices, counts, row_offsets, topk):
+    result = []
+    for row in range(len(row_offsets) - 1):
+        candidates = []
+        for cta in range(row_offsets[row], row_offsets[row + 1]):
+            for slot in range(counts[cta]):
+                candidates.append((float(values[cta, slot]), int(indices[cta, slot])))
+        candidates.sort(key=lambda item: (-_ordered_i32(item[0]), item[1]))
+        result.append(candidates[:topk])
+    return result
+
+
+@pytest.mark.parametrize("topk", [512, 1024])
+def test_candidate_topk_merge_total_order_and_page_map(topk):
+    if not torch.cuda.is_available():
+        pytest.skip("requires a ROCm GPU")
+    arch = torch.cuda.get_device_properties(0).gcnArchName
+    if not arch.startswith("gfx9"):
+        pytest.skip("candidate merger currently requires wave64")
+
+    from aiter.ops.flydsl.candidate_topk_merge import flydsl_candidate_topk_merge
+
+    rows = 3
+    ctas_per_row = 2
+    ctas = rows * ctas_per_row
+    page_size = 64
+    count0 = topk // 2 + 1
+    count1 = topk + 2 - count0
+    counts_cpu = [count0, count1] * rows
+    row_offsets_cpu = [0, 2, 4, 6]
+
+    values = torch.full((ctas, topk), -float("inf"), dtype=torch.float32)
+    indices = torch.full((ctas, topk), -1, dtype=torch.int32)
+    generator = torch.Generator().manual_seed(2026)
+    for row in range(rows):
+        row_values = torch.randint(
+            -8,
+            9,
+            (topk + 2,),
+            generator=generator,
+            dtype=torch.int32,
+        ).float()
+        if row == 1:
+            # Cutoff: K-1 values above zero, then +0 beats -0 even though -0
+            # owns the smaller index.
+            row_values.fill_(-1.0)
+            row_values[2 : topk + 1] = 1.0
+            row_values[0] = -0.0
+            row_values[1] = 0.0
+        elif row == 2:
+            # NaN is below -inf. Exactly one low value is needed after K-1
+            # positive values, so -inf wins and both NaNs lose.
+            row_values.fill_(float("nan"))
+            row_values[2 : topk + 1] = 1.0
+            row_values[1] = -float("inf")
+
+        for plane in range(ctas_per_row):
+            cta = row * ctas_per_row + plane
+            begin = 0 if plane == 0 else count0
+            end = begin + counts_cpu[cta]
+            values[cta, : counts_cpu[cta]] = row_values[begin:end]
+            indices[cta, : counts_cpu[cta]] = torch.arange(
+                begin,
+                end,
+                dtype=torch.int32,
+            )
+
+    max_blocks = (topk + 2 + page_size - 1) // page_size
+    block_table = (
+        torch.arange(rows * max_blocks, dtype=torch.int32).reshape(rows, max_blocks)
+        + 100
+    )
+    row_to_batch = torch.arange(rows, dtype=torch.int32)
+    expected = _reference(
+        values,
+        indices,
+        counts_cpu,
+        row_offsets_cpu,
+        topk,
+    )
+
+    values = values.cuda()
+    indices = indices.cuda()
+    counts = torch.tensor(counts_cpu, dtype=torch.int32, device="cuda")
+    row_offsets = torch.tensor(row_offsets_cpu, dtype=torch.int32, device="cuda")
+    row_to_batch = row_to_batch.cuda()
+    block_table = block_table.cuda()
+    out_values = torch.empty(rows, topk, dtype=torch.float32, device="cuda")
+    out_raw = torch.empty(rows, topk, dtype=torch.int32, device="cuda")
+    out_physical = torch.empty(rows, topk, dtype=torch.int32, device="cuda")
+    out_counts = torch.empty(rows, dtype=torch.int32, device="cuda")
+
+    flydsl_candidate_topk_merge(
+        values,
+        indices,
+        counts,
+        row_offsets,
+        row_to_batch,
+        block_table,
+        out_values,
+        out_raw,
+        out_physical,
+        out_counts,
+        page_size,
+    )
+    torch.cuda.synchronize()
+
+    torch.testing.assert_close(
+        out_counts.cpu(),
+        torch.full((rows,), topk, dtype=torch.int32),
+        rtol=0,
+        atol=0,
+    )
+    for row, wanted in enumerate(expected):
+        wanted_indices = torch.tensor(
+            sorted(index for _, index in wanted),
+            dtype=torch.int32,
+        )
+        got_indices = torch.sort(out_raw[row].cpu()).values
+        torch.testing.assert_close(got_indices, wanted_indices, rtol=0, atol=0)
+
+        # Values and physical slots must follow each emitted raw index.
+        source = {
+            int(indices[cta, slot].cpu()): values[cta, slot].cpu()
+            for cta in range(row_offsets_cpu[row], row_offsets_cpu[row + 1])
+            for slot in range(counts_cpu[cta])
+        }
+        for slot in range(topk):
+            raw = int(out_raw[row, slot])
+            assert torch.equal(out_values[row, slot].cpu(), source[raw])
+            expected_physical = (
+                int(block_table[row, raw // page_size]) * page_size + raw % page_size
+            )
+            assert int(out_physical[row, slot]) == expected_physical

--- a/op_tests/test_flydsl_pa_mqa_topk_fp4_prefill.py
+++ b/op_tests/test_flydsl_pa_mqa_topk_fp4_prefill.py
@@ -824,9 +824,51 @@ def test_score_batch_lds_budget() -> None:
 def test_legacy_compile_cache_does_not_evict_live_modules() -> None:
     from aiter.ops.flydsl.kernels.mqa_logits.pa_mqa_logits_fp4_prefill import (
         compile_pa_mqa_logits_fp4_prefill,
+        compile_pa_mqa_logits_fp4_prefill_topk,
     )
 
     assert compile_pa_mqa_logits_fp4_prefill.cache_info().maxsize is None
+    assert compile_pa_mqa_logits_fp4_prefill_topk.cache_info().maxsize is None
+
+
+@requires_gfx950_flydsl
+def test_fused_compile_cache_reuses_runtime_page_table_stride() -> None:
+    from aiter.ops.flydsl import flydsl_pa_mqa_topk_fp4_prefill
+    from aiter.ops.flydsl.kernels.mqa_logits.pa_mqa_logits_fp4_prefill import (
+        compile_pa_mqa_logits_fp4_prefill_topk,
+    )
+
+    wide_case = list(_make_case(seed=149))
+    narrow_case = list(wide_case)
+    narrow_case[4] = wide_case[4][:, :64].contiguous()
+    narrow_case[8] = torch.clamp(wide_case[8], max=64 * KV_BLOCK_SIZE)
+    narrow_case[9] = 64 * KV_BLOCK_SIZE
+
+    compile_pa_mqa_logits_fp4_prefill_topk.cache_clear()
+    for case in (narrow_case, wide_case):
+        expected = _stable_reference(
+            _full_logits(case, 1.25),
+            case[4],
+            case[6],
+            case[7],
+            case[8],
+            512,
+        )
+        result = flydsl_pa_mqa_topk_fp4_prefill(
+            *case,
+            topk=512,
+            weight_scale=1.25,
+            parallel_unit_num=case[0].shape[0],
+        )
+        torch.cuda.synchronize()
+        for actual, wanted in zip(result, expected, strict=True):
+            torch.testing.assert_close(actual, wanted, rtol=0, atol=0)
+
+    cache_info = compile_pa_mqa_logits_fp4_prefill_topk.cache_info()
+    assert cache_info.misses == 1
+    assert cache_info.hits == 1
+    assert cache_info.currsize == 1
+    compile_pa_mqa_logits_fp4_prefill_topk.cache_clear()
 
 
 @requires_gfx950_flydsl

--- a/op_tests/test_flydsl_pa_mqa_topk_fp4_prefill.py
+++ b/op_tests/test_flydsl_pa_mqa_topk_fp4_prefill.py
@@ -1,0 +1,883 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+"""Focused public-path tests for FP4 paged-MQA streaming TopK."""
+
+from __future__ import annotations
+
+import importlib.util
+import math
+import struct
+
+import pytest
+import torch
+
+
+def _gfx950_flydsl_available() -> bool:
+    if importlib.util.find_spec("flydsl") is None:
+        return False
+    if not torch.cuda.is_available() or torch.version.hip is None:
+        return False
+    try:
+        return torch.cuda.get_device_properties(0).gcnArchName.split(":")[0] == "gfx950"
+    except (AttributeError, RuntimeError):
+        return False
+
+
+requires_gfx950_flydsl = pytest.mark.skipif(
+    not _gfx950_flydsl_available(),
+    reason="requires a ROCm gfx950 GPU and FlyDSL",
+)
+
+HEADS = 64
+HEAD_DIM = 128
+KV_BLOCK_SIZE = 64
+
+
+def _make_case(seed: int = 7):
+    from op_tests.test_flydsl_pa_mqa_logits_fp4_prefill import (
+        indexer_k_fp4_paged_preshuffle,
+        quant_q_fp4_preshuffle,
+    )
+
+    torch.manual_seed(seed)
+    device = torch.device("cuda")
+    batch = 2
+    max_seq_len = 5120
+    blocks_per_seq = max_seq_len // KV_BLOCK_SIZE
+    num_blocks = batch * blocks_per_seq
+    block_tables = torch.randperm(
+        num_blocks,
+        device=device,
+        dtype=torch.int32,
+    ).reshape(batch, blocks_per_seq)
+    kv = torch.randn(
+        batch,
+        max_seq_len,
+        HEAD_DIM,
+        dtype=torch.bfloat16,
+        device=device,
+    )
+    logical_batch = torch.arange(batch, device=device).repeat_interleave(max_seq_len)
+    logical_token = torch.arange(max_seq_len, device=device).repeat(batch)
+    physical_page = block_tables[
+        logical_batch,
+        logical_token // KV_BLOCK_SIZE,
+    ].to(torch.int64)
+    slot_mapping = (physical_page * KV_BLOCK_SIZE + logical_token % KV_BLOCK_SIZE).to(
+        torch.int32
+    )
+    kv_cache = torch.zeros(
+        num_blocks,
+        1,
+        4,
+        KV_BLOCK_SIZE,
+        16,
+        dtype=torch.uint8,
+        device=device,
+    )
+    kv_scale = torch.zeros(
+        num_blocks,
+        1,
+        4,
+        KV_BLOCK_SIZE,
+        dtype=torch.uint8,
+        device=device,
+    )
+    indexer_k_fp4_paged_preshuffle(
+        kv.reshape(-1, HEAD_DIM),
+        slot_mapping,
+        kv_cache,
+        kv_scale,
+        KV_BLOCK_SIZE,
+    )
+
+    row_to_batch = torch.tensor([0, 1, 0, 1, 0, 1], dtype=torch.int32, device=device)
+    local_starts = torch.tensor(
+        [37, 0, 4011, 1700, 2200, 900],
+        dtype=torch.int32,
+        device=device,
+    )
+    local_ends = torch.tensor(
+        [5097, 777, 4411, 1700, 4900, 5050],
+        dtype=torch.int32,
+        device=device,
+    )
+    rows = row_to_batch.numel()
+    q = torch.randn(rows, HEADS, HEAD_DIM, dtype=torch.bfloat16, device=device)
+    weights = (torch.randn(rows, HEADS, dtype=torch.float32, device=device) * 0.1).to(
+        torch.bfloat16
+    )
+    q_fp4, q_scale = quant_q_fp4_preshuffle(q)
+    return (
+        q_fp4,
+        q_scale,
+        kv_cache,
+        kv_scale,
+        block_tables,
+        weights,
+        row_to_batch,
+        local_starts,
+        local_ends,
+        max_seq_len,
+    )
+
+
+def _stable_reference(full_logits, block_tables, row_to_batch, starts, ends, topk):
+    rows = full_logits.shape[0]
+    values = torch.full(
+        (rows, topk),
+        -float("inf"),
+        dtype=torch.float32,
+        device=full_logits.device,
+    )
+    raw_indices = torch.full(
+        (rows, topk),
+        -1,
+        dtype=torch.int32,
+        device=full_logits.device,
+    )
+    physical_indices = torch.full_like(raw_indices, -1)
+    counts = torch.empty(rows, dtype=torch.int32, device=full_logits.device)
+    for row in range(rows):
+        start, end = int(starts[row]), int(ends[row])
+        count = min(topk, max(end - start, 0))
+        counts[row] = count
+        if count == 0:
+            continue
+        if end - start <= topk:
+            raw = torch.arange(start, end, device=full_logits.device)
+        else:
+            raw = (
+                torch.argsort(
+                    full_logits[row, start:end],
+                    descending=True,
+                    stable=True,
+                )[:count]
+                + start
+            )
+        raw_indices[row, :count] = raw.to(torch.int32)
+        values[row, :count] = full_logits[row, raw]
+        batch = int(row_to_batch[row])
+        physical_indices[row, :count] = (
+            block_tables[batch, raw // KV_BLOCK_SIZE] * KV_BLOCK_SIZE
+            + raw % KV_BLOCK_SIZE
+        ).to(torch.int32)
+    return values, raw_indices, physical_indices, counts
+
+
+def _full_logits(case, weight_scale: float):
+    from aiter.ops.flydsl import flydsl_pa_mqa_logits_fp4_prefill
+
+    return flydsl_pa_mqa_logits_fp4_prefill(
+        *case,
+        weight_scale=weight_scale,
+        block_k=256,
+        kv_block_size=KV_BLOCK_SIZE,
+    )
+
+
+def _ordered_i32(value: float) -> int:
+    bits = struct.unpack("<I", struct.pack("<f", value))[0]
+    if (bits & 0x7FFFFFFF) > 0x7F800000:
+        return -(1 << 31)
+    signed = bits if bits < (1 << 31) else bits - (1 << 32)
+    return signed ^ ((signed >> 31) & 0x7FFFFFFF)
+
+
+def test_reference_total_order_has_required_special_values() -> None:
+    assert _ordered_i32(float("nan")) < _ordered_i32(float("-inf"))
+    assert _ordered_i32(float("-inf")) < _ordered_i32(-0.0)
+    assert _ordered_i32(-0.0) < _ordered_i32(+0.0)
+    assert _ordered_i32(+0.0) < _ordered_i32(float("inf"))
+
+
+@requires_gfx950_flydsl
+@pytest.mark.parametrize("topk", [512, 1024])
+def test_fused_public_path_matches_full_logits(topk: int) -> None:
+    from aiter.ops.flydsl import (
+        allocate_fp4_prefill_topk_workspace,
+        flydsl_pa_mqa_topk_fp4_prefill,
+    )
+
+    case = _make_case(seed=71 + topk)
+    rows = case[0].shape[0]
+    weight_scale = 1.25
+    full_logits = _full_logits(case, weight_scale)
+    expected = _stable_reference(
+        full_logits,
+        case[4],
+        case[6],
+        case[7],
+        case[8],
+        topk,
+    )
+
+    # Match serving: one schedule slot per row. The case includes an empty row,
+    # so this also verifies that compact row offsets, rather than row == CTA,
+    # drive the no-radix merge.
+    parallel_unit_num = rows
+    fused_workspace = allocate_fp4_prefill_topk_workspace(
+        rows,
+        parallel_unit_num,
+        topk,
+        case[0].device,
+    )
+    fused = flydsl_pa_mqa_topk_fp4_prefill(
+        *case[:6],
+        case[6],
+        case[7],
+        case[8],
+        case[9],
+        topk=topk,
+        weight_scale=weight_scale,
+        parallel_unit_num=parallel_unit_num,
+        workspace=fused_workspace,
+    )
+
+    torch.cuda.synchronize()
+
+    actual = (
+        fused.values,
+        fused.raw_indices,
+        fused.physical_indices,
+        fused.counts,
+    )
+    for got, wanted in zip(actual, expected, strict=True):
+        torch.testing.assert_close(got, wanted, rtol=0, atol=0)
+
+
+@requires_gfx950_flydsl
+@pytest.mark.parametrize("topk", [512, 1024])
+def test_fused_split_candidate_path_matches_full_logits(topk: int) -> None:
+    from aiter.ops.flydsl import (
+        allocate_fp4_prefill_topk_workspace,
+        flydsl_pa_mqa_topk_fp4_prefill,
+    )
+
+    case = _make_case(seed=83 + topk)
+    rows = case[0].shape[0]
+    parallel_unit_num = 512
+    weight_scale = 1.25
+    expected = _stable_reference(
+        _full_logits(case, weight_scale),
+        case[4],
+        case[6],
+        case[7],
+        case[8],
+        topk,
+    )
+    workspace = allocate_fp4_prefill_topk_workspace(
+        rows,
+        parallel_unit_num,
+        topk,
+        case[0].device,
+    )
+    result = flydsl_pa_mqa_topk_fp4_prefill(
+        *case,
+        topk=topk,
+        weight_scale=weight_scale,
+        parallel_unit_num=parallel_unit_num,
+        workspace=workspace,
+    )
+    torch.cuda.synchronize()
+
+    row_offsets = workspace.row_offsets.cpu()
+    assert torch.any(row_offsets[1:] - row_offsets[:-1] > 1)
+    actual = (
+        result.values,
+        result.raw_indices,
+        result.physical_indices,
+        result.counts,
+    )
+    for got, wanted in zip(actual, expected, strict=True):
+        torch.testing.assert_close(got, wanted, rtol=0, atol=0)
+
+
+@requires_gfx950_flydsl
+@pytest.mark.parametrize("topk", [512, 1024])
+def test_equal_score_pool_stays_monotonic_across_compactions(topk: int) -> None:
+    from aiter.ops.flydsl import (
+        allocate_fp4_prefill_topk_workspace,
+        flydsl_pa_mqa_topk_fp4_prefill,
+    )
+
+    case = _make_case(seed=91 + topk)
+    case[5][0].zero_()
+    case[5][5].zero_()
+    rows = case[0].shape[0]
+    score_batch_chunks = 2
+    workspace = allocate_fp4_prefill_topk_workspace(
+        rows,
+        rows,
+        topk,
+        case[0].device,
+    )
+    result = flydsl_pa_mqa_topk_fp4_prefill(
+        *case,
+        topk=topk,
+        weight_scale=1.25,
+        parallel_unit_num=rows,
+        score_batch_chunks=score_batch_chunks,
+        workspace=workspace,
+    )
+    torch.cuda.synchronize()
+
+    row_offsets = workspace.row_offsets.cpu().tolist()
+    for row in (0, 5):
+        start = int(case[7][row])
+        end = int(case[8][row])
+        assert end - start > topk + score_batch_chunks * 256
+        cta = row_offsets[row]
+        assert row_offsets[row + 1] == cta + 1
+        expected_raw = torch.arange(
+            start,
+            start + topk,
+            dtype=torch.int32,
+            device=case[0].device,
+        )
+        assert int(workspace.candidate_counts[cta]) == topk
+        torch.testing.assert_close(
+            workspace.candidate_indices[cta],
+            expected_raw,
+            rtol=0,
+            atol=0,
+        )
+        assert int(result.counts[row]) == topk
+        torch.testing.assert_close(
+            result.raw_indices[row],
+            expected_raw,
+            rtol=0,
+            atol=0,
+        )
+
+
+@requires_gfx950_flydsl
+@pytest.mark.parametrize("score_batch_chunks", [1, 2])
+def test_short_rows_publish_complete_score_batches(score_batch_chunks: int) -> None:
+    from aiter.ops.flydsl import flydsl_pa_mqa_topk_fp4_prefill
+
+    case = list(_make_case(seed=109 + score_batch_chunks))
+    case[7] = torch.tensor(
+        [37, 0, 4011, 1700, 2200, 900],
+        dtype=torch.int32,
+        device=case[0].device,
+    )
+    case[8] = case[7] + torch.tensor(
+        [1, 255, 256, 257, 511, 777],
+        dtype=torch.int32,
+        device=case[0].device,
+    )
+    topk = 1024
+    full_logits = _full_logits(case, 1.25)
+    expected = _stable_reference(
+        full_logits,
+        case[4],
+        case[6],
+        case[7],
+        case[8],
+        topk,
+    )
+
+    for _ in range(3):
+        result = flydsl_pa_mqa_topk_fp4_prefill(
+            *case,
+            topk=topk,
+            weight_scale=1.25,
+            parallel_unit_num=case[0].shape[0],
+            score_batch_chunks=score_batch_chunks,
+        )
+        torch.cuda.synchronize()
+        actual = (
+            result.values,
+            result.raw_indices,
+            result.physical_indices,
+            result.counts,
+        )
+        for got, wanted in zip(actual, expected, strict=True):
+            torch.testing.assert_close(got, wanted, rtol=0, atol=0)
+
+
+@requires_gfx950_flydsl
+@pytest.mark.parametrize("topk", [512, 1024])
+def test_finalizer_orders_long_rows_and_keeps_short_rows_sequential(
+    topk: int,
+) -> None:
+    from aiter.ops.flydsl.mqa_topk_finalize import order_and_map_mqa_topk
+
+    rows = 2
+    page_size = 64
+    max_seq_len = topk + page_size
+    generator = torch.Generator().manual_seed(99 + topk)
+
+    raw_long = torch.randperm(topk, generator=generator, dtype=torch.int64)
+    values_by_raw = torch.linspace(-3.0, 3.0, topk, dtype=torch.float32)
+    values_by_raw[0] = float("nan")
+    values_by_raw[1] = -float("inf")
+    values_by_raw[2] = -0.0
+    values_by_raw[3] = +0.0
+    values_by_raw[4:12] = 1.0
+    source_values = torch.full((rows, topk), -float("inf"), dtype=torch.float32)
+    source_raw = torch.full((rows, topk), -1, dtype=torch.int32)
+    source_raw[0] = raw_long.to(torch.int32)
+    source_values[0] = values_by_raw[raw_long]
+
+    short_raw = torch.randperm(10, generator=generator) + 100
+    source_raw[1, :10] = short_raw.to(torch.int32)
+    source_values[1, :10] = torch.arange(10, dtype=torch.float32)[short_raw - 100]
+    counts = torch.tensor([topk, 10], dtype=torch.int32)
+    starts = torch.tensor([0, 100], dtype=torch.int32)
+    ends = torch.tensor([topk + 1, 110], dtype=torch.int32)
+    row_to_batch = torch.tensor([0, 1], dtype=torch.int32)
+    table_width = math.ceil(max_seq_len / page_size)
+    block_tables = (
+        torch.arange(rows * table_width, dtype=torch.int32)
+        .reshape(rows, table_width)
+        .flip(1)
+        .contiguous()
+    )
+
+    out_values = torch.empty_like(source_values, device="cuda")
+    out_raw = torch.empty_like(source_raw, device="cuda")
+    out_slots = torch.empty_like(source_raw, device="cuda")
+    order_and_map_mqa_topk(
+        source_values.cuda(),
+        source_raw.cuda(),
+        counts.cuda(),
+        starts.cuda(),
+        ends.cuda(),
+        row_to_batch.cuda(),
+        block_tables.cuda(),
+        out_values,
+        out_raw,
+        out_slots,
+        max_seq_len,
+        topk,
+        page_size,
+    )
+    torch.cuda.synchronize()
+
+    expected_long = sorted(
+        range(topk),
+        key=lambda raw: (-_ordered_i32(float(values_by_raw[raw])), raw),
+    )
+    assert out_raw[0].cpu().tolist() == expected_long
+    assert out_raw[1, :10].cpu().tolist() == list(range(100, 110))
+    assert torch.all(out_raw[1, 10:] == -1)
+    for row, count in ((0, topk), (1, 10)):
+        raw = out_raw[row, :count].cpu()
+        expected_slots = (
+            block_tables[row, raw // page_size] * page_size + raw % page_size
+        )
+        torch.testing.assert_close(
+            out_slots[row, :count].cpu(),
+            expected_slots,
+            rtol=0,
+            atol=0,
+        )
+
+
+def _make_empty_window_case(table_width: int):
+    device = torch.device("cuda")
+    rows = 2
+    max_seq_len = table_width * 64
+    starts = (
+        torch.tensor([0, 17], dtype=torch.int32, device=device)
+        if table_width
+        else torch.zeros(rows, dtype=torch.int32, device=device)
+    )
+    return (
+        torch.zeros((rows, 64, 64), dtype=torch.uint8, device=device),
+        torch.zeros((rows, 1, 4, 16, 4), dtype=torch.uint8, device=device),
+        torch.empty((0, 1, 4, 64, 16), dtype=torch.uint8, device=device),
+        torch.empty((0, 1, 4, 64), dtype=torch.uint8, device=device),
+        torch.full((1, table_width), -1, dtype=torch.int32, device=device),
+        torch.zeros((rows, 64), dtype=torch.bfloat16, device=device),
+        torch.zeros(rows, dtype=torch.int32, device=device),
+        starts,
+        starts.clone(),
+        max_seq_len,
+    )
+
+
+@requires_gfx950_flydsl
+@pytest.mark.parametrize("table_width", [0, 1])
+def test_empty_windows_never_dereference_invalid_pages(table_width: int) -> None:
+    from aiter.ops.flydsl import flydsl_pa_mqa_topk_fp4_prefill
+
+    case = _make_empty_window_case(table_width)
+    result = flydsl_pa_mqa_topk_fp4_prefill(
+        *case,
+        topk=512,
+        parallel_unit_num=case[0].shape[0],
+    )
+    torch.cuda.synchronize()
+
+    assert torch.count_nonzero(result.counts) == 0
+    assert torch.all(result.raw_indices == -1)
+    assert torch.all(result.physical_indices == -1)
+    assert torch.all(torch.isneginf(result.values))
+
+
+@requires_gfx950_flydsl
+def test_short_rows_never_dereference_padding_pages() -> None:
+    from aiter.ops.flydsl import flydsl_pa_mqa_topk_fp4_prefill
+
+    case = list(_make_case(seed=127))
+    case[4][:, 1:] = -1
+    case[7] = torch.tensor(
+        [0, 1, 7, 16, 31, 48],
+        dtype=torch.int32,
+        device=case[0].device,
+    )
+    case[8] = torch.tensor(
+        [1, 3, 15, 32, 63, 64],
+        dtype=torch.int32,
+        device=case[0].device,
+    )
+    result = flydsl_pa_mqa_topk_fp4_prefill(
+        *case,
+        topk=512,
+        parallel_unit_num=case[0].shape[0],
+        score_batch_chunks=1,
+    )
+    torch.cuda.synchronize()
+
+    for row in range(case[0].shape[0]):
+        start = int(case[7][row])
+        end = int(case[8][row])
+        count = end - start
+        expected_raw = torch.arange(
+            start,
+            end,
+            dtype=torch.int32,
+            device=case[0].device,
+        )
+        batch = int(case[6][row])
+        expected_physical = case[4][batch, 0] * KV_BLOCK_SIZE + expected_raw
+        assert int(result.counts[row]) == count
+        torch.testing.assert_close(
+            result.raw_indices[row, :count], expected_raw, rtol=0, atol=0
+        )
+        torch.testing.assert_close(
+            result.physical_indices[row, :count],
+            expected_physical,
+            rtol=0,
+            atol=0,
+        )
+        assert torch.all(result.raw_indices[row, count:] == -1)
+
+
+@requires_gfx950_flydsl
+def test_windows_are_clamped_to_sequence_capacity() -> None:
+    from aiter.ops.flydsl import flydsl_pa_mqa_topk_fp4_prefill
+
+    case = list(_make_case(seed=131))
+    max_seq_len = case[9]
+    case[7] = torch.tensor(
+        [-257, -1, 0, max_seq_len - 100, max_seq_len, max_seq_len + 1],
+        dtype=torch.int32,
+        device=case[0].device,
+    )
+    case[8] = torch.tensor(
+        [1, 63, max_seq_len + 513, max_seq_len + 1, max_seq_len + 2, max_seq_len + 3],
+        dtype=torch.int32,
+        device=case[0].device,
+    )
+    result = flydsl_pa_mqa_topk_fp4_prefill(
+        *case,
+        topk=1024,
+        parallel_unit_num=case[0].shape[0],
+        score_batch_chunks=2,
+    )
+    torch.cuda.synchronize()
+
+    for row in range(case[0].shape[0]):
+        start = max(0, min(int(case[7][row]), max_seq_len))
+        end = max(start, min(int(case[8][row]), max_seq_len))
+        count = min(end - start, 1024)
+        assert int(result.counts[row]) == count
+        if end - start <= 1024:
+            expected_raw = torch.arange(
+                start,
+                end,
+                dtype=torch.int32,
+                device=case[0].device,
+            )
+            torch.testing.assert_close(
+                result.raw_indices[row, :count], expected_raw, rtol=0, atol=0
+            )
+        if count:
+            assert torch.all(result.raw_indices[row, :count] >= start)
+            assert torch.all(result.raw_indices[row, :count] < end)
+        assert torch.all(result.raw_indices[row, count:] == -1)
+
+
+@requires_gfx950_flydsl
+def test_fused_topk_allocates_on_supplied_stream(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import importlib
+
+    module = importlib.import_module(
+        "aiter.ops.flydsl.kernels.mqa_logits.pa_mqa_logits_fp4_prefill"
+    )
+    case = _make_empty_window_case(1)
+    stream = torch.cuda.Stream(device=case[0].device)
+    original_allocate = module.allocate_fp4_prefill_topk_workspace
+    allocation_streams: list[int] = []
+
+    def checked_allocate(rows, parallel_unit_num, topk, device):
+        allocation_streams.append(torch.cuda.current_stream(device).cuda_stream)
+        return original_allocate(rows, parallel_unit_num, topk, device)
+
+    monkeypatch.setattr(
+        module,
+        "allocate_fp4_prefill_topk_workspace",
+        checked_allocate,
+    )
+    result = module.flydsl_pa_mqa_topk_fp4_prefill(
+        *case,
+        topk=512,
+        parallel_unit_num=case[0].shape[0],
+        stream=stream,
+    )
+    stream.synchronize()
+
+    assert allocation_streams == [stream.cuda_stream]
+    assert torch.count_nonzero(result.counts) == 0
+
+
+@requires_gfx950_flydsl
+def test_fused_topk_validates_stream_before_allocating(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import importlib
+
+    module = importlib.import_module(
+        "aiter.ops.flydsl.kernels.mqa_logits.pa_mqa_logits_fp4_prefill"
+    )
+    case = _make_empty_window_case(1)
+    allocated = False
+
+    def unexpected_allocate(*args, **kwargs):
+        nonlocal allocated
+        allocated = True
+        raise AssertionError("workspace allocation must follow stream validation")
+
+    class WrongDeviceStream:
+        device = torch.device("cuda", (case[0].device.index or 0) + 1)
+
+    monkeypatch.setattr(
+        module,
+        "allocate_fp4_prefill_topk_workspace",
+        unexpected_allocate,
+    )
+    with pytest.raises(ValueError, match="stream must belong"):
+        module.flydsl_pa_mqa_topk_fp4_prefill(
+            *case,
+            topk=512,
+            parallel_unit_num=case[0].shape[0],
+            stream=WrongDeviceStream(),
+        )
+    assert not allocated
+
+
+@requires_gfx950_flydsl
+def test_fused_topk_rejects_capture_before_allocating(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import importlib
+
+    module = importlib.import_module(
+        "aiter.ops.flydsl.kernels.mqa_logits.pa_mqa_logits_fp4_prefill"
+    )
+    case = _make_empty_window_case(1)
+    allocated = False
+
+    def unexpected_allocate(*args, **kwargs):
+        nonlocal allocated
+        allocated = True
+        raise AssertionError("capture rejection must precede workspace allocation")
+
+    monkeypatch.setattr(
+        module,
+        "allocate_fp4_prefill_topk_workspace",
+        unexpected_allocate,
+    )
+    monkeypatch.setattr(torch.cuda, "is_current_stream_capturing", lambda: True)
+    with pytest.raises(RuntimeError, match="does not support.*graph capture"):
+        module.flydsl_pa_mqa_topk_fp4_prefill(
+            *case,
+            topk=512,
+            parallel_unit_num=case[0].shape[0],
+        )
+    assert not allocated
+
+
+@requires_gfx950_flydsl
+def test_schedule_rejects_noncontiguous_row_offsets() -> None:
+    from aiter.ops.flydsl.kernels.mqa_logits.pa_mqa_logits_fp4_prefill import (
+        compute_prefill_schedule,
+    )
+
+    rows = 2
+    device = torch.device("cuda")
+    metadata = torch.zeros(rows, dtype=torch.int32, device=device)
+    backing = torch.empty(2 * (rows + 1), dtype=torch.int32, device=device)
+    row_offsets = backing[::2]
+    assert not row_offsets.is_contiguous()
+
+    with pytest.raises(ValueError, match="contiguous"):
+        compute_prefill_schedule(
+            metadata,
+            metadata,
+            metadata,
+            256,
+            rows,
+            64,
+            row_offsets_out=row_offsets,
+        )
+
+
+@pytest.mark.skipif(
+    importlib.util.find_spec("flydsl") is None,
+    reason="requires FlyDSL",
+)
+def test_single_cta_row_plan_property() -> None:
+    from aiter.ops.flydsl.kernels.mqa_logits.pa_mqa_logits_fp4_prefill import (
+        _row_plan_torch,
+    )
+
+    generator = torch.Generator().manual_seed(20260905)
+    rows = 1024
+    block_k = 256
+    s_max = 64
+    for _ in range(32):
+        starts = torch.randint(
+            -block_k,
+            s_max * block_k,
+            (rows,),
+            dtype=torch.int32,
+            generator=generator,
+        )
+        ends = torch.randint(
+            -block_k,
+            s_max * block_k,
+            (rows,),
+            dtype=torch.int32,
+            generator=generator,
+        )
+        plan = _row_plan_torch(
+            starts,
+            ends,
+            block_k,
+            rows,
+            s_max,
+            s_max * block_k,
+            single_cta_per_row=True,
+        )
+
+        window_starts = torch.clamp(starts, min=0, max=s_max * block_k)
+        window_ends = torch.maximum(
+            torch.clamp(ends, min=0, max=s_max * block_k),
+            window_starts,
+        )
+        first_chunks = window_starts // block_k
+        end_chunks = (window_ends + block_k - 1) // block_k
+        chunks = torch.where(
+            window_ends > window_starts,
+            torch.clamp(end_chunks - first_chunks, min=0),
+            0,
+        )
+        expected_ctas = (chunks > 0).to(torch.int32)
+        actual_ctas = plan.incl - plan.excl
+
+        torch.testing.assert_close(actual_ctas, expected_ctas, rtol=0, atol=0)
+        assert int(plan.safe) == max(int(chunks.max()), 1)
+        assert int(plan.total_splits) == int(expected_ctas.sum())
+
+
+@pytest.mark.skipif(
+    importlib.util.find_spec("flydsl") is None,
+    reason="requires FlyDSL",
+)
+def test_score_batch_lds_budget() -> None:
+    from aiter.ops.flydsl.kernels.mqa_logits.pa_mqa_logits_fp4_prefill import (
+        DEFAULT_SCORE_BATCH_CHUNKS,
+        SUPPORTED_SCORE_BATCH_CHUNKS,
+        _streaming_topk_lds_bytes,
+    )
+
+    assert DEFAULT_SCORE_BATCH_CHUNKS == 20
+    assert SUPPORTED_SCORE_BATCH_CHUNKS == (1, 2, 4, 8, 16, 20, 24)
+    assert _streaming_topk_lds_bytes(512, 16) == 37_936
+    assert _streaming_topk_lds_bytes(1024, 16) == 42_032
+    assert _streaming_topk_lds_bytes(1024, 24) == 58_416
+    assert _streaming_topk_lds_bytes(1024, 16) < 64 * 1024
+
+
+@pytest.mark.skipif(
+    importlib.util.find_spec("flydsl") is None,
+    reason="requires FlyDSL",
+)
+def test_legacy_compile_cache_does_not_evict_live_modules() -> None:
+    from aiter.ops.flydsl.kernels.mqa_logits.pa_mqa_logits_fp4_prefill import (
+        compile_pa_mqa_logits_fp4_prefill,
+    )
+
+    assert compile_pa_mqa_logits_fp4_prefill.cache_info().maxsize is None
+
+
+@requires_gfx950_flydsl
+@pytest.mark.parametrize("topk", [512, 1024])
+def test_single_cta_copy_uses_offsets_and_counts(topk: int) -> None:
+    from aiter.ops.flydsl.kernels.mqa_logits.pa_mqa_logits_fp4_prefill import (
+        _copy_single_cta_topk_candidates,
+    )
+
+    rows = 5
+    row_offsets = torch.tensor(
+        [0, 1, 1, 2, 3, 3],
+        dtype=torch.int32,
+        device="cuda",
+    )
+    counts = torch.tensor([topk, 7, 0], dtype=torch.int32, device="cuda")
+    values = torch.arange(3 * topk, dtype=torch.float32, device="cuda").reshape(
+        3,
+        topk,
+    )
+    indices = torch.arange(3 * topk, dtype=torch.int32, device="cuda").reshape(
+        3,
+        topk,
+    )
+    out_values = torch.empty(rows, topk, dtype=torch.float32, device="cuda")
+    out_indices = torch.empty(rows, topk, dtype=torch.int32, device="cuda")
+    out_counts = torch.empty(rows, dtype=torch.int32, device="cuda")
+
+    _copy_single_cta_topk_candidates(
+        values,
+        indices,
+        counts,
+        row_offsets,
+        out_values,
+        out_indices,
+        out_counts,
+    )
+    torch.cuda.synchronize()
+
+    torch.testing.assert_close(
+        out_counts.cpu(),
+        torch.tensor([topk, 0, 7, 0, 0], dtype=torch.int32),
+        rtol=0,
+        atol=0,
+    )
+    torch.testing.assert_close(out_values[0], values[0], rtol=0, atol=0)
+    torch.testing.assert_close(out_indices[0], indices[0], rtol=0, atol=0)
+    torch.testing.assert_close(out_values[2, :7], values[1, :7], rtol=0, atol=0)
+    torch.testing.assert_close(out_indices[2, :7], indices[1, :7], rtol=0, atol=0)
+    invalid_rows = torch.tensor([1, 3, 4], device="cuda")
+    assert torch.all(torch.isneginf(out_values[invalid_rows]))
+    assert torch.all(out_indices[invalid_rows] == -1)
+    assert torch.all(torch.isneginf(out_values[2, 7:]))
+    assert torch.all(out_indices[2, 7:] == -1)


### PR DESCRIPTION
## Motivation

The DeepSeek-V4 FP4 indexer currently materializes an FP32 `[query_rows, c4_context]` score matrix before TopK. At 768K full-token context this is about 0.75 MiB per query row; a 1024-row local prefill is about 768 MiB per C4 layer invocation. SGLang currently avoids allocator fragmentation with a persistent 2 GiB slab ([sgl-project/sglang#37660](https://github.com/sgl-project/sglang/pull/37660)), but that reserves context-sized storage instead of removing the intermediate.

This draft adds an AITER operator that computes exact TopK without materializing the full logits matrix.

## Changes

- Add `flydsl_pa_mqa_topk_fp4_prefill` for gfx950 FP4 paged MQA.
- Fuse score production with CTA-local exact TopK:
  - scores stream through a bounded LDS pool;
  - four-byte score radix plus four-byte logical-index radix implements total order `(score descending, logical index ascending)`;
  - NaNs sort below numeric values and `+0 > -0` is preserved;
  - each CTA emits only `(candidate_value, raw_index, valid_count)`.
- Merge split candidates exactly, then map raw C4 positions through the page table.
- Preserve the existing short-row contract: when `length <= topk`, return every logical position sequentially and pad with `-1`.
- Add a bounded context-tiled implementation as a correctness/reference fallback.
- Keep the existing full-logits API source-compatible.

For the common SGLang prefill shape `rows=1024, parallel_unit_num=1024, topk=1024`, internal candidate + merge scratch is about 20 MiB, independent of context length, versus roughly 768 MiB of logits at 768K context. No device-global context-sized allocation is introduced.

## Scope

Initial production specialization:

- gfx950 / wave64
- H=64, D=128
- FP4 E2M1 payload with shuffled UE8M0 scales
- KV page size 64, score block 256
- TopK 512 or 1024
- ragged prefill windows

Graph capture is rejected explicitly in this first version; SGLang will retain its existing graph path as fallback. A dependent SGLang draft will capability-probe this API and keep old AITER compatibility. [sgl-project/sglang#38086](https://github.com/sgl-project/sglang/pull/38086) remains an independent workspace-based alternative.

## Validation

Completed:

- Black / Ruff / Python syntax checks
- CPU reference/property tests for exact candidate union and special-value ordering
- offline gfx950 FlyDSL compilation for TopK 512/1024 and the legacy scorer
- safety review for empty windows, nonzero starts, speculative page lookahead, stream affinity, and launcher lifetime

Queued on MI355X:

- runtime fused vs full-logits correctness for TopK 512/1024
- shuffled page tables, empty/short/ragged windows, and non-current streams
- fused/tiled/full-logits latency and peak-memory benchmarks
- dependent SGLang adapter tests

This stays draft until those GPU and end-to-end long-context results are attached.