### PR TITLE
[Perf][gfx1250] Emit ubench summaries as JSON

### DIFF
--- a/aiter/test_common.py
+++ b/aiter/test_common.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: MIT
 # Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
 import copy
+import json
 import multiprocessing as mp
 import os
 
@@ -19,6 +20,30 @@ _SMI_LABEL_COUNTS = {}
 # pd.set_option("display.width", None)
 # pd.set_option("display.max_colwidth", None)
 # pd.set_option("display.expand_frame_repr", False)
+
+
+def print_json_table(name, rows, keep=None):
+    """Print benchmark rows as one record-oriented JSON object.
+
+    A single-line object is intentional: parent benchmark drivers can validate
+    and forward it without parsing pandas' human-readable table formats.
+    """
+    if isinstance(rows, pd.DataFrame):
+        df = rows.copy()
+    else:
+        df = pd.DataFrame([row for row in rows if row is not None])
+    if not df.empty:
+        df = df.replace("", pd.NA).dropna(axis=1, how="all")
+        if keep is not None:
+            cols = [column for column in keep if column in df.columns]
+            cols += [
+                column
+                for column in df.columns
+                if "err_msg" in column and column not in cols
+            ]
+            df = df[cols]
+    records = json.loads(df.to_json(orient="records"))
+    print(json.dumps({"name": name, "rows": records}), flush=True)
 
 
 def ensure_spawn_method():

--- a/op_tests/bench_gfx1250_combo.py
+++ b/op_tests/bench_gfx1250_combo.py
@@ -84,6 +84,8 @@ Other variables:
 Optional GPU telemetry replays each already-prepared benchmark case in its own
 sampling window, after its normal latency measurement:
 
+    # ROCm ships the binding here without a setup.py; make it importable first.
+    export PYTHONPATH=/opt/rocm/share/amd_smi${PYTHONPATH:+:$PYTHONPATH}
     python op_tests/bench_gfx1250_combo.py --dsv4 \
       --smi-monitor --smi-device 0 --smi-interval 0.05 --smi-duration 1.0
 

--- a/op_tests/bench_gfx1250_combo.py
+++ b/op_tests/bench_gfx1250_combo.py
@@ -6,10 +6,11 @@ Imports the top-level @benchmark sweep fns from the aiter op_tests (which the
 aiter-op-test skill keeps importable for exactly this kind of combination
 testing) and runs each over its own shape axes.
 
-Output discipline: combo-owned pandas summaries are printed as record-oriented
-JSON. Existing child-UT summaries are extracted without changing those UTs. All
-the underlying noise (per-config "calling ..." logs, JIT build output, aiter
-import banners, pandas/torch/ROCTracer warnings, including C-level fd writes) is
+Output discipline: combo-owned summaries and AITER child-UT summaries are
+printed as record-oriented JSON. Child JSON is validated and forwarded without
+parsing human-readable tables. MORI EP keeps its external tool output. All the
+underlying noise (per-config "calling ..." logs, JIT build output, aiter import
+banners, pandas/torch/ROCTracer warnings, including C-level fd writes) is
 silenced via os-level fd redirection while the kernels run.
 
 Run from the aiter repo root so `op_tests/` siblings import cleanly:
@@ -301,7 +302,6 @@ def _silence():
 
 # Import aiter + the op-test modules quietly (import-time banners suppressed).
 with _silence():
-    import pandas as pd
     import test_f4gemm as gemm_mod
     import test_flydsl_grouped_gemm_gfx1250 as moe_mod
     import test_fmha_fwd_with_sink_asm as mha_mod  # has __main__ guard
@@ -318,6 +318,7 @@ with _silence():
         DATA_DISTS,
         E8M0_SCALE_DISTS,
         make_generator,
+        print_json_table,
         run_perftest,
     )
 
@@ -717,19 +718,7 @@ def _collect_smi_rows(lines):
 
 def _print_table(name, rows, keep=None):
     """Print one named DataFrame as a JSON object with record-oriented rows."""
