### PR TITLE
[HIP] perf(mhc): cap the split-k partial-reduction width in mhc_pre_big_fuse

### DIFF
--- a/csrc/kernels/mhc_kernels.cu
+++ b/csrc/kernels/mhc_kernels.cu
@@ -14,6 +14,22 @@
 #include "aiter_tensor.h"
 
 
+// Width of the stage-1 split-k partial reduction in the mhc_pre_big_fuse kernels.
+// Stage 2 sums this many LDS partials on a single serial dependent chain, so a
+// smaller cap shortens the block-wide critical section. Override at build time.
+#ifndef MHC_RM_REDUCE_SPLITS_CAP
+#define MHC_RM_REDUCE_SPLITS_CAP 24
+#endif
+
+// Warp count for the wave64 small-m hidden_size=7168 rms-fused path. Capping the
+// reduction above is what makes 9 warps pay: uncapped, the stage-2 chain would be
+// 96 deep at 9 warps against 53 at 5. Legal values with residual_block=1024 are 5
+// and 9 (at 9, pre_thread_num=512 and res_vec_size=8, so lanes still issue 16B
+// loads). Override at build time to retune for another architecture.
+#ifndef MHC_RM_NUM_WARPS_7168
+#define MHC_RM_NUM_WARPS_7168 9
+#endif
+
 namespace aiter {
 #if defined(__gfx1250__)
     static constexpr bool mhc_async_load_oob_guard = true;
@@ -781,7 +797,17 @@ namespace aiter {
         constexpr int pre_thread_num = block_size - warp_size;
         static_assert(hc_mult3 % 4 == 0, "hc_mult3 must be divisible by 4");
         static constexpr int hc_mult3_threads = num_rows * hc_mult3 / 4;
-        static constexpr int reduce_splits_per_round = block_size / hc_mult3_threads;
+        // The split-k partials are summed twice: stage 1 spreads n_splits over
+        // reduce_splits_per_round lanes (parallel, global loads), stage 2 sums those
+        // LDS partials on only num_rows*hc_mult3 threads -- a fully serial dependent
+        // chain that every other wave waits on at the following __syncthreads.
+        // block_size/hc_mult3_threads makes that chain 53 deep at 5 warps and 96 deep
+        // at 9 warps, and past n_splits (56 here) the extra lanes contribute nothing
+        // but still cost an LDS read. Cap the width so stage 2 stays short; stage 1
+        // just does a few more (independent, unrolled) loads per lane.
+        static constexpr int reduce_splits_raw = block_size / hc_mult3_threads;
+        static constexpr int reduce_splits_per_round =
+            reduce_splits_raw < MHC_RM_REDUCE_SPLITS_CAP ? reduce_splits_raw : MHC_RM_REDUCE_SPLITS_CAP;
         static constexpr int reduce_active_threads = hc_mult3_threads * reduce_splits_per_round;
         static_assert(hc_mult == 4, "hc_mult only supports 4");
         static_assert(reduce_active_threads <= block_size,
@@ -1598,7 +1624,17 @@ namespace aiter {
         constexpr int pre_thread_num = block_size - warp_size;
         static_assert(hc_mult3 % 4 == 0, "hc_mult3 must be divisible by 4");
         static constexpr int hc_mult3_threads = num_rows * hc_mult3 / 4;
-        static constexpr int reduce_splits_per_round = block_size / hc_mult3_threads;
+        // The split-k partials are summed twice: stage 1 spreads n_splits over
+        // reduce_splits_per_round lanes (parallel, global loads), stage 2 sums those
+        // LDS partials on only num_rows*hc_mult3 threads -- a fully serial dependent
+        // chain that every other wave waits on at the following __syncthreads.
+        // block_size/hc_mult3_threads makes that chain 53 deep at 5 warps and 96 deep
+        // at 9 warps, and past n_splits (56 here) the extra lanes contribute nothing
+        // but still cost an LDS read. Cap the width so stage 2 stays short; stage 1
+        // just does a few more (independent, unrolled) loads per lane.
+        static constexpr int reduce_splits_raw = block_size / hc_mult3_threads;
+        static constexpr int reduce_splits_per_round =
+            reduce_splits_raw < MHC_RM_REDUCE_SPLITS_CAP ? reduce_splits_raw : MHC_RM_REDUCE_SPLITS_CAP;
         static constexpr int reduce_active_threads = hc_mult3_threads * reduce_splits_per_round;
         static_assert(hc_mult == 4, "hc_mult only supports 4");
         static_assert(reduce_active_threads <= block_size,
@@ -1810,6 +1846,12 @@ namespace aiter {
                 }
             };
 
+            // Measured on gfx950 (m128/m120/m112, num_warps=9): flattening this
+            // residual stream into an out_loop-deep prefetch -- every 16B load in
+            // flight instead of the 2-stage double buffer below -- REGRESSED ~2%.
+            // The extra live loads cost more in register pressure, and give a
+            // single drain point, than the added memory-level parallelism buys.
+            // Recorded so the experiment is not repeated.
             res_vec_t v_res0 = load_res_loop(0);
             res_vec_t v_res1 = load_res_loop(1);
             int i = 0;
@@ -2021,7 +2063,7 @@ namespace aiter {
 #define MHC_PRE_BIG_FUSE_RM_KERNEL_DISPATCH(m) \
     if (hidden_size == 7168) { \
         if (m < 4 * cu_num) { \
-            if (WARP_SIZE == 32) { \
+            if (WARP_SIZE == 32 || MHC_RM_NUM_WARPS_7168 == 9) { \
                 MHC_PRE_BIG_FUSE_RM_KERNEL_IMPL(9, 4, 1, 7168, 1024, 1024, false); \
             } else { \
                 MHC_PRE_BIG_FUSE_RM_KERNEL_IMPL(5, 4, 1, 7168, 1024, 1024, false); \


### PR DESCRIPTION
## What

Two coupled changes to the `mhc_pre_big_fuse` kernels in `csrc/kernels/mhc_kernels.cu`:

1. **Cap the stage-1 split-k partial-reduction width** at `MHC_RM_REDUCE_SPLITS_CAP` (build-time override, default 24).
2. **Switch the wave64 small-m `hidden_size=7168` rms-fused path from 5 warps to 9** (`MHC_RM_NUM_WARPS_7168`, build-time override, default 9) — the same width the wave32 branch already dispatches.

45 insertions, 3 deletions, one file.

## Why

The split-k partials are summed in two stages. Stage 1 spreads `n_splits` over `reduce_splits_per_round` lanes with independent global loads. Stage 2 then sums those LDS partials on only `num_rows * hc_mult3` threads — a fully serial dependent chain that every other wave in the block waits on at the following `__syncthreads`.

Deriving that width from `block_size / hc_mult3_threads` makes the chain **53 deep at 5 warps and 96 deep at 9**. And past `n_splits` (56 at the DeepSeek-V4 decode shapes) the extra lanes contribute nothing to the sum while still costing an LDS read. Capping shortens the block-wide critical section; stage 1 absorbs the difference as a few more independent, unrolled loads per lane.

The two changes are coupled and that is why they land together: capping is what makes the wider block worth using, since at 9 warps the *uncapped* chain would be 96 deep.

Both widths are build-time overrides so another architecture can retune without touching kernel bodies.

## Measurements, and how much to trust them

Measured on gfx950 / MI355X against a torch reference at `hidden_size=7168`, `hc_mult=4`, `num_tokens` in {112, 120, 128}, HIP-graph timing:

| | |
|---|---|
| baseline | 0.0286 ms |
| this change | 0.0282 ms |
| mean per-case speedup | **1.38%** |
| SNR | 48.4 dB, unchanged from baseline |

**I would rather you take that number as directional than as settled, and here is why.** A later standalone re-measurement of the same build put it at 0.19%. In the same harness, two configurations that are *functionally identical* at these shapes (one adds only default-off environment knobs) measured 1.46% apart. So the run-to-run floor is the same order as the effect, and I do not think this harness can resolve a sub-2% delta at these shapes without many more repeats.

The durable argument is structural rather than statistical: the reduction past `n_splits` is provably dead work, and the chain it shortens is serial and block-wide. If you want the delta pinned down before merging, the thing to do is re-run with substantially more bench repeats — I am happy to do that if you tell me the repeat count and shape set you would find convincing.

For scale, in an end-to-end TP8 decode trace of DeepSeek-V4-Pro-0813 this operator family is 3.75% of per-rank GPU busy time, so even a 2.66% kernel win is roughly 0.02 ms on a 19.92 ms ITL. This is a kernel-quality change, not a serving-latency change, and it should be reviewed as one.

## Correctness

- SNR 48.4 dB against the torch reference, unchanged from baseline.
- `hipcc -fsyntax-only --offload-arch=gfx950` on this file: **0 errors, 18 warnings — byte-identical warning count to `main`** (all 18 pre-exist in the included headers).
- Not run here: `op_tests/test_mhc.py` on hardware, because this sandbox has no built aiter. **Please treat a green `test_mhc.py` as a merge precondition**; I can run it on an MI355X if that helps.

## A recorded negative

The patch adds a comment, not code, for an experiment that did not work: flattening the residual stream into an `out_loop`-deep prefetch (every 16B load in flight instead of the 2-stage double buffer) **regressed ~2%** on all three shapes — the extra live loads cost more in register pressure, and give a single drain point, than the added memory-level parallelism buys. It is written down so the next person does not repeat it.

## Provenance

Found by an automated kernel-optimization campaign (KernelForge) on DeepSeek-V4-Pro-0813 decode, then hand-reduced for review: the campaign's environment-variable sweep knobs and its disabled dead-code branch have been removed, and the one behaviour change they were hiding (the 5→9 warp switch, which the original patch delivered through a `getenv` defaulting to 9) is now explicit and compile-time.
