### PR TITLE
[HIP] [Bugfix] asm_mla: route ctypes entrypoint failures through the error bridge instead of std::abort

### DIFF
--- a/csrc/py_itfs_cu/asm_mla.cu
+++ b/csrc/py_itfs_cu/asm_mla.cu
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
 #include "aiter_tensor.h"
+#include "aiter_ctypes_error.h"
 #include "asm_mla_configs.hpp"
 #include <hip/hip_fp16.h>
 #include <hip/hip_runtime.h>
@@ -27,6 +28,11 @@
 #include <sys/stat.h>
 #include <vector>
 #endif
+
+// TLS error bridge for this .so (module_mla_asm). Lets the ctypes entrypoints
+// below turn AITER_CHECK / HIP_CALL failures into a Python RuntimeError instead
+// of std::abort()-ing the worker process.
+AITER_CTYPES_ERROR_DEF
 
 struct __attribute__((packed)) KernelArgs
 {
@@ -645,37 +651,64 @@ static void mla_decode_gfx1250_dispatch(
 #endif
 }
 
-AITER_C_ITFS
-void mla_decode_stage1_asm_fwd(
-    aiter_tensor_t* Q,                    //   [num_seqs, num_heads, head_size]
-    aiter_tensor_t* KV,                   //   [num_page, page_size, num_kv_heads, head_size] or [num_page, page_size*(nhead_kv*(kv_lora_rank+scale_dim+qk_rope_head_dim))]
-    aiter_tensor_t* qo_indptr,            //   [batch_size+1]
-    aiter_tensor_t* kv_indptr,            //   [batch_size+1]
-    aiter_tensor_t* kv_page_indices,      //   [num_page_used]
-    aiter_tensor_t* kv_last_page_lens,    //   [batch_size]
-    aiter_tensor_t* num_kv_splits_indptr, //   metadata (nullable)
-    aiter_tensor_t* work_meta_data,       //   metadata addr (nullable)
-    aiter_tensor_t* work_indptr,          //   metadata (nullable)
-    aiter_tensor_t* work_info_set,        //   [batch_size+1] (nullable)
-    int max_seqlen_q,
-    int page_size,
-    int nhead_kv,
-    float softmax_scale,
-    // following are output
-    aiter_tensor_t* splitData,            //   [batch_size, num_kv_splits, num_heads, v_head_dim]
-    aiter_tensor_t* splitLse,             //   [batch_size, num_kv_splits, num_heads,  1]
-    aiter_tensor_t* output,               //   [batch_size, num_heads, v_head_dim]
-    aiter_tensor_t* lse,                  //   [batch_size, num_heads] (nullable)
-    aiter_tensor_t* q_scale,              //   [1] (nullable)
-    aiter_tensor_t* kv_scale,             //   [1] (nullable)
-    aiter_tensor_t* g_kv_indptr,          //   [batch_size+1] GLOBAL kv_indptr for round-robin CP (nullable)
-    int cp_world_size,                    //   round-robin CP world size (1 == disabled)
-    int cp_rank,                          //   round-robin CP rank id
-    aiter_tensor_t* valid_split_count,    //   [batch_size] scratch for packed gfx1250 kernels (nullable)
-    int use_valid_split_count_reduce,     //   enable packed-kernel valid split count writeback/reduce
-    int causal,                           //   apply the causal mask across the max_seqlen_q query tokens
-    hipStream_t stream)
-{    
+AITER_CTYPES_DEFINE_ENTRYPOINT_VOID(
+    mla_decode_stage1_asm_fwd,
+    (aiter_tensor_t * Q,                  //   [num_seqs, num_heads, head_size]
+     aiter_tensor_t* KV,                  //   [num_page, page_size, num_kv_heads, head_size] or [num_page, page_size*(nhead_kv*(kv_lora_rank+scale_dim+qk_rope_head_dim))]
+     aiter_tensor_t* qo_indptr,           //   [batch_size+1]
+     aiter_tensor_t* kv_indptr,           //   [batch_size+1]
+     aiter_tensor_t* kv_page_indices,     //   [num_page_used]
+     aiter_tensor_t* kv_last_page_lens,   //   [batch_size]
+     aiter_tensor_t* num_kv_splits_indptr, //   metadata (nullable)
+     aiter_tensor_t* work_meta_data,      //   metadata addr (nullable)
+     aiter_tensor_t* work_indptr,         //   metadata (nullable)
+     aiter_tensor_t* work_info_set,       //   [batch_size+1] (nullable)
+     int max_seqlen_q,
+     int page_size,
+     int nhead_kv,
+     float softmax_scale,
+     // following are output
+     aiter_tensor_t* splitData,           //   [batch_size, num_kv_splits, num_heads, v_head_dim]
+     aiter_tensor_t* splitLse,            //   [batch_size, num_kv_splits, num_heads,  1]
+     aiter_tensor_t* output,              //   [batch_size, num_heads, v_head_dim]
+     aiter_tensor_t* lse,                 //   [batch_size, num_heads] (nullable)
+     aiter_tensor_t* q_scale,             //   [1] (nullable)
+     aiter_tensor_t* kv_scale,            //   [1] (nullable)
+     aiter_tensor_t* g_kv_indptr,         //   [batch_size+1] GLOBAL kv_indptr for round-robin CP (nullable)
+     int cp_world_size,                   //   round-robin CP world size (1 == disabled)
+     int cp_rank,                         //   round-robin CP rank id
+     aiter_tensor_t* valid_split_count,   //   [batch_size] scratch for packed gfx1250 kernels (nullable)
+     int use_valid_split_count_reduce,    //   enable packed-kernel valid split count writeback/reduce
+     int causal,                          //   apply the causal mask across the max_seqlen_q query tokens
+     hipStream_t stream),
+    (Q,
+     KV,
+     qo_indptr,
+     kv_indptr,
+     kv_page_indices,
+     kv_last_page_lens,
+     num_kv_splits_indptr,
+     work_meta_data,
+     work_indptr,
+     work_info_set,
+     max_seqlen_q,
+     page_size,
+     nhead_kv,
+     softmax_scale,
+     splitData,
+     splitLse,
+     output,
+     lse,
+     q_scale,
+     kv_scale,
+     g_kv_indptr,
+     cp_world_size,
+     cp_rank,
+     valid_split_count,
+     use_valid_split_count_reduce,
+     causal,
+     stream))
+{
     int batch           = qo_indptr->size(0) - 1;
     int num_heads       = Q->size(1);
     int head_size       = Q->size(2);
@@ -1091,26 +1124,44 @@ struct __attribute__((packed)) PsKernelArgs
 };
 
 
-AITER_C_ITFS
-void mla_prefill_ps_asm_fwd(
-    aiter_tensor_t* Q,                    //  [num_seqs, num_q_heads, qk_hetad_size], fp8
-    aiter_tensor_t* K,                    //   [num_page, num_kv_heads, qk_head_size], fp8
-    aiter_tensor_t* V,                    //   [num_page, num_kv_heads, v_head_size], fp8
-    aiter_tensor_t* qo_indptr,            //   [batch_size+1], int
-    aiter_tensor_t* kv_indptr,            //   [batch_size+1], int
-    aiter_tensor_t* kv_page_indices,      //   [num_page_used], int
-    aiter_tensor_t* work_indptr,          //   [available_tgs+1], int (nullable)
-    aiter_tensor_t* work_info_set,        //   [max_works], int (nullable)
-    int max_seqlen_q,
-    float softmax_scale,
-    int is_causal,
-    aiter_tensor_t* splitData,            //   [num_q_heads, num_seqs, max_kv_split, v_head_dim], fp32
-    aiter_tensor_t* splitLse,             //   [num_q_heads, num_seqs, max_kv_split,  1], fp32
-    aiter_tensor_t* output,               //   [num_seqs, num_q_heads, v_head_dim], bf16
-    aiter_tensor_t* q_scale,              //   fp32, scalar (nullable)
-    aiter_tensor_t* k_scale,              //   fp32, scalar (nullable)
-    aiter_tensor_t* v_scale,              //   fp32, scalar (nullable)
-    hipStream_t stream)
+AITER_CTYPES_DEFINE_ENTRYPOINT_VOID(
+    mla_prefill_ps_asm_fwd,
+    (aiter_tensor_t * Q,                 //  [num_seqs, num_q_heads, qk_hetad_size], fp8
+     aiter_tensor_t* K,                  //   [num_page, num_kv_heads, qk_head_size], fp8
+     aiter_tensor_t* V,                  //   [num_page, num_kv_heads, v_head_size], fp8
+     aiter_tensor_t* qo_indptr,          //   [batch_size+1], int
+     aiter_tensor_t* kv_indptr,          //   [batch_size+1], int
+     aiter_tensor_t* kv_page_indices,    //   [num_page_used], int
+     aiter_tensor_t* work_indptr,        //   [available_tgs+1], int (nullable)
+     aiter_tensor_t* work_info_set,      //   [max_works], int (nullable)
+     int max_seqlen_q,
+     float softmax_scale,
+     int is_causal,
+     aiter_tensor_t* splitData,          //   [num_q_heads, num_seqs, max_kv_split, v_head_dim], fp32
+     aiter_tensor_t* splitLse,           //   [num_q_heads, num_seqs, max_kv_split,  1], fp32
+     aiter_tensor_t* output,             //   [num_seqs, num_q_heads, v_head_dim], bf16
+     aiter_tensor_t* q_scale,            //   fp32, scalar (nullable)
+     aiter_tensor_t* k_scale,            //   fp32, scalar (nullable)
+     aiter_tensor_t* v_scale,            //   fp32, scalar (nullable)
+     hipStream_t stream),
+    (Q,
+     K,
+     V,
+     qo_indptr,
+     kv_indptr,
+     kv_page_indices,
+     work_indptr,
+     work_info_set,
+     max_seqlen_q,
+     softmax_scale,
+     is_causal,
+     splitData,
+     splitLse,
+     output,
+     q_scale,
+     k_scale,
+     v_scale,
+     stream))
 {
     int num_q_tokens  = Q->size(0);
     int num_head_q    = Q->size(1);
@@ -1208,19 +1259,30 @@ void mla_prefill_ps_asm_fwd(
 }
 
 
-AITER_C_ITFS
-void mla_prefill_asm_fwd(
-    aiter_tensor_t* Q,                    //   [num_seqs, num_heads, head_size]
-    aiter_tensor_t* KV,                   //   [num_page, page_size, num_kv_heads, head_size]
-    aiter_tensor_t* qo_indptr,            //   [batch_size+1]
-    aiter_tensor_t* kv_indptr,            //   [batch_size+1]
-    aiter_tensor_t* kv_page_indices,      //   [num_page_used]
-    aiter_tensor_t* kv_last_page_lens,    //   [batch_size]
-    int max_seqlen_q,
-    float softmax_scale,
-    aiter_tensor_t* splitData,            //   [batch_size, num_kv_splits, num_heads, v_head_dim]
-    aiter_tensor_t* splitLse,             //   [batch_size, num_kv_splits, num_heads,  1]
-    hipStream_t stream)
+AITER_CTYPES_DEFINE_ENTRYPOINT_VOID(
+    mla_prefill_asm_fwd,
+    (aiter_tensor_t * Q,                 //   [num_seqs, num_heads, head_size]
+     aiter_tensor_t* KV,                 //   [num_page, page_size, num_kv_heads, head_size]
+     aiter_tensor_t* qo_indptr,          //   [batch_size+1]
+     aiter_tensor_t* kv_indptr,          //   [batch_size+1]
+     aiter_tensor_t* kv_page_indices,    //   [num_page_used]
+     aiter_tensor_t* kv_last_page_lens,  //   [batch_size]
+     int max_seqlen_q,
+     float softmax_scale,
+     aiter_tensor_t* splitData,          //   [batch_size, num_kv_splits, num_heads, v_head_dim]
+     aiter_tensor_t* splitLse,           //   [batch_size, num_kv_splits, num_heads,  1]
+     hipStream_t stream),
+    (Q,
+     KV,
+     qo_indptr,
+     kv_indptr,
+     kv_page_indices,
+     kv_last_page_lens,
+     max_seqlen_q,
+     softmax_scale,
+     splitData,
+     splitLse,
+     stream))
 {
     int sub_Q           = 128;
     int batch           = kv_indptr->size(0) - 1;


### PR DESCRIPTION
## Summary

Wrap the three raw `AITER_C_ITFS` ctypes entrypoints in
`csrc/py_itfs_cu/asm_mla.cu` —

- `mla_decode_stage1_asm_fwd`
- `mla_prefill_ps_asm_fwd`
- `mla_prefill_asm_fwd`

— in `AITER_CTYPES_DEFINE_ENTRYPOINT_VOID`, matching `asm_mla_v4.cu`. An
`AITER_CHECK` / `HIP_CALL` failure inside these now surfaces as a Python
`RuntimeError` via the `aiter_get_last_error` TLS bridge instead of
`std::abort()`-ing the calling process.

## Motivation

`asm_mla.cu` is the only file left in `csrc/py_itfs_cu/` still on raw
`extern "C"` entrypoints (3 raw, 0 wrapped). Its own `asm_mla_v4.cu` sibling was
already migrated, with a comment noting it's done "so that AITER_CHECK /
HIP_CALL" raise instead of abort.

Because `mla_decode_stage1_asm_fwd` is called via ctypes with no
`aiter_safe_call` on the stack, `aiter_detail::g_aiter_can_throw` stays `false`,
so `check_fail()` takes the `std::abort()` branch. Any kernel-selection miss —
e.g. `get_heuristic_kernel_mla` failing to find a row (persistent MLA decode,
`gqa_ratio=16`, `max_seqlen_q > 4`, which gfx942 has no persistent kernel for) —
kills the worker with `SIGABRT` and no recoverable error.

This is hit today by speculative-decode / MTP serving on MLA models (DeepSeek,
GLM, Kimi-K3) once the verify window exceeds 4 tokens — see
ROCm/aiter#4752 for the fp8-KV variant of the same abort. Downstream, vLLM's
`tests/v1/attention/test_mla_backends.py::test_backend_correctness[…spec_decode_medium]`
takes the whole pytest process down instead of reporting a failure.

This PR does not add the missing kernel — it makes the failure catchable so
callers can fall back, log, or fail a single request instead of the process.

## Changes

- `#include "aiter_ctypes_error.h"`
- one `AITER_CTYPES_ERROR_DEF` at file scope (`module_mla_asm` is a
  single-source JIT module, so the once-per-`.so` requirement holds)
- the three entrypoints rewritten as
  `AITER_CTYPES_DEFINE_ENTRYPOINT_VOID(name, (decl-args), (call-args)) { … }`;
  bodies unchanged

No Python change needed — `aiter/jit/core.py`'s ctypes path already probes for
`aiter_ctypes_abi_version` / `aiter_get_last_error` and raises `RuntimeError` on
a non-zero return. No other C++/pybind callers of the three functions.

## Testing

Validated on a rented MI300X (gfx942), ROCm CI image
`rocm/vllm-ci:build-01a0781b`, `amd-aiter 0.1.21.post1`, this patch applied to
the installed tree and `module_mla_asm` JIT-rebuilt.

**Failure path — abort becomes RuntimeError**

| case (persistent MLA decode, `gqa=16`) | before | after |
|---|---|---|
| bf16 Q / bf16 KV, `max_seqlen_q=8` | `SIGABRT` (core dumped) | `RuntimeError: mla_decode_stage1_asm_fwd failed: [AITER] …asm_mla.cu:199 get_heuristic_kernel_mla: cannot get heuristic kernel! …qseqlen:8…` |
| bf16 Q / bf16 KV, `max_seqlen_q=5` | `SIGABRT` | `RuntimeError` (same string, `qseqlen:5`) |
| bf16 Q / fp8 KV, `max_seqlen_q=5` | `SIGABRT` | `RuntimeError` |

**No regression on the working path** (`op_tests/`, run from the matching tag):

- `test_mla_persistent.py -d bf16 -kvd bf16 -c 1024 -b 2 -n 16,1 --no-causal` —
  `checkAllclose` PASS, `err=0`, `_fold_seqlen_indptr` CUDA-graph capture PASS
- `test_mla.py -d bf16 -kvd bf16 -c 1024 -b 2` — `mla_prefill-normal`,
  `mla_prefill-absorb` (`mla_prefill_asm_fwd`) `checkAllclose` PASS
- a supported decode shape (`gqa=16`, `max_seqlen_q=1`) runs to completion
  through the wrapped entrypoint

`mla_prefill_ps_asm_fwd` is gfx950-only (its op test self-skips on gfx942); it
compiles cleanly in the same translation unit but was not exercised at runtime
here.

- [x] Existing MLA op tests pass on gfx942
- [x] Tested on MI300X (gfx942)
- [ ] Tested on MI355X (gfx950)  — `mla_prefill_ps` runtime path still needs this

## Related

- ROCm/aiter#4752 — the same `get_heuristic_kernel_mla` abort in the bf16-query + fp8-KV column (this PR's change covers it too; the missing gfx942 kernel is a separate ask).
- vllm-project/vllm#55609 — downstream tracking issue: `test_mla_backends.py` on ROCm hits this abort via `ROCM_AITER_MLA` decode at `query_len > 4`.
- vllm-project/vllm#53944 — the vLLM CI-coverage change that surfaced it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