-    df = pd.DataFrame([r for r in rows if r is not None])
-    if not df.empty:
-        # Drop columns that are entirely empty, then whitelist/order via `keep`.
-        # The @benchmark decorator dumps every call arg as a column, which makes
-        # the tables wide; `keep` trims to shape ids + perf. ALWAYS surface any
-        # err_msg / *err column so failures never get silently hidden.
-        df = df.replace("", pd.NA).dropna(axis=1, how="all")
-        if keep is not None:
-            cols = [c for c in keep if c in df.columns]
-            cols += [c for c in df.columns if "err_msg" in c and c not in cols]
-            df = df[cols]
-    records = json.loads(df.to_json(orient="records"))
-    print(json.dumps({"name": name, "rows": records}, indent=2), flush=True)
+    print_json_table(name, rows, keep=keep)
 
 
 # Compiler / logger / IR-dump chatter the child UTs interleave with results.
@@ -749,47 +738,31 @@ _NOISE = (
 )
 
 
-def _md_row(line):
-    """Markdown table row emitted by a child UT."""
-    return line.startswith("|")
-
-
 def _quiet(line):
     """Any non-empty line that is not compiler/logger noise."""
     return bool(line.strip()) and not any(n in line for n in _NOISE)
 
 
+def _json_tables(lines):
+    """Validated one-line JSON tables emitted by child UTs."""
+    tables = []
+    for line in lines:
+        try:
+            table = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if (
+            isinstance(table, dict)
+            and isinstance(table.get("name"), str)
+            and isinstance(table.get("rows"), list)
+        ):
+            tables.append(json.dumps(table))
+    return tables
+
+
 def _lines(pred):
     """Adapt a per-line predicate into a block extractor."""
     return lambda lines: [ln for ln in lines if pred(ln)]
-
-
-def _md_tables(*labels):
-    """Keep the markdown tables, labelling each by the columns it carries.
-
-    A child UT often emits several tables in a row with different columns and
-    nothing saying which is which. `labels` is ((column, ...), title) pairs; the
-    first entry whose columns all appear in a header row names that table.
-    """
-
-    def extract(lines):
-        md = [ln for ln in lines if _md_row(ln)]
-        out = []
-        for i, line in enumerate(md):
-            is_header = i + 1 < len(md) and set(md[i + 1]) <= set("|-: ")
-            if is_header:
-                title = next(
-                    (t for cols, t in labels if all(c in line for c in cols)),
-                    None,
-                )
-                if title:
-                    out.append(f"\n----- {title} -----")
-                elif out:
-                    out.append("")
-            out.append(line)
-        return out
-
-    return extract
 
 
 def _isnum(field):
@@ -799,125 +772,6 @@ def _isnum(field):
     except ValueError:
         return False
     return True
-
-
-def _md_kernel_table(lines):
-    """Render a rank-major kernel table as markdown, keeping the summary lines.
-
-    mega_moe prints '[cfg] ...' / '# MEGA-MOE ...' lines around a space-aligned
-    'Name rank0 rank1 rank2 rank3 avg calls' table. Kernel names contain spaces
-    ("void at::native::reduce_kernel<512, 1, ...>"), so split from the right:
-    the column count is fixed even when the name is not.
-    """
-    out, rows, cols = [], [], None
-    seen = set()
-
-    def flush():
-        if cols and rows:
-            out.append(pd.DataFrame(rows, columns=cols).to_markdown(index=False))
-            rows.clear()
-
-    for line in lines:
-        if not _quiet(line):
-            continue
-        if line.startswith("Name") and "rank0" in line:
-            flush()
-            cols = line.rsplit(maxsplit=6)
-            continue
-        fields = line.rsplit(maxsplit=6)
-        if cols and len(fields) == 7 and all(_isnum(f) for f in fields[1:]):
-            rows.append(fields)
-            continue
-        flush()
-        # Non-table lines are kept for the "[cfg] ..." summary, but the child
-        # also emits "no grouped CSV config matched (...)" once per layer per
-        # rank -- hundreds of byte-identical lines around one table. Keep the
-        # first of each; a repeat carries nothing the first did not.
-        if line in seen:
-            continue
-        seen.add(line)
-        out.append(line)
-    flush()
-    return "\n".join(out).splitlines()
-
-
-def _md_from_pandas(marker, columns):
-    """Re-emit a pandas-printed block as markdown.
-
-    Some UTs print their result with DataFrame.__str__ (space aligned, leading
-    index column) right after a marker line, which reads nothing like the
-    markdown every other op produces.
-    """
-
-    def extract(lines):
-        for i, line in enumerate(lines):
-            if line.strip() != marker or i + 2 >= len(lines):
-                continue
-            values = lines[i + 2].split()[1 : len(columns) + 1]
-            if len(values) != len(columns):
-                continue
-            df = pd.DataFrame([values], columns=list(columns))
-            return df.to_markdown(index=False).splitlines()
-        return []
-
-    return extract
-
-
-def _space_table(header_col):
-    """Keep a UT's own aligned summary table, verbatim.
-
-    Anchors on the header row carrying `header_col` and takes the data rows that
-    follow, so the table survives the trace fragments and compiler warnings
-    interleaved before it.
-
-    Emitted as the UT formatted it rather than rebuilt as markdown: pandas
-    writes multi-word column names ("opus us", "asm TFLOPS"), so the header
-    splits into 33 words against 21 data fields and cannot be mapped back to
-    columns. A column name also appears in a UT's argument echo
-    ("total_tokens = 1024,"), so require the next line to look like data.
-
-    "Looks like data" counts numeric fields rather than testing the first one:
-    the sparse-prefill table leads with prec/mode (bf16, dense), so a
-    first-field test drops the whole table. An argument echo carries one
-    number, a data row carries most of a row of them.
-    """
-
-    def is_data(fields):
-        return sum(1 for f in fields if _isnum(f)) >= 4
-
-    def extract(lines):
-        for i, line in enumerate(lines):
-            if header_col not in line.split() or i + 1 >= len(lines):
-                continue
-            first = lines[i + 1].split()
-            if not first or not is_data(first):
-                continue
-            width = len(first)
-            out = [line]
-            for follower in lines[i + 1 :]:
-                fields = follower.split()
-                if len(fields) != width or not is_data(fields):
-                    break
-                out.append(follower)
-            return out
-        return []
-
-    return extract
-
-
-def _table_row(*headers):
-    """Whitespace-aligned table: the header line plus its numeric rows."""
-
-    def keep(line):
-        if not _quiet(line):
-            return False
-        if any(h in line for h in headers):
-            return True
-        # A data row starts with a bare number; "100% |####|" (pip) does not.
-        head = line.split(maxsplit=1)[0]
-        return head.strip("-").replace(",", "").replace(".", "").isdigit()
-
-    return keep
 
 
 def _gpu_trace_rows(lines):
@@ -961,21 +815,11 @@ def _kernel_digest(lines):
     for name, n, us in _gpu_trace_rows(lines):
         total[name] = total.get(name, 0.0) + us
         calls[name] = calls.get(name, 0.0) + n
-    if not total:
-        return []
     ranked = sorted(total, key=total.get, reverse=True)
-    table = pd.DataFrame(
-        [
-            {"kernel": k, "calls": round(calls[k]), "device us": round(total[k], 1)}
-            for k in ranked
-        ]
-    )
-    return ["", "----- kernels on GPU -----"] + table.to_markdown(
-        index=False
-    ).splitlines()
-
-
-_DEFAULT_EXTRACT = _md_tables()
+    return [
+        {"kernel": k, "calls": round(calls[k]), "device_us": round(total[k], 1)}
+        for k in ranked
+    ]
 
 
 _FAILURES = []
@@ -1032,7 +876,7 @@ def _pin_arch(env):
 
 
 def _run_child(name, cmd, cwd, env=None, extract=None, timeout=None, tail=30,
-               kernels=True, smi=True):
+               kernels=True, smi=True, structured=False):
     """Run a child UT with its output captured and surface only its results.
 
     Child UTs print their own progress, aiter INFO lines and (with FlyDSL) a
@@ -1040,7 +884,7 @@ def _run_child(name, cmd, cwd, env=None, extract=None, timeout=None, tail=30,
     it, echo what `extract` pulls out, and fall back to the tail of the output
     when the child fails or emits nothing recognisable.
     """
-    extract = extract or _DEFAULT_EXTRACT
+    extract = extract or _json_tables
     # Give every child invocation its combo-owned SMI case label. UTs remain
     # unaware of telemetry; the common perftest hook reads this environment.
     if smi and os.environ.get("AITER_SMI_MONITOR") == "1":
@@ -1060,6 +904,13 @@ def _run_child(name, cmd, cwd, env=None, extract=None, timeout=None, tail=30,
         )
     except subprocess.TimeoutExpired as exc:
         captured = exc.output or ""
+        if structured:
+            _print_table(name, [{
+                "err_msg": f"timed out after {timeout}s",
+                "output_tail": "\n".join(captured.splitlines()[-tail:]),
+            }])
+            _note_failure(name, f"timed out after {timeout}s")
+            return
         print(f"\n===== {name} =====", flush=True)
         print(f"--- timed out after {timeout}s, last {tail} lines ---")
         print("\n".join(captured.splitlines()[-tail:]), flush=True)
@@ -1071,7 +922,28 @@ def _run_child(name, cmd, cwd, env=None, extract=None, timeout=None, tail=30,
     # an annotation and must not stand in for a result table, or an extractor
     # that stops matching turns into a silent hole instead of a failure.
     results = extract(lines)
-    rows = list(results) + (_kernel_digest(lines) if kernels else [])
+    kernel_rows = _kernel_digest(lines) if kernels else []
+    if structured:
+        print("\n".join(results), flush=True)
+        if kernel_rows:
+            _print_table(f"{name} kernels", kernel_rows)
+        if proc.returncode != 0 or not results:
+            reason = (
+                f"child exited {proc.returncode}"
+                if proc.returncode != 0
+                else "no JSON result tables recognised"
+            )
+            _print_table(name, [{
+                "exit_code": proc.returncode,
+                "err_msg": reason,
+                "output_tail": "\n".join(lines[-tail:]),
+            }])
+        if proc.returncode != 0:
+            _note_failure(name, f"child exited {proc.returncode}")
+        elif not results:
+            _note_failure(name, "no JSON result tables recognised")
+        return
+    rows = list(results)
     print(f"\n===== {name} =====", flush=True)
     print("\n".join(rows) if rows else "(no result rows recognised)", flush=True)
     if proc.returncode != 0 or not results:
@@ -1294,6 +1166,8 @@ def run_a8w8_blockscale(args):
             ],
             cwd=os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
             env=env,
+            extract=_json_tables,
+            structured=True,
         )
 
     init_pairs = _init_pairs(
@@ -1471,8 +1345,9 @@ def run_mega_moe(args):
             ],
             cwd=os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
             env={**env, "AITER_FORCE_A8W4": force_a8w4},
-            extract=_md_kernel_table,
+            extract=_json_tables,
             kernels=False,
+            structured=True,
         )
 
 
@@ -1496,11 +1371,8 @@ def run_mhc(args):
                 str(args.seed),
             ],
             cwd=os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
-            extract=_md_tables(
-                (("hip_nofuse_us",), "mhc: fused vs unfused RMSNorm"),
-                (("unfused_us",), "mhc_post_pre"),
-                (("hip_us",), "mhc_head"),
-            ),
+            extract=_json_tables,
+            structured=True,
         )
 
     data_inits = args.data_init or ["norm"]
@@ -1548,10 +1420,8 @@ def run_qk_norm(args):
                 str(args.seed),
             ],
             cwd=repo_root,
-            extract=_md_tables(
-                (("quant_group_size",), "rope + quant"),
-                (("rows_written",), "fused SWA write"),
-            ),
+            extract=_json_tables,
+            structured=True,
         )
 
     if args.smi_monitor:
@@ -1599,10 +1469,8 @@ def run_score_qk(args):
                 str(args.seed),
             ],
             cwd=repo_root,
-            extract=_md_from_pandas(
-                "paged_mqa_logits:",
-                ("batch", "next_n", "heads", "index_dim", "avg_kv_len", "TFLOPS"),
-            ),
+            extract=_json_tables,
+            structured=True,
         )
 
 
@@ -1839,7 +1707,9 @@ def run_mla_v4_decode(args):
         rows,
         keep=_MLA_V4_COMPARE_KEEP,
     )
