### PR TITLE
[FlyDSL][fix] (tuned_gemm): detach GEMM inputs before FlyDSL DLPack export

### DIFF
--- a/aiter/tuned_gemm.py
+++ b/aiter/tuned_gemm.py
@@ -495,6 +495,12 @@ def flydsl_gemm(
         and bias.dtype == inp.dtype
     ):
         fused_bias = bias
+
+        inp = inp.detach()
+        weights = weights.detach()
+        if fused_bias is not None:
+            fused_bias = fused_bias.detach()
+
     out = flydsl_gemm_kernels.flydsl_hgemm(
         inp,
         weights,


### PR DESCRIPTION
## Summary

flydsl 0.3.2 (#4912) exports kernel args via tensor.__dlpack__(), which raises BufferError("Can't export tensors that require gradient") on grad-tracking tensors. 
gpt-oss CUDA-graph capture on gfx950 hits this and crashes the server. 
Detach inp/weights/bias before flydsl_hgemm.

## Validation

Verified on MI355X: candidate 636098e5 + flydsl 0.3.2 crashes unpatched, serves clean with this patch.

