### PR TITLE
[Perf][gfx1250] Scope bundled amdsmi import to SMI monitor

### DIFF
--- a/op_tests/bench_gfx1250_combo.py
+++ b/op_tests/bench_gfx1250_combo.py
@@ -85,14 +85,14 @@ Other variables:
 Optional GPU telemetry replays each already-prepared benchmark case in its own
 sampling window, after its normal latency measurement:
 
-    # ROCm ships the binding here without a setup.py; make it importable first.
-    export PYTHONPATH=/opt/rocm/share/amd_smi${PYTHONPATH:+:$PYTHONPATH}
     python op_tests/bench_gfx1250_combo.py --dsv4 \
       --smi-monitor --smi-device 0 --smi-interval 0.05 --smi-duration 1.0
 
 Input initialization, compilation, correctness and warmup are outside the SMI
-window. The monitor uses the Python ``amdsmi`` package and prints a case-tagged
-min/mean/median/max table for clocks, power, temperature, activity and VRAM.
+window. The monitor privately loads ROCm's unpackaged ``amdsmi`` binding from
+``/opt/rocm/share/amd_smi`` when needed, without changing combo's environment,
+and prints a case-tagged min/mean/median/max table for clocks, power,
+temperature, activity and VRAM.
 ``mega_moe`` has every rank monitor its local GPU around synchronized graph
 replays, then gathers the four summaries to rank 0; ``mori_ep`` remains disabled
 until its dispatch/combine loop exposes an aligned telemetry window.

--- a/op_tests/smi_monitor.py
+++ b/op_tests/smi_monitor.py
@@ -3,9 +3,9 @@
 # ruff: noqa: BLE001, PYI034, S110, UP035, UP037
 """AMD GPU metrics monitor using amdsmi.
 
-ROCm ships the binding without a setup.py. Make it importable with::
-
-    export PYTHONPATH=/opt/rocm/share/amd_smi${PYTHONPATH:+:$PYTHONPATH}
+ROCm ships the binding without a setup.py. If the normal import fails, this
+module temporarily searches ``/opt/rocm/share/amd_smi`` while importing it.
+Neither ``PYTHONPATH`` nor the caller's lasting ``sys.path`` is changed.
 
 Usage (context manager):
     with GpuMonitor(device_index=0, interval_s=0.05) as mon:
@@ -23,17 +23,38 @@ Usage (explicit start/stop):
 from __future__ import annotations
 
 import ctypes
+import importlib
 import json
 import os
+import sys
 import threading
 import time
 from contextlib import contextmanager
 from typing import Generator
 
 SMI_RESULT_PREFIX = "AITER_SMI_RESULT "
+_ROCM_AMDSMI_PATH = "/opt/rocm/share/amd_smi"
+
+
+def _import_amdsmi():
+    """Import amdsmi, temporarily searching ROCm's unpackaged binding."""
+    try:
+        return importlib.import_module("amdsmi")
+    except ImportError:
+        if not os.path.isdir(_ROCM_AMDSMI_PATH):
+            raise
+
+    added_path = _ROCM_AMDSMI_PATH not in sys.path
+    if added_path:
+        sys.path.insert(0, _ROCM_AMDSMI_PATH)
+    try:
+        return importlib.import_module("amdsmi")
+    finally:
+        if added_path:
+            sys.path.remove(_ROCM_AMDSMI_PATH)
 
 try:
-    import amdsmi
+    amdsmi = _import_amdsmi()
 
     _AMDSMI_AVAILABLE = True
 except ImportError:


### PR DESCRIPTION
## Summary

- load ROCm's unpackaged `amdsmi` binding from `/opt/rocm/share/amd_smi` only when the normal import fails
- temporarily add the binding path during the `smi_monitor.py` import and remove it immediately afterward
- do not modify `PYTHONPATH` or leave a lasting `sys.path` change in the combo process
- remove the now-unnecessary manual `PYTHONPATH` export from the combo usage docs

## Validation

- `python3 -m py_compile op_tests/smi_monitor.py op_tests/bench_gfx1250_combo.py`
- `git diff --check`

Runtime GPU validation is left to the submitter.