-    print("\n".join(_kernel_digest(box[0].splitlines())), flush=True)
+    kernel_rows = _kernel_digest(box[0].splitlines())
+    if kernel_rows:
+        _print_table("mla_v4 decode kernels", kernel_rows)
 
 
 def run_inverse_rope(args):
@@ -1868,6 +1738,8 @@ def run_inverse_rope(args):
                 str(args.seed),
             ],
             cwd=os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+            extract=_json_tables,
+            structured=True,
         )
 
     data_inits = args.data_init or ["norm"]
@@ -1924,11 +1796,8 @@ def run_mla_v4_prefill(args):
                 *init_values,
             ],
             cwd=os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
-            # Not _table_row: the UT has no "latency_us" column (it prints
-            # "opus us"/"asm us"), so that predicate fell through to its
-            # starts-with-a-number rule, swallowed the profiler's kernel lines
-            # as data, and dropped the real header, which starts with "n".
-            extract=_space_table("total_pages"),
+            extract=_json_tables,
+            structured=True,
         )
 
     if args.smi_monitor:

--- a/op_tests/multigpu_tests/test_mega_moe_gfx1250.py
+++ b/op_tests/multigpu_tests/test_mega_moe_gfx1250.py
@@ -57,7 +57,7 @@ from aiter import (
 from aiter.fused_moe import fused_moe
 from aiter.ops.flydsl.moe_common import GateMode
 from aiter.ops.shuffle import moe_shuffle_scale, shuffle_weight
-from aiter.test_common import add_data_init_args, fill, make_generator
+from aiter.test_common import add_data_init_args, fill, make_generator, print_json_table
 from aiter.utility import fp4_utils
 
 try:
@@ -861,7 +861,7 @@ def _run_distributed_smi_replay(pipe, dist_ctx, median_us, n_layers):
 def _aggregate_prof_table(prof, dist_ctx, per_layer_denom=1.0, row_limit=200):
     """Collect the torch.profiler per-kernel table ACROSS ranks (collective; call
     on every rank). Each rank contributes {name: (self_device_us_total, count)};
-    rank 0 returns a table of each kernel's per-call self device time with ONE
+    rank 0 returns rows with each kernel's per-call self device time with ONE
     COLUMN PER RANK plus the cross-rank mean, so a straggler (a throttled GPU, an
     unbalanced expert distribution) shows up as a row that disagrees across
     columns instead of being averaged away. `-` means the kernel never ran there.
@@ -895,31 +895,24 @@ def _aggregate_prof_table(prof, dist_ctx, per_layer_denom=1.0, row_limit=200):
         rows.append((avg_self, name, per_call, pc_avg, avg_count))
     rows.sort(key=lambda r: (-r[0], r[1]))
     dev_per_layer = total_self / per_layer_denom if per_layer_denom else 0.0
-    # Wide enough for a full TDM GEMM name, whose tile/warp/buffer recipe and its
-    # `_epscatter` / `_prefetch` suffix are the whole point of reading this table
-    # (e.g. a8w4_tdm_fp4_t256x256x256_w2x2_b3_K3072_e96_cn4_prefetch_epscatter).
-    name_w = 72
-    lines = [
-        (
-            f"# per-call self device time (us) by rank, {world} ranks "
-            f"(rows sorted by total self time):"
-        ),
-        f"{'Name':<{name_w}}"
-        + "".join(f"{f'rank{r}':>11}" for r in range(world))
-        + f"{'avg':>11}{'calls':>8}",
-    ]
-    for avg_self, name, per_call, pc_avg, avg_count in rows[:row_limit]:
-        cells = "".join(
-            f"{v:>11.3f}" if v is not None else f"{'-':>11}" for v in per_call
-        )
-        lines.append(
-            f"{name[:name_w]:<{name_w}}{cells}{pc_avg:>11.3f}{avg_count:>8.1f}"
-        )
-    lines.append(
-        f"# TOTAL self device time over ALL {len(rows)} kernels = {total_self:.1f} us "
-        f"-> {dev_per_layer:.1f} us/layer (device-busy; compare to per_layer wall)"
-    )
-    return "\n".join(lines)
+    table_rows = []
+    for _avg_self, name, per_call, pc_avg, avg_count in rows[:row_limit]:
+        row = {
+            "kernel": name,
+            "avg_us": pc_avg,
+            "calls": avg_count,
+        }
+        row.update({f"rank{rank}_us": value for rank, value in enumerate(per_call)})
+        table_rows.append(row)
+    return {
+        "rows": table_rows,
+        "summary": [{
+            "world_size": world,
+            "profiled_kernels": len(rows),
+            "total_self_device_us": total_self,
+            "device_us_per_layer": dev_per_layer,
+        }],
+    }
 
 
 def _device_shared_ffn(tokens, sw1, sw2):
@@ -1056,22 +1049,33 @@ def main():
                 if dist_ctx.rank == 0:
                     print(f"# trace export failed: {_e}", flush=True)
     if dist_ctx.rank == 0:
-        prof_note = (
-            f"prof_device={prof_us:.1f}us"
-            if prof_us > 0
-            else "prof_device=n/a (this ROCm torch.profiler emits no device time)"
-        )
-        print(
-            f"# MEGA-MOE layers={n_layers} tokens/rank={ct}: "
-            f"median={stats['median']:.1f} us per_layer={per_layer_us:.1f} us "
-            f"(min={stats['min']:.1f} mean={stats['mean']:.1f} max={stats['max']:.1f} us "
-            f"over {args.iters} timed replays after {args.warmup} warmup, avg over "
-            f"{dist_ctx.world} ranks; dispatch+gemm+combine, 1 replay = {n_layers} layers) "
-            f"{prof_note}",
-            flush=True,
+        print_json_table(
+            "mega_moe summary",
+            [{
+                "quant_type": args.quant_type,
+                "combine": args.combine,
+                "data_init": data_dist,
+                "seed": args.seed,
+                "world_size": dist_ctx.world,
+                "tokens_per_rank": ct,
+                "experts": E,
+                "topk": topk,
+                "hidden": hdim,
+                "intermediate": idim,
+                "layers": n_layers,
+                "warmup": args.warmup,
+                "iters": args.iters,
+                "min_us": stats["min"],
+                "mean_us": stats["mean"],
+                "median_us": stats["median"],
+                "max_us": stats["max"],
+                "per_layer_us": per_layer_us,
+                "prof_device_us": prof_us if prof_us > 0 else None,
+            }],
         )
         if tbl is not None:
-            print(tbl, flush=True)
+            print_json_table("mega_moe kernel profile", tbl["rows"])
+            print_json_table("mega_moe kernel profile summary", tbl["summary"])
 
     # ---- accuracy (isolated CPU/fp32 reference): end-to-end accumulated compare.
     accuracy_failure = None

--- a/op_tests/op_benchmarks/triton/bench_deepgemm_attention.py
+++ b/op_tests/op_benchmarks/triton/bench_deepgemm_attention.py
@@ -15,7 +15,13 @@ from aiter.ops.triton.attention.pa_mqa_logits import (
 )
 from aiter.ops.triton.utils._triton import arch_info
 from aiter.ops.triton.utils.types import get_fp8_e4m3_dtype
-from aiter.test_common import DATA_DISTS, fill, make_generator, run_perftest
+from aiter.test_common import (
+    DATA_DISTS,
+    fill,
+    make_generator,
+    print_json_table,
+    run_perftest,
+)
 
 
 def cdiv(x: int, y: int) -> int:
@@ -192,6 +198,7 @@ def create_paged_mqa_logits_configs(args: argparse.Namespace):
 def run_benchmark(args: argparse.Namespace, data_init: str = "norm"):
     ChunkK = 128
     WavePerEU = 5
+    rows = []
 
     @triton.testing.perf_report(create_paged_mqa_logits_configs(args))
     def test_deepgemm_fp8_paged_mqa_logits(
@@ -418,9 +425,26 @@ def run_benchmark(args: argparse.Namespace, data_init: str = "norm"):
 
             os.system("zip -r paged_mqa_logits_aot_kernel paged_mqa_logits")
 
+        rows.append(
+            {
+                "data_init": data_init,
+                "seed": args.seed,
+                "batch": batch_size,
+                "next_n": next_n,
+                "heads": heads,
+                "index_dim": index_dim,
+                "avg_kv_len": avg_kv_length,
+                "kv_storage": kv_storage_kind,
+                "blocksize": blocksize,
+                "latency_us": elapsed_us,
+                "TFLOPS": flops,
+                "logits_diff": float(logits_diff),
+            }
+        )
         return flops
 
-    test_deepgemm_fp8_paged_mqa_logits.run(print_data=True)
+    test_deepgemm_fp8_paged_mqa_logits.run(print_data=False)
+    print_json_table("paged_mqa_logits summary", rows)
 
 
 if __name__ == "__main__":

--- a/op_tests/smi_monitor.py
+++ b/op_tests/smi_monitor.py
@@ -3,6 +3,10 @@
 # ruff: noqa: BLE001, PYI034, S110, UP035, UP037
 """AMD GPU metrics monitor using amdsmi.
 
+ROCm ships the binding without a setup.py. Make it importable with::
+
+    export PYTHONPATH=/opt/rocm/share/amd_smi${PYTHONPATH:+:$PYTHONPATH}
+
 Usage (context manager):
     with GpuMonitor(device_index=0, interval_s=0.05) as mon:
         run_workload()

--- a/op_tests/test_flydsl_qk_norm_rope_quant.py
+++ b/op_tests/test_flydsl_qk_norm_rope_quant.py
@@ -26,14 +26,13 @@ import argparse
 import itertools
 import math
 
-import pandas as pd
 import torch
 
 import aiter
 from aiter import dtypes
 from aiter.jit.utils.chip_info import get_gfx
 from aiter.ops.flydsl import flydsl_qk_norm_rope_quant
-from aiter.test_common import benchmark, checkAllclose, run_perftest
+from aiter.test_common import benchmark, checkAllclose, print_json_table, run_perftest
 
 torch.set_default_device("cuda")
 
@@ -846,10 +845,7 @@ def main():
                 **init_kw,
             )
         )
