### PR TITLE
[FlyDSL] Add FP4 LiteTopK prefill operator

### DIFF
--- a/aiter/ops/flydsl/__init__.py
+++ b/aiter/ops/flydsl/__init__.py
@@ -25,6 +25,18 @@ if _base_version < _MIN_FLYDSL_VERSION:
     )
 
 _LAZY_IMPORTS = {
+    "FP4_LITETOPK_SUPPORTED_TOPKS": (
+        ".pa_mqa_litetopk_fp4",
+        "FP4_LITETOPK_SUPPORTED_TOPKS",
+    ),
+    "FP4LiteTopKResult": (
+        ".pa_mqa_litetopk_fp4",
+        "FP4LiteTopKResult",
+    ),
+    "FP4LiteTopKWorkspace": (
+        ".pa_mqa_litetopk_fp4",
+        "FP4LiteTopKWorkspace",
+    ),
     "FP8_MQA_LOGITS_DEFAULT_VARIANT": (
         ".kernels.mqa_logits.fp8_mqa_logits",
         "DEFAULT_VARIANT",
@@ -36,6 +48,26 @@ _LAZY_IMPORTS = {
     "compute_varqlen_windows": (
         ".kernels.mqa_logits.pa_mqa_logits_fp4_prefill",
         "compute_varqlen_windows",
+    ),
+    "allocate_fp4_litetopk_workspace": (
+        ".pa_mqa_litetopk_fp4",
+        "allocate_fp4_litetopk_workspace",
+    ),
+    "fp4_litetopk_workspace_nbytes": (
+        ".pa_mqa_litetopk_fp4",
+        "fp4_litetopk_workspace_nbytes",
+    ),
+    "fp4_litetopk_workspace_size": (
+        ".pa_mqa_litetopk_fp4",
+        "fp4_litetopk_workspace_size",
+    ),
+    "flydsl_pa_mqa_litetopk_fp4_prefill": (
+        ".pa_mqa_litetopk_fp4",
+        "flydsl_pa_mqa_litetopk_fp4_prefill",
+    ),
+    "prepare_fp4_litetopk_seed": (
+        ".pa_mqa_litetopk_fp4",
+        "prepare_fp4_litetopk_seed",
     ),
     "flydsl_flash_attn_func": (".fmha_kernels", "flydsl_flash_attn_func"),
     "flydsl_fp8_mqa_logits": (
@@ -69,9 +101,13 @@ _LAZY_IMPORTS = {
 }
 
 __all__ = [
+    "FP4_LITETOPK_SUPPORTED_TOPKS",
     "FP8_MQA_LOGITS_DEFAULT_VARIANT",
     "FP8_MQA_LOGITS_VARIANTS",
+    "FP4LiteTopKResult",
+    "FP4LiteTopKWorkspace",
     "GateMode",
+    "allocate_fp4_litetopk_workspace",
     "compute_varqlen_windows",
     "flydsl_flash_attn_func",
     "flydsl_fp8_mqa_logits",
@@ -79,11 +115,15 @@ __all__ = [
     "flydsl_mla_reduce_v1",
     "flydsl_moe_stage1",
     "flydsl_moe_stage2",
+    "flydsl_pa_mqa_litetopk_fp4_prefill",
     "flydsl_pa_mqa_logits_fp4",
     "flydsl_pa_mqa_logits_fp4_prefill",
     "flydsl_pa_mqa_logits_fp4_varqlen",
     "flydsl_preshuffle_gemm_a8",
     "flydsl_qk_norm_rope_quant",
+    "fp4_litetopk_workspace_nbytes",
+    "fp4_litetopk_workspace_size",
+    "prepare_fp4_litetopk_seed",
 ]
 
 

--- a/aiter/ops/flydsl/kernels/mqa_logits/pa_mqa_litetopk_fp4_common.py
+++ b/aiter/ops/flydsl/kernels/mqa_logits/pa_mqa_litetopk_fp4_common.py
@@ -1,0 +1,27 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+import flydsl.expr as fx
+from flydsl.expr import Array, Int32
+
+FP4_LITETOPK_SUPPORTED_TOPKS = (512, 1024)
+
+
+@fx.struct
+class LiteTopKScanStorage:
+    histogram: Array[Int32, 256, 16]
+    scan: Array[Int32, 9, 16]
+    state: Array[Int32, 3, 4]
+
+
+@fx.struct
+class LiteTopKSeedStorage:
+    scores: Array[fx.Float32, 8192, 16]
+    histogram: Array[Int32, 256, 16]
+    scan: Array[Int32, 9, 16]
+    maxima: Array[fx.Float32, 8, 16]
+    neg_minima: Array[fx.Float32, 8, 16]
+    finite_counts: Array[Int32, 8, 16]
+    nonfinite_counts: Array[Int32, 8, 16]
+    calibration: Array[fx.Float32, 2, 16]
+    state: Array[Int32, 2, 4]

--- a/aiter/ops/flydsl/kernels/mqa_logits/pa_mqa_logits_fp4_common.py
+++ b/aiter/ops/flydsl/kernels/mqa_logits/pa_mqa_logits_fp4_common.py
@@ -15,14 +15,18 @@ from flydsl.expr.typing import T
 _NON_WRITER_LANE_OFF = 1 << 30
 
 
-def _i32_buffer(ptr, width=1):
+def _i32_buffer(ptr, width=1, elem_offset=None):
     """OOB-checked global i32 buffer-tensor over ``ptr`` (mirrors a max_size V#).
 
     ``width`` shapes it ``(N, width)`` so a per-``width`` row can be sliced and
     vector-copied; ``width=1`` gives a flat tensor for scalar ``[idx]`` loads.
+    ``elem_offset`` is folded into the 64-bit base pointer before creating the
+    descriptor, keeping subsequent V# offsets below the 32-bit hardware limit.
     """
     src = fx.get_iter(ptr)
     it = fx.recast_iter(fx.PointerType.get(T.i32, src.memspace, 4), src)
+    if elem_offset is not None:
+        it = fx.add_offset(it, fx.Int64(elem_offset))
     if width == 1:
         lay = fx.make_layout((1 << 30,), (1,))
     else:

--- a/aiter/ops/flydsl/kernels/mqa_logits/pa_mqa_logits_fp4_prefill.py
+++ b/aiter/ops/flydsl/kernels/mqa_logits/pa_mqa_logits_fp4_prefill.py
@@ -1,10 +1,9 @@
 # SPDX-License-Identifier: MIT
 # Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+# ruff: noqa: SIM102
 
 
-from __future__ import annotations
-
-from functools import lru_cache
+from functools import cache
 from typing import NamedTuple
 
 import flydsl.compiler as flyc
@@ -12,10 +11,20 @@ import flydsl.expr as fx
 import torch
 import triton
 import triton.language as tl
-from flydsl.expr import gpu, rocdl
+from flydsl._mlir.dialects import llvm
+from flydsl.expr import arith, as_ir_value, const_expr, gpu, rocdl
 from flydsl.expr.primitive import range_constexpr
+from flydsl.expr.rocdl import ballot, readlane
 from flydsl.expr.typing import Float4E2M1FN, Int32, T
 
+from ..kernels_common import atomic_add_i32
+from ..tensor_shim import _run_compiled, ptr_buf_tensor
+from ..topk_per_row_decode import _warp_inclusive_prefix_i32
+from .pa_mqa_litetopk_fp4_common import (
+    FP4_LITETOPK_SUPPORTED_TOPKS,
+    LiteTopKScanStorage,
+    LiteTopKSeedStorage,
+)
 from .pa_mqa_logits_fp4_common import (
     _NON_WRITER_LANE_OFF,
     _i32_buffer,
@@ -32,6 +41,18 @@ DEFAULT_BLOCK_THREADS = DEFAULT_NUM_WARPS * WARP_SIZE  # 256
 
 # cta_info packed fields per CTA.
 CTA_INFO_WIDTH = 6
+
+
+def _popcount_i64(value):
+    return fx.Int32(
+        llvm.call_intrinsic(
+            T.i64,
+            "llvm.ctpop.i64",
+            [as_ir_value(value)],
+            [],
+            [],
+        )
+    )
 
 
 def compute_prefill_schedule(
@@ -359,11 +380,20 @@ def _prefill_cta_info_kernel(
 def build_pa_mqa_logits_fp4_prefill_module(
     block_k=256,
     kv_block_size=64,
-    max_blocks_per_seq=256,
     max_chunks_per_cta=16,
     num_warps=DEFAULT_NUM_WARPS,
     heads=DEFAULT_HEADS,
     head_dim=DEFAULT_HEAD_DIM,
+    relative_output=False,
+    litetopk=False,
+    seed_calibration=False,
+    seed_emit=False,
+    seed_status_nonfinite=1 << 2,
+    seed_status_candidate_overflow=1 << 0,
+    seed_status_underfilled=1 << 1,
+    litetopk_topk=512,
+    litetopk_refresh_every=64,
+    seed_report_page_errors=False,
 ):
     """Build the ragged-prefill FP4 MQA logits kernel."""
     block_threads_k = num_warps * WARP_SIZE
@@ -379,6 +409,11 @@ def build_pa_mqa_logits_fp4_prefill_module(
         N_TILES % num_warps == 0
     ), f"block_k={block_k} -> N_TILES={N_TILES} must be multiple of num_warps={num_warps}"
     N_TILES_PER_WARP = N_TILES // num_warps
+    assert not (litetopk and seed_calibration)
+    assert not seed_calibration or relative_output
+    assert not seed_calibration or num_warps <= 8
+    assert not seed_emit or seed_calibration
+    assert not seed_report_page_errors or seed_emit
 
     assert (
         kv_block_size % MFMA_N == 0
@@ -388,9 +423,6 @@ def build_pa_mqa_logits_fp4_prefill_module(
     ), f"block_k={block_k} must be a multiple of kv_block_size={kv_block_size}"
     TILES_PER_BLOCK = kv_block_size // MFMA_N
     N_PHYS = (N_TILES_PER_WARP + TILES_PER_BLOCK - 1) // TILES_PER_BLOCK
-
-    # block_tables row stride (i32 elements).
-    _stride_bt = max_blocks_per_seq
 
     # KV preshuffle layout: [block_id, K_TILES, K_chunk=4, kv_block_size, 16] uint8.
     _kv_chunk_bytes = 16
@@ -451,7 +483,23 @@ def build_pa_mqa_logits_fp4_prefill_module(
         weights_ptr: fx.Tensor,
         cta_info_ptr: fx.Tensor,  # [n_ctas, 6] i32
         stride_out_row: Int32,
+        stride_block_table: Int32,
+        block_table_rows: Int32,
         weight_scale: fx.Float32,
+        origin_ptr: fx.Tensor,
+        inv_delta_ptr: fx.Tensor,
+        threshold_ptr: fx.Tensor,
+        histogram_ptr: fx.Tensor,
+        candidate_values_ptr: fx.Tensor,
+        candidate_indices_ptr: fx.Tensor,
+        candidate_counts_ptr: fx.Tensor,
+        page_errors_ptr: fx.Tensor,
+        score_errors_ptr: fx.Tensor,
+        status_ptr: fx.Tensor,
+        candidate_stride: Int32,
+        merge_cap: Int32,
+        block_table_capacity: Int32,
+        physical_page_capacity: Int32,
     ):
         tid = gpu.thread_idx.x
         pid = gpu.block_idx.x
@@ -478,54 +526,148 @@ def build_pa_mqa_logits_fp4_prefill_module(
         # load; the V# below needs num_records in an SGPR or the store is wrapped
         # in a waterfall loop.
         def _uniform(v):
-            return fx.Int32(fx.rocdl.readfirstlane(T.i32, v.ir_value()))
+            return fx.Int32(fx.rocdl.readfirstlane(T.i32, v))
 
         local_start = _uniform(cta_info_bt[(fx.Int32(1), fx.Int32(0))])
         local_end = _uniform(cta_info_bt[(fx.Int32(1), fx.Int32(1))])
 
-        kv_bt = _i32_buffer(kv_cache_ptr, width=4)
-        kvs_bt = _i32_buffer(kv_scale_ptr, width=1)
-        bt_bt = _i32_buffer(kv_indices_ptr, width=1)
-
         ZERO_F = fx.Float32(0.0)
         c0_i32 = fx.Int32(0)
 
-        row_id = cta_info_vec[0]
-        batch_id = cta_info_vec[1]
-        chunk_start = cta_info_vec[2]
-        chunk_count = cta_info_vec[3]
+        row_id = _uniform(cta_info_vec[0])
+        batch_id = _uniform(cta_info_vec[1])
+        chunk_start = _uniform(cta_info_vec[2])
+        chunk_count = _uniform(cta_info_vec[3])
 
-        # A V# spanning exactly [local_start, local_end) of this row: num_records
-        # then IS the window test, in hardware. A token below the window
-        # underflows to a huge unsigned offset and is dropped by the same bound,
-        # so one check covers both ends. Lanes 16..63 hold redundant copies of
-        # the butterfly result and must not write; a large constant added to
-        # their offset puts them past num_records. It must be a CONSTANT, not a
-        # multiple of win_len: `token_base - local_start` is negative for a
-        # token below a non-zero window start, and adding win_len to that lands
-        # back INSIDE the window, racing the lane that owns the column. Both
-        # terms are chunk-invariant, so both live here.
         win_len = local_end - local_start
-        _row_elems = fx.Int64(row_id) * fx.Int64(stride_out_row) + fx.Int64(local_start)
-        out_win = fx.rocdl.make_buffer_tensor(
-            fx.make_view(
+        if const_expr(litetopk):
+            origin_buf = ptr_buf_tensor(fx.get_iter(origin_ptr), fx.Float32)
+            inv_delta_buf = ptr_buf_tensor(fx.get_iter(inv_delta_ptr), fx.Float32)
+            threshold_buf = ptr_buf_tensor(fx.get_iter(threshold_ptr), fx.Int32)
+            histogram_buf = ptr_buf_tensor(fx.get_iter(histogram_ptr), fx.Int32)
+            candidate_values_it = fx.add_offset(
                 fx.recast_iter(
-                    fx.PointerType.get(T.f32, out_logits_ptr.memspace, 4),
-                    fx.add_offset(fx.get_iter(out_logits_ptr), _row_elems),
+                    fx.PointerType.get(T.f32, candidate_values_ptr.memspace, 4),
+                    fx.get_iter(candidate_values_ptr),
                 ),
-                fx.make_layout((win_len, 1), (1, 1)),
-            ),
-            max_size=False,
-            num_records_bytes=win_len * fx.Int32(4),
-        )
-        out_lane_off = lane_mod_16 + (lane_div_16 > fx.Int32(0)).select(
-            fx.Int32(_NON_WRITER_LANE_OFF), fx.Int32(0)
-        )
-        out_atom = fx.make_copy_atom(fx.rocdl.BufferCopy32b(), 1)
-        out_reg_ty = fx.MemRefType.get(
-            T.f32, fx.LayoutType.get(1, 1), fx.AddressSpace.Register
-        )
-        out_reg_lay = fx.make_layout(1, 1)
+                fx.Int64(row_id) * fx.Int64(candidate_stride),
+            )
+            candidate_indices_it = fx.add_offset(
+                fx.recast_iter(
+                    fx.PointerType.get(T.i32, candidate_indices_ptr.memspace, 4),
+                    fx.get_iter(candidate_indices_ptr),
+                ),
+                fx.Int64(row_id) * fx.Int64(candidate_stride),
+            )
+            candidate_values_buf = ptr_buf_tensor(candidate_values_it, fx.Float32)
+            candidate_indices_buf = ptr_buf_tensor(candidate_indices_it, fx.Int32)
+            candidate_counts_buf = ptr_buf_tensor(
+                fx.get_iter(candidate_counts_ptr), fx.Int32
+            )
+            score_errors_buf = ptr_buf_tensor(fx.get_iter(score_errors_ptr), fx.Int32)
+            row_origin = origin_buf[row_id]
+            row_inv_delta = inv_delta_buf[row_id]
+            row_threshold = threshold_buf[row_id]
+            scan_storage = fx.SharedAllocator().allocate(LiteTopKScanStorage)
+            scan_histogram = scan_storage.histogram.peek().view(fx.make_layout(256, 1))
+            scan_prefix = scan_storage.scan.peek().view(
+                fx.make_layout(num_warps + 1, 1)
+            )
+            scan_state = scan_storage.state.peek().view(fx.make_layout(3, 1))
+            if tid < fx.Int32(256):
+                scan_histogram[tid] = histogram_buf[row_id * fx.Int32(256) + tid]
+            if tid == 0:
+                scan_state[0] = candidate_counts_buf[row_id]
+                scan_state[1] = row_threshold
+                scan_state[2] = score_errors_buf[row_id]
+            gpu.barrier()
+        else:
+            # A V# spanning exactly [local_start, local_end) of this row:
+            # num_records is the window test in hardware. Non-writer lanes use
+            # an offset outside the descriptor and are dropped by the same bound.
+            if const_expr(not seed_emit):
+                _row_elems = fx.Int64(row_id) * fx.Int64(stride_out_row)
+                if const_expr(not relative_output):
+                    _row_elems = _row_elems + fx.Int64(local_start)
+                out_win = fx.rocdl.make_buffer_tensor(
+                    fx.make_view(
+                        fx.recast_iter(
+                            fx.PointerType.get(T.f32, out_logits_ptr.memspace, 4),
+                            fx.add_offset(fx.get_iter(out_logits_ptr), _row_elems),
+                        ),
+                        fx.make_layout((win_len, 1), (1, 1)),
+                    ),
+                    max_size=False,
+                    num_records_bytes=win_len * fx.Int32(4),
+                )
+                out_lane_off = lane_mod_16 + (lane_div_16 > fx.Int32(0)).select(
+                    fx.Int32(_NON_WRITER_LANE_OFF), fx.Int32(0)
+                )
+                out_atom = fx.make_copy_atom(fx.rocdl.BufferCopy32b(), 1)
+                out_reg_ty = fx.MemRefType.get(
+                    T.f32, fx.LayoutType.get(1, 1), fx.AddressSpace.Register
+                )
+                out_reg_lay = fx.make_layout(1, 1)
+            if const_expr(seed_calibration):
+                origin_buf = ptr_buf_tensor(fx.get_iter(origin_ptr), fx.Float32)
+                inv_delta_buf = ptr_buf_tensor(fx.get_iter(inv_delta_ptr), fx.Float32)
+                status_buf = ptr_buf_tensor(fx.get_iter(status_ptr), fx.Int32)
+                seed_storage = fx.SharedAllocator().allocate(LiteTopKSeedStorage)
+                seed_scores = seed_storage.scores.peek().view(fx.make_layout(8192, 1))
+                seed_histogram = seed_storage.histogram.peek().view(
+                    fx.make_layout(256, 1)
+                )
+                seed_scan = seed_storage.scan.peek().view(
+                    fx.make_layout(num_warps + 1, 1)
+                )
+                seed_maxima = seed_storage.maxima.peek().view(fx.make_layout(8, 1))
+                seed_neg_minima = seed_storage.neg_minima.peek().view(
+                    fx.make_layout(8, 1)
+                )
+                seed_finite_counts = seed_storage.finite_counts.peek().view(
+                    fx.make_layout(8, 1)
+                )
+                seed_nonfinite_counts = seed_storage.nonfinite_counts.peek().view(
+                    fx.make_layout(8, 1)
+                )
+                seed_calibration_values = seed_storage.calibration.peek().view(
+                    fx.make_layout(2, 1)
+                )
+                seed_state = seed_storage.state.peek().view(fx.make_layout(2, 1))
+                if const_expr(seed_emit):
+                    threshold_buf = ptr_buf_tensor(fx.get_iter(threshold_ptr), fx.Int32)
+                    histogram_buf = ptr_buf_tensor(fx.get_iter(histogram_ptr), fx.Int32)
+                    candidate_values_it = fx.add_offset(
+                        fx.recast_iter(
+                            fx.PointerType.get(T.f32, candidate_values_ptr.memspace, 4),
+                            fx.get_iter(candidate_values_ptr),
+                        ),
+                        fx.Int64(row_id) * fx.Int64(candidate_stride),
+                    )
+                    candidate_indices_it = fx.add_offset(
+                        fx.recast_iter(
+                            fx.PointerType.get(
+                                T.i32, candidate_indices_ptr.memspace, 4
+                            ),
+                            fx.get_iter(candidate_indices_ptr),
+                        ),
+                        fx.Int64(row_id) * fx.Int64(candidate_stride),
+                    )
+                    candidate_values_buf = ptr_buf_tensor(
+                        candidate_values_it, fx.Float32
+                    )
+                    candidate_indices_buf = ptr_buf_tensor(
+                        candidate_indices_it, fx.Int32
+                    )
+                    candidate_counts_buf = ptr_buf_tensor(
+                        fx.get_iter(candidate_counts_ptr), fx.Int32
+                    )
+                    seed_select_starts_buf = ptr_buf_tensor(
+                        fx.get_iter(out_logits_ptr), fx.Int32
+                    )
+                    seed_select_ends_buf = ptr_buf_tensor(
+                        fx.get_iter(score_errors_ptr), fx.Int32
+                    )
 
         # Q load (hoisted): per (k_tile, mi_idx) a thread loads its 16-byte FP4
         # chunk for head row mi_idx*16+lane_mod_16. Q: [total_tokens, H, D/2] uint8.
@@ -613,8 +755,45 @@ def build_pa_mqa_logits_fp4_prefill_module(
                 + lane_mod_16
             )
             bi_base = _floordiv_kb(token_local_base)
-            phys_vec = bt_bt[batch_id * _stride_bt + bi_base]
-            return _phys_to_list(phys_vec)
+            if const_expr(litetopk or relative_output):
+                batch_valid = (batch_id >= fx.Int32(0)) & (batch_id < block_table_rows)
+                page_valid = (bi_base >= fx.Int32(0)) & (bi_base < block_table_capacity)
+                safe_batch = batch_valid.select(batch_id, fx.Int32(0))
+                safe_page = page_valid.select(bi_base, fx.Int32(0))
+                bt_row = _i32_buffer(
+                    kv_indices_ptr,
+                    width=1,
+                    elem_offset=fx.Int64(safe_batch) * fx.Int64(stride_block_table),
+                )
+                phys_vec = bt_row[safe_page]
+                physical_valid = (phys_vec >= fx.Int32(0)) & (
+                    phys_vec < physical_page_capacity
+                )
+                token_page_start = (chunk_start + c_i32_arg) * fx.Int32(
+                    block_k
+                ) + ni_base * fx.Int32(MFMA_N)
+                page_live = (token_page_start < local_end) & (
+                    token_page_start + fx.Int32(kv_block_size) > local_start
+                )
+            else:
+                bt_row = _i32_buffer(
+                    kv_indices_ptr,
+                    width=1,
+                    elem_offset=fx.Int64(batch_id) * fx.Int64(stride_block_table),
+                )
+                phys_vec = bt_row[bi_base]
+                physical_valid = fx.Boolean(True)
+                safe_phys = phys_vec
+            if const_expr(litetopk or seed_report_page_errors):
+                if (
+                    (lane_id == 0)
+                    & page_live
+                    & ~(batch_valid & page_valid & physical_valid)
+                ):
+                    atomic_add_i32(page_errors_ptr, 1, row_id, "agent")
+            if const_expr(litetopk or relative_output):
+                safe_phys = physical_valid.select(phys_vec, fx.Int32(0))
+            return _phys_to_list(safe_phys)
 
         def _prefetch_chunk(c_i32_arg, phys_list):
             assert N_TILES_PER_WARP == 4, "packed kvs assumes NTPW=4"
@@ -623,11 +802,19 @@ def build_pa_mqa_logits_fp4_prefill_module(
             kv_list = []
             kvs_packed_list = []
 
-            phys_shared = phys_list[0]
+            phys_shared = _uniform(phys_list[0])
+            kv_bt = _i32_buffer(
+                kv_cache_ptr,
+                width=4,
+                elem_offset=fx.Int64(phys_shared) * fx.Int64(_stride_kv_block // 4),
+            )
+            kvs_bt = _i32_buffer(
+                kv_scale_ptr,
+                width=1,
+                elem_offset=fx.Int64(phys_shared) * fx.Int64(_stride_kvs_block // 4),
+            )
             kvs_base_off_elems = (
-                phys_shared * _stride_kvs_block
-                + lane_div_16 * kv_block_size
-                + lane_mod_16 * fx.Int32(N_TILES_PER_WARP)
+                lane_div_16 * kv_block_size + lane_mod_16 * fx.Int32(N_TILES_PER_WARP)
             ) >> fx.Int32(2)
             for k_tile in range_constexpr(k_tiles):
                 kvs_packed = kvs_bt[
@@ -643,8 +830,7 @@ def build_pa_mqa_logits_fp4_prefill_module(
             )
             token_in_block0 = _mod_kb(token_local0)
             kv_base_off_elems = (
-                phys_shared * _stride_kv_block
-                + lane_div_16 * kv_block_size * _kv_chunk_bytes
+                lane_div_16 * kv_block_size * _kv_chunk_bytes
                 + token_in_block0 * _kv_chunk_bytes
             ) >> fx.Int32(2)
             for nt in range_constexpr(N_TILES_PER_WARP):
@@ -681,14 +867,50 @@ def build_pa_mqa_logits_fp4_prefill_module(
                     accs[mi_idx] = c_frag.load()
             return accs
 
-        def _post_process_nt(accs, nt, c_i32_arg):
-            """relu + per-head weight + per-thread sum + bperm + windowed store."""
-            zero = fx.Vector.filled(4, 0.0, fx.Float32)
-            ni_warp = warp_id * fx.Int32(N_TILES_PER_WARP) + fx.Int32(nt)
-            token_base = (chunk_start + c_i32_arg) * fx.Int32(
-                block_k
-            ) + ni_warp * fx.Int32(MFMA_N)
+        def _store_candidate(values_buf, indices_buf, offset, score, logical_index):
+            values_buf[offset] = score
+            indices_buf[offset] = logical_index
 
+        def _block_exclusive_prefix_i32(value, scan):
+            warp = tid // fx.Int32(WARP_SIZE)
+            inclusive = _warp_inclusive_prefix_i32(value, lane_id, WARP_SIZE)
+            exclusive = inclusive - value
+            if lane_id == fx.Int32(WARP_SIZE - 1):
+                scan[warp] = inclusive
+            gpu.barrier()
+            if warp == 0:
+                wave_value = fx.Int32(0)
+                if lane_id < fx.Int32(num_warps):
+                    wave_value = scan[lane_id]
+                wave_inclusive = _warp_inclusive_prefix_i32(
+                    wave_value, lane_id, WARP_SIZE
+                )
+                if lane_id < fx.Int32(num_warps):
+                    scan[lane_id] = wave_inclusive - wave_value
+                if lane_id == fx.Int32(num_warps - 1):
+                    scan[num_warps] = wave_inclusive
+            gpu.barrier()
+            result = scan[warp] + exclusive
+            total = scan[num_warps]
+            gpu.barrier()
+            return result, total
+
+        def _refresh_litetopk_threshold(histogram, state, scan):
+            gpu.barrier()
+            count = fx.Int32(0)
+            if tid < fx.Int32(256):
+                count = histogram[tid]
+            before, _ = _block_exclusive_prefix_i32(count, scan)
+            old_threshold = state[1]
+            crosses_topk = (before < fx.Int32(litetopk_topk)) & (
+                before + count >= fx.Int32(litetopk_topk)
+            )
+            if crosses_topk & (tid < old_threshold):
+                state[1] = tid
+            gpu.barrier()
+
+        def _reduce_nt_score(accs):
+            zero = fx.Vector.filled(4, 0.0, fx.Float32)
             thread_sum = ZERO_F
             for mi_idx in range_constexpr(m_tiles):
                 relu_v = fx.Vector(accs[mi_idx]).maximumf(zero)
@@ -706,22 +928,202 @@ def build_pa_mqa_logits_fp4_prefill_module(
                 return val + peer_i32.bitcast(fx.Float32)
 
             thread_sum = _bperm_xor_add(thread_sum, 16)
-            thread_sum = _bperm_xor_add(thread_sum, 32)
+            return _bperm_xor_add(thread_sum, 32)
+
+        def _post_process_nt(accs, nt, c_i32_arg, chunk_threshold):
+            """relu + per-head weight + per-thread sum + bperm + windowed store."""
+            ni_warp = warp_id * fx.Int32(N_TILES_PER_WARP) + fx.Int32(nt)
+            token_base = (chunk_start + c_i32_arg) * fx.Int32(
+                block_k
+            ) + ni_warp * fx.Int32(MFMA_N)
+            thread_sum = _reduce_nt_score(accs)
+            lane_i32 = fx.Int32(lane_id)
             # `weight_scale` already folded into `w_per_lane` (hoisted, once/wave).
 
-            # Window and writer-lane guards are both in the V#; nothing is
-            # tested here. Cells outside stay at the caller's -inf pre-fill.
-            r_out = fx.memref_alloca(out_reg_ty, out_reg_lay)
-            fx.memref_store_vec(
-                fx.Vector.from_elements([thread_sum], dtype=fx.Float32), r_out
-            )
-            fx.copy(
-                out_atom,
-                r_out,
-                fx.slice(out_win, (token_base - local_start + out_lane_off, None)),
-            )
+            if const_expr(litetopk):
+                logical_index = token_base + lane_mod_16
+                is_writer = lane_div_16 == fx.Int32(0)
+                in_window = (logical_index >= local_start) & (logical_index < local_end)
+                score_bits = thread_sum.bitcast(fx.Int32) & fx.Int32(0x7FFFFFFF)
+                finite = arith.cmpi(
+                    arith.CmpIPredicate.ult,
+                    score_bits,
+                    fx.Int32(0x7F800000),
+                )
+                genuine = is_writer & in_window & finite
+                bucket_f = (-thread_sum - row_origin) * row_inv_delta
+                bucket_f = finite.select(bucket_f, fx.Float32(255.0))
+                bucket = fx.Int32(fx.clampf(bucket_f, 0.0, 255.0))
+                keep = genuine & (bucket <= chunk_threshold)
+                if keep:
+                    atomic_add_i32(
+                        scan_histogram,
+                        1,
+                        bucket,
+                        "workgroup",
+                    )
+                nonfinite = is_writer & in_window & ~finite
+                if nonfinite:
+                    atomic_add_i32(scan_state, 1, 2, "workgroup")
 
-        def _compute_chunk(kv_list_in, kvs_packed_list_in, c_i32_arg, nt0_accs_in=None):
+                keep_mask = fx.Int64(ballot(T.i64, keep))
+                if keep_mask != fx.Int64(0):
+                    lower_mask = (fx.Int64(1) << fx.Int64(lane_i32)) - fx.Int64(1)
+                    exclusive = _popcount_i64(keep_mask & lower_mask)
+                    wave_total = _popcount_i64(keep_mask)
+                    wave_base_lane0 = fx.Int32(0)
+                    if lane_id == 0:
+                        wave_base_lane0 = atomic_add_i32(
+                            scan_state,
+                            wave_total,
+                            0,
+                            "workgroup",
+                        )
+                    wave_base = fx.Int32(readlane(T.i32, wave_base_lane0.ir_value(), 0))
+                    if keep:
+                        candidate_slot = wave_base + exclusive
+                        if candidate_slot < merge_cap:
+                            _store_candidate(
+                                candidate_values_buf,
+                                candidate_indices_buf,
+                                candidate_slot,
+                                thread_sum,
+                                logical_index,
+                            )
+            else:
+                r_out = fx.memref_alloca(out_reg_ty, out_reg_lay)
+                fx.memref_store_vec(
+                    fx.Vector.from_elements([thread_sum], dtype=fx.Float32), r_out
+                )
+                fx.copy(
+                    out_atom,
+                    r_out,
+                    fx.slice(out_win, (token_base - local_start + out_lane_off, None)),
+                )
+
+        def _post_process_litetopk_chunk(
+            score_nt0,
+            score_nt1,
+            score_nt2,
+            score_nt3,
+            c_i32_arg,
+            chunk_threshold,
+        ):
+            thread_sum = (lane_div_16 == fx.Int32(1)).select(score_nt1, score_nt0)
+            thread_sum = (lane_div_16 == fx.Int32(2)).select(score_nt2, thread_sum)
+            thread_sum = (lane_div_16 == fx.Int32(3)).select(score_nt3, thread_sum)
+            lane_i32 = fx.Int32(lane_id)
+            logical_index = (
+                (chunk_start + c_i32_arg) * fx.Int32(block_k)
+                + warp_id * fx.Int32(N_TILES_PER_WARP * MFMA_N)
+                + lane_i32
+            )
+            in_window = (logical_index >= local_start) & (logical_index < local_end)
+            score_bits = thread_sum.bitcast(fx.Int32) & fx.Int32(0x7FFFFFFF)
+            finite = arith.cmpi(
+                arith.CmpIPredicate.ult,
+                score_bits,
+                fx.Int32(0x7F800000),
+            )
+            genuine = in_window & finite
+            bucket_f = (-thread_sum - row_origin) * row_inv_delta
+            bucket_f = finite.select(bucket_f, fx.Float32(255.0))
+            bucket = fx.Int32(fx.clampf(bucket_f, 0.0, 255.0))
+            keep = genuine & (bucket <= chunk_threshold)
+            if keep:
+                atomic_add_i32(
+                    scan_histogram,
+                    1,
+                    bucket,
+                    "workgroup",
+                )
+            if in_window & ~finite:
+                atomic_add_i32(scan_state, 1, 2, "workgroup")
+
+            keep_mask = fx.Int64(ballot(T.i64, keep))
+            if keep_mask != fx.Int64(0):
+                lower_mask = (fx.Int64(1) << fx.Int64(lane_i32)) - fx.Int64(1)
+                exclusive = _popcount_i64(keep_mask & lower_mask)
+                wave_total = _popcount_i64(keep_mask)
+                wave_base_lane0 = fx.Int32(0)
+                if lane_id == 0:
+                    wave_base_lane0 = atomic_add_i32(
+                        scan_state,
+                        wave_total,
+                        0,
+                        "workgroup",
+                    )
+                wave_base = fx.Int32(readlane(T.i32, wave_base_lane0.ir_value(), 0))
+                if keep:
+                    candidate_slot = wave_base + exclusive
+                    if candidate_slot < merge_cap:
+                        _store_candidate(
+                            candidate_values_buf,
+                            candidate_indices_buf,
+                            candidate_slot,
+                            thread_sum,
+                            logical_index,
+                        )
+
+        def _post_process_seed_chunk(
+            score_nt0,
+            score_nt1,
+            score_nt2,
+            score_nt3,
+            c_i32_arg,
+            seed_scores_out,
+            row_max,
+            row_neg_min,
+            finite_count,
+            nonfinite_count,
+        ):
+            thread_sum = (lane_div_16 == fx.Int32(1)).select(score_nt1, score_nt0)
+            thread_sum = (lane_div_16 == fx.Int32(2)).select(score_nt2, thread_sum)
+            thread_sum = (lane_div_16 == fx.Int32(3)).select(score_nt3, thread_sum)
+            logical_index = (
+                (chunk_start + c_i32_arg) * fx.Int32(block_k)
+                + warp_id * fx.Int32(N_TILES_PER_WARP * MFMA_N)
+                + fx.Int32(lane_id)
+            )
+            in_window = (logical_index >= local_start) & (logical_index < local_end)
+
+            if const_expr(seed_emit):
+                if in_window:
+                    seed_scores_out[logical_index - local_start] = thread_sum
+            else:
+                r_out = fx.memref_alloca(out_reg_ty, out_reg_lay)
+                fx.memref_store_vec(
+                    fx.Vector.from_elements([thread_sum], dtype=fx.Float32), r_out
+                )
+                fx.copy(
+                    out_atom,
+                    r_out,
+                    fx.slice(out_win, (logical_index - local_start, None)),
+                )
+
+            score_bits = thread_sum.bitcast(fx.Int32) & fx.Int32(0x7FFFFFFF)
+            finite = arith.cmpi(
+                arith.CmpIPredicate.ult,
+                score_bits,
+                fx.Int32(0x7F800000),
+            )
+            genuine = in_window & finite
+            neg_inf = fx.Float32(-float("inf"))
+            row_max = row_max.maximumf(genuine.select(thread_sum, neg_inf))
+            row_neg_min = row_neg_min.maximumf(genuine.select(-thread_sum, neg_inf))
+            finite_count = finite_count + genuine.select(fx.Int32(1), fx.Int32(0))
+            nonfinite_count = nonfinite_count + (in_window & ~finite).select(
+                fx.Int32(1), fx.Int32(0)
+            )
+            return row_max, row_neg_min, finite_count, nonfinite_count
+
+        def _compute_chunk(
+            kv_list_in,
+            kvs_packed_list_in,
+            c_i32_arg,
+            nt0_accs_in=None,
+            seed_accs=None,
+        ):
             assert (
                 N_TILES_PER_WARP == 4
             ), "pipelined-nt structure currently hardcoded for NTPW=4"
@@ -731,17 +1133,46 @@ def build_pa_mqa_logits_fp4_prefill_module(
                 if nt0_accs_in is None
                 else list(nt0_accs_in)
             )
+            chunk_threshold = scan_state[1] if const_expr(litetopk) else c0_i32
 
-            accs_nt1 = _issue_nt_mfmas(kv_list_in, kvs_packed_list_in, 1)
-            _post_process_nt(accs_nt0, 0, c_i32_arg)
-
-            accs_nt2 = _issue_nt_mfmas(kv_list_in, kvs_packed_list_in, 2)
-            _post_process_nt(accs_nt1, 1, c_i32_arg)
-
-            accs_nt3 = _issue_nt_mfmas(kv_list_in, kvs_packed_list_in, 3)
-            _post_process_nt(accs_nt2, 2, c_i32_arg)
-
-            _post_process_nt(accs_nt3, 3, c_i32_arg)
+            if const_expr(litetopk or seed_calibration):
+                accs_nt1 = _issue_nt_mfmas(kv_list_in, kvs_packed_list_in, 1)
+                score_nt0 = _reduce_nt_score(accs_nt0)
+                accs_nt2 = _issue_nt_mfmas(kv_list_in, kvs_packed_list_in, 2)
+                score_nt1 = _reduce_nt_score(accs_nt1)
+                accs_nt3 = _issue_nt_mfmas(kv_list_in, kvs_packed_list_in, 3)
+                score_nt2 = _reduce_nt_score(accs_nt2)
+                score_nt3 = _reduce_nt_score(accs_nt3)
+                if const_expr(litetopk):
+                    _post_process_litetopk_chunk(
+                        score_nt0,
+                        score_nt1,
+                        score_nt2,
+                        score_nt3,
+                        c_i32_arg,
+                        chunk_threshold,
+                    )
+                    return []
+                return list(
+                    _post_process_seed_chunk(
+                        score_nt0,
+                        score_nt1,
+                        score_nt2,
+                        score_nt3,
+                        c_i32_arg,
+                        seed_scores,
+                        *seed_accs,
+                    )
+                )
+            else:
+                accs_nt1 = _issue_nt_mfmas(kv_list_in, kvs_packed_list_in, 1)
+                _post_process_nt(accs_nt0, 0, c_i32_arg, chunk_threshold)
+                accs_nt2 = _issue_nt_mfmas(kv_list_in, kvs_packed_list_in, 2)
+                _post_process_nt(accs_nt1, 1, c_i32_arg, chunk_threshold)
+                accs_nt3 = _issue_nt_mfmas(kv_list_in, kvs_packed_list_in, 3)
+                _post_process_nt(accs_nt2, 2, c_i32_arg, chunk_threshold)
+                _post_process_nt(accs_nt3, 3, c_i32_arg, chunk_threshold)
+                return []
 
         # === Prologue ===
         N_KV = k_tiles * N_TILES_PER_WARP
@@ -765,6 +1196,13 @@ def build_pa_mqa_logits_fp4_prefill_module(
         init_args = (
             list(kv_pre) + list(kvs_pre) + list(phys_next_pre) + nt0_init_scalars
         )
+        if const_expr(seed_calibration):
+            init_args = init_args + [
+                fx.Float32(-float("inf")),
+                fx.Float32(-float("inf")),
+                fx.Int32(0),
+                fx.Int32(0),
+            ]
         for c_idx, state in range(0, chunk_count_minus_1_idx, 1, init=init_args):
             kv_cur_list = [state[i] for i in range(N_KV)]
             kvs_cur_list = [state[N_KV + i] for i in range(N_KVS)]
@@ -781,9 +1219,22 @@ def build_pa_mqa_logits_fp4_prefill_module(
             c_next_i32 = c_idx_i32 + fx.Int32(1)
             c_next_next_i32 = c_next_i32 + fx.Int32(1)
 
-            _compute_chunk(
-                kv_cur_list, kvs_cur_list, c_idx_i32, nt0_accs_in=nt0_accs_cur
+            seed_acc_base = nt0_acc_base + m_tiles * 4
+            seed_accs_cur = (
+                [state[seed_acc_base + i] for i in range(4)]
+                if const_expr(seed_calibration)
+                else None
             )
+            seed_accs_next = _compute_chunk(
+                kv_cur_list,
+                kvs_cur_list,
+                c_idx_i32,
+                nt0_accs_in=nt0_accs_cur,
+                seed_accs=seed_accs_cur,
+            )
+            if const_expr(litetopk and litetopk_refresh_every > 0):
+                if (c_next_i32 % fx.Int32(litetopk_refresh_every)) == 0:
+                    _refresh_litetopk_threshold(scan_histogram, scan_state, scan_prefix)
 
             kv_next, kvs_next = _prefetch_chunk(c_next_i32, phys_next_list)
 
@@ -801,6 +1252,7 @@ def build_pa_mqa_logits_fp4_prefill_module(
                 + list(kvs_next)
                 + list(phys_next_next_list)
                 + nt0_next_scalars
+                + seed_accs_next
             )
 
         # === Epilogue: process last chunk (chunk_count - 1) ===
@@ -814,9 +1266,240 @@ def build_pa_mqa_logits_fp4_prefill_module(
             )
             for mi in range(m_tiles)
         ]
-        _compute_chunk(
-            kv_last_list, kvs_last_list, last_c_i32, nt0_accs_in=nt0_accs_last
+        seed_acc_base = nt0_acc_base + m_tiles * 4
+        seed_accs_last = (
+            [results[seed_acc_base + i] for i in range(4)]
+            if const_expr(seed_calibration)
+            else None
         )
+        seed_accs_final = _compute_chunk(
+            kv_last_list,
+            kvs_last_list,
+            last_c_i32,
+            nt0_accs_in=nt0_accs_last,
+            seed_accs=seed_accs_last,
+        )
+        if const_expr(litetopk):
+            if const_expr(litetopk_refresh_every > 0):
+                _refresh_litetopk_threshold(scan_histogram, scan_state, scan_prefix)
+            gpu.barrier()
+            if tid < fx.Int32(256):
+                histogram_offset = row_id * fx.Int32(256) + tid
+                histogram_buf[histogram_offset] = scan_histogram[tid]
+            if tid == 0:
+                candidate_counts_buf[row_id] = scan_state[0]
+                threshold_buf[row_id] = scan_state[1]
+                score_errors_buf[row_id] = scan_state[2]
+        elif const_expr(seed_calibration):
+            row_max, row_neg_min, finite_count, nonfinite_count = seed_accs_final
+
+            def _wave_reduce_max_f32(value):
+                value = fx.Float32(value)
+                for distance in (1, 2, 4, 8, 16, 32):
+                    peer_i32 = fx.Int32(
+                        rocdl.ds_bpermute(
+                            T.i32,
+                            (fx.Int32(lane_id) ^ fx.Int32(distance)) * fx.Int32(4),
+                            value.bitcast(fx.Int32),
+                        )
+                    )
+                    value = value.maximumf(peer_i32.bitcast(fx.Float32))
+                return value
+
+            def _wave_reduce_add_i32(value):
+                value = fx.Int32(value)
+                for distance in (1, 2, 4, 8, 16, 32):
+                    peer = fx.Int32(
+                        rocdl.ds_bpermute(
+                            T.i32,
+                            (fx.Int32(lane_id) ^ fx.Int32(distance)) * fx.Int32(4),
+                            value,
+                        )
+                    )
+                    value = value + peer
+                return value
+
+            row_max = _wave_reduce_max_f32(row_max)
+            row_neg_min = _wave_reduce_max_f32(row_neg_min)
+            finite_count = _wave_reduce_add_i32(finite_count)
+            nonfinite_count = _wave_reduce_add_i32(nonfinite_count)
+            if lane_id == 0:
+                seed_maxima[warp_id] = row_max
+                seed_neg_minima[warp_id] = row_neg_min
+                seed_finite_counts[warp_id] = finite_count
+                seed_nonfinite_counts[warp_id] = nonfinite_count
+            gpu.barrier()
+
+            if tid == 0:
+                block_max = fx.Float32(-float("inf"))
+                block_neg_min = fx.Float32(-float("inf"))
+                block_finite_count = fx.Int32(0)
+                block_nonfinite_count = fx.Int32(0)
+                for wave in range_constexpr(num_warps):
+                    block_max = block_max.maximumf(seed_maxima[wave])
+                    block_neg_min = block_neg_min.maximumf(seed_neg_minima[wave])
+                    block_finite_count = block_finite_count + seed_finite_counts[wave]
+                    block_nonfinite_count = (
+                        block_nonfinite_count + seed_nonfinite_counts[wave]
+                    )
+
+                has_finite = block_finite_count > fx.Int32(0)
+                safe_max = has_finite.select(block_max, fx.Float32(0.0))
+                safe_min = has_finite.select(-block_neg_min, fx.Float32(0.0))
+                seed_origin = -safe_max
+                magnitude = safe_max.maximumf(-safe_max).maximumf(
+                    safe_min.maximumf(-safe_min)
+                )
+                span = (safe_max - safe_min).maximumf(
+                    magnitude * fx.Float32(1.0 / 256.0)
+                )
+                span = span.maximumf(fx.Float32(1.0e-6))
+                seed_inv_delta = fx.Float32(255.0) / span
+                origin_bits = seed_origin.bitcast(fx.Int32) & fx.Int32(0x7FFFFFFF)
+                inv_delta_bits = seed_inv_delta.bitcast(fx.Int32) & fx.Int32(0x7FFFFFFF)
+                affine_finite = arith.cmpi(
+                    arith.CmpIPredicate.ult,
+                    origin_bits,
+                    fx.Int32(0x7F800000),
+                ) & arith.cmpi(
+                    arith.CmpIPredicate.ult,
+                    inv_delta_bits,
+                    fx.Int32(0x7F800000),
+                )
+                bad_calibration = (
+                    (block_nonfinite_count > fx.Int32(0))
+                    | ((local_end > local_start) & ~has_finite)
+                    | ~affine_finite
+                )
+                origin_buf[row_id] = affine_finite.select(seed_origin, fx.Float32(0.0))
+                inv_delta_buf[row_id] = affine_finite.select(
+                    seed_inv_delta, fx.Float32(1.0)
+                )
+                status_buf[row_id] = status_buf[row_id] | bad_calibration.select(
+                    fx.Int32(seed_status_nonfinite), fx.Int32(0)
+                )
+                if const_expr(seed_emit):
+                    seed_calibration_values[0] = affine_finite.select(
+                        seed_origin, fx.Float32(0.0)
+                    )
+                    seed_calibration_values[1] = affine_finite.select(
+                        seed_inv_delta, fx.Float32(1.0)
+                    )
+
+            if const_expr(seed_emit):
+                if tid < fx.Int32(256):
+                    seed_histogram[tid] = fx.Int32(0)
+                if tid == 0:
+                    required = (win_len < fx.Int32(litetopk_topk)).select(
+                        win_len, fx.Int32(litetopk_topk)
+                    )
+                    seed_state[0] = (required > fx.Int32(0)).select(
+                        fx.Int32(255), fx.Int32(0)
+                    )
+                    seed_state[1] = required
+                gpu.barrier()
+
+                seed_origin_shared = seed_calibration_values[0]
+                seed_inv_delta_shared = seed_calibration_values[1]
+                for seed_base in range(
+                    fx.Int32(0), fx.Int32(8192), fx.Int32(block_threads_k)
+                ):
+                    seed_slot = fx.Int32(seed_base) + tid
+                    seed_score = seed_scores[seed_slot]
+                    seed_finite_bits = seed_score.bitcast(fx.Int32) & fx.Int32(
+                        0x7FFFFFFF
+                    )
+                    seed_finite = arith.cmpi(
+                        arith.CmpIPredicate.ult,
+                        seed_finite_bits,
+                        fx.Int32(0x7F800000),
+                    )
+                    seed_genuine = (seed_slot < win_len) & seed_finite
+                    seed_bucket_f = (
+                        -seed_score - seed_origin_shared
+                    ) * seed_inv_delta_shared
+                    seed_bucket_f = seed_finite.select(seed_bucket_f, fx.Float32(255.0))
+                    seed_bucket = fx.Int32(fx.clampf(seed_bucket_f, 0.0, 255.0))
+                    if seed_genuine:
+                        atomic_add_i32(
+                            seed_histogram,
+                            1,
+                            seed_bucket,
+                            "workgroup",
+                        )
+
+                gpu.barrier()
+                seed_count = fx.Int32(0)
+                if tid < fx.Int32(256):
+                    seed_count = seed_histogram[tid]
+                seed_before, _ = _block_exclusive_prefix_i32(seed_count, seed_scan)
+                seed_required = seed_state[1]
+                seed_crosses = (seed_before < seed_required) & (
+                    seed_before + seed_count >= seed_required
+                )
+                if seed_crosses & (tid < fx.Int32(256)):
+                    seed_state[0] = tid
+                gpu.barrier()
+
+                if tid < fx.Int32(256):
+                    histogram_buf[row_id * fx.Int32(256) + tid] = seed_histogram[tid]
+                if tid == 0:
+                    threshold_buf[row_id] = seed_state[0]
+
+                seed_emit_result = None
+                for seed_base, seed_emit_state in range(
+                    fx.Int32(0),
+                    fx.Int32(8192),
+                    fx.Int32(block_threads_k),
+                    init=[fx.Int32(0)],
+                ):
+                    seed_attempted = fx.Int32(seed_emit_state[0])
+                    seed_slot = fx.Int32(seed_base) + tid
+                    seed_score = seed_scores[seed_slot]
+                    seed_finite_bits = seed_score.bitcast(fx.Int32) & fx.Int32(
+                        0x7FFFFFFF
+                    )
+                    seed_finite = arith.cmpi(
+                        arith.CmpIPredicate.ult,
+                        seed_finite_bits,
+                        fx.Int32(0x7F800000),
+                    )
+                    seed_genuine = (seed_slot < win_len) & seed_finite
+                    seed_bucket_f = (
+                        -seed_score - seed_origin_shared
+                    ) * seed_inv_delta_shared
+                    seed_bucket_f = seed_finite.select(seed_bucket_f, fx.Float32(255.0))
+                    seed_bucket = fx.Int32(fx.clampf(seed_bucket_f, 0.0, 255.0))
+                    seed_keep = seed_genuine & (seed_bucket <= seed_state[0])
+                    seed_exclusive, seed_total = _block_exclusive_prefix_i32(
+                        seed_keep.select(fx.Int32(1), fx.Int32(0)), seed_scan
+                    )
+                    seed_candidate_slot = seed_attempted + seed_exclusive
+                    if seed_keep & (seed_candidate_slot < merge_cap):
+                        _store_candidate(
+                            candidate_values_buf,
+                            candidate_indices_buf,
+                            seed_candidate_slot,
+                            seed_score,
+                            local_start + seed_slot,
+                        )
+                    seed_emit_result = yield [seed_attempted + seed_total]
+
+                seed_attempted = fx.Int32(seed_emit_result)
+                if tid == 0:
+                    candidate_counts_buf[row_id] = seed_attempted
+                    seed_select_starts_buf[row_id] = fx.Int32(0)
+                    seed_select_ends_buf[row_id] = (seed_attempted < merge_cap).select(
+                        seed_attempted, merge_cap
+                    )
+                    seed_status = status_buf[row_id]
+                    seed_status = seed_status | (seed_attempted > merge_cap).select(
+                        fx.Int32(seed_status_candidate_overflow), fx.Int32(0)
+                    )
+                    seed_status = seed_status | (seed_attempted < seed_required).select(
+                        fx.Int32(seed_status_underfilled), fx.Int32(0)
+                    )
+                    status_buf[row_id] = seed_status
 
     return pa_mqa_logits_fp4_prefill_kernel, block_threads_k
 
@@ -826,23 +1509,23 @@ def build_pa_mqa_logits_fp4_prefill_module(
 # ============================================================================
 
 
-@lru_cache(maxsize=32)
+@cache
 def compile_pa_mqa_logits_fp4_prefill(
     *,
     block_k: int = 256,
     kv_block_size: int = 64,
-    max_blocks_per_seq: int = 256,
     num_warps: int = DEFAULT_NUM_WARPS,
     heads: int = DEFAULT_HEADS,
     head_dim: int = DEFAULT_HEAD_DIM,
+    relative_output: bool = False,
 ):
     kfn, block_threads = build_pa_mqa_logits_fp4_prefill_module(
         block_k=block_k,
         kv_block_size=kv_block_size,
-        max_blocks_per_seq=max_blocks_per_seq,
         num_warps=num_warps,
         heads=heads,
         head_dim=head_dim,
+        relative_output=relative_output,
     )
 
     @flyc.jit
@@ -856,16 +1539,481 @@ def compile_pa_mqa_logits_fp4_prefill(
         w,
         cta_info_,
         stride_out: fx.Int32,
+        stride_bt: fx.Int32,
+        block_table_rows: fx.Int32,
+        block_table_capacity: fx.Int32,
+        physical_page_capacity: fx.Int32,
         weight_scale: fx.Float32,
         gx: fx.Int32,
         stream: fx.Stream,
     ):
         gxi = fx.Int64(gx)
-        kfn(out, q, qs, kv, kvs, bt, w, cta_info_, stride_out, weight_scale).launch(
-            grid=(gxi,), block=(block_threads, 1, 1), stream=stream
-        )
+        kfn(
+            out,
+            q,
+            qs,
+            kv,
+            kvs,
+            bt,
+            w,
+            cta_info_,
+            stride_out,
+            stride_bt,
+            block_table_rows,
+            weight_scale,
+            out,
+            out,
+            out,
+            out,
+            out,
+            out,
+            out,
+            out,
+            out,
+            out,
+            fx.Int32(0),
+            fx.Int32(0),
+            block_table_capacity,
+            physical_page_capacity,
+        ).launch(grid=(gxi,), block=(block_threads, 1, 1), stream=stream)
 
     return launch_pa_mqa_logits_fp4_prefill, block_threads
+
+
+@cache
+def compile_pa_mqa_litetopk_fp4_seed(
+    *,
+    block_k: int = 256,
+    kv_block_size: int = 64,
+    num_warps: int = DEFAULT_NUM_WARPS,
+    heads: int = DEFAULT_HEADS,
+    head_dim: int = DEFAULT_HEAD_DIM,
+    topk: int = 512,
+    status_candidate_overflow: int = 1 << 0,
+    status_underfilled: int = 1 << 1,
+    status_nonfinite: int = 1 << 2,
+    report_page_errors: bool = False,
+):
+    kfn, block_threads = build_pa_mqa_logits_fp4_prefill_module(
+        block_k=block_k,
+        kv_block_size=kv_block_size,
+        num_warps=num_warps,
+        heads=heads,
+        head_dim=head_dim,
+        relative_output=True,
+        seed_calibration=True,
+        seed_emit=True,
+        seed_report_page_errors=report_page_errors,
+        seed_status_candidate_overflow=status_candidate_overflow,
+        seed_status_underfilled=status_underfilled,
+        seed_status_nonfinite=status_nonfinite,
+        litetopk_topk=topk,
+    )
+
+    @flyc.jit
+    def launch_pa_mqa_litetopk_fp4_seed(
+        q,
+        qs,
+        kv,
+        kvs,
+        bt,
+        w,
+        cta_info_,
+        origin,
+        inv_delta,
+        threshold,
+        histogram,
+        candidate_values,
+        candidate_indices,
+        candidate_counts,
+        select_starts,
+        select_ends,
+        status,
+        page_errors,
+        candidate_stride: fx.Int32,
+        merge_cap: fx.Int32,
+        stride_bt: fx.Int32,
+        block_table_rows: fx.Int32,
+        block_table_capacity: fx.Int32,
+        physical_page_capacity: fx.Int32,
+        weight_scale: fx.Float32,
+        gx: fx.Int32,
+        stream: fx.Stream,
+    ):
+        gxi = fx.Int64(gx)
+        kfn(
+            select_starts,
+            q,
+            qs,
+            kv,
+            kvs,
+            bt,
+            w,
+            cta_info_,
+            fx.Int32(0),
+            stride_bt,
+            block_table_rows,
+            weight_scale,
+            origin,
+            inv_delta,
+            threshold,
+            histogram,
+            candidate_values,
+            candidate_indices,
+            candidate_counts,
+            page_errors,
+            select_ends,
+            status,
+            candidate_stride,
+            merge_cap,
+            block_table_capacity,
+            physical_page_capacity,
+        ).launch(grid=(gxi,), block=(block_threads, 1, 1), stream=stream)
+
+    return launch_pa_mqa_litetopk_fp4_seed, block_threads
+
+
+def flydsl_pa_mqa_litetopk_fp4_seed(
+    q_fp4: torch.Tensor,
+    q_scale: torch.Tensor,
+    kv_cache: torch.Tensor,
+    kv_scale: torch.Tensor,
+    block_tables: torch.Tensor,
+    weights: torch.Tensor,
+    cta_info: torch.Tensor,
+    origin: torch.Tensor,
+    inv_delta: torch.Tensor,
+    threshold: torch.Tensor,
+    histogram: torch.Tensor,
+    candidate_values: torch.Tensor,
+    candidate_indices: torch.Tensor,
+    candidate_counts: torch.Tensor,
+    select_starts: torch.Tensor,
+    select_ends: torch.Tensor,
+    status: torch.Tensor,
+    *,
+    n_ctas: int,
+    merge_cap: int,
+    topk: int,
+    status_candidate_overflow: int,
+    status_underfilled: int,
+    status_nonfinite: int,
+    page_errors: torch.Tensor | None = None,
+    weight_scale: float = 1.0,
+    block_k: int = 256,
+    kv_block_size: int = 64,
+    num_warps: int = DEFAULT_NUM_WARPS,
+    stream: torch.cuda.Stream | None = None,
+) -> None:
+    """Score and emit the complete bounded LiteTopK seed in one CTA per row."""
+    rows, heads, head_dim_packed = q_fp4.shape
+    if heads != DEFAULT_HEADS or head_dim_packed * 2 != DEFAULT_HEAD_DIM:
+        raise ValueError("LiteTopK seed requires H=64 and D=128")
+    if n_ctas != rows:
+        raise ValueError("LiteTopK seed requires exactly one CTA per row")
+    if cta_info.shape != (rows, CTA_INFO_WIDTH) or cta_info.dtype != torch.int32:
+        raise ValueError("cta_info must be int32 [rows, 6]")
+    if any(t.dtype != torch.float32 or t.shape != (rows,) for t in (origin, inv_delta)):
+        raise ValueError("origin and inv_delta must be float32 [rows]")
+    row_i32 = (threshold, candidate_counts, select_starts, select_ends, status)
+    if any(t.dtype != torch.int32 or t.shape != (rows,) for t in row_i32):
+        raise ValueError("seed row metadata must be int32 [rows]")
+    if histogram.dtype != torch.int32 or histogram.shape != (rows, 256):
+        raise ValueError("histogram must be int32 [rows, 256]")
+    if candidate_values.dtype != torch.float32 or candidate_values.shape != (
+        rows,
+        merge_cap,
+    ):
+        raise ValueError("candidate_values shape does not match rows and merge_cap")
+    if candidate_indices.dtype != torch.int32 or candidate_indices.shape != (
+        rows,
+        merge_cap,
+    ):
+        raise ValueError("candidate_indices shape does not match rows and merge_cap")
+    if page_errors is not None and (
+        page_errors.dtype != torch.int32 or page_errors.shape != (rows,)
+    ):
+        raise ValueError("page_errors must be int32 [rows]")
+    tensors = (
+        q_fp4,
+        q_scale,
+        kv_cache,
+        kv_scale,
+        block_tables,
+        weights,
+        cta_info,
+        origin,
+        inv_delta,
+        histogram,
+        candidate_values,
+        candidate_indices,
+        *row_i32,
+        *((page_errors,) if page_errors is not None else ()),
+    )
+    if any(t.device != q_fp4.device for t in tensors):
+        raise ValueError("all LiteTopK seed tensors must be on one device")
+    if any(not t.is_contiguous() for t in tensors):
+        raise ValueError("all LiteTopK seed tensors must be contiguous")
+    if stream is None:
+        stream = torch.cuda.current_stream(q_fp4.device)
+    if torch.device(stream.device) != q_fp4.device:
+        raise ValueError("stream and LiteTopK seed tensors must be on one device")
+
+    with torch.cuda.device(q_fp4.device), torch.cuda.stream(stream):
+        launcher, _ = compile_pa_mqa_litetopk_fp4_seed(
+            block_k=block_k,
+            kv_block_size=kv_block_size,
+            num_warps=num_warps,
+            heads=heads,
+            head_dim=head_dim_packed * 2,
+            topk=topk,
+            status_candidate_overflow=status_candidate_overflow,
+            status_underfilled=status_underfilled,
+            status_nonfinite=status_nonfinite,
+            report_page_errors=page_errors is not None,
+        )
+        _run_compiled(
+            launcher,
+            q_fp4,
+            q_scale,
+            kv_cache,
+            kv_scale,
+            block_tables,
+            weights,
+            cta_info,
+            origin,
+            inv_delta,
+            threshold,
+            histogram,
+            candidate_values,
+            candidate_indices,
+            candidate_counts,
+            select_starts,
+            select_ends,
+            status,
+            page_errors if page_errors is not None else candidate_values,
+            candidate_values.stride(0),
+            merge_cap,
+            block_tables.stride(0),
+            block_tables.shape[0],
+            block_tables.shape[1],
+            kv_cache.shape[0],
+            float(weight_scale),
+            n_ctas,
+            stream,
+        )
+
+
+@cache
+def compile_pa_mqa_litetopk_fp4_prefill_scan(
+    *,
+    block_k: int = 256,
+    kv_block_size: int = 64,
+    num_warps: int = DEFAULT_NUM_WARPS,
+    heads: int = DEFAULT_HEADS,
+    head_dim: int = DEFAULT_HEAD_DIM,
+    topk: int = 512,
+    refresh_every: int = 64,
+):
+    kfn, block_threads = build_pa_mqa_logits_fp4_prefill_module(
+        block_k=block_k,
+        kv_block_size=kv_block_size,
+        num_warps=num_warps,
+        heads=heads,
+        head_dim=head_dim,
+        litetopk=True,
+        litetopk_topk=topk,
+        litetopk_refresh_every=refresh_every,
+    )
+
+    @flyc.jit
+    def launch_pa_mqa_litetopk_fp4_prefill_scan(
+        q,
+        qs,
+        kv,
+        kvs,
+        bt,
+        w,
+        cta_info_,
+        origin,
+        inv_delta,
+        threshold,
+        histogram,
+        candidate_values,
+        candidate_indices,
+        candidate_counts,
+        page_errors,
+        score_errors,
+        candidate_stride: fx.Int32,
+        merge_cap: fx.Int32,
+        block_table_capacity: fx.Int32,
+        physical_page_capacity: fx.Int32,
+        stride_bt: fx.Int32,
+        block_table_rows: fx.Int32,
+        weight_scale: fx.Float32,
+        gx: fx.Int32,
+        stream: fx.Stream,
+    ):
+        gxi = fx.Int64(gx)
+        kfn(
+            candidate_values,
+            q,
+            qs,
+            kv,
+            kvs,
+            bt,
+            w,
+            cta_info_,
+            fx.Int32(0),
+            stride_bt,
+            block_table_rows,
+            weight_scale,
+            origin,
+            inv_delta,
+            threshold,
+            histogram,
+            candidate_values,
+            candidate_indices,
+            candidate_counts,
+            page_errors,
+            score_errors,
+            score_errors,
+            candidate_stride,
+            merge_cap,
+            block_table_capacity,
+            physical_page_capacity,
+        ).launch(grid=(gxi,), block=(block_threads, 1, 1), stream=stream)
+
+    return launch_pa_mqa_litetopk_fp4_prefill_scan, block_threads
+
+
+def flydsl_pa_mqa_litetopk_fp4_prefill_scan(
+    q_fp4: torch.Tensor,
+    q_scale: torch.Tensor,
+    kv_cache: torch.Tensor,
+    kv_scale: torch.Tensor,
+    block_tables: torch.Tensor,
+    weights: torch.Tensor,
+    cta_info: torch.Tensor,
+    origin: torch.Tensor,
+    inv_delta: torch.Tensor,
+    threshold: torch.Tensor,
+    histogram: torch.Tensor,
+    candidate_values: torch.Tensor,
+    candidate_indices: torch.Tensor,
+    candidate_counts: torch.Tensor,
+    page_errors: torch.Tensor,
+    score_errors: torch.Tensor,
+    *,
+    n_ctas: int,
+    merge_cap: int,
+    topk: int = 512,
+    refresh_every: int = 64,
+    weight_scale: float = 1.0,
+    block_k: int = 256,
+    kv_block_size: int = 64,
+    num_warps: int = DEFAULT_NUM_WARPS,
+    stream: torch.cuda.Stream | None = None,
+) -> None:
+    """Run FP4 paged scoring with a conservative, monotonically-tightened gate."""
+    rows, heads, head_dim_packed = q_fp4.shape
+    if heads != DEFAULT_HEADS or head_dim_packed * 2 != DEFAULT_HEAD_DIM:
+        raise ValueError("LiteTopK scan requires H=64 and D=128")
+    if n_ctas != rows:
+        raise ValueError("LiteTopK scan requires exactly one CTA per query row")
+    if cta_info.shape != (rows, CTA_INFO_WIDTH) or cta_info.dtype != torch.int32:
+        raise ValueError("cta_info must be int32 [rows, 6]")
+    if histogram.shape != (rows, 256) or histogram.dtype != torch.int32:
+        raise ValueError("histogram must be int32 [rows, 256]")
+    if topk not in FP4_LITETOPK_SUPPORTED_TOPKS:
+        raise ValueError(
+            "the FP4 LiteTopK scan requires topk in "
+            f"{FP4_LITETOPK_SUPPORTED_TOPKS}, got {topk}"
+        )
+    if refresh_every * block_k != 16_384:
+        raise ValueError("the production LiteTopK scan requires a 16384-token refresh")
+    if candidate_values.shape != (rows, merge_cap):
+        raise ValueError("candidate_values shape does not match rows and merge_cap")
+    if candidate_indices.shape != (rows, merge_cap):
+        raise ValueError("candidate_indices shape does not match rows and merge_cap")
+    if candidate_values.dtype != torch.float32:
+        raise ValueError("candidate_values must be float32")
+    if candidate_indices.dtype != torch.int32:
+        raise ValueError("candidate_indices must be int32")
+    row_vectors = (
+        origin,
+        inv_delta,
+        threshold,
+        candidate_counts,
+        page_errors,
+        score_errors,
+    )
+    if any(t.shape != (rows,) for t in row_vectors):
+        raise ValueError("LiteTopK row metadata must have shape [rows]")
+    if origin.dtype != torch.float32 or inv_delta.dtype != torch.float32:
+        raise ValueError("origin and inv_delta must be float32")
+    if threshold.dtype != torch.int32 or candidate_counts.dtype != torch.int32:
+        raise ValueError("threshold and candidate_counts must be int32")
+    tensors = (
+        q_fp4,
+        q_scale,
+        kv_cache,
+        kv_scale,
+        block_tables,
+        weights,
+        cta_info,
+        histogram,
+        candidate_values,
+        candidate_indices,
+        *row_vectors,
+    )
+    if any(t.device != q_fp4.device for t in tensors):
+        raise ValueError("all LiteTopK scan tensors must be on one device")
+    if any(not t.is_contiguous() for t in tensors):
+        raise ValueError("all LiteTopK scan tensors must be contiguous")
+    if stream is None:
+        stream = torch.cuda.current_stream(q_fp4.device)
+    if torch.device(stream.device) != q_fp4.device:
+        raise ValueError("stream and LiteTopK tensors must be on one device")
+
+    with torch.cuda.device(q_fp4.device), torch.cuda.stream(stream):
+        launcher, _ = compile_pa_mqa_litetopk_fp4_prefill_scan(
+            block_k=block_k,
+            kv_block_size=kv_block_size,
+            num_warps=num_warps,
+            heads=heads,
+            head_dim=head_dim_packed * 2,
+            topk=topk,
+            refresh_every=refresh_every,
+        )
+        _run_compiled(
+            launcher,
+            q_fp4,
+            q_scale,
+            kv_cache,
+            kv_scale,
+            block_tables,
+            weights,
+            cta_info,
+            origin,
+            inv_delta,
+            threshold,
+            histogram,
+            candidate_values,
+            candidate_indices,
+            candidate_counts,
+            page_errors,
+            score_errors,
+            candidate_values.stride(0),
+            merge_cap,
+            block_tables.shape[1],
+            kv_cache.shape[0],
+            block_tables.stride(0),
+            block_tables.shape[0],
+            float(weight_scale),
+            n_ctas,
+            stream,
+        )
 
 
 def flydsl_pa_mqa_logits_fp4_prefill(
@@ -889,61 +2037,68 @@ def flydsl_pa_mqa_logits_fp4_prefill(
     cta_info: torch.Tensor | None = None,
     n_ctas: int | None = None,
     stream: torch.cuda.Stream | None = None,
+    relative_output: bool = False,
 ) -> torch.Tensor:
     """Ragged-prefill FP4 paged MQA logits (gfx950)."""
     total_tokens, heads, head_dim_packed = q_fp4.shape
     head_dim = head_dim_packed * 2
-    max_blocks_per_seq = block_tables.shape[1]
-
     if (cta_info is None) != (n_ctas is None):
         raise ValueError("Pass both cta_info and n_ctas, or neither.")
-    schedule_internal = cta_info is None
-    if schedule_internal:
-        _, cta_info, n_ctas = compute_prefill_schedule(
-            row_to_batch,
-            local_starts,
-            local_ends,
-            block_k,
-            parallel_unit_num,
-            max_seq_len,
-        )
-
-    if out is None:
-        out = torch.full(
-            (total_tokens, max_seq_len),
-            float("-inf"),
-            dtype=torch.float32,
-            device=q_fp4.device,
-        )
-    elif schedule_internal:
-        out.fill_(float("-inf"))
-
-    launcher, _ = compile_pa_mqa_logits_fp4_prefill(
-        block_k=block_k,
-        kv_block_size=kv_block_size,
-        max_blocks_per_seq=max_blocks_per_seq,
-        num_warps=num_warps,
-        heads=heads,
-        head_dim=head_dim,
-    )
-
     if stream is None:
-        stream = torch.cuda.current_stream()
+        stream = torch.cuda.current_stream(q_fp4.device)
+    if torch.device(stream.device) != q_fp4.device:
+        raise ValueError("stream and FP4 prefill tensors must be on one device")
 
-    launcher(
-        out,
-        q_fp4,
-        q_scale,
-        kv_cache,
-        kv_scale,
-        block_tables,
-        weights,
-        cta_info,
-        out.stride(0),
-        float(weight_scale),
-        n_ctas,
-        stream,
-    )
+    with torch.cuda.device(q_fp4.device), torch.cuda.stream(stream):
+        schedule_internal = cta_info is None
+        if schedule_internal:
+            _, cta_info, n_ctas = compute_prefill_schedule(
+                row_to_batch,
+                local_starts,
+                local_ends,
+                block_k,
+                parallel_unit_num,
+                max_seq_len,
+            )
+
+        if out is None:
+            out = torch.full(
+                (total_tokens, max_seq_len),
+                float("-inf"),
+                dtype=torch.float32,
+                device=q_fp4.device,
+            )
+        elif schedule_internal:
+            out.fill_(float("-inf"))
+
+        launcher, _ = compile_pa_mqa_logits_fp4_prefill(
+            block_k=block_k,
+            kv_block_size=kv_block_size,
+            num_warps=num_warps,
+            heads=heads,
+            head_dim=head_dim,
+            relative_output=relative_output,
+        )
+
+        _run_compiled(
+            launcher,
+            out,
+            q_fp4,
+            q_scale,
+            kv_cache,
+            kv_scale,
+            block_tables,
+            weights,
+            cta_info,
+            out.stride(0),
+            block_tables.stride(0),
+            block_tables.shape[0],
+            block_tables.shape[1],
+            kv_cache.shape[0],
+            float(weight_scale),
+            n_ctas,
+            stream,
+        )
     return out
 
 

--- a/aiter/ops/flydsl/pa_mqa_litetopk_fp4.py
+++ b/aiter/ops/flydsl/pa_mqa_litetopk_fp4.py
@@ -1,0 +1,809 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+from __future__ import annotations
+
+from itertools import pairwise
+from typing import NamedTuple
+
+import torch
+
+from .kernels.mqa_logits.pa_mqa_litetopk_fp4_common import (
+    FP4_LITETOPK_SUPPORTED_TOPKS,
+)
+
+DEFAULT_TOPK = 512
+DEFAULT_SAMPLE_LEN = 8192
+DEFAULT_NUM_BUCKETS = 256
+DEFAULT_REFRESH_EVERY = 64
+DEFAULT_MERGE_CAP = 196_608
+_SCAN_BLOCK_K = 512
+_SCAN_NUM_WARPS = 8
+
+STATUS_OK = 0
+STATUS_CANDIDATE_OVERFLOW = 1 << 0
+STATUS_UNDERFILLED = 1 << 1
+STATUS_NONFINITE = 1 << 2
+STATUS_INVALID_INDEX = 1 << 3
+STATUS_BAD_CERTIFICATE = 1 << 4
+STATUS_SELECTOR_FAILURE = 1 << 5
+
+
+class FP4LiteTopKWorkspace(NamedTuple):
+    sample_logits: torch.Tensor
+    sample_ends: torch.Tensor
+    scan_cta_info: torch.Tensor
+    origin: torch.Tensor
+    inv_delta: torch.Tensor
+    threshold: torch.Tensor
+    histogram: torch.Tensor
+    candidate_values: torch.Tensor
+    candidate_indices: torch.Tensor
+    candidate_counts: torch.Tensor
+    page_errors: torch.Tensor
+    score_errors: torch.Tensor
+    select_starts: torch.Tensor
+    select_ends: torch.Tensor
+    selected_slots: torch.Tensor
+    selected_values: torch.Tensor
+    output_counts: torch.Tensor
+    status: torch.Tensor
+    status_ok: torch.Tensor
+    selector_workspace: torch.Tensor
+    row_capacity: int
+    topk: int
+    sample_len: int
+    num_buckets: int
+    merge_cap: int
+    stream_id: int
+
+
+class FP4LiteTopKResult(NamedTuple):
+    values: torch.Tensor
+    raw_indices: torch.Tensor
+    physical_indices: torch.Tensor
+    counts: torch.Tensor
+    candidate_counts: torch.Tensor
+    status: torch.Tensor
+
+
+def fp4_litetopk_workspace_nbytes(workspace: FP4LiteTopKWorkspace) -> int:
+    """Return the bytes owned by a LiteTopK workspace."""
+    return sum(
+        tensor.numel() * tensor.element_size()
+        for tensor in workspace
+        if isinstance(tensor, torch.Tensor)
+    )
+
+
+def fp4_litetopk_workspace_size(
+    rows: int,
+    *,
+    topk: int = DEFAULT_TOPK,
+    sample_len: int = DEFAULT_SAMPLE_LEN,
+    num_buckets: int = DEFAULT_NUM_BUCKETS,
+    merge_cap: int = DEFAULT_MERGE_CAP,
+) -> int:
+    """Return required workspace bytes without allocating device memory."""
+    if (
+        rows <= 0
+        or topk <= 0
+        or sample_len < topk
+        or num_buckets <= 1
+        or merge_cap < topk
+    ):
+        raise ValueError("invalid LiteTopK workspace dimensions")
+    from aiter.ops.topk import topk_ob_workspace_size
+
+    row_bytes = (
+        sample_len * 4
+        + 6 * 4
+        + num_buckets * 4
+        + merge_cap * (4 + 4)
+        + topk * (4 + 4)
+        + 11 * 4
+    )
+    return (
+        row_bytes * rows
+        + 4
+        + max(1, int(topk_ob_workspace_size(rows, merge_cap, topk, False)))
+    )
+
+
+def _tensor_byte_range(tensor: torch.Tensor) -> tuple[int, int]:
+    start = tensor.data_ptr()
+    return start, start + tensor.numel() * tensor.element_size()
+
+
+def _byte_ranges_overlap(left: tuple[int, int], right: tuple[int, int]) -> bool:
+    return left[0] < right[1] and right[0] < left[1]
+
+
+def _same_byte_range(left: torch.Tensor, right: torch.Tensor) -> bool:
+    return _tensor_byte_range(left) == _tensor_byte_range(right)
+
+
+def _workspace_tensors(workspace: FP4LiteTopKWorkspace) -> tuple[torch.Tensor, ...]:
+    return tuple(item for item in workspace if isinstance(item, torch.Tensor))
+
+
+def _validate_pairwise_disjoint(
+    tensors: tuple[torch.Tensor, ...], *, message: str
+) -> None:
+    ranges = sorted(_tensor_byte_range(tensor) for tensor in tensors)
+    if any(_byte_ranges_overlap(left, right) for left, right in pairwise(ranges)):
+        raise ValueError(message)
+
+
+def _validate_workspace(
+    workspace: FP4LiteTopKWorkspace,
+    *,
+    rows: int,
+    device: torch.device,
+    stream: torch.cuda.Stream,
+    topk: int,
+    sample_len: int,
+    num_buckets: int,
+    merge_cap: int,
+) -> tuple[tuple[torch.Tensor, tuple[int, int]], ...]:
+    if (
+        workspace.row_capacity < rows
+        or workspace.topk != topk
+        or workspace.sample_len != sample_len
+        or workspace.num_buckets != num_buckets
+        or workspace.merge_cap != merge_cap
+        or workspace.stream_id != stream.cuda_stream
+    ):
+        raise ValueError("workspace is incompatible with this LiteTopK call")
+    capacity = workspace.row_capacity
+    expected = (
+        (workspace.sample_logits, torch.float32, (capacity, sample_len)),
+        (workspace.sample_ends, torch.int32, (capacity,)),
+        (workspace.scan_cta_info, torch.int32, (capacity, 6)),
+        (workspace.origin, torch.float32, (capacity,)),
+        (workspace.inv_delta, torch.float32, (capacity,)),
+        (workspace.threshold, torch.int32, (capacity,)),
+        (workspace.histogram, torch.int32, (capacity, num_buckets)),
+        (workspace.candidate_values, torch.float32, (capacity, merge_cap)),
+        (workspace.candidate_indices, torch.int32, (capacity, merge_cap)),
+        (workspace.candidate_counts, torch.int32, (capacity,)),
+        (workspace.page_errors, torch.int32, (capacity,)),
+        (workspace.score_errors, torch.int32, (capacity,)),
+        (workspace.select_starts, torch.int32, (capacity,)),
+        (workspace.select_ends, torch.int32, (capacity,)),
+        (workspace.selected_slots, torch.int32, (capacity, topk)),
+        (workspace.selected_values, torch.float32, (capacity, topk)),
+        (workspace.output_counts, torch.int32, (capacity,)),
+        (workspace.status, torch.int32, (capacity,)),
+        (workspace.status_ok, torch.int32, (1,)),
+    )
+    if any(
+        tensor.dtype != dtype
+        or tuple(tensor.shape) != shape
+        or tensor.device != device
+        or not tensor.is_contiguous()
+        for tensor, dtype, shape in expected
+    ):
+        raise ValueError("workspace tensors have incompatible metadata")
+    from aiter.ops.topk import topk_ob_workspace_size
+
+    required_selector_bytes = topk_ob_workspace_size(rows, merge_cap, topk, False)
+    if (
+        workspace.selector_workspace.dtype != torch.uint8
+        or workspace.selector_workspace.device != device
+        or not workspace.selector_workspace.is_contiguous()
+        or workspace.selector_workspace.numel() < required_selector_bytes
+    ):
+        raise ValueError("selector_workspace is too small or has incompatible metadata")
+    workspace_tensors = _workspace_tensors(workspace)
+    workspace_ranges = tuple(
+        (tensor, _tensor_byte_range(tensor)) for tensor in workspace_tensors
+    )
+    sorted_ranges = sorted(byte_range for _, byte_range in workspace_ranges)
+    if any(
+        _byte_ranges_overlap(left, right) for left, right in pairwise(sorted_ranges)
+    ):
+        raise ValueError("LiteTopK workspace tensors must not overlap")
+    return workspace_ranges
+
+
+def _validate_result(
+    out: FP4LiteTopKResult,
+    workspace: FP4LiteTopKWorkspace,
+    *,
+    rows: int,
+    topk: int,
+    device: torch.device,
+    inputs: tuple[torch.Tensor, ...] = (),
+    workspace_ranges: tuple[tuple[torch.Tensor, tuple[int, int]], ...] | None = None,
+) -> None:
+    expected = (
+        (out.values, torch.float32, (rows, topk)),
+        (out.raw_indices, torch.int32, (rows, topk)),
+        (out.physical_indices, torch.int32, (rows, topk)),
+        (out.counts, torch.int32, (rows,)),
+        (out.candidate_counts, torch.int32, (rows,)),
+        (out.status, torch.int32, (rows,)),
+    )
+    if any(
+        tensor.dtype != dtype
+        or tensor.shape != shape
+        or tensor.device != device
+        or not tensor.is_contiguous()
+        for tensor, dtype, shape in expected
+    ):
+        raise ValueError("LiteTopK output tensors have incompatible metadata")
+    if (
+        out.counts.data_ptr() != workspace.output_counts[:rows].data_ptr()
+        or out.candidate_counts.data_ptr()
+        != workspace.candidate_counts[:rows].data_ptr()
+        or out.status.data_ptr() != workspace.status[:rows].data_ptr()
+    ):
+        raise ValueError("candidate_counts and status outputs must alias the workspace")
+    output_tensors = tuple(out)
+    output_ranges = tuple(
+        (output, _tensor_byte_range(output)) for output in output_tensors
+    )
+    sorted_output_ranges = sorted(byte_range for _, byte_range in output_ranges)
+    if any(
+        _byte_ranges_overlap(left, right)
+        for left, right in pairwise(sorted_output_ranges)
+    ):
+        raise ValueError("LiteTopK output tensors must not overlap")
+
+    allowed_workspace_aliases = (
+        (out.values, workspace.selected_values, workspace.selected_values[:rows]),
+        (out.counts, workspace.output_counts, workspace.output_counts[:rows]),
+        (
+            out.candidate_counts,
+            workspace.candidate_counts,
+            workspace.candidate_counts[:rows],
+        ),
+        (out.status, workspace.status, workspace.status[:rows]),
+    )
+    if workspace_ranges is None:
+        workspace_ranges = tuple(
+            (scratch, _tensor_byte_range(scratch))
+            for scratch in _workspace_tensors(workspace)
+        )
+    allowed_workspace_ranges = tuple(
+        (candidate, owner, _tensor_byte_range(view))
+        for candidate, owner, view in allowed_workspace_aliases
+    )
+    input_ranges = tuple(_tensor_byte_range(input_tensor) for input_tensor in inputs)
+    for output, output_range in output_ranges:
+        allowed_owner = next(
+            (
+                owner
+                for candidate, owner, view_range in allowed_workspace_ranges
+                if candidate is output and output_range == view_range
+            ),
+            None,
+        )
+        for scratch, scratch_range in workspace_ranges:
+            if scratch is allowed_owner:
+                continue
+            if _byte_ranges_overlap(output_range, scratch_range):
+                raise ValueError("LiteTopK outputs must not overlap workspace scratch")
+        if any(
+            _byte_ranges_overlap(output_range, input_range)
+            for input_range in input_ranges
+        ):
+            raise ValueError("LiteTopK outputs must not overlap read-only inputs")
+    if any(
+        _byte_ranges_overlap(scratch_range, input_range)
+        for _, scratch_range in workspace_ranges
+        for input_range in input_ranges
+    ):
+        raise ValueError("LiteTopK workspace must not overlap read-only inputs")
+
+
+def allocate_fp4_litetopk_workspace(
+    rows: int,
+    device: torch.device | str,
+    *,
+    topk: int = DEFAULT_TOPK,
+    sample_len: int = DEFAULT_SAMPLE_LEN,
+    num_buckets: int = DEFAULT_NUM_BUCKETS,
+    merge_cap: int = DEFAULT_MERGE_CAP,
+    stream: torch.cuda.Stream | None = None,
+) -> FP4LiteTopKWorkspace:
+    """Allocate caller-owned scratch for the FP4 LiteTopK prefill path."""
+    if rows <= 0:
+        raise ValueError(f"rows must be positive, got {rows}")
+    if topk <= 0:
+        raise ValueError(f"topk must be positive, got {topk}")
+    if sample_len < topk:
+        raise ValueError(f"sample_len must be at least topk, got {sample_len} < {topk}")
+    if num_buckets <= 1:
+        raise ValueError(f"num_buckets must be greater than one, got {num_buckets}")
+    if merge_cap < topk:
+        raise ValueError(f"merge_cap must be at least topk, got {merge_cap} < {topk}")
+
+    device = torch.device(device)
+    if device.type != "cuda":
+        raise ValueError(f"LiteTopK workspace requires a GPU device, got {device}")
+    if device.index is None:
+        device = torch.device("cuda", torch.cuda.current_device())
+    if stream is None:
+        stream = torch.cuda.current_stream(device)
+    try:
+        stream_device = torch.device(stream.device)
+    except (AttributeError, TypeError) as exc:
+        raise TypeError("stream must be a torch.cuda.Stream") from exc
+    if stream_device != device:
+        raise ValueError(
+            f"stream device {stream_device} does not match workspace device {device}"
+        )
+
+    from aiter.ops.topk import topk_ob_workspace_size
+
+    with torch.cuda.stream(stream):
+        if torch.cuda.is_current_stream_capturing():
+            raise RuntimeError("FP4 LiteTopK workspace allocation is not capture-safe")
+        selector_bytes = topk_ob_workspace_size(rows, merge_cap, topk, False)
+        return FP4LiteTopKWorkspace(
+            sample_logits=torch.empty(
+                (rows, sample_len), dtype=torch.float32, device=device
+            ),
+            sample_ends=torch.empty(rows, dtype=torch.int32, device=device),
+            scan_cta_info=torch.empty((rows, 6), dtype=torch.int32, device=device),
+            origin=torch.empty(rows, dtype=torch.float32, device=device),
+            inv_delta=torch.empty(rows, dtype=torch.float32, device=device),
+            threshold=torch.empty(rows, dtype=torch.int32, device=device),
+            histogram=torch.empty(
+                (rows, num_buckets), dtype=torch.int32, device=device
+            ),
+            candidate_values=torch.empty(
+                (rows, merge_cap), dtype=torch.float32, device=device
+            ),
+            candidate_indices=torch.empty(
+                (rows, merge_cap), dtype=torch.int32, device=device
+            ),
+            candidate_counts=torch.empty(rows, dtype=torch.int32, device=device),
+            page_errors=torch.empty(rows, dtype=torch.int32, device=device),
+            score_errors=torch.empty(rows, dtype=torch.int32, device=device),
+            select_starts=torch.zeros(rows, dtype=torch.int32, device=device),
+            select_ends=torch.empty(rows, dtype=torch.int32, device=device),
+            selected_slots=torch.empty((rows, topk), dtype=torch.int32, device=device),
+            selected_values=torch.empty(
+                (rows, topk), dtype=torch.float32, device=device
+            ),
+            output_counts=torch.empty(rows, dtype=torch.int32, device=device),
+            status=torch.empty(rows, dtype=torch.int32, device=device),
+            status_ok=torch.empty(1, dtype=torch.int32, device=device),
+            selector_workspace=torch.empty(
+                max(1, int(selector_bytes)), dtype=torch.uint8, device=device
+            ),
+            row_capacity=rows,
+            topk=topk,
+            sample_len=sample_len,
+            num_buckets=num_buckets,
+            merge_cap=merge_cap,
+            stream_id=stream.cuda_stream,
+        )
+
+
+def prepare_fp4_litetopk_seed(
+    sample_logits: torch.Tensor,
+    row_starts: torch.Tensor,
+    row_ends: torch.Tensor,
+    workspace: FP4LiteTopKWorkspace,
+    *,
+    max_seq_len: int,
+    emit_candidates: bool = True,
+    reset_status: bool = True,
+    stream: torch.cuda.Stream | None = None,
+) -> None:
+    """Build the conservative gate and emit the exact-once calibration prefix."""
+    rows = sample_logits.shape[0]
+    if rows > workspace.row_capacity:
+        raise ValueError(
+            f"workspace holds {workspace.row_capacity} rows, but input has {rows}"
+        )
+    device = sample_logits.device
+    if stream is None:
+        stream = torch.cuda.current_stream(device)
+    workspace_ranges = _validate_workspace(
+        workspace,
+        rows=rows,
+        device=device,
+        stream=stream,
+        topk=workspace.topk,
+        sample_len=workspace.sample_len,
+        num_buckets=workspace.num_buckets,
+        merge_cap=workspace.merge_cap,
+    )
+    seed_inputs = (sample_logits, row_starts, row_ends)
+    _validate_pairwise_disjoint(
+        seed_inputs,
+        message="LiteTopK seed inputs must not overlap",
+    )
+    sample_owner = (
+        workspace.sample_logits
+        if _same_byte_range(sample_logits, workspace.sample_logits[:rows])
+        else None
+    )
+    for seed_input in seed_inputs:
+        seed_range = _tensor_byte_range(seed_input)
+        for scratch, scratch_range in workspace_ranges:
+            if seed_input is sample_logits and scratch is sample_owner:
+                continue
+            if _byte_ranges_overlap(seed_range, scratch_range):
+                raise ValueError("LiteTopK seed inputs must not overlap workspace")
+    with torch.cuda.device(device), torch.cuda.stream(stream):
+        if reset_status:
+            workspace.status[:rows].zero_()
+        if not emit_candidates:
+            workspace.candidate_counts[:rows].zero_()
+            workspace.select_starts[:rows].zero_()
+            workspace.select_ends[:rows].zero_()
+    _launch_fp4_litetopk_seed(
+        sample_logits,
+        row_starts,
+        row_ends,
+        workspace,
+        max_seq_len=max_seq_len,
+        emit_candidates=emit_candidates,
+        stream=stream,
+    )
+
+
+def _launch_fp4_litetopk_seed(
+    sample_logits: torch.Tensor,
+    row_starts: torch.Tensor,
+    row_ends: torch.Tensor,
+    workspace: FP4LiteTopKWorkspace,
+    *,
+    max_seq_len: int,
+    emit_candidates: bool,
+    stream: torch.cuda.Stream,
+) -> None:
+    from aiter.ops.triton.attention.pa_mqa_litetopk_seed import (
+        prepare_pa_mqa_litetopk_seed,
+    )
+
+    rows = sample_logits.shape[0]
+    prepare_pa_mqa_litetopk_seed(
+        sample_logits,
+        row_starts,
+        row_ends,
+        origin=workspace.origin[:rows],
+        inv_delta=workspace.inv_delta[:rows],
+        threshold=workspace.threshold[:rows],
+        histogram=workspace.histogram[:rows],
+        candidate_values=workspace.candidate_values[:rows],
+        candidate_indices=workspace.candidate_indices[:rows],
+        candidate_counts=workspace.candidate_counts[:rows],
+        select_starts=workspace.select_starts[:rows],
+        select_ends=workspace.select_ends[:rows],
+        status=workspace.status[:rows],
+        max_seq_len=max_seq_len,
+        topk=workspace.topk,
+        sample_len=workspace.sample_len,
+        num_buckets=workspace.num_buckets,
+        merge_cap=workspace.merge_cap,
+        status_candidate_overflow=STATUS_CANDIDATE_OVERFLOW,
+        status_underfilled=STATUS_UNDERFILLED,
+        status_nonfinite=STATUS_NONFINITE,
+        status_invalid_index=STATUS_INVALID_INDEX,
+        emit_candidates=emit_candidates,
+        stream=stream,
+    )
+
+
+def flydsl_pa_mqa_litetopk_fp4_prefill(
+    q_fp4: torch.Tensor,
+    q_scale: torch.Tensor,
+    kv_cache: torch.Tensor,
+    kv_scale: torch.Tensor,
+    block_tables: torch.Tensor,
+    weights: torch.Tensor,
+    row_to_batch: torch.Tensor,
+    local_starts: torch.Tensor,
+    local_ends: torch.Tensor,
+    max_seq_len: int,
+    *,
+    topk: int = DEFAULT_TOPK,
+    sample_len: int = DEFAULT_SAMPLE_LEN,
+    num_buckets: int = DEFAULT_NUM_BUCKETS,
+    refresh_every: int = DEFAULT_REFRESH_EVERY,
+    merge_cap: int = DEFAULT_MERGE_CAP,
+    weight_scale: float = 1.0,
+    workspace: FP4LiteTopKWorkspace | None = None,
+    out: FP4LiteTopKResult | None = None,
+    stream: torch.cuda.Stream | None = None,
+    enforce_status: bool = True,
+) -> FP4LiteTopKResult:
+    """Run bounded-prefix FP4 paged-MQA scoring and LiteTopK selection."""
+    if topk not in FP4_LITETOPK_SUPPORTED_TOPKS:
+        raise ValueError(
+            "FP4 LiteTopK requires topk in "
+            f"{FP4_LITETOPK_SUPPORTED_TOPKS}, got {topk}"
+        )
+    if sample_len != DEFAULT_SAMPLE_LEN:
+        raise ValueError(
+            f"the initial LiteTopK path requires sample_len={DEFAULT_SAMPLE_LEN}"
+        )
+    if num_buckets != DEFAULT_NUM_BUCKETS:
+        raise ValueError(
+            f"the initial LiteTopK path requires num_buckets={DEFAULT_NUM_BUCKETS}"
+        )
+    if refresh_every != DEFAULT_REFRESH_EVERY:
+        raise ValueError(
+            "the production LiteTopK path requires "
+            f"refresh_every={DEFAULT_REFRESH_EVERY}"
+        )
+    if merge_cap != DEFAULT_MERGE_CAP:
+        raise ValueError(
+            f"the production LiteTopK path requires merge_cap={DEFAULT_MERGE_CAP}"
+        )
+    if q_fp4.ndim != 3 or tuple(q_fp4.shape[1:]) != (64, 64):
+        raise ValueError("q_fp4 must have shape [rows, 64, 64]")
+    rows = q_fp4.shape[0]
+    if rows <= 0:
+        raise ValueError("LiteTopK requires at least one query row")
+    if q_fp4.dtype != torch.uint8 or q_scale.dtype != torch.uint8:
+        raise ValueError("q_fp4 and q_scale must use the packed uint8 FP4 ABI")
+    if q_scale.shape != (rows, 1, 4, 16, 4):
+        raise ValueError("q_scale must have shape [rows, 1, 4, 16, 4]")
+    if kv_cache.dtype != torch.uint8 or tuple(kv_cache.shape[1:]) != (
+        1,
+        4,
+        64,
+        16,
+    ):
+        raise ValueError("kv_cache must be uint8 [pages, 1, 4, 64, 16]")
+    if kv_scale.dtype != torch.uint8 or tuple(kv_scale.shape) != (
+        kv_cache.shape[0],
+        1,
+        4,
+        64,
+    ):
+        raise ValueError("kv_scale must be uint8 [pages, 1, 4, 64]")
+    if weights.shape != (rows, 64) or weights.dtype != torch.bfloat16:
+        raise ValueError("weights must be bfloat16 [rows, 64]")
+    if block_tables.dtype != torch.int32 or block_tables.ndim != 2:
+        raise ValueError("block_tables must be a 2D int32 tensor")
+    if block_tables.shape[0] == 0 or block_tables.shape[1] == 0:
+        raise ValueError("block_tables must have nonzero row and column capacity")
+    if kv_cache.shape[0] == 0:
+        raise ValueError("kv_cache must contain at least one physical page")
+    metadata = (row_to_batch, local_starts, local_ends)
+    if any(t.dtype != torch.int32 or t.shape != (rows,) for t in metadata):
+        raise ValueError("row_to_batch/local_starts/local_ends must be int32 [rows]")
+    if max_seq_len <= 0 or max_seq_len > merge_cap:
+        raise ValueError(
+            f"max_seq_len must be in [1, merge_cap={merge_cap}], got {max_seq_len}"
+        )
+    if max_seq_len > block_tables.shape[1] * 64:
+        raise ValueError("max_seq_len exceeds block_tables capacity")
+    device = q_fp4.device
+    if device.type != "cuda":
+        raise ValueError("q_fp4 must be on a GPU device")
+    arch = str(torch.cuda.get_device_properties(device).gcnArchName).split(":")[0]
+    if arch != "gfx950":
+        raise ValueError(f"FP4 LiteTopK requires gfx950, got {arch}")
+    inputs = (
+        q_fp4,
+        q_scale,
+        kv_cache,
+        kv_scale,
+        block_tables,
+        weights,
+        *metadata,
+    )
+    if any(t.device != device for t in inputs):
+        raise ValueError("all FP4 LiteTopK inputs must be on one device")
+    if any(not t.is_contiguous() for t in inputs):
+        raise ValueError("all FP4 LiteTopK inputs must be contiguous")
+    if stream is None:
+        stream = torch.cuda.current_stream(device)
+    if torch.device(stream.device) != device:
+        raise ValueError("stream and FP4 LiteTopK inputs must be on one device")
+
+    with torch.cuda.device(device), torch.cuda.stream(stream):
+        if torch.cuda.is_current_stream_capturing():
+            raise RuntimeError("FP4 LiteTopK does not support graph capture")
+        if workspace is None:
+            workspace = allocate_fp4_litetopk_workspace(
+                rows,
+                device,
+                topk=topk,
+                sample_len=sample_len,
+                num_buckets=num_buckets,
+                merge_cap=merge_cap,
+                stream=stream,
+            )
+        workspace_ranges = _validate_workspace(
+            workspace,
+            rows=rows,
+            device=device,
+            stream=stream,
+            topk=topk,
+            sample_len=sample_len,
+            num_buckets=num_buckets,
+            merge_cap=merge_cap,
+        )
+        if out is None:
+            out = FP4LiteTopKResult(
+                values=torch.empty((rows, topk), dtype=torch.float32, device=device),
+                raw_indices=torch.empty((rows, topk), dtype=torch.int32, device=device),
+                physical_indices=torch.empty(
+                    (rows, topk), dtype=torch.int32, device=device
+                ),
+                counts=workspace.output_counts[:rows],
+                candidate_counts=workspace.candidate_counts[:rows],
+                status=workspace.status[:rows],
+            )
+        _validate_result(
+            out,
+            workspace,
+            rows=rows,
+            topk=topk,
+            device=device,
+            inputs=inputs,
+            workspace_ranges=workspace_ranges,
+        )
+
+        suffix_cta_info = workspace.selected_slots.view(-1)[: rows * 6].view(rows, 6)
+
+    from aiter.ops.triton.attention.pa_mqa_litetopk_seed import (
+        build_pa_mqa_litetopk_scan_schedule,
+    )
+
+    from .kernels.mqa_logits.pa_mqa_logits_fp4_prefill import (
+        flydsl_pa_mqa_litetopk_fp4_prefill_scan,
+        flydsl_pa_mqa_litetopk_fp4_seed,
+    )
+
+    build_pa_mqa_litetopk_scan_schedule(
+        row_to_batch,
+        local_starts,
+        local_ends,
+        workspace.scan_cta_info[:rows],
+        segment_start=0,
+        segment_end=max_seq_len,
+        block_k=_SCAN_BLOCK_K,
+        stream=stream,
+        page_errors=workspace.page_errors[:rows],
+        max_seq_len=max_seq_len,
+        block_table_rows=block_tables.shape[0],
+        suffix_cta_info=suffix_cta_info,
+        sample_len=sample_len,
+        score_errors=workspace.score_errors[:rows],
+        status=workspace.status[:rows],
+        sample_ends=workspace.sample_ends[:rows],
+        status_ok=workspace.status_ok,
+    )
+
+    flydsl_pa_mqa_litetopk_fp4_seed(
+        q_fp4,
+        q_scale,
+        kv_cache,
+        kv_scale,
+        block_tables,
+        weights,
+        workspace.scan_cta_info[:rows],
+        workspace.origin[:rows],
+        workspace.inv_delta[:rows],
+        workspace.threshold[:rows],
+        workspace.histogram[:rows],
+        workspace.candidate_values[:rows],
+        workspace.candidate_indices[:rows],
+        workspace.candidate_counts[:rows],
+        workspace.select_starts[:rows],
+        workspace.select_ends[:rows],
+        workspace.status[:rows],
+        weight_scale=weight_scale,
+        n_ctas=rows,
+        merge_cap=merge_cap,
+        topk=topk,
+        status_candidate_overflow=STATUS_CANDIDATE_OVERFLOW,
+        status_underfilled=STATUS_UNDERFILLED,
+        stream=stream,
+        status_nonfinite=STATUS_NONFINITE,
+        page_errors=workspace.page_errors[:rows],
+        block_k=_SCAN_BLOCK_K,
+        num_warps=_SCAN_NUM_WARPS,
+    )
+    flydsl_pa_mqa_litetopk_fp4_prefill_scan(
+        q_fp4,
+        q_scale,
+        kv_cache,
+        kv_scale,
+        block_tables,
+        weights,
+        suffix_cta_info,
+        workspace.origin[:rows],
+        workspace.inv_delta[:rows],
+        workspace.threshold[:rows],
+        workspace.histogram[:rows],
+        workspace.candidate_values[:rows],
+        workspace.candidate_indices[:rows],
+        workspace.candidate_counts[:rows],
+        workspace.page_errors[:rows],
+        workspace.score_errors[:rows],
+        n_ctas=rows,
+        merge_cap=merge_cap,
+        topk=topk,
+        refresh_every=refresh_every * 256 // _SCAN_BLOCK_K,
+        weight_scale=weight_scale,
+        block_k=_SCAN_BLOCK_K,
+        num_warps=_SCAN_NUM_WARPS,
+        stream=stream,
+    )
+
+    from aiter.ops.topk import _top_k_per_row_prefill
+    from aiter.ops.triton.attention.pa_mqa_litetopk_finalize import (
+        finalize_pa_mqa_litetopk,
+        prepare_pa_mqa_litetopk_select,
+    )
+
+    prepare_pa_mqa_litetopk_select(
+        workspace.candidate_counts[:rows],
+        workspace.page_errors[:rows],
+        workspace.score_errors[:rows],
+        workspace.histogram[:rows],
+        local_starts,
+        local_ends,
+        workspace.threshold[:rows],
+        workspace.select_ends[:rows],
+        workspace.status[:rows],
+        topk=topk,
+        merge_cap=merge_cap,
+        num_buckets=num_buckets,
+        status_candidate_overflow=STATUS_CANDIDATE_OVERFLOW,
+        status_underfilled=STATUS_UNDERFILLED,
+        status_nonfinite=STATUS_NONFINITE,
+        status_invalid_index=STATUS_INVALID_INDEX,
+        status_bad_certificate=STATUS_BAD_CERTIFICATE,
+        stream=stream,
+    )
+    with torch.cuda.device(device), torch.cuda.stream(stream):
+        _top_k_per_row_prefill(
+            workspace.candidate_values[:rows],
+            workspace.select_starts[:rows],
+            workspace.select_ends[:rows],
+            workspace.selected_slots[:rows],
+            workspace.selected_values[:rows],
+            rows,
+            workspace.candidate_values.stride(0),
+            workspace.candidate_values.stride(1),
+            topk,
+            workspace.selector_workspace,
+            True,
+        )
+    finalize_pa_mqa_litetopk(
+        workspace.candidate_indices[:rows],
+        workspace.select_ends[:rows],
+        workspace.selected_slots[:rows],
+        workspace.selected_values[:rows],
+        row_to_batch,
+        local_starts,
+        local_ends,
+        block_tables,
+        workspace.status[:rows],
+        out.values,
+        out.raw_indices,
+        out.physical_indices,
+        out.counts,
+        topk=topk,
+        page_size=64,
+        physical_page_capacity=kv_cache.shape[0],
+        status_nonfinite=STATUS_NONFINITE,
+        status_invalid_index=STATUS_INVALID_INDEX,
+        status_selector_failure=STATUS_SELECTOR_FAILURE,
+        stream=stream,
+        status_ok=workspace.status_ok,
+    )
+    if enforce_status:
+        with torch.cuda.device(device), torch.cuda.stream(stream):
+            assert_async = getattr(torch, "_assert_async", None)
+            if assert_async is not None:
+                assert_async(
+                    workspace.status_ok, "FP4 LiteTopK produced an invalid row"
+                )
+            elif not bool(workspace.status_ok):
+                raise RuntimeError("FP4 LiteTopK produced an invalid row")
+    return out

--- a/aiter/ops/triton/_triton_kernels/attention/pa_mqa_litetopk_finalize.py
+++ b/aiter/ops/triton/_triton_kernels/attention/pa_mqa_litetopk_finalize.py
@@ -1,0 +1,270 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+# ruff: noqa: PLR0124
+
+import triton
+import triton.language as tl
+
+from aiter.ops.triton.utils._triton.kernel_repr import make_kernel_repr
+
+_preselect_repr = make_kernel_repr(
+    "_pa_mqa_litetopk_preselect_kernel", ["NUM_BUCKETS", "TOPK"]
+)
+_finalize_repr = make_kernel_repr("_pa_mqa_litetopk_finalize_kernel", ["TOPK", "BLOCK"])
+_validate_pages_repr = make_kernel_repr(
+    "_pa_mqa_litetopk_validate_pages_kernel", ["PAGE_SIZE", "BLOCK"]
+)
+
+
+@triton.jit(
+    repr=_validate_pages_repr,
+    do_not_specialize=[
+        "rows",
+        "max_seq_len",
+        "block_table_stride",
+        "block_table_rows",
+        "block_table_capacity",
+        "physical_page_capacity",
+    ],
+)
+def _pa_mqa_litetopk_validate_pages_kernel(
+    row_to_batch_ptr,
+    row_starts_ptr,
+    row_ends_ptr,
+    block_tables_ptr,
+    page_errors_ptr,
+    status_ptr,
+    rows,
+    max_seq_len,
+    block_table_stride,
+    block_table_rows,
+    block_table_capacity,
+    physical_page_capacity,
+    STATUS_INVALID_INDEX: tl.constexpr,
+    PAGE_SIZE: tl.constexpr,
+    BLOCK: tl.constexpr,
+):
+    row = tl.program_id(0)
+    if row >= rows:
+        return
+    batch = tl.load(row_to_batch_ptr + row)
+    row_start = tl.load(row_starts_ptr + row)
+    row_end = tl.load(row_ends_ptr + row)
+    valid_window = (row_start >= 0) & (row_end >= row_start) & (row_end <= max_seq_len)
+    batch_ok = (batch >= 0) & (batch < block_table_rows)
+    safe_batch = tl.where(batch_ok, batch, 0)
+    block_table_row_base = safe_batch.to(tl.int64) * block_table_stride.to(tl.int64)
+    first_page = tl.maximum(row_start, 0) // PAGE_SIZE
+    last_page = (tl.minimum(row_end, max_seq_len) + PAGE_SIZE - 1) // PAGE_SIZE
+    errors = tl.where(valid_window & batch_ok, 0, 1)
+    offsets = tl.arange(0, BLOCK)
+    for base in range(0, block_table_capacity, BLOCK):
+        page_offsets = base + offsets
+        live = (
+            valid_window
+            & batch_ok
+            & (page_offsets >= first_page)
+            & (page_offsets < last_page)
+            & (page_offsets < block_table_capacity)
+        )
+        pages = tl.load(
+            block_tables_ptr + block_table_row_base + tl.where(live, page_offsets, 0),
+            mask=live,
+            other=0,
+        )
+        invalid = live & ((pages < 0) | (pages >= physical_page_capacity))
+        errors += tl.sum(invalid.to(tl.int32), axis=0)
+    status = tl.load(status_ptr + row)
+    status |= tl.where(errors != 0, STATUS_INVALID_INDEX, 0)
+    tl.store(page_errors_ptr + row, errors)
+    tl.store(status_ptr + row, status)
+
+
+@triton.jit(
+    repr=_preselect_repr,
+    do_not_specialize=["merge_cap"],
+)
+def _pa_mqa_litetopk_preselect_kernel(
+    candidate_counts_ptr,
+    page_errors_ptr,
+    score_errors_ptr,
+    histogram_ptr,
+    row_starts_ptr,
+    row_ends_ptr,
+    threshold_ptr,
+    select_ends_ptr,
+    status_ptr,
+    merge_cap,
+    STATUS_CANDIDATE_OVERFLOW: tl.constexpr,
+    STATUS_UNDERFILLED: tl.constexpr,
+    STATUS_NONFINITE: tl.constexpr,
+    STATUS_INVALID_INDEX: tl.constexpr,
+    STATUS_BAD_CERTIFICATE: tl.constexpr,
+    NUM_BUCKETS: tl.constexpr,
+    TOPK: tl.constexpr,
+):
+    row = tl.program_id(0)
+    buckets = tl.arange(0, NUM_BUCKETS)
+    histogram = tl.load(histogram_ptr + row * NUM_BUCKETS + buckets)
+    row_start = tl.load(row_starts_ptr + row)
+    row_end = tl.load(row_ends_ptr + row)
+    row_len = tl.maximum(row_end - row_start, 0)
+    required = tl.minimum(row_len, TOPK)
+    attempted = tl.load(candidate_counts_ptr + row)
+    threshold = tl.load(threshold_ptr + row)
+    status = tl.load(status_ptr + row)
+    status |= tl.where(attempted > merge_cap, STATUS_CANDIDATE_OVERFLOW, 0)
+    status |= tl.where(attempted < required, STATUS_UNDERFILLED, 0)
+    status |= tl.where(tl.load(score_errors_ptr + row) != 0, STATUS_NONFINITE, 0)
+    status |= tl.where(tl.load(page_errors_ptr + row) != 0, STATUS_INVALID_INDEX, 0)
+    threshold_count = tl.sum(tl.where(buckets <= threshold, histogram, 0), axis=0)
+    bad_certificate = (
+        (threshold < 0)
+        | (threshold >= NUM_BUCKETS)
+        | (threshold_count < required)
+        | (attempted < threshold_count)
+        | (attempted > row_len)
+    )
+    status |= tl.where(bad_certificate, STATUS_BAD_CERTIFICATE, 0)
+    tl.store(status_ptr + row, status)
+    tl.store(select_ends_ptr + row, tl.where(status == 0, attempted, 0))
+
+
+@triton.jit(
+    repr=_finalize_repr,
+    do_not_specialize=[
+        "candidate_stride",
+        "block_table_stride",
+        "block_table_rows",
+        "block_table_capacity",
+        "page_size",
+        "physical_page_capacity",
+    ],
+)
+def _pa_mqa_litetopk_finalize_kernel(
+    candidate_indices_ptr,
+    select_ends_ptr,
+    selected_slots_ptr,
+    selected_values_ptr,
+    row_to_batch_ptr,
+    row_starts_ptr,
+    row_ends_ptr,
+    block_tables_ptr,
+    status_ptr,
+    out_values_ptr,
+    out_raw_indices_ptr,
+    out_physical_indices_ptr,
+    out_counts_ptr,
+    status_ok_ptr,
+    candidate_stride,
+    block_table_stride,
+    block_table_rows,
+    block_table_capacity,
+    page_size,
+    physical_page_capacity,
+    STATUS_NONFINITE: tl.constexpr,
+    STATUS_INVALID_INDEX: tl.constexpr,
+    STATUS_SELECTOR_FAILURE: tl.constexpr,
+    AGGREGATE_STATUS: tl.constexpr,
+    TOPK: tl.constexpr,
+    BLOCK: tl.constexpr,
+):
+    row = tl.program_id(0)
+    lanes = tl.arange(0, BLOCK)
+    lane_mask = lanes < TOPK
+    row_start = tl.load(row_starts_ptr + row)
+    row_end = tl.load(row_ends_ptr + row)
+    required = tl.minimum(tl.maximum(row_end - row_start, 0), TOPK)
+    needed = lane_mask & (lanes < required)
+    select_end = tl.load(select_ends_ptr + row)
+    row_i64 = row.to(tl.int64)
+    candidate_row_base = row_i64 * candidate_stride.to(tl.int64)
+    output_row_base = row_i64 * TOPK
+
+    slots = tl.load(
+        selected_slots_ptr + output_row_base + lanes,
+        mask=lane_mask,
+        other=-1,
+    )
+    slot_ok = needed & (slots >= 0) & (slots < select_end)
+    safe_slots = tl.where(slot_ok, slots, 0)
+    values = tl.load(
+        selected_values_ptr + output_row_base + lanes,
+        mask=lane_mask,
+        other=-float("inf"),
+    ).to(tl.float32)
+    raw_indices = tl.load(
+        candidate_indices_ptr + candidate_row_base + safe_slots,
+        mask=slot_ok,
+        other=-1,
+    ).to(tl.int32)
+    finite = (values == values) & (values != float("inf")) & (values != -float("inf"))
+    raw_ok = needed & (raw_indices >= row_start) & (raw_indices < row_end)
+    safe_raw = tl.where(raw_ok, raw_indices, 0)
+    page_offsets = safe_raw // page_size
+    page_ok = (
+        needed
+        & raw_ok
+        & (raw_indices >= 0)
+        & (page_offsets >= 0)
+        & (page_offsets < block_table_capacity)
+    )
+    batch = tl.load(row_to_batch_ptr + row)
+    batch_ok = (batch >= 0) & (batch < block_table_rows)
+    safe_batch = tl.where(batch_ok, batch, 0)
+    block_table_row_base = safe_batch.to(tl.int64) * block_table_stride.to(tl.int64)
+    pages = tl.load(
+        block_tables_ptr + block_table_row_base + page_offsets,
+        mask=page_ok & batch_ok,
+        other=-1,
+    ).to(tl.int32)
+    physical_i64 = pages.to(tl.int64) * page_size.to(tl.int64) + (
+        safe_raw.to(tl.int64) % page_size.to(tl.int64)
+    )
+    physical_ok = (
+        page_ok
+        & batch_ok
+        & (pages >= 0)
+        & (pages < physical_page_capacity)
+        & (physical_i64 >= 0)
+        & (physical_i64 <= 0x7FFFFFFF)
+    )
+    physical = tl.where(physical_ok, physical_i64, 0).to(tl.int32)
+
+    status = tl.load(status_ptr + row)
+    status |= tl.where(
+        tl.sum((needed & ~slot_ok).to(tl.int32), axis=0) > 0,
+        STATUS_SELECTOR_FAILURE,
+        0,
+    )
+    status |= tl.where(
+        tl.sum((needed & ~finite).to(tl.int32), axis=0) > 0,
+        STATUS_NONFINITE,
+        0,
+    )
+    status |= tl.where(
+        tl.sum((needed & ~physical_ok).to(tl.int32), axis=0) > 0,
+        STATUS_INVALID_INDEX,
+        0,
+    )
+    success = status == 0
+    if AGGREGATE_STATUS:
+        tl.atomic_min(status_ok_ptr, 0, mask=~success)
+    publish = lane_mask & (lanes < required) & success
+    tl.store(
+        out_values_ptr + output_row_base + lanes,
+        tl.where(publish, values, -float("inf")),
+        mask=lane_mask,
+    )
+    tl.store(
+        out_raw_indices_ptr + output_row_base + lanes,
+        tl.where(publish, raw_indices, -1),
+        mask=lane_mask,
+    )
+    tl.store(
+        out_physical_indices_ptr + output_row_base + lanes,
+        tl.where(publish, physical, -1),
+        mask=lane_mask,
+    )
+    tl.store(status_ptr + row, status)
+    tl.store(out_counts_ptr + row, tl.where(success, required, 0))

--- a/aiter/ops/triton/_triton_kernels/attention/pa_mqa_litetopk_seed.py
+++ b/aiter/ops/triton/_triton_kernels/attention/pa_mqa_litetopk_seed.py
@@ -1,0 +1,373 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+# ruff: noqa: PLR0124
+
+import triton
+import triton.language as tl
+
+from aiter.ops.triton.utils._triton.kernel_repr import make_kernel_repr
+
+_seed_calibrate_repr = make_kernel_repr(
+    "_pa_mqa_litetopk_seed_calibrate_kernel",
+    ["SAMPLE_LEN", "BLOCK"],
+)
+_seed_histogram_repr = make_kernel_repr(
+    "_pa_mqa_litetopk_seed_histogram_kernel",
+    ["SAMPLE_LEN", "NUM_BUCKETS", "TOPK", "BLOCK"],
+)
+_seed_emit_repr = make_kernel_repr(
+    "_pa_mqa_litetopk_seed_emit_kernel",
+    ["SAMPLE_LEN", "NUM_BUCKETS", "TOPK", "BLOCK"],
+)
+_scan_schedule_repr = make_kernel_repr(
+    "_pa_mqa_litetopk_scan_schedule_kernel",
+    [
+        "VALIDATE_ROWS",
+        "RESET_STATE",
+        "DUAL_SCHEDULE",
+        "SAMPLE_LEN",
+        "BLOCK_K",
+        "BLOCK",
+    ],
+)
+_refresh_threshold_repr = make_kernel_repr(
+    "_pa_mqa_litetopk_refresh_threshold_kernel", ["NUM_BUCKETS", "TOPK"]
+)
+
+
+@triton.jit
+def _finite_f32(value):
+    return (value == value) & (value != float("inf")) & (value != -float("inf"))
+
+
+@triton.jit
+def _bucket_f32(value, origin, inv_delta, NUM_BUCKETS: tl.constexpr):
+    affine = (-value - origin) * inv_delta
+    affine = tl.where(_finite_f32(affine), affine, float(NUM_BUCKETS - 1))
+    affine = tl.maximum(0.0, tl.minimum(affine, float(NUM_BUCKETS - 1)))
+    return affine.to(tl.int32)
+
+
+@triton.jit(repr=_seed_calibrate_repr, do_not_specialize=["max_seq_len"])
+def _pa_mqa_litetopk_seed_calibrate_kernel(
+    sample_logits_ptr,
+    row_starts_ptr,
+    row_ends_ptr,
+    origin_ptr,
+    inv_delta_ptr,
+    status_ptr,
+    sample_stride,
+    max_seq_len,
+    STATUS_NONFINITE: tl.constexpr,
+    STATUS_INVALID_INDEX: tl.constexpr,
+    SAMPLE_LEN: tl.constexpr,
+    BLOCK: tl.constexpr,
+):
+    row = tl.program_id(0)
+    row_start = tl.load(row_starts_ptr + row)
+    row_end = tl.load(row_ends_ptr + row)
+    invalid_window = (row_start < 0) | (row_end < row_start) | (row_end > max_seq_len)
+    row_len = tl.maximum(row_end - row_start, 0)
+    sample_count = tl.minimum(row_len, SAMPLE_LEN)
+
+    row_max = -float("inf")
+    row_min = float("inf")
+    finite_count = 0
+    nonfinite_count = 0
+    offsets = tl.arange(0, BLOCK)
+    for base in tl.static_range(0, SAMPLE_LEN, BLOCK):
+        columns = base + offsets
+        genuine = columns < sample_count
+        values = tl.load(
+            sample_logits_ptr + row * sample_stride + columns,
+            mask=genuine,
+            other=0.0,
+        ).to(tl.float32)
+        finite = genuine & _finite_f32(values)
+        row_max = tl.maximum(
+            row_max,
+            tl.max(tl.where(finite, values, -float("inf")), axis=0),
+        )
+        row_min = tl.minimum(
+            row_min,
+            tl.min(tl.where(finite, values, float("inf")), axis=0),
+        )
+        finite_count += tl.sum(finite.to(tl.int32), axis=0)
+        nonfinite_count += tl.sum((genuine & ~finite).to(tl.int32), axis=0)
+
+    has_finite = finite_count > 0
+    safe_max = tl.where(has_finite, row_max, 0.0)
+    safe_min = tl.where(has_finite, row_min, 0.0)
+    origin = -safe_max
+    magnitude = tl.maximum(tl.abs(safe_max), tl.abs(safe_min))
+    span = tl.maximum(safe_max - safe_min, magnitude * (1.0 / 256.0))
+    span = tl.maximum(span, 1.0e-6)
+    inv_delta = 255.0 / span
+
+    bad_affine = ~_finite_f32(origin) | ~_finite_f32(inv_delta)
+    status = tl.load(status_ptr + row)
+    status |= tl.where(invalid_window, STATUS_INVALID_INDEX, 0)
+    status |= tl.where(
+        (nonfinite_count > 0) | ((sample_count > 0) & ~has_finite) | bad_affine,
+        STATUS_NONFINITE,
+        0,
+    )
+    tl.store(origin_ptr + row, tl.where(bad_affine, 0.0, origin))
+    tl.store(inv_delta_ptr + row, tl.where(bad_affine, 1.0, inv_delta))
+    tl.store(status_ptr + row, status)
+
+
+@triton.jit(repr=_seed_histogram_repr)
+def _pa_mqa_litetopk_seed_histogram_kernel(
+    sample_logits_ptr,
+    row_starts_ptr,
+    row_ends_ptr,
+    origin_ptr,
+    inv_delta_ptr,
+    histogram_ptr,
+    threshold_ptr,
+    sample_stride,
+    SAMPLE_LEN: tl.constexpr,
+    NUM_BUCKETS: tl.constexpr,
+    TOPK: tl.constexpr,
+    BLOCK: tl.constexpr,
+):
+    row = tl.program_id(0)
+    row_start = tl.load(row_starts_ptr + row)
+    row_end = tl.load(row_ends_ptr + row)
+    row_len = tl.maximum(row_end - row_start, 0)
+    sample_count = tl.minimum(row_len, SAMPLE_LEN)
+    origin = tl.load(origin_ptr + row)
+    inv_delta = tl.load(inv_delta_ptr + row)
+
+    histogram = tl.zeros((NUM_BUCKETS,), dtype=tl.int32)
+    offsets = tl.arange(0, BLOCK)
+    for base in tl.static_range(0, SAMPLE_LEN, BLOCK):
+        columns = base + offsets
+        genuine = columns < sample_count
+        values = tl.load(
+            sample_logits_ptr + row * sample_stride + columns,
+            mask=genuine,
+            other=0.0,
+        ).to(tl.float32)
+        finite = genuine & _finite_f32(values)
+        buckets = _bucket_f32(values, origin, inv_delta, NUM_BUCKETS)
+        histogram += tl.histogram(buckets, NUM_BUCKETS, mask=finite)
+
+    bucket_offsets = tl.arange(0, NUM_BUCKETS)
+    tl.store(histogram_ptr + row * NUM_BUCKETS + bucket_offsets, histogram)
+    required = tl.minimum(row_len, TOPK)
+    inclusive = tl.cumsum(histogram, axis=0)
+    first = tl.min(tl.where(inclusive >= required, bucket_offsets, NUM_BUCKETS), axis=0)
+    threshold = tl.where(required > 0, tl.minimum(first, NUM_BUCKETS - 1), 0)
+    tl.store(threshold_ptr + row, threshold)
+
+
+@triton.jit(repr=_seed_emit_repr)
+def _pa_mqa_litetopk_seed_emit_kernel(
+    sample_logits_ptr,
+    row_starts_ptr,
+    row_ends_ptr,
+    origin_ptr,
+    inv_delta_ptr,
+    threshold_ptr,
+    candidate_values_ptr,
+    candidate_indices_ptr,
+    candidate_counts_ptr,
+    select_starts_ptr,
+    select_ends_ptr,
+    status_ptr,
+    sample_stride,
+    candidate_stride,
+    merge_cap,
+    STATUS_CANDIDATE_OVERFLOW: tl.constexpr,
+    STATUS_UNDERFILLED: tl.constexpr,
+    SAMPLE_LEN: tl.constexpr,
+    NUM_BUCKETS: tl.constexpr,
+    TOPK: tl.constexpr,
+    BLOCK: tl.constexpr,
+):
+    row = tl.program_id(0)
+    row_start = tl.load(row_starts_ptr + row)
+    row_end = tl.load(row_ends_ptr + row)
+    row_len = tl.maximum(row_end - row_start, 0)
+    sample_count = tl.minimum(row_len, SAMPLE_LEN)
+    origin = tl.load(origin_ptr + row)
+    inv_delta = tl.load(inv_delta_ptr + row)
+    threshold = tl.load(threshold_ptr + row)
+    row_i64 = row.to(tl.int64)
+    sample_row_base = row_i64 * sample_stride.to(tl.int64)
+    candidate_row_base = row_i64 * candidate_stride.to(tl.int64)
+
+    attempted = 0
+    offsets = tl.arange(0, BLOCK)
+    for base in tl.static_range(0, SAMPLE_LEN, BLOCK):
+        columns = base + offsets
+        genuine = columns < sample_count
+        values = tl.load(
+            sample_logits_ptr + sample_row_base + columns,
+            mask=genuine,
+            other=0.0,
+        ).to(tl.float32)
+        finite = genuine & _finite_f32(values)
+        buckets = _bucket_f32(values, origin, inv_delta, NUM_BUCKETS)
+        keep = finite & (buckets <= threshold)
+        inclusive = tl.cumsum(keep.to(tl.int32), axis=0)
+        positions = attempted + inclusive - 1
+        in_capacity = positions < merge_cap
+        store_mask = keep & in_capacity
+        safe_positions = tl.where(store_mask, positions, 0)
+        tl.store(
+            candidate_values_ptr + candidate_row_base + safe_positions,
+            values,
+            mask=store_mask,
+        )
+        tl.store(
+            candidate_indices_ptr + candidate_row_base + safe_positions,
+            row_start + columns,
+            mask=store_mask,
+        )
+        attempted += tl.sum(keep.to(tl.int32), axis=0)
+
+    required = tl.minimum(row_len, TOPK)
+    status = tl.load(status_ptr + row)
+    status |= tl.where(attempted > merge_cap, STATUS_CANDIDATE_OVERFLOW, 0)
+    status |= tl.where(attempted < required, STATUS_UNDERFILLED, 0)
+    tl.store(candidate_counts_ptr + row, attempted)
+    tl.store(select_starts_ptr + row, 0)
+    tl.store(select_ends_ptr + row, tl.minimum(attempted, merge_cap))
+    tl.store(status_ptr + row, status)
+
+
+@triton.jit(
+    repr=_scan_schedule_repr,
+    do_not_specialize=[
+        "rows",
+        "segment_start",
+        "segment_end",
+        "max_seq_len",
+        "block_table_rows",
+    ],
+)
+def _pa_mqa_litetopk_scan_schedule_kernel(
+    row_to_batch_ptr,
+    row_starts_ptr,
+    row_ends_ptr,
+    cta_info_ptr,
+    suffix_cta_info_ptr,
+    page_errors_ptr,
+    score_errors_ptr,
+    status_ptr,
+    sample_ends_ptr,
+    status_ok_ptr,
+    rows,
+    segment_start,
+    segment_end,
+    max_seq_len,
+    block_table_rows,
+    VALIDATE_ROWS: tl.constexpr,
+    RESET_STATE: tl.constexpr,
+    RESET_STATUS_OK: tl.constexpr,
+    DUAL_SCHEDULE: tl.constexpr,
+    SAMPLE_LEN: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+    BLOCK: tl.constexpr,
+):
+    offsets = tl.program_id(0) * BLOCK + tl.arange(0, BLOCK)
+    row_live = offsets < rows
+    safe_row = tl.where(row_live, offsets, 0)
+    row_start = tl.load(row_starts_ptr + safe_row, mask=row_live, other=0)
+    row_end = tl.load(row_ends_ptr + safe_row, mask=row_live, other=0)
+    batch = tl.load(row_to_batch_ptr + safe_row, mask=row_live, other=0)
+    work_live = row_live
+    if VALIDATE_ROWS:
+        invalid = (
+            (row_start < 0)
+            | (row_end < row_start)
+            | (row_end > max_seq_len)
+            | (batch < 0)
+            | (batch >= block_table_rows)
+        )
+        errors = invalid.to(tl.int32)
+        tl.store(page_errors_ptr + safe_row, errors, mask=row_live)
+        work_live &= errors == 0
+    if RESET_STATE:
+        tl.store(score_errors_ptr + safe_row, 0, mask=row_live)
+        tl.store(status_ptr + safe_row, 0, mask=row_live)
+    if RESET_STATUS_OK & (tl.program_id(0) == 0):
+        tl.store(status_ok_ptr, 1)
+    window_start = tl.where(work_live, tl.maximum(row_start, segment_start), 0)
+    window_end = tl.where(work_live, tl.minimum(row_end, segment_end), 0)
+    scan_start = window_start
+    scan_end = (
+        tl.minimum(window_start + SAMPLE_LEN, window_end)
+        if DUAL_SCHEDULE
+        else window_end
+    )
+    nonempty = work_live & (scan_end > scan_start)
+    first_chunk = scan_start // BLOCK_K
+    last_chunk = (scan_end + BLOCK_K - 1) // BLOCK_K
+    chunk_count = tl.where(nonempty, tl.maximum(last_chunk - first_chunk, 1), 1)
+    base = offsets * 6
+    tl.store(cta_info_ptr + base + 0, safe_row, mask=row_live)
+    tl.store(cta_info_ptr + base + 1, tl.where(work_live, batch, 0), mask=row_live)
+    tl.store(cta_info_ptr + base + 2, tl.where(nonempty, first_chunk, 0), mask=row_live)
+    tl.store(cta_info_ptr + base + 3, chunk_count, mask=row_live)
+    tl.store(cta_info_ptr + base + 4, tl.where(nonempty, scan_start, 0), mask=row_live)
+    tl.store(cta_info_ptr + base + 5, tl.where(nonempty, scan_end, 0), mask=row_live)
+    if DUAL_SCHEDULE:
+        tl.store(sample_ends_ptr + safe_row, scan_end, mask=row_live)
+        suffix_start = scan_end
+        suffix_end = window_end
+        suffix_nonempty = work_live & (suffix_end > suffix_start)
+        suffix_first_chunk = suffix_start // BLOCK_K
+        suffix_last_chunk = (suffix_end + BLOCK_K - 1) // BLOCK_K
+        suffix_chunk_count = tl.where(
+            suffix_nonempty,
+            tl.maximum(suffix_last_chunk - suffix_first_chunk, 1),
+            1,
+        )
+        tl.store(suffix_cta_info_ptr + base + 0, safe_row, mask=row_live)
+        tl.store(
+            suffix_cta_info_ptr + base + 1,
+            tl.where(work_live, batch, 0),
+            mask=row_live,
+        )
+        tl.store(
+            suffix_cta_info_ptr + base + 2,
+            tl.where(suffix_nonempty, suffix_first_chunk, 0),
+            mask=row_live,
+        )
+        tl.store(suffix_cta_info_ptr + base + 3, suffix_chunk_count, mask=row_live)
+        tl.store(
+            suffix_cta_info_ptr + base + 4,
+            tl.where(suffix_nonempty, suffix_start, 0),
+            mask=row_live,
+        )
+        tl.store(
+            suffix_cta_info_ptr + base + 5,
+            tl.where(suffix_nonempty, suffix_end, 0),
+            mask=row_live,
+        )
+
+
+@triton.jit(repr=_refresh_threshold_repr)
+def _pa_mqa_litetopk_refresh_threshold_kernel(
+    histogram_ptr,
+    threshold_ptr,
+    NUM_BUCKETS: tl.constexpr,
+    TOPK: tl.constexpr,
+):
+    row = tl.program_id(0)
+    buckets = tl.arange(0, NUM_BUCKETS)
+    histogram = tl.load(histogram_ptr + row * NUM_BUCKETS + buckets)
+    inclusive = tl.cumsum(histogram, axis=0)
+    first = tl.min(tl.where(inclusive >= TOPK, buckets, NUM_BUCKETS), axis=0)
+    old_threshold = tl.load(threshold_ptr + row)
+    has_topk = tl.sum(histogram, axis=0) >= TOPK
+    new_threshold = tl.where(
+        has_topk,
+        tl.minimum(old_threshold, tl.minimum(first, NUM_BUCKETS - 1)),
+        old_threshold,
+    )
+    tl.store(threshold_ptr + row, new_threshold)

--- a/aiter/ops/triton/attention/pa_mqa_litetopk_finalize.py
+++ b/aiter/ops/triton/attention/pa_mqa_litetopk_finalize.py
@@ -1,0 +1,175 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+from __future__ import annotations
+
+import torch
+import triton
+
+from aiter.ops.triton._triton_kernels.attention.pa_mqa_litetopk_finalize import (
+    _pa_mqa_litetopk_finalize_kernel,
+    _pa_mqa_litetopk_preselect_kernel,
+    _pa_mqa_litetopk_validate_pages_kernel,
+)
+
+
+def validate_pa_mqa_litetopk_pages(
+    row_to_batch: torch.Tensor,
+    row_starts: torch.Tensor,
+    row_ends: torch.Tensor,
+    block_tables: torch.Tensor,
+    page_errors: torch.Tensor,
+    status: torch.Tensor,
+    *,
+    max_seq_len: int,
+    physical_page_capacity: int,
+    page_size: int,
+    status_invalid_index: int,
+    stream: torch.cuda.Stream,
+) -> None:
+    rows = row_to_batch.shape[0]
+    block = 256
+    device = row_to_batch.device
+    if torch.device(stream.device) != device:
+        raise ValueError("stream and page metadata must be on the same device")
+    with torch.cuda.device(device), torch.cuda.stream(stream):
+        _pa_mqa_litetopk_validate_pages_kernel[(rows,)](
+            row_to_batch,
+            row_starts,
+            row_ends,
+            block_tables,
+            page_errors,
+            status,
+            rows,
+            max_seq_len,
+            block_tables.stride(0),
+            block_tables.shape[0],
+            block_tables.shape[1],
+            physical_page_capacity,
+            STATUS_INVALID_INDEX=status_invalid_index,
+            PAGE_SIZE=page_size,
+            BLOCK=block,
+            num_warps=4,
+            num_stages=1,
+        )
+
+
+def prepare_pa_mqa_litetopk_select(
+    candidate_counts: torch.Tensor,
+    page_errors: torch.Tensor,
+    score_errors: torch.Tensor,
+    histogram: torch.Tensor,
+    row_starts: torch.Tensor,
+    row_ends: torch.Tensor,
+    threshold: torch.Tensor,
+    select_ends: torch.Tensor,
+    status: torch.Tensor,
+    *,
+    topk: int,
+    merge_cap: int,
+    num_buckets: int,
+    status_candidate_overflow: int,
+    status_underfilled: int,
+    status_nonfinite: int,
+    status_invalid_index: int,
+    status_bad_certificate: int,
+    stream: torch.cuda.Stream,
+) -> None:
+    rows = candidate_counts.shape[0]
+    device = candidate_counts.device
+    if torch.device(stream.device) != device:
+        raise ValueError("stream and selection metadata must be on the same device")
+    with torch.cuda.device(device), torch.cuda.stream(stream):
+        _pa_mqa_litetopk_preselect_kernel[(rows,)](
+            candidate_counts,
+            page_errors,
+            score_errors,
+            histogram,
+            row_starts,
+            row_ends,
+            threshold,
+            select_ends,
+            status,
+            merge_cap,
+            STATUS_CANDIDATE_OVERFLOW=status_candidate_overflow,
+            STATUS_UNDERFILLED=status_underfilled,
+            STATUS_NONFINITE=status_nonfinite,
+            STATUS_INVALID_INDEX=status_invalid_index,
+            STATUS_BAD_CERTIFICATE=status_bad_certificate,
+            NUM_BUCKETS=num_buckets,
+            TOPK=topk,
+            num_warps=4,
+            num_stages=1,
+        )
+
+
+def finalize_pa_mqa_litetopk(
+    candidate_indices: torch.Tensor,
+    select_ends: torch.Tensor,
+    selected_slots: torch.Tensor,
+    selected_values: torch.Tensor,
+    row_to_batch: torch.Tensor,
+    row_starts: torch.Tensor,
+    row_ends: torch.Tensor,
+    block_tables: torch.Tensor,
+    status: torch.Tensor,
+    out_values: torch.Tensor,
+    out_raw_indices: torch.Tensor,
+    out_physical_indices: torch.Tensor,
+    out_counts: torch.Tensor,
+    *,
+    topk: int,
+    page_size: int,
+    physical_page_capacity: int,
+    status_nonfinite: int,
+    status_invalid_index: int,
+    status_selector_failure: int,
+    stream: torch.cuda.Stream,
+    status_ok: torch.Tensor | None = None,
+) -> None:
+    rows = candidate_indices.shape[0]
+    block = triton.next_power_of_2(topk)
+    device = candidate_indices.device
+    if torch.device(stream.device) != device:
+        raise ValueError("stream and finalizer tensors must be on the same device")
+    aggregate_status = status_ok is not None
+    if status_ok is None:
+        status_ok = status
+    elif (
+        status_ok.dtype != torch.int32
+        or status_ok.numel() != 1
+        or status_ok.device != device
+        or not status_ok.is_contiguous()
+    ):
+        raise ValueError("status_ok must be a contiguous one-element int32 tensor")
+    with torch.cuda.device(device), torch.cuda.stream(stream):
+        _pa_mqa_litetopk_finalize_kernel[(rows,)](
+            candidate_indices,
+            select_ends,
+            selected_slots,
+            selected_values,
+            row_to_batch,
+            row_starts,
+            row_ends,
+            block_tables,
+            status,
+            out_values,
+            out_raw_indices,
+            out_physical_indices,
+            out_counts,
+            status_ok,
+            candidate_indices.stride(0),
+            block_tables.stride(0),
+            block_tables.shape[0],
+            block_tables.shape[1],
+            page_size,
+            physical_page_capacity,
+            STATUS_NONFINITE=status_nonfinite,
+            STATUS_INVALID_INDEX=status_invalid_index,
+            STATUS_SELECTOR_FAILURE=status_selector_failure,
+            AGGREGATE_STATUS=aggregate_status,
+            TOPK=topk,
+            BLOCK=block,
+            num_warps=4 if topk <= 512 else 8,
+            num_stages=1,
+        )

--- a/aiter/ops/triton/attention/pa_mqa_litetopk_seed.py
+++ b/aiter/ops/triton/attention/pa_mqa_litetopk_seed.py
@@ -1,0 +1,323 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+from __future__ import annotations
+
+from itertools import pairwise
+
+import torch
+import triton
+
+from aiter.ops.triton._triton_kernels.attention.pa_mqa_litetopk_seed import (
+    _pa_mqa_litetopk_refresh_threshold_kernel,
+    _pa_mqa_litetopk_scan_schedule_kernel,
+    _pa_mqa_litetopk_seed_calibrate_kernel,
+    _pa_mqa_litetopk_seed_emit_kernel,
+    _pa_mqa_litetopk_seed_histogram_kernel,
+)
+
+
+def prepare_pa_mqa_litetopk_seed(
+    sample_logits: torch.Tensor,
+    row_starts: torch.Tensor,
+    row_ends: torch.Tensor,
+    *,
+    origin: torch.Tensor,
+    inv_delta: torch.Tensor,
+    threshold: torch.Tensor,
+    histogram: torch.Tensor,
+    candidate_values: torch.Tensor,
+    candidate_indices: torch.Tensor,
+    candidate_counts: torch.Tensor,
+    select_starts: torch.Tensor,
+    select_ends: torch.Tensor,
+    status: torch.Tensor,
+    max_seq_len: int,
+    topk: int,
+    sample_len: int,
+    num_buckets: int,
+    merge_cap: int,
+    status_candidate_overflow: int,
+    status_underfilled: int,
+    status_nonfinite: int,
+    status_invalid_index: int,
+    emit_candidates: bool = True,
+    stream: torch.cuda.Stream | None = None,
+) -> None:
+    """Calibrate the LiteTopK gate and emit a row's bounded seed candidates."""
+    rows = sample_logits.shape[0]
+    if sample_logits.dtype != torch.float32 or sample_logits.ndim != 2:
+        raise ValueError("sample_logits must be a 2D float32 tensor")
+    if sample_logits.shape[1] != sample_len:
+        raise ValueError(
+            f"sample_logits width must equal sample_len={sample_len}, "
+            f"got {sample_logits.shape[1]}"
+        )
+    if sample_len < topk:
+        raise ValueError("sample_len must be at least topk")
+    if num_buckets != 256:
+        raise ValueError("the initial LiteTopK seed implementation requires 256 bins")
+    if merge_cap < topk or candidate_values.shape != (rows, merge_cap):
+        raise ValueError("candidate_values shape does not match rows and merge_cap")
+    expected_i32_rows = (
+        row_starts,
+        row_ends,
+        threshold,
+        candidate_counts,
+        select_starts,
+        select_ends,
+        status,
+    )
+    if any(t.dtype != torch.int32 or t.shape != (rows,) for t in expected_i32_rows):
+        raise ValueError("row metadata and status tensors must be int32 [rows]")
+    if origin.dtype != torch.float32 or origin.shape != (rows,):
+        raise ValueError("origin must be float32 [rows]")
+    if inv_delta.dtype != torch.float32 or inv_delta.shape != (rows,):
+        raise ValueError("inv_delta must be float32 [rows]")
+    if histogram.dtype != torch.int32 or histogram.shape != (rows, num_buckets):
+        raise ValueError("histogram must be int32 [rows, num_buckets]")
+    if candidate_indices.dtype != torch.int32 or candidate_indices.shape != (
+        rows,
+        merge_cap,
+    ):
+        raise ValueError("candidate_indices shape does not match rows and merge_cap")
+    tensors = (
+        sample_logits,
+        *expected_i32_rows,
+        origin,
+        inv_delta,
+        histogram,
+        candidate_values,
+        candidate_indices,
+    )
+    device = sample_logits.device
+    if device.type != "cuda" or any(t.device != device for t in tensors):
+        raise ValueError("all seed tensors must be on the same GPU device")
+    if any(not t.is_contiguous() for t in tensors):
+        raise ValueError("all seed tensors must be contiguous")
+    if rows == 0:
+        return
+    if stream is None:
+        stream = torch.cuda.current_stream(device)
+    if torch.device(stream.device) != device:
+        raise ValueError("stream and seed tensors must be on the same device")
+
+    block = 256
+    with torch.cuda.device(device), torch.cuda.stream(stream):
+        _pa_mqa_litetopk_seed_calibrate_kernel[(rows,)](
+            sample_logits,
+            row_starts,
+            row_ends,
+            origin,
+            inv_delta,
+            status,
+            sample_logits.stride(0),
+            max_seq_len,
+            STATUS_NONFINITE=status_nonfinite,
+            STATUS_INVALID_INDEX=status_invalid_index,
+            SAMPLE_LEN=sample_len,
+            BLOCK=block,
+            num_warps=4,
+            num_stages=1,
+        )
+        _pa_mqa_litetopk_seed_histogram_kernel[(rows,)](
+            sample_logits,
+            row_starts,
+            row_ends,
+            origin,
+            inv_delta,
+            histogram,
+            threshold,
+            sample_logits.stride(0),
+            SAMPLE_LEN=sample_len,
+            NUM_BUCKETS=num_buckets,
+            TOPK=topk,
+            BLOCK=block,
+            num_warps=4,
+            num_stages=1,
+        )
+        if emit_candidates:
+            _pa_mqa_litetopk_seed_emit_kernel[(rows,)](
+                sample_logits,
+                row_starts,
+                row_ends,
+                origin,
+                inv_delta,
+                threshold,
+                candidate_values,
+                candidate_indices,
+                candidate_counts,
+                select_starts,
+                select_ends,
+                status,
+                sample_logits.stride(0),
+                candidate_values.stride(0),
+                merge_cap,
+                STATUS_CANDIDATE_OVERFLOW=status_candidate_overflow,
+                STATUS_UNDERFILLED=status_underfilled,
+                SAMPLE_LEN=sample_len,
+                NUM_BUCKETS=num_buckets,
+                TOPK=topk,
+                BLOCK=block,
+                num_warps=4,
+                num_stages=1,
+            )
+
+
+def build_pa_mqa_litetopk_scan_schedule(
+    row_to_batch: torch.Tensor,
+    row_starts: torch.Tensor,
+    row_ends: torch.Tensor,
+    cta_info: torch.Tensor,
+    *,
+    segment_start: int,
+    segment_end: int,
+    block_k: int,
+    stream: torch.cuda.Stream,
+    page_errors: torch.Tensor | None = None,
+    max_seq_len: int | None = None,
+    block_table_rows: int | None = None,
+    suffix_cta_info: torch.Tensor | None = None,
+    sample_len: int = 0,
+    score_errors: torch.Tensor | None = None,
+    status: torch.Tensor | None = None,
+    sample_ends: torch.Tensor | None = None,
+    status_ok: torch.Tensor | None = None,
+) -> None:
+    rows = row_to_batch.shape[0]
+    block = 256
+    device = row_to_batch.device
+    if torch.device(stream.device) != device:
+        raise ValueError("stream and scan metadata must be on the same device")
+    validate_rows = page_errors is not None
+    if validate_rows:
+        if page_errors.dtype != torch.int32 or page_errors.shape != (rows,):
+            raise ValueError("page_errors must be int32 [rows]")
+        if page_errors.device != device or not page_errors.is_contiguous():
+            raise ValueError("page_errors must be contiguous and on the scan device")
+        if max_seq_len is None or block_table_rows is None:
+            raise ValueError(
+                "max_seq_len and block_table_rows are required with page_errors"
+            )
+    else:
+        page_errors = cta_info
+        max_seq_len = segment_end
+        block_table_rows = 1
+    dual_schedule = suffix_cta_info is not None
+    if dual_schedule:
+        if (
+            suffix_cta_info.dtype != torch.int32
+            or suffix_cta_info.shape != (rows, 6)
+            or suffix_cta_info.device != device
+            or not suffix_cta_info.is_contiguous()
+        ):
+            raise ValueError("suffix_cta_info must be contiguous int32 [rows, 6]")
+        if sample_len <= 0:
+            raise ValueError("sample_len must be positive with suffix_cta_info")
+        if (
+            sample_ends is None
+            or sample_ends.dtype != torch.int32
+            or sample_ends.shape != (rows,)
+            or sample_ends.device != device
+            or not sample_ends.is_contiguous()
+        ):
+            raise ValueError("sample_ends must be contiguous int32 [rows]")
+    else:
+        suffix_cta_info = cta_info
+        sample_ends = cta_info
+    reset_state = score_errors is not None or status is not None
+    if reset_state:
+        if score_errors is None or status is None:
+            raise ValueError("score_errors and status must be provided together")
+        if not validate_rows:
+            raise ValueError("page_errors is required when resetting scan state")
+        for name, tensor in (("score_errors", score_errors), ("status", status)):
+            if (
+                tensor.dtype != torch.int32
+                or tensor.shape != (rows,)
+                or tensor.device != device
+                or not tensor.is_contiguous()
+            ):
+                raise ValueError(f"{name} must be contiguous int32 [rows]")
+    else:
+        score_errors = cta_info
+        status = cta_info
+    reset_status_ok = status_ok is not None
+    if status_ok is None:
+        status_ok = cta_info
+    elif (
+        status_ok.dtype != torch.int32
+        or status_ok.numel() != 1
+        or status_ok.device != device
+        or not status_ok.is_contiguous()
+    ):
+        raise ValueError("status_ok must be a contiguous one-element int32 tensor")
+    written_outputs = [cta_info]
+    if dual_schedule:
+        written_outputs.extend((suffix_cta_info, sample_ends))
+    if validate_rows:
+        written_outputs.append(page_errors)
+    if reset_state:
+        written_outputs.extend((score_errors, status))
+    if reset_status_ok:
+        written_outputs.append(status_ok)
+    byte_ranges = []
+    for tensor in written_outputs:
+        start = tensor.data_ptr()
+        byte_ranges.append((start, start + tensor.numel() * tensor.element_size()))
+    byte_ranges.sort()
+    if any(
+        left_start < right_end and right_start < left_end
+        for (left_start, left_end), (right_start, right_end) in pairwise(byte_ranges)
+    ):
+        raise ValueError("scan schedule outputs must not overlap")
+    with torch.cuda.device(device), torch.cuda.stream(stream):
+        _pa_mqa_litetopk_scan_schedule_kernel[(triton.cdiv(rows, block),)](
+            row_to_batch,
+            row_starts,
+            row_ends,
+            cta_info,
+            suffix_cta_info,
+            page_errors,
+            score_errors,
+            status,
+            sample_ends,
+            status_ok,
+            rows,
+            segment_start,
+            segment_end,
+            max_seq_len,
+            block_table_rows,
+            VALIDATE_ROWS=validate_rows,
+            RESET_STATE=reset_state,
+            RESET_STATUS_OK=reset_status_ok,
+            DUAL_SCHEDULE=dual_schedule,
+            SAMPLE_LEN=sample_len,
+            BLOCK_K=block_k,
+            BLOCK=block,
+            num_warps=4,
+            num_stages=1,
+        )
+
+
+def refresh_pa_mqa_litetopk_threshold(
+    histogram: torch.Tensor,
+    threshold: torch.Tensor,
+    *,
+    topk: int,
+    num_buckets: int,
+    stream: torch.cuda.Stream,
+) -> None:
+    rows = histogram.shape[0]
+    device = histogram.device
+    if torch.cuda.device_count() and torch.device(stream.device) != device:
+        raise ValueError("stream and threshold tensors must be on the same device")
+    with torch.cuda.device(device), torch.cuda.stream(stream):
+        _pa_mqa_litetopk_refresh_threshold_kernel[(rows,)](
+            histogram,
+            threshold,
+            NUM_BUCKETS=num_buckets,
+            TOPK=topk,
+            num_warps=4,
+            num_stages=1,
+        )

--- a/op_tests/op_benchmarks/bench_flydsl_pa_mqa_fp4_litetopk.py
+++ b/op_tests/op_benchmarks/bench_flydsl_pa_mqa_fp4_litetopk.py
@@ -1,0 +1,228 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+"""Benchmark FP4 paged MQA + stable TopK against FP4 LiteTopK on gfx950."""
+
+from __future__ import annotations
+
+import argparse
+import statistics
+import sys
+from pathlib import Path
+
+import torch
+
+_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(_ROOT))
+
+from aiter.ops.flydsl import (
+    FP4LiteTopKResult,
+    allocate_fp4_litetopk_workspace,
+    flydsl_pa_mqa_litetopk_fp4_prefill,
+    flydsl_pa_mqa_logits_fp4_prefill,
+    fp4_litetopk_workspace_nbytes,
+)
+from aiter.ops.flydsl.kernels.mqa_logits.pa_mqa_logits_fp4_prefill import (
+    compute_prefill_schedule,
+)
+from aiter.ops.topk import (
+    _top_k_per_row_prefill,
+    topk_ob_workspace_size,
+)
+from op_tests.test_flydsl_pa_mqa_logits_fp4_prefill import (
+    indexer_k_fp4_paged_preshuffle,
+    quant_q_fp4_preshuffle,
+)
+
+_MODEL_TOPKS = {
+    "deepseek-v4-flash": 512,
+    "deepseek-v4-pro": 1024,
+}
+
+
+def _paired_time_ms(
+    first_fn, second_fn, warmup: int, iterations: int
+) -> tuple[tuple[float, float], tuple[float, float]]:
+    functions = (first_fn, second_fn)
+    for iteration in range(warmup):
+        order = (0, 1) if iteration % 2 == 0 else (1, 0)
+        for index in order:
+            functions[index]()
+    torch.cuda.synchronize()
+    times = ([], [])
+    for iteration in range(iterations):
+        order = (0, 1) if iteration % 2 == 0 else (1, 0)
+        events = []
+        for index in order:
+            start = torch.cuda.Event(enable_timing=True)
+            end = torch.cuda.Event(enable_timing=True)
+            start.record()
+            functions[index]()
+            end.record()
+            events.append((index, start, end))
+        events[-1][2].synchronize()
+        for index, start, end in events:
+            times[index].append(start.elapsed_time(end))
+
+    summaries = []
+    for samples in times:
+        samples.sort()
+        p90 = samples[min(len(samples) - 1, int(0.9 * len(samples)))]
+        summaries.append((statistics.median(samples), p90))
+    return summaries[0], summaries[1]
+
+
+def benchmark(
+    model: str, rows: int, raw_context: int, warmup: int, iterations: int
+) -> None:
+    heads, head_dim, page_size = 64, 128, 64
+    topk = _MODEL_TOPKS[model]
+    if raw_context % 4:
+        raise ValueError("raw context must be divisible by the C4 compression ratio")
+    context = raw_context // 4
+    device = torch.device("cuda", torch.cuda.current_device())
+    torch.manual_seed(71)
+    q = torch.randn(rows, heads, head_dim, dtype=torch.bfloat16, device=device)
+    k = torch.randn(context, head_dim, dtype=torch.bfloat16, device=device)
+    weights = (torch.randn(rows, heads, device=device) * 0.1).to(torch.bfloat16)
+    q_fp4, q_scale = quant_q_fp4_preshuffle(q)
+
+    pages = (context + page_size - 1) // page_size
+    block_tables = torch.arange(pages, dtype=torch.int32, device=device)[None]
+    guarded_tables = torch.cat(
+        (block_tables, torch.zeros((1, 4), dtype=torch.int32, device=device)),
+        dim=1,
+    )
+    kv_cache = torch.zeros(pages, 1, 4, page_size, 16, dtype=torch.uint8, device=device)
+    kv_scale = torch.zeros(pages, 1, 4, page_size, dtype=torch.uint8, device=device)
+    indices = torch.arange(context, dtype=torch.int32, device=device)
+    indexer_k_fp4_paged_preshuffle(k, indices, kv_cache, kv_scale, page_size)
+
+    row_to_batch = torch.zeros(rows, dtype=torch.int32, device=device)
+    row_starts = torch.zeros(rows, dtype=torch.int32, device=device)
+    row_ends = torch.full((rows,), context, dtype=torch.int32, device=device)
+    _, cta_info, n_ctas = compute_prefill_schedule(
+        row_to_batch,
+        row_starts,
+        row_ends,
+        256,
+        max(1024, rows),
+        context,
+    )
+    dense = torch.empty((rows, context), dtype=torch.float32, device=device)
+    dense_indices = torch.empty((rows, topk), dtype=torch.int32, device=device)
+    dense_values = torch.empty((rows, topk), dtype=torch.float32, device=device)
+    dense_topk_workspace = torch.empty(
+        topk_ob_workspace_size(rows, context, topk, False),
+        dtype=torch.uint8,
+        device=device,
+    )
+
+    def run_legacy():
+        flydsl_pa_mqa_logits_fp4_prefill(
+            q_fp4,
+            q_scale,
+            kv_cache,
+            kv_scale,
+            guarded_tables,
+            weights,
+            row_to_batch,
+            row_starts,
+            row_ends,
+            context,
+            out=dense,
+            cta_info=cta_info,
+            n_ctas=n_ctas,
+            parallel_unit_num=max(1024, rows),
+        )
+        _top_k_per_row_prefill(
+            dense,
+            row_starts,
+            row_ends,
+            dense_indices,
+            dense_values,
+            rows,
+            dense.stride(0),
+            dense.stride(1),
+            topk,
+            dense_topk_workspace,
+            True,
+        )
+
+    workspace = allocate_fp4_litetopk_workspace(rows, device, topk=topk)
+    result = FP4LiteTopKResult(
+        values=torch.empty((rows, topk), dtype=torch.float32, device=device),
+        raw_indices=torch.empty((rows, topk), dtype=torch.int32, device=device),
+        physical_indices=torch.empty((rows, topk), dtype=torch.int32, device=device),
+        counts=workspace.output_counts,
+        candidate_counts=workspace.candidate_counts,
+        status=workspace.status,
+    )
+
+    def run_litetopk():
+        flydsl_pa_mqa_litetopk_fp4_prefill(
+            q_fp4,
+            q_scale,
+            kv_cache,
+            kv_scale,
+            guarded_tables,
+            weights,
+            row_to_batch,
+            row_starts,
+            row_ends,
+            context,
+            topk=topk,
+            workspace=workspace,
+            out=result,
+        )
+
+    run_legacy()
+    run_litetopk()
+    torch.cuda.synchronize()
+    for row in range(rows):
+        assert torch.equal(
+            torch.sort(result.raw_indices[row]).values,
+            torch.sort(dense_indices[row]).values,
+        )
+    assert result.status.eq(0).all()
+    (legacy_p50, legacy_p90), (lite_p50, lite_p90) = _paired_time_ms(
+        run_legacy, run_litetopk, warmup, iterations
+    )
+    print(
+        {
+            "model": model,
+            "query_rows": rows,
+            "heads": heads,
+            "head_dim": head_dim,
+            "topk": topk,
+            "raw_context": raw_context,
+            "c4_context": context,
+            "warmup": warmup,
+            "iterations": iterations,
+            "legacy_ms_p50": legacy_p50,
+            "legacy_ms_p90": legacy_p90,
+            "litetopk_ms_p50": lite_p50,
+            "litetopk_ms_p90": lite_p90,
+            "ratio": lite_p50 / legacy_p50,
+            "workspace_mib": fp4_litetopk_workspace_nbytes(workspace) / 2**20,
+            "candidate_mean": result.candidate_counts.float().mean().item(),
+            "candidate_max": result.candidate_counts.max().item(),
+        }
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--model", choices=tuple(_MODEL_TOPKS), default="deepseek-v4-flash"
+    )
+    parser.add_argument("--rows", type=int, default=8192)
+    parser.add_argument("--raw-context", type=int, default=262144)
+    parser.add_argument("--warmup", type=int, default=10)
+    parser.add_argument("--iterations", type=int, default=50)
+    args = parser.parse_args()
+    benchmark(args.model, args.rows, args.raw_context, args.warmup, args.iterations)
+
+
+if __name__ == "__main__":
+    main()

--- a/op_tests/test_flydsl_pa_mqa_litetopk_fp4.py
+++ b/op_tests/test_flydsl_pa_mqa_litetopk_fp4.py
@@ -1,0 +1,1009 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+from unittest.mock import patch
+
+import pytest
+import torch
+
+from aiter.ops.triton.utils._triton.arch_info import get_arch
+
+pytestmark = pytest.mark.skipif(
+    get_arch() != "gfx950", reason="FP4 LiteTopK requires gfx950"
+)
+
+from aiter.ops.flydsl import (
+    FP4_LITETOPK_SUPPORTED_TOPKS,
+    allocate_fp4_litetopk_workspace,
+    flydsl_pa_mqa_litetopk_fp4_prefill,
+    flydsl_pa_mqa_logits_fp4_prefill,
+    fp4_litetopk_workspace_nbytes,
+    fp4_litetopk_workspace_size,
+    prepare_fp4_litetopk_seed,
+)
+from aiter.ops.flydsl.pa_mqa_litetopk_fp4 import STATUS_CANDIDATE_OVERFLOW
+from aiter.ops.topk import top_k_per_row_prefill
+from aiter.ops.triton.attention.pa_mqa_litetopk_seed import (
+    refresh_pa_mqa_litetopk_threshold,
+)
+from op_tests.test_flydsl_pa_mqa_logits_fp4_prefill import (
+    indexer_k_fp4_paged_preshuffle,
+    quant_q_fp4_preshuffle,
+)
+
+
+def _run_seed(sample_logits, row_starts, row_ends, *, topk, merge_cap):
+    rows, sample_len = sample_logits.shape
+    workspace = allocate_fp4_litetopk_workspace(
+        rows,
+        sample_logits.device,
+        topk=topk,
+        sample_len=sample_len,
+        merge_cap=merge_cap,
+    )
+    prepare_fp4_litetopk_seed(
+        sample_logits,
+        row_starts,
+        row_ends,
+        workspace,
+        max_seq_len=int(row_ends.max().item()),
+    )
+    torch.cuda.synchronize()
+    return workspace
+
+
+def test_fp4_supported_topk_contract():
+    assert FP4_LITETOPK_SUPPORTED_TOPKS == (512, 1024)
+
+
+def test_seed_is_conservative_and_ordered():
+    torch.manual_seed(7)
+    rows, sample_len, topk = 3, 1024, 128
+    scores = torch.randn(rows, sample_len, dtype=torch.float32, device="cuda")
+    starts = torch.tensor([0, 17, 31], dtype=torch.int32, device="cuda")
+    ends = starts + torch.tensor([1024, 900, 700], dtype=torch.int32, device="cuda")
+    workspace = _run_seed(scores, starts, ends, topk=topk, merge_cap=sample_len)
+
+    for row in range(rows):
+        count = int(workspace.candidate_counts[row].item())
+        indices = workspace.candidate_indices[row, :count].cpu()
+        assert count >= topk
+        assert torch.equal(indices, indices.sort().values)
+        selected = set(indices.tolist())
+        reference = torch.topk(
+            scores[row, : int(ends[row] - starts[row])], topk
+        ).indices
+        reference = set((reference.cpu() + starts[row].cpu()).tolist())
+        assert reference.issubset(selected)
+    assert torch.count_nonzero(workspace.status).item() == 0
+
+
+def test_workspace_size_query_matches_allocation():
+    workspace = allocate_fp4_litetopk_workspace(
+        3, "cuda:0", topk=128, sample_len=1024, merge_cap=2048
+    )
+    assert fp4_litetopk_workspace_size(
+        3, topk=128, sample_len=1024, merge_cap=2048
+    ) == fp4_litetopk_workspace_nbytes(workspace)
+
+
+def test_seed_flat_scores_and_overflow_are_explicit():
+    sample_len, topk, merge_cap = 2048, 512, 1024
+    scores = torch.ones(1, sample_len, dtype=torch.float32, device="cuda")
+    starts = torch.zeros(1, dtype=torch.int32, device="cuda")
+    ends = torch.full((1,), sample_len, dtype=torch.int32, device="cuda")
+    workspace = _run_seed(scores, starts, ends, topk=topk, merge_cap=merge_cap)
+
+    assert int(workspace.candidate_counts[0].item()) == sample_len
+    assert int(workspace.select_ends[0].item()) == merge_cap
+    assert int(workspace.status[0].item()) & STATUS_CANDIDATE_OVERFLOW
+    assert torch.equal(
+        workspace.candidate_indices[0].cpu(), torch.arange(merge_cap, dtype=torch.int32)
+    )
+
+
+def test_seed_helper_resets_stale_status():
+    scores = torch.randn(1, 1024, dtype=torch.float32, device="cuda")
+    starts = torch.zeros(1, dtype=torch.int32, device="cuda")
+    ends = torch.full((1,), 1024, dtype=torch.int32, device="cuda")
+    workspace = allocate_fp4_litetopk_workspace(
+        1, "cuda:0", topk=128, sample_len=1024, merge_cap=2048
+    )
+    workspace.status.fill_(0x7FFFFFFF)
+
+    prepare_fp4_litetopk_seed(
+        scores,
+        starts,
+        ends,
+        workspace,
+        max_seq_len=1024,
+    )
+    torch.cuda.synchronize()
+
+    assert workspace.status.cpu().tolist() == [0]
+
+
+def test_seed_helper_rejects_input_alias_and_clears_no_emit_metadata():
+    scores = torch.randn(1, 1024, dtype=torch.float32, device="cuda")
+    starts = torch.zeros(1, dtype=torch.int32, device="cuda")
+    ends = torch.full((1,), 1024, dtype=torch.int32, device="cuda")
+    workspace = allocate_fp4_litetopk_workspace(
+        1, "cuda:0", topk=128, sample_len=1024, merge_cap=2048
+    )
+    workspace.candidate_counts.fill_(99)
+    workspace.select_starts.fill_(7)
+    workspace.select_ends.fill_(88)
+    prepare_fp4_litetopk_seed(
+        scores,
+        starts,
+        ends,
+        workspace,
+        max_seq_len=1024,
+        emit_candidates=False,
+    )
+    torch.cuda.synchronize()
+    assert workspace.candidate_counts.cpu().tolist() == [0]
+    assert workspace.select_starts.cpu().tolist() == [0]
+    assert workspace.select_ends.cpu().tolist() == [0]
+
+    with pytest.raises(ValueError, match="seed inputs must not overlap workspace"):
+        prepare_fp4_litetopk_seed(
+            scores,
+            starts,
+            workspace.status,
+            workspace,
+            max_seq_len=1024,
+        )
+
+
+def test_threshold_refresh_only_tightens():
+    histogram = torch.zeros(2, 256, dtype=torch.int32, device="cuda")
+    histogram[0, :4] = torch.tensor([100, 100, 200, 200], device="cuda")
+    histogram[1, :8] = 100
+    threshold = torch.tensor([20, 3], dtype=torch.int32, device="cuda")
+    refresh_pa_mqa_litetopk_threshold(
+        histogram,
+        threshold,
+        topk=512,
+        num_buckets=256,
+        stream=torch.cuda.current_stream(),
+    )
+    torch.cuda.synchronize()
+    assert threshold.cpu().tolist() == [3, 3]
+
+
+def test_fused_litetopk_matches_dense_set_and_maps_pages():
+    _check_fused_litetopk(rows=1, seq_len=1024, starts_list=[0], seed=29)
+
+
+def test_fused_litetopk_k1024_matches_dense_set_and_maps_pages():
+    _check_fused_litetopk(
+        rows=1,
+        seq_len=16_384,
+        starts_list=[37],
+        ends_list=[16_379],
+        seed=30,
+        topk=1024,
+    )
+
+
+def test_full_operator_rejects_fp8_topk():
+    with pytest.raises(ValueError, match=r"topk in \(512, 1024\)"):
+        flydsl_pa_mqa_litetopk_fp4_prefill(
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            1,
+            topk=2048,
+        )
+
+
+def test_fused_seed_calibration_matches_triton_oracle():
+    from aiter.ops.flydsl.kernels.mqa_logits.pa_mqa_logits_fp4_prefill import (
+        flydsl_pa_mqa_litetopk_fp4_seed,
+    )
+    from aiter.ops.flydsl.pa_mqa_litetopk_fp4 import (
+        STATUS_CANDIDATE_OVERFLOW,
+        STATUS_NONFINITE,
+        STATUS_UNDERFILLED,
+    )
+    from aiter.ops.triton.attention.pa_mqa_litetopk_seed import (
+        build_pa_mqa_litetopk_scan_schedule,
+    )
+
+    rows, seq_len, heads, head_dim = 4, 8192, 64, 128
+    torch.manual_seed(31)
+    q = torch.randn(rows, heads, head_dim, dtype=torch.bfloat16, device="cuda")
+    q[1].zero_()
+    k = torch.randn(seq_len, head_dim, dtype=torch.bfloat16, device="cuda")
+    weights = (torch.randn(rows, heads, device="cuda") * 0.1).to(torch.bfloat16)
+    weights[3].fill_(float("inf"))
+    q_fp4, q_scale = quant_q_fp4_preshuffle(q)
+
+    num_pages = seq_len // 64
+    block_tables = torch.randperm(num_pages, device="cuda").to(torch.int32)[None]
+    kv_cache = torch.zeros(num_pages, 1, 4, 64, 16, dtype=torch.uint8, device="cuda")
+    kv_scale = torch.zeros(num_pages, 1, 4, 64, dtype=torch.uint8, device="cuda")
+    logical = torch.arange(seq_len, dtype=torch.int32, device="cuda")
+    physical = block_tables[0, logical.long() // 64] * 64 + logical % 64
+    indexer_k_fp4_paged_preshuffle(k, physical, kv_cache, kv_scale, 64)
+
+    row_to_batch = torch.zeros(rows, dtype=torch.int32, device="cuda")
+    starts = torch.tensor([17, 0, 400, 63], dtype=torch.int32, device="cuda")
+    ends = torch.tensor([8192, 8192, 400, 128], dtype=torch.int32, device="cuda")
+    sample_ends = torch.minimum(starts + 8192, ends)
+    cta_info = torch.empty((rows, 6), dtype=torch.int32, device="cuda")
+    build_pa_mqa_litetopk_scan_schedule(
+        row_to_batch,
+        starts,
+        sample_ends,
+        cta_info,
+        segment_start=0,
+        segment_end=seq_len,
+        block_k=512,
+        stream=torch.cuda.current_stream(),
+    )
+
+    fused_workspace = allocate_fp4_litetopk_workspace(rows, "cuda", merge_cap=1024)
+    oracle_workspace = allocate_fp4_litetopk_workspace(rows, "cuda", merge_cap=1024)
+    oracle_workspace.sample_logits.fill_(float("-inf"))
+    fused_workspace.status.zero_()
+
+    flydsl_pa_mqa_litetopk_fp4_seed(
+        q_fp4,
+        q_scale,
+        kv_cache,
+        kv_scale,
+        block_tables,
+        weights,
+        cta_info,
+        fused_workspace.origin,
+        fused_workspace.inv_delta,
+        fused_workspace.threshold,
+        fused_workspace.histogram,
+        fused_workspace.candidate_values,
+        fused_workspace.candidate_indices,
+        fused_workspace.candidate_counts,
+        fused_workspace.select_starts,
+        fused_workspace.select_ends,
+        fused_workspace.status,
+        n_ctas=rows,
+        merge_cap=fused_workspace.merge_cap,
+        topk=fused_workspace.topk,
+        status_candidate_overflow=STATUS_CANDIDATE_OVERFLOW,
+        status_underfilled=STATUS_UNDERFILLED,
+        status_nonfinite=STATUS_NONFINITE,
+        block_k=512,
+        num_warps=8,
+    )
+    flydsl_pa_mqa_logits_fp4_prefill(
+        q_fp4,
+        q_scale,
+        kv_cache,
+        kv_scale,
+        block_tables,
+        weights,
+        row_to_batch,
+        starts,
+        sample_ends,
+        seq_len,
+        out=oracle_workspace.sample_logits,
+        cta_info=cta_info,
+        n_ctas=rows,
+        parallel_unit_num=rows,
+        relative_output=True,
+        block_k=512,
+        num_warps=8,
+    )
+    prepare_fp4_litetopk_seed(
+        oracle_workspace.sample_logits,
+        starts,
+        ends,
+        oracle_workspace,
+        max_seq_len=seq_len,
+    )
+    torch.cuda.synchronize()
+
+    assert torch.equal(fused_workspace.origin, oracle_workspace.origin)
+    assert torch.equal(fused_workspace.inv_delta, oracle_workspace.inv_delta)
+    assert torch.equal(fused_workspace.histogram, oracle_workspace.histogram)
+    assert torch.equal(fused_workspace.threshold, oracle_workspace.threshold)
+    assert torch.equal(
+        fused_workspace.candidate_counts, oracle_workspace.candidate_counts
+    )
+    assert torch.equal(fused_workspace.select_starts, oracle_workspace.select_starts)
+    assert torch.equal(fused_workspace.select_ends, oracle_workspace.select_ends)
+    for row in range(rows):
+        count = min(
+            int(fused_workspace.candidate_counts[row]), fused_workspace.merge_cap
+        )
+        assert torch.equal(
+            fused_workspace.candidate_values[row, :count].view(torch.int32),
+            oracle_workspace.candidate_values[row, :count].view(torch.int32),
+        )
+        assert torch.equal(
+            fused_workspace.candidate_indices[row, :count],
+            oracle_workspace.candidate_indices[row, :count],
+        )
+    assert torch.equal(fused_workspace.status, oracle_workspace.status)
+    assert int(fused_workspace.status[3]) & STATUS_NONFINITE
+
+
+def test_fused_litetopk_long_nonzero_windows():
+    _check_fused_litetopk(
+        rows=2,
+        seq_len=32768,
+        starts_list=[37, 1000],
+        ends_list=[32761, 30000],
+        seed=37,
+    )
+
+
+def test_fused_litetopk_production_min_context():
+    _check_fused_litetopk(
+        rows=1,
+        seq_len=65_536,
+        starts_list=[113],
+        ends_list=[65_531],
+        seed=41,
+    )
+
+
+@pytest.mark.parametrize("topk", [512, 1024])
+def test_fused_litetopk_production_max_context(topk: int):
+    _check_fused_litetopk(
+        rows=1,
+        seq_len=196_608,
+        starts_list=[211],
+        ends_list=[196_601],
+        seed=53,
+        topk=topk,
+    )
+
+
+def test_full_operator_explicit_non_default_stream():
+    stream = torch.cuda.Stream()
+    _check_fused_litetopk(
+        rows=1,
+        seq_len=16_384,
+        starts_list=[29],
+        ends_list=[16_379],
+        seed=59,
+        stream=stream,
+    )
+
+
+@pytest.mark.skipif(torch.cuda.device_count() < 2, reason="requires two GPUs")
+def test_full_operator_explicit_non_current_device():
+    current_device = torch.cuda.current_device()
+    target_device = 1 if current_device == 0 else 0
+    with torch.cuda.device(target_device):
+        stream = torch.cuda.Stream(device=target_device)
+    try:
+        torch.cuda.set_device(current_device)
+        _check_fused_litetopk(
+            rows=1,
+            seq_len=1024,
+            starts_list=[17],
+            ends_list=[1019],
+            seed=61,
+            device=torch.device("cuda", target_device),
+            stream=stream,
+        )
+    finally:
+        torch.cuda.set_device(current_device)
+
+
+def test_full_operator_concurrent_streams():
+    streams = (torch.cuda.Stream(), torch.cuda.Stream())
+    pending = []
+    for seed, stream in zip((67, 71), streams):
+        pending.append(
+            _check_fused_litetopk(
+                rows=1,
+                seq_len=1024,
+                starts_list=[seed % 31],
+                ends_list=[1024],
+                seed=seed,
+                stream=stream,
+                synchronize=False,
+            )
+        )
+    for stream in streams:
+        stream.synchronize()
+    for validate in pending:
+        validate()
+
+
+def test_nonfinite_suffix_fails_closed():
+    from aiter.ops.flydsl import pa_mqa_litetopk_fp4 as impl
+    from aiter.ops.flydsl.kernels.mqa_logits.pa_mqa_logits_fp4_prefill import (
+        flydsl_pa_mqa_litetopk_fp4_prefill_scan,
+    )
+    from aiter.ops.triton.attention.pa_mqa_litetopk_finalize import (
+        prepare_pa_mqa_litetopk_select,
+    )
+    from aiter.ops.triton.attention.pa_mqa_litetopk_seed import (
+        build_pa_mqa_litetopk_scan_schedule,
+    )
+
+    rows, seq_len, heads, head_dim = 1, 16_384, 64, 128
+    q = torch.ones(rows, heads, head_dim, dtype=torch.bfloat16, device="cuda")
+    k = torch.ones(seq_len, head_dim, dtype=torch.bfloat16, device="cuda")
+    weights = torch.ones(rows, heads, dtype=torch.bfloat16, device="cuda")
+    q_fp4, q_scale = quant_q_fp4_preshuffle(q)
+    num_pages = seq_len // 64
+    block_tables = torch.arange(num_pages, dtype=torch.int32, device="cuda")[None]
+    kv_cache = torch.zeros(num_pages, 1, 4, 64, 16, dtype=torch.uint8, device="cuda")
+    kv_scale = torch.zeros(num_pages, 1, 4, 64, dtype=torch.uint8, device="cuda")
+    logical = torch.arange(seq_len, dtype=torch.int32, device="cuda")
+    indexer_k_fp4_paged_preshuffle(k, logical, kv_cache, kv_scale, 64)
+    row_to_batch = torch.zeros(rows, dtype=torch.int32, device="cuda")
+    starts = torch.zeros(rows, dtype=torch.int32, device="cuda")
+    ends = torch.full((rows,), seq_len, dtype=torch.int32, device="cuda")
+    workspace = allocate_fp4_litetopk_workspace(rows, "cuda:0")
+    sample_logits = torch.ones(
+        rows, workspace.sample_len, dtype=torch.float32, device="cuda"
+    )
+    prepare_fp4_litetopk_seed(
+        sample_logits,
+        starts,
+        ends,
+        workspace,
+        max_seq_len=seq_len,
+    )
+    sample_ends = torch.full(
+        (rows,), workspace.sample_len, dtype=torch.int32, device="cuda"
+    )
+    build_pa_mqa_litetopk_scan_schedule(
+        row_to_batch,
+        sample_ends,
+        ends,
+        workspace.scan_cta_info,
+        segment_start=0,
+        segment_end=seq_len,
+        block_k=256,
+        stream=torch.cuda.current_stream(),
+    )
+    flydsl_pa_mqa_litetopk_fp4_prefill_scan(
+        q_fp4,
+        q_scale,
+        kv_cache,
+        kv_scale,
+        block_tables,
+        weights,
+        workspace.scan_cta_info,
+        workspace.origin,
+        workspace.inv_delta,
+        workspace.threshold,
+        workspace.histogram,
+        workspace.candidate_values,
+        workspace.candidate_indices,
+        workspace.candidate_counts,
+        workspace.page_errors,
+        workspace.score_errors,
+        n_ctas=rows,
+        merge_cap=workspace.merge_cap,
+        weight_scale=float("inf"),
+    )
+    prepare_pa_mqa_litetopk_select(
+        workspace.candidate_counts,
+        workspace.page_errors,
+        workspace.score_errors,
+        workspace.histogram,
+        starts,
+        ends,
+        workspace.threshold,
+        workspace.select_ends,
+        workspace.status,
+        topk=workspace.topk,
+        merge_cap=workspace.merge_cap,
+        num_buckets=workspace.num_buckets,
+        status_candidate_overflow=impl.STATUS_CANDIDATE_OVERFLOW,
+        status_underfilled=impl.STATUS_UNDERFILLED,
+        status_nonfinite=impl.STATUS_NONFINITE,
+        status_invalid_index=impl.STATUS_INVALID_INDEX,
+        status_bad_certificate=impl.STATUS_BAD_CERTIFICATE,
+        stream=torch.cuda.current_stream(),
+    )
+    torch.cuda.synchronize()
+
+    assert int(workspace.score_errors[0]) > 0
+    assert int(workspace.status[0]) & impl.STATUS_NONFINITE
+    assert int(workspace.select_ends[0]) == 0
+
+
+@pytest.mark.parametrize("topk", [512, 1024])
+def test_fused_litetopk_empty_and_short_rows(topk: int):
+    _check_fused_litetopk(
+        rows=2,
+        seq_len=1024,
+        starts_list=[0, 63],
+        ends_list=[0, 128],
+        seed=43,
+        topk=topk,
+    )
+
+
+def test_suffix_affine_is_clamped_before_int32_conversion():
+    rows, heads, head_dim, topk = 1, 64, 128, 512
+    sample_len = 8192
+    low_count = 8192
+    seq_len = sample_len + low_count + topk
+    q = torch.zeros(rows, heads, head_dim, dtype=torch.bfloat16, device="cuda")
+    q[:, : heads // 2, 0] = 1
+    q[:, heads // 2 :, 0] = -1
+    weights = torch.ones(rows, heads, dtype=torch.bfloat16, device="cuda")
+    weights[:, : heads // 2] = -1
+    k = torch.zeros(seq_len, head_dim, dtype=torch.bfloat16, device="cuda")
+    k[sample_len : sample_len + low_count, 0] = 1
+    k[-topk:, 0] = -1
+    q_fp4, q_scale = quant_q_fp4_preshuffle(q)
+
+    num_pages = (seq_len + 63) // 64
+    block_tables = torch.arange(num_pages, dtype=torch.int32, device="cuda").unsqueeze(
+        0
+    )
+    kv_cache = torch.zeros(num_pages, 1, 4, 64, 16, dtype=torch.uint8, device="cuda")
+    kv_scale = torch.zeros(num_pages, 1, 4, 64, dtype=torch.uint8, device="cuda")
+    logical = torch.arange(seq_len, dtype=torch.int32, device="cuda")
+    indexer_k_fp4_paged_preshuffle(k, logical, kv_cache, kv_scale, 64)
+    row_to_batch = torch.zeros(rows, dtype=torch.int32, device="cuda")
+    starts = torch.zeros(rows, dtype=torch.int32, device="cuda")
+    ends = torch.full((rows,), seq_len, dtype=torch.int32, device="cuda")
+
+    result = flydsl_pa_mqa_litetopk_fp4_prefill(
+        q_fp4,
+        q_scale,
+        kv_cache,
+        kv_scale,
+        block_tables,
+        weights,
+        row_to_batch,
+        starts,
+        ends,
+        seq_len,
+    )
+    torch.cuda.synchronize()
+
+    assert result.status.cpu().tolist() == [0]
+    assert result.candidate_counts.cpu().tolist() == [sample_len + topk]
+    expected = torch.arange(seq_len - topk, seq_len, dtype=torch.int32)
+    assert torch.equal(torch.sort(result.raw_indices[0]).values.cpu(), expected)
+
+
+@pytest.mark.parametrize("topk", [512, 1024])
+def test_full_operator_all_ties_returns_valid_unique_set(topk: int):
+    rows, seq_len, heads, head_dim = 1, 16_384, 64, 128
+    q = torch.zeros(rows, heads, head_dim, dtype=torch.bfloat16, device="cuda")
+    k = torch.zeros(seq_len, head_dim, dtype=torch.bfloat16, device="cuda")
+    weights = torch.ones(rows, heads, dtype=torch.bfloat16, device="cuda")
+    q_fp4, q_scale = quant_q_fp4_preshuffle(q)
+    num_pages = seq_len // 64
+    block_tables = torch.randperm(num_pages, device="cuda").to(torch.int32)[None]
+    kv_cache = torch.zeros(num_pages, 1, 4, 64, 16, dtype=torch.uint8, device="cuda")
+    kv_scale = torch.zeros(num_pages, 1, 4, 64, dtype=torch.uint8, device="cuda")
+    logical = torch.arange(seq_len, dtype=torch.int32, device="cuda")
+    physical = block_tables[0, logical.long() // 64] * 64 + logical % 64
+    indexer_k_fp4_paged_preshuffle(k, physical, kv_cache, kv_scale, 64)
+    row_to_batch = torch.zeros(rows, dtype=torch.int32, device="cuda")
+    starts = torch.zeros(rows, dtype=torch.int32, device="cuda")
+    ends = torch.full((rows,), seq_len, dtype=torch.int32, device="cuda")
+    workspace = allocate_fp4_litetopk_workspace(rows, "cuda", topk=topk)
+
+    result = flydsl_pa_mqa_litetopk_fp4_prefill(
+        q_fp4,
+        q_scale,
+        kv_cache,
+        kv_scale,
+        block_tables,
+        weights,
+        row_to_batch,
+        starts,
+        ends,
+        seq_len,
+        topk=topk,
+        workspace=workspace,
+    )
+    torch.cuda.synchronize()
+
+    selected = result.raw_indices[0]
+    assert result.status.cpu().tolist() == [0]
+    assert result.counts.cpu().tolist() == [topk]
+    assert result.candidate_counts.cpu().tolist() == [seq_len]
+    assert selected.unique().numel() == topk
+    assert ((selected >= 0) & (selected < seq_len)).all()
+    expected_physical = block_tables[0, selected.long() // 64] * 64 + selected % 64
+    assert torch.equal(result.physical_indices[0], expected_physical)
+
+
+def _check_fused_litetopk(
+    *,
+    rows: int,
+    seq_len: int,
+    starts_list: list[int],
+    seed: int,
+    ends_list: list[int] | None = None,
+    device: torch.device | str = "cuda",
+    stream: torch.cuda.Stream | None = None,
+    synchronize: bool = True,
+    topk: int = 512,
+):
+    heads, head_dim = 64, 128
+    device = torch.device(device)
+    torch.manual_seed(seed)
+    q = torch.randn(rows, heads, head_dim, dtype=torch.bfloat16, device=device)
+    k = torch.randn(seq_len, head_dim, dtype=torch.bfloat16, device=device)
+    weights = (torch.randn(rows, heads, dtype=torch.float32, device=device) * 0.1).to(
+        torch.bfloat16
+    )
+    q_fp4, q_scale = quant_q_fp4_preshuffle(q)
+
+    num_pages = (seq_len + 63) // 64
+    block_tables = torch.randperm(num_pages, device=device).to(torch.int32)[None]
+    kv_cache = torch.zeros(num_pages, 1, 4, 64, 16, dtype=torch.uint8, device=device)
+    kv_scale = torch.zeros(num_pages, 1, 4, 64, dtype=torch.uint8, device=device)
+    logical = torch.arange(seq_len, dtype=torch.int32, device=device)
+    physical = block_tables[0, logical.long() // 64] * 64 + logical % 64
+    indexer_k_fp4_paged_preshuffle(k, physical, kv_cache, kv_scale, 64)
+
+    row_to_batch = torch.zeros(rows, dtype=torch.int32, device=device)
+    starts = torch.tensor(starts_list, dtype=torch.int32, device=device)
+    ends = torch.tensor(
+        ends_list if ends_list is not None else [seq_len] * rows,
+        dtype=torch.int32,
+        device=device,
+    )
+    dense = flydsl_pa_mqa_logits_fp4_prefill(
+        q_fp4,
+        q_scale,
+        kv_cache,
+        kv_scale,
+        block_tables,
+        weights,
+        row_to_batch,
+        starts,
+        ends,
+        seq_len,
+        parallel_unit_num=rows,
+    )
+    reference = torch.empty((rows, topk), dtype=torch.int32, device=device)
+    top_k_per_row_prefill(
+        dense,
+        starts,
+        ends,
+        reference,
+        None,
+        rows,
+        dense.stride(0),
+        dense.stride(1),
+        topk,
+        stable=True,
+    )
+    workspace = allocate_fp4_litetopk_workspace(rows, device, topk=topk, stream=stream)
+
+    result = flydsl_pa_mqa_litetopk_fp4_prefill(
+        q_fp4,
+        q_scale,
+        kv_cache,
+        kv_scale,
+        block_tables,
+        weights,
+        row_to_batch,
+        starts,
+        ends,
+        seq_len,
+        topk=topk,
+        workspace=workspace,
+        stream=stream,
+    )
+    if stream is None:
+        torch.cuda.synchronize()
+    elif synchronize:
+        stream.synchronize()
+
+    def validate():
+        assert result.status.cpu().tolist() == [0] * rows
+        assert workspace.status_ok.cpu().tolist() == [1]
+        expected_counts = [
+            min(topk, end - start) for start, end in zip(starts_list, ends)
+        ]
+        assert result.counts.cpu().tolist() == expected_counts
+        for row in range(rows):
+            count = expected_counts[row]
+            assert torch.equal(
+                torch.sort(result.raw_indices[row, :count]).values,
+                torch.sort(reference[row, :count]).values,
+            )
+            assert result.raw_indices[row, count:].eq(-1).all()
+            assert result.physical_indices[row, count:].eq(-1).all()
+            assert torch.isneginf(result.values[row, count:]).all()
+            if count:
+                raw = result.raw_indices[row, :count]
+                expected_physical = block_tables[0, raw.long() // 64] * 64 + raw % 64
+                assert torch.equal(
+                    result.physical_indices[row, :count], expected_physical
+                )
+                assert torch.equal(result.values[row, :count], dense[row, raw.long()])
+
+    if synchronize:
+        validate()
+    return validate
+
+
+@pytest.mark.parametrize(
+    "seq_len,bad_page,negative", [(1024, 3, True), (16_384, 192, False)]
+)
+def test_invalid_live_page_fails_closed(seq_len, bad_page, negative):
+    from aiter.ops.flydsl.pa_mqa_litetopk_fp4 import STATUS_INVALID_INDEX
+
+    rows, heads, head_dim = 1, 64, 128
+    torch.manual_seed(47)
+    q = torch.randn(rows, heads, head_dim, dtype=torch.bfloat16, device="cuda")
+    k = torch.randn(seq_len, head_dim, dtype=torch.bfloat16, device="cuda")
+    weights = torch.ones(rows, heads, dtype=torch.bfloat16, device="cuda")
+    q_fp4, q_scale = quant_q_fp4_preshuffle(q)
+    num_pages = (seq_len + 63) // 64
+    block_tables = torch.arange(num_pages, dtype=torch.int32, device="cuda")[None]
+    kv_cache = torch.zeros(num_pages, 1, 4, 64, 16, dtype=torch.uint8, device="cuda")
+    kv_scale = torch.zeros(num_pages, 1, 4, 64, dtype=torch.uint8, device="cuda")
+    logical = torch.arange(seq_len, dtype=torch.int32, device="cuda")
+    indexer_k_fp4_paged_preshuffle(k, logical, kv_cache, kv_scale, 64)
+    block_tables[0, bad_page] = -1 if negative else num_pages + 7
+    row_to_batch = torch.zeros(rows, dtype=torch.int32, device="cuda")
+    starts = torch.zeros(rows, dtype=torch.int32, device="cuda")
+    ends = torch.full((rows,), seq_len, dtype=torch.int32, device="cuda")
+    workspace = allocate_fp4_litetopk_workspace(rows, "cuda")
+
+    result = flydsl_pa_mqa_litetopk_fp4_prefill(
+        q_fp4,
+        q_scale,
+        kv_cache,
+        kv_scale,
+        block_tables,
+        weights,
+        row_to_batch,
+        starts,
+        ends,
+        seq_len,
+        workspace=workspace,
+        enforce_status=False,
+    )
+    torch.cuda.synchronize()
+
+    assert int(workspace.page_errors[0]) > 0
+    assert workspace.status_ok.cpu().tolist() == [0]
+    assert int(workspace.sample_ends[0]) == min(seq_len, workspace.sample_len)
+    assert int(result.status[0]) & STATUS_INVALID_INDEX
+    assert int(result.counts[0]) == 0
+    assert result.raw_indices.eq(-1).all()
+    assert result.physical_indices.eq(-1).all()
+
+    block_tables[0, bad_page] = bad_page
+    result = flydsl_pa_mqa_litetopk_fp4_prefill(
+        q_fp4,
+        q_scale,
+        kv_cache,
+        kv_scale,
+        block_tables,
+        weights,
+        row_to_batch,
+        starts,
+        ends,
+        seq_len,
+        workspace=workspace,
+    )
+    torch.cuda.synchronize()
+    assert result.status.cpu().tolist() == [0]
+    assert result.counts.cpu().tolist() == [512]
+
+
+def test_invalid_row_metadata_fails_closed():
+    from aiter.ops.flydsl.pa_mqa_litetopk_fp4 import STATUS_INVALID_INDEX
+
+    rows, seq_len, heads, head_dim = 4, 1024, 64, 128
+    torch.manual_seed(59)
+    q = torch.randn(rows, heads, head_dim, dtype=torch.bfloat16, device="cuda")
+    k = torch.randn(seq_len, head_dim, dtype=torch.bfloat16, device="cuda")
+    weights = torch.ones(rows, heads, dtype=torch.bfloat16, device="cuda")
+    q_fp4, q_scale = quant_q_fp4_preshuffle(q)
+    num_pages = seq_len // 64
+    block_tables = torch.arange(num_pages, dtype=torch.int32, device="cuda")[None]
+    kv_cache = torch.zeros(num_pages, 1, 4, 64, 16, dtype=torch.uint8, device="cuda")
+    kv_scale = torch.zeros(num_pages, 1, 4, 64, dtype=torch.uint8, device="cuda")
+    logical = torch.arange(seq_len, dtype=torch.int32, device="cuda")
+    indexer_k_fp4_paged_preshuffle(k, logical, kv_cache, kv_scale, 64)
+    row_to_batch = torch.tensor([0, 1, 0, 0], dtype=torch.int32, device="cuda")
+    starts = torch.tensor([-1, 0, 900, 0], dtype=torch.int32, device="cuda")
+    ends = torch.tensor([1024, 1024, 800, 1025], dtype=torch.int32, device="cuda")
+
+    result = flydsl_pa_mqa_litetopk_fp4_prefill(
+        q_fp4,
+        q_scale,
+        kv_cache,
+        kv_scale,
+        block_tables,
+        weights,
+        row_to_batch,
+        starts,
+        ends,
+        seq_len,
+        enforce_status=False,
+    )
+    torch.cuda.synchronize()
+
+    assert torch.all((result.status & STATUS_INVALID_INDEX) != 0)
+    assert result.counts.eq(0).all()
+    assert result.raw_indices.eq(-1).all()
+    assert result.physical_indices.eq(-1).all()
+
+
+def test_invalid_padding_page_outside_window_is_ignored():
+    rows, seq_len, heads, head_dim = 1, 1024, 64, 128
+    torch.manual_seed(61)
+    q = torch.randn(rows, heads, head_dim, dtype=torch.bfloat16, device="cuda")
+    k = torch.randn(seq_len, head_dim, dtype=torch.bfloat16, device="cuda")
+    weights = torch.ones(rows, heads, dtype=torch.bfloat16, device="cuda")
+    q_fp4, q_scale = quant_q_fp4_preshuffle(q)
+    num_pages = seq_len // 64
+    block_tables = torch.arange(num_pages, dtype=torch.int32, device="cuda")[None]
+    block_tables[0, 15] = -1
+    kv_cache = torch.zeros(num_pages, 1, 4, 64, 16, dtype=torch.uint8, device="cuda")
+    kv_scale = torch.zeros(num_pages, 1, 4, 64, dtype=torch.uint8, device="cuda")
+    logical = torch.arange(seq_len, dtype=torch.int32, device="cuda")
+    indexer_k_fp4_paged_preshuffle(k, logical, kv_cache, kv_scale, 64)
+
+    result = flydsl_pa_mqa_litetopk_fp4_prefill(
+        q_fp4,
+        q_scale,
+        kv_cache,
+        kv_scale,
+        block_tables,
+        weights,
+        torch.zeros(rows, dtype=torch.int32, device="cuda"),
+        torch.zeros(rows, dtype=torch.int32, device="cuda"),
+        torch.full((rows,), 512, dtype=torch.int32, device="cuda"),
+        seq_len,
+    )
+    torch.cuda.synchronize()
+
+    assert result.status.cpu().tolist() == [0]
+    assert result.counts.cpu().tolist() == [512]
+
+
+def test_scan_schedule_rejects_aliased_dual_outputs():
+    from aiter.ops.triton.attention.pa_mqa_litetopk_seed import (
+        build_pa_mqa_litetopk_scan_schedule,
+    )
+
+    rows = 1
+    row_to_batch = torch.zeros(rows, dtype=torch.int32, device="cuda")
+    starts = torch.zeros(rows, dtype=torch.int32, device="cuda")
+    ends = torch.full((rows,), 1024, dtype=torch.int32, device="cuda")
+    cta_info = torch.empty((rows, 6), dtype=torch.int32, device="cuda")
+    sample_ends = torch.empty(rows, dtype=torch.int32, device="cuda")
+    with pytest.raises(ValueError, match="must not overlap"):
+        build_pa_mqa_litetopk_scan_schedule(
+            row_to_batch,
+            starts,
+            ends,
+            cta_info,
+            segment_start=0,
+            segment_end=1024,
+            block_k=512,
+            stream=torch.cuda.current_stream(),
+            suffix_cta_info=cta_info,
+            sample_len=512,
+            sample_ends=sample_ends,
+        )
+
+
+def test_workspace_rejects_capture_before_allocation():
+    with (
+        patch("torch.cuda.is_current_stream_capturing", return_value=True),
+        patch("torch.empty") as empty,
+        pytest.raises(RuntimeError, match="not capture-safe"),
+    ):
+        allocate_fp4_litetopk_workspace(1, "cuda:0")
+    empty.assert_not_called()
+
+
+def test_explicit_non_default_stream():
+    stream = torch.cuda.Stream()
+    scores = torch.randn(1, 1024, dtype=torch.float32, device="cuda")
+    starts = torch.zeros(1, dtype=torch.int32, device="cuda")
+    ends = torch.full((1,), 1024, dtype=torch.int32, device="cuda")
+    workspace = allocate_fp4_litetopk_workspace(
+        1,
+        "cuda:0",
+        topk=128,
+        sample_len=1024,
+        merge_cap=2048,
+        stream=stream,
+    )
+    prepare_fp4_litetopk_seed(
+        scores,
+        starts,
+        ends,
+        workspace,
+        max_seq_len=1024,
+        stream=stream,
+    )
+    stream.synchronize()
+    assert workspace.status.cpu().tolist() == [0]
+    assert int(workspace.candidate_counts[0]) >= 128
+
+
+def test_rejects_incompatible_caller_output():
+    rows = 1
+    workspace = allocate_fp4_litetopk_workspace(rows, "cuda:0")
+    bad_result = type("Output", (), {})()
+    bad_result.values = torch.empty((rows, 511), dtype=torch.float32, device="cuda")
+    bad_result.raw_indices = torch.empty((rows, 512), dtype=torch.int32, device="cuda")
+    bad_result.physical_indices = torch.empty_like(bad_result.raw_indices)
+    bad_result.counts = workspace.output_counts
+    bad_result.candidate_counts = workspace.candidate_counts
+    bad_result.status = workspace.status
+    from aiter.ops.flydsl.pa_mqa_litetopk_fp4 import _validate_result
+
+    with pytest.raises(ValueError, match="output tensors"):
+        _validate_result(
+            bad_result,
+            workspace,
+            rows=rows,
+            topk=512,
+            device=torch.device("cuda:0"),
+        )
+
+
+def test_rejects_aliased_workspace_and_output():
+    from aiter.ops.flydsl.pa_mqa_litetopk_fp4 import (
+        FP4LiteTopKResult,
+        _validate_result,
+        _validate_workspace,
+    )
+
+    workspace = allocate_fp4_litetopk_workspace(
+        1, "cuda:0", topk=128, sample_len=1024, merge_cap=2048
+    )
+    stream = torch.cuda.current_stream()
+    aliased_workspace = workspace._replace(status=workspace.output_counts)
+    with pytest.raises(ValueError, match="workspace tensors must not overlap"):
+        _validate_workspace(
+            aliased_workspace,
+            rows=1,
+            device=torch.device("cuda:0"),
+            stream=stream,
+            topk=128,
+            sample_len=1024,
+            num_buckets=256,
+            merge_cap=2048,
+        )
+
+    raw = torch.empty((1, 128), dtype=torch.int32, device="cuda")
+    out = FP4LiteTopKResult(
+        values=workspace.sample_logits[:, :128],
+        raw_indices=raw,
+        physical_indices=torch.empty_like(raw),
+        counts=workspace.output_counts,
+        candidate_counts=workspace.candidate_counts,
+        status=workspace.status,
+    )
+    with pytest.raises(ValueError, match="outputs must not overlap workspace"):
+        _validate_result(
+            out,
+            workspace,
+            rows=1,
+            topk=128,
+            device=torch.device("cuda:0"),
+        )
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))


### PR DESCRIPTION
## Summary

Add a `gfx950` FP4 LiteTopK path for DeepSeek-V4 paged-MQA prefill without materializing the dense `[Q, S]` score matrix.

The API is qualified for the released [V4-Flash](https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash/blob/60d8d70770c6776ff598c94bb586a859a38244f1/config.json) and [V4-Pro](https://huggingface.co/deepseek-ai/DeepSeek-V4-Pro/blob/b5968e9190ef611bbf34a7229255be88a0e937c1/config.json) contracts. `Q=8192` is the shared benchmark workload; H/D/K come from each model config.

| Model | Q | H | D | K | KV context |
|---|---:|---:|---:|---:|---|
| DeepSeek-V4-Flash | 8192 | 64 | 128 | 512 | C4 (`raw / 4`) |
| DeepSeek-V4-Pro | 8192 | 64 | 128 | 1024 | C4 (`raw / 4`) |

## Implementation

- Fuse FP4 paged-MQA scoring, calibrated candidate filtering, stable exact TopK, and page mapping.
- Export the explicit supported-K contract `(512, 1024)` and reject other values.
- Fail closed on overflow, underfill, invalid metadata/pages, nonfinite scores, and selector failures.
- Preserve caller device/stream ownership and 64-bit candidate/page addressing.

## Validation

MI355X (`gfx950`), ROCm 7.2.4. These are operator benchmarks over deterministic tensors with the released model shapes, not full-model E2E runs. Each point is the median of three fresh processes; each process uses 5 warmup and 15 measured alternating dense/LiteTopK pairs. Exact TopK sets are checked outside timing.

| Model | Raw context | C4 context | Dense + TopK | LiteTopK | Speedup |
|---|---:|---:|---:|---:|---:|
| V4-Flash, K512 | 262,144 | 65,536 | 3.9780 ms | 3.9221 ms | 1.0142x |
| V4-Flash, K512 | 524,288 | 131,072 | 8.0164 ms | 7.2235 ms | 1.1098x |
| V4-Flash, K512 | 786,432 | 196,608 | 12.3227 ms | 10.4344 ms | 1.1810x |
| V4-Pro, K1024 | 262,144 | 65,536 | 4.0832 ms | 4.1911 ms | 0.9743x |
| V4-Pro, K1024 | 524,288 | 131,072 | 8.0133 ms | 7.4099 ms | 1.0814x |
| V4-Pro, K1024 | 786,432 | 196,608 | 12.5843 ms | 10.6433 ms | 1.1824x |

- FP4 suite: `29 passed, 1 skipped`; the two-GPU non-current-device case passes separately.
- Black, Ruff, and `git diff --check`: pass.

```bash
AITER_USE_SYSTEM_TRITON=1 pytest -q op_tests/test_flydsl_pa_mqa_litetopk_fp4.py
AITER_USE_SYSTEM_TRITON=1 python op_tests/op_benchmarks/bench_flydsl_pa_mqa_fp4_litetopk.py \
  --model deepseek-v4-flash --rows 8192 --raw-context 262144 --warmup 5 --iterations 15
```

## References

- Original implementation: https://github.com/Heisenberg-Yin/LiteTopK
- Downstream integration: https://github.com/sgl-project/sglang/pull/38303