-    aiter.logger.info(
-        "flydsl_qk_norm_rope_quant summary (markdown):\n%s",
-        pd.DataFrame(rows).to_markdown(index=False),
-    )
+    print_json_table("flydsl_qk_norm_rope_quant summary", rows)
 
     # Separate arg signature -> its own table (merging would scatter NaNs).
     # The scatter is decode-only and bf16-only; keep T in the decode range.
@@ -864,10 +860,7 @@ def main():
         [t for t in args.T if 8 <= t <= 96] or [16, 64],
     ):
         swa_rows.append(test_flydsl_swa_write(T, H, D, args.RD, mode, **init_kw))
-    aiter.logger.info(
-        "flydsl_qk_norm_rope_quant fused SWA write summary (markdown):\n%s",
-        pd.DataFrame(swa_rows).to_markdown(index=False),
-    )
+    print_json_table("flydsl_qk_norm_rope_quant fused SWA write summary", swa_rows)
 
 
 if __name__ == "__main__":

--- a/op_tests/test_gemm_a8w8_blockscale.py
+++ b/op_tests/test_gemm_a8w8_blockscale.py
@@ -19,7 +19,7 @@ from aiter import dtypes
 from aiter import test_common as bench_init
 from aiter.ops.gemm_op_a8w8 import gemm_a8w8_blockscale_ck, gemm_a8w8_blockscale_cktile
 from aiter.ops.shuffle import shuffle_weight
-from aiter.test_common import benchmark, checkAllclose, perftest
+from aiter.test_common import benchmark, checkAllclose, perftest, print_json_table
 from aiter.utility import fp4_utils
 
 block_shape = (128, 128)
@@ -455,22 +455,7 @@ else:
                         )
                         df.append(ret)
 
-df = pd.DataFrame(df)
-
-# Configure pandas to show all columns without truncation
-pd.set_option("display.max_columns", None)
-pd.set_option("display.width", None)
-pd.set_option("display.max_colwidth", None)
-pd.set_option("display.expand_frame_repr", False)
-
-print("\n" + "=" * 150)
-print("COMPLETE PERFORMANCE SUMMARY (All Columns)")
-print("=" * 150)
-print(df.to_string(index=False))
-print("=" * 150)
-
-df_md = df.to_markdown(index=False)
-aiter.logger.info("gemm_a8w8_blockscale summary (markdown):\n%s", df_md)
+print_json_table("gemm_a8w8_blockscale summary", df)
 
 # Correctness check: verify split-K produces matching results
 print("\nRunning split-K correctness checks ...")

--- a/op_tests/test_inverse_rope_group_quant.py
+++ b/op_tests/test_inverse_rope_group_quant.py
@@ -16,7 +16,6 @@ import os
 import sys
 from collections import namedtuple
 
-import pandas as pd
 import torch
 
 import aiter
@@ -37,6 +36,7 @@ from aiter.test_common import (
     checkAllclose,
     fill,
     make_generator,
+    print_json_table,
     run_perftest,
 )
 
@@ -850,11 +850,7 @@ def main():
                     data_init=data_init,
                     seed=args.seed,
                 )
-        df = pd.DataFrame(df)
-        aiter.logger.info(
-            "inverse_rope_group_quant summary (markdown):\n%s",
-            df.to_markdown(index=False),
-        )
+        print_json_table("inverse_rope_group_quant summary", df)
         if args.graph:
             aiter.logger.info("all graph capture/replay checks passed")
 

--- a/op_tests/test_mhc.py
+++ b/op_tests/test_mhc.py
@@ -4,7 +4,6 @@
 
 import argparse
 
-import pandas as pd
 import torch
 
 import aiter
@@ -16,6 +15,7 @@ from aiter.test_common import (
     checkAllclose,
     fill,
     make_generator,
+    print_json_table,
     run_perftest,
 )
 
@@ -1108,9 +1108,7 @@ for dtype in args.dtype:
                         seed=args.seed,
                     )
                     df.append(ret)
-df = pd.DataFrame(df)
-df_md = df.to_markdown(index=False)
-aiter.logger.info("mhc_pre summary (markdown):\n%s", df_md)
+print_json_table("mhc_pre summary", df)
 
 if not args.hc_head:
     df = []
@@ -1128,9 +1126,7 @@ if not args.hc_head:
                             seed=args.seed,
                         )
                         df.append(ret)
-    df = pd.DataFrame(df)
-    df_md = df.to_markdown(index=False)
-    aiter.logger.info("mhc_post summary (markdown):\n%s", df_md)
+    print_json_table("mhc_post summary", df)
 
     df = []
     for dtype in args.dtype:
@@ -1153,8 +1149,6 @@ if not args.hc_head:
                             continue
                         df.append(ret)
     if df:
-        df = pd.DataFrame(df)
-        df_md = df.to_markdown(index=False)
-        aiter.logger.info("mhc_post_pre summary (markdown):\n%s", df_md)
+        print_json_table("mhc_post_pre summary", df)
     else:
         aiter.logger.info("mhc_post_pre: all cases skipped")

--- a/op_tests/test_pa_sparse_prefill.py
+++ b/op_tests/test_pa_sparse_prefill.py
@@ -51,6 +51,7 @@ from aiter.test_common import (
     fill,
     make_generator,
     perftest,
+    print_json_table,
 )
 
 try:
@@ -849,7 +850,6 @@ if __name__ == "__main__":
         rest = [c for c in df.columns if c not in lead]
         metrics = [c for b in _BACKENDS for c in rest if c.startswith(f"{b} ")]
         df = df[lead + [c for c in rest if c not in metrics] + metrics]
-        print()
-        print(df.to_string(index=False, na_rep="-"))  # na_rep: backend not run
+        print_json_table("pa_sparse_prefill summary", df)
         sys.exit(0)
     sys.exit(0)


### PR DESCRIPTION
## Summary

- document the ROCm-bundled `amdsmi` binding path required by SMI monitoring
- add a shared record-oriented JSON table printer
- make AITER-owned DSv4 child UTs emit JSON directly instead of Markdown/aligned text
- validate and forward child JSON in `bench_gfx1250_combo.py`
- emit Mega MoE end-to-end and per-rank kernel profile results as JSON
- keep the external MORI EP output unchanged

Converted UTs: A8W8 blockscale, inverse RoPE, MLA v4 prefill, mHC, QK norm, score-QK, and Mega MoE.

## Validation

- `python3 -m py_compile` for all modified Python files
- `git diff --check`
- JSON child-result extraction smoke test

Runtime GPU validation is intentionally left to the submitter.