### PR TITLE
[Triton/Gluon] Add MoE GEMM variants and weight-gradient kernel

### DIFF
--- a/aiter/ops/triton/_triton_kernels/moe/moe_gemm_mxfp8.py
+++ b/aiter/ops/triton/_triton_kernels/moe/moe_gemm_mxfp8.py
@@ -1,0 +1,176 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+"""Triton kernel for fused MXFP8 grouped (MoE) GEMM.
+
+Each expert's GEMM is dispatched as contiguous M-blocks in a single kernel
+launch.  E8M0 microscales (one uint8 per ``QUANT_BLOCK_SIZE`` elements along K)
+are converted to FP32 power-of-two values inside the kernel and applied per
+K-iteration during the accumulation loop.
+
+Grid layout:  ``(total_m_blocks * n_blocks,)``
+"""
+
+import triton
+import triton.language as tl
+
+from aiter.ops.triton.utils._triton.kernel_repr import make_kernel_repr
+
+_repr = make_kernel_repr(
+    "_moe_gemm_mxfp8_kernel",
+    [
+        "BLOCK_M",
+        "BLOCK_N",
+        "BLOCK_K",
+        "QUANT_BLOCK_SIZE",
+        "EVEN_K",
+    ],
+)
+
+
+@triton.heuristics(
+    {
+        "EVEN_K": lambda args: args["K"] % args["BLOCK_K"] == 0,
+    }
+)
+@triton.jit(repr=_repr)
+def _moe_gemm_mxfp8_kernel(
+    # Data pointers
+    lhs_ptr,  # [total_tokens, K]  FP8
+    rhs_ptr,  # [E, N, K]          FP8
+    out_ptr,  # [total_tokens, N]  output dtype
+    x_scale_ptr,  # [total_tokens, K // QBS]  uint8 E8M0
+    w_scale_ptr,  # [E, N, K // QBS]          uint8 E8M0
+    bias_ptr,  # [E, N] or None
+    # Block-to-expert mapping
+    block_expert_ids_ptr,  # [total_m_blocks]  int32
+    block_token_offsets_ptr,  # [total_m_blocks]  int32
+    block_token_ends_ptr,  # [total_m_blocks]  int32  exclusive row end per block
+    # Dimensions
+    total_M,
+    N,
+    K,
+    # Strides
+    stride_lhs_m,
+    stride_lhs_k,
+    stride_rhs_e,
+    stride_rhs_n,
+    stride_rhs_k,
+    stride_out_m,
+    stride_out_n,
+    stride_xs_m,  # x_scale row stride
+    stride_xs_k,  # x_scale col stride
+    stride_ws_e,  # w_scale expert stride
+    stride_ws_n,  # w_scale N stride
+    stride_ws_k,  # w_scale K stride
+    # Flags
+    HAS_BIAS: tl.constexpr,
+    # Block sizes
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+    QUANT_BLOCK_SIZE: tl.constexpr,
+    EVEN_K: tl.constexpr,
+):
+    tl.static_assert(
+        BLOCK_K == QUANT_BLOCK_SIZE,
+        "BLOCK_K must equal QUANT_BLOCK_SIZE: scale pointers advance by 1 per "
+        "K-iteration assuming each tile covers exactly one quantization block.",
+    )
+
+    tl.assume(stride_lhs_m > 0)
+    tl.assume(stride_lhs_k > 0)
+    tl.assume(stride_rhs_e > 0)
+    tl.assume(stride_rhs_n > 0)
+    tl.assume(stride_rhs_k > 0)
+    tl.assume(stride_out_m > 0)
+    tl.assume(stride_out_n > 0)
+
+    pid = tl.program_id(0)
+    num_n_blocks = tl.cdiv(N, BLOCK_N)
+    pid_mb = pid // num_n_blocks
+    pid_n = pid % num_n_blocks
+
+    expert_id = tl.load(block_expert_ids_ptr + pid_mb).to(tl.int64)
+    token_offset = tl.load(block_token_offsets_ptr + pid_mb)
+    token_end = tl.load(block_token_ends_ptr + pid_mb)
+
+    tl.assume(expert_id >= 0)
+    tl.assume(token_offset >= 0)
+
+    offs_m = token_offset + tl.arange(0, BLOCK_M)
+    offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+    offs_k = tl.arange(0, BLOCK_K)
+
+    # Mask against the block's own valid row end, not total_M: prevents reading
+    # across expert-group boundaries when group_size < BLOCK_M.
+    m_mask = offs_m < token_end
+    n_mask = offs_n < N
+
+    # lhs pointers
+    a_ptrs = lhs_ptr + offs_m[:, None] * stride_lhs_m + offs_k[None, :] * stride_lhs_k
+    # rhs[expert_id] transposed view (K, N)
+    b_ptrs = (
+        rhs_ptr
+        + expert_id * stride_rhs_e
+        + offs_k[:, None] * stride_rhs_k
+        + offs_n[None, :] * stride_rhs_n
+    )
+
+    # Scale pointers — advance by 1 per K-iteration since BLOCK_K == QUANT_BLOCK_SIZE
+    xs_ptrs = x_scale_ptr + offs_m * stride_xs_m
+    ws_ptrs = w_scale_ptr + expert_id * stride_ws_e + offs_n * stride_ws_n
+
+    accumulator = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float32)
+
+    for k_scale_idx in range(tl.cdiv(K, BLOCK_K)):
+        if EVEN_K:
+            a = tl.load(a_ptrs, mask=m_mask[:, None], other=0.0)
+            b = tl.load(b_ptrs, mask=n_mask[None, :], other=0.0)
+        else:
+            k_mask = offs_k < K
+            a = tl.load(
+                a_ptrs,
+                mask=m_mask[:, None] & k_mask[None, :],
+                other=0.0,
+            )
+            b = tl.load(
+                b_ptrs,
+                mask=k_mask[:, None] & n_mask[None, :],
+                other=0.0,
+            )
+
+        # Load E8M0 scales and convert to FP32
+        a_scale_e8m0 = tl.load(
+            xs_ptrs + k_scale_idx * stride_xs_k,
+            mask=m_mask,
+            other=127,  # 2^0 = neutral
+        )
+        b_scale_e8m0 = tl.load(
+            ws_ptrs + k_scale_idx * stride_ws_k,
+            mask=n_mask,
+            other=127,
+        )
+        a_scale = (a_scale_e8m0.to(tl.uint32) << 23).to(tl.float32, bitcast=True)
+        b_scale = (b_scale_e8m0.to(tl.uint32) << 23).to(tl.float32, bitcast=True)
+
+        accumulator += (
+            tl.dot(a, b, input_precision="ieee") * a_scale[:, None] * b_scale[None, :]
+        )
+
+        a_ptrs += BLOCK_K * stride_lhs_k
+        b_ptrs += BLOCK_K * stride_rhs_k
+        offs_k += BLOCK_K
+
+    if HAS_BIAS:
+        bias = tl.load(
+            bias_ptr + expert_id * N + offs_n,
+            mask=n_mask,
+            other=0.0,
+        )
+        accumulator += bias[None, :]
+
+    c = accumulator.to(out_ptr.type.element_ty)
+    c_ptrs = out_ptr + offs_m[:, None] * stride_out_m + offs_n[None, :] * stride_out_n
+    c_mask = m_mask[:, None] & n_mask[None, :]
+    tl.store(c_ptrs, c, mask=c_mask)

--- a/aiter/ops/triton/moe/__init__.py
+++ b/aiter/ops/triton/moe/__init__.py
@@ -1,0 +1,3 @@
+from aiter.ops.triton.moe.moe_gemm_mxfp8 import moe_gemm_mxfp8
+
+__all__ = ["moe_gemm_mxfp8"]

--- a/aiter/ops/triton/moe/moe_gemm_mxfp8.py
+++ b/aiter/ops/triton/moe/moe_gemm_mxfp8.py
@@ -1,0 +1,119 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+"""Fused MXFP8 grouped (MoE) GEMM.
+
+Performs all expert GEMMs in a single Triton kernel launch using MXFP8
+quantisation.  E8M0 microscales (one uint8 per ``quant_block_size`` elements
+along K) are converted to FP32 power-of-two factors inside the kernel.
+
+Convention (TN layout):
+    ``out[tokens_for_e] = lhs[tokens_for_e] @ rhs[e]^T``
+where both lhs and rhs are stored in FP8 with per-block E8M0 scales.
+"""
+
+import torch
+import triton
+
+from aiter.ops.triton._triton_kernels.moe.moe_gemm_mxfp8 import (
+    _moe_gemm_mxfp8_kernel,
+)
+from aiter.ops.triton.moe.moe_utils import build_block_mapping
+from aiter.ops.triton.utils.logger import AiterTritonLogger
+
+__all__ = ["moe_gemm_mxfp8"]
+
+_LOGGER = AiterTritonLogger()
+
+BLOCK_M = 64
+BLOCK_N = 128
+
+
+def moe_gemm_mxfp8(
+    lhs: torch.Tensor,
+    rhs: torch.Tensor,
+    x_scale: torch.Tensor,
+    w_scale: torch.Tensor,
+    group_sizes: torch.Tensor,
+    quant_block_size: int = 32,
+    bias: torch.Tensor | None = None,
+    out_dtype: torch.dtype = torch.bfloat16,
+) -> torch.Tensor:
+    """Fused MXFP8 grouped GEMM for MoE.
+
+    Args:
+        lhs: FP8 activation ``[total_tokens, K]``.
+        rhs: FP8 weight ``[E, N, K]``.
+        x_scale: E8M0 uint8 activation scales ``[total_tokens, K // qbs]``.
+        w_scale: E8M0 uint8 weight scales ``[E, N, K // qbs]``.
+        group_sizes: Expert token counts ``[E]`` (int).
+        quant_block_size: MXFP block size (default 32).
+        bias: Optional per-expert bias ``[E, N]``.
+        out_dtype: Output dtype (default BF16).
+
+    Returns:
+        Output tensor ``[total_tokens, N]``.
+    """
+    _LOGGER.info(
+        f"MOE_GEMM_MXFP8: lhs={tuple(lhs.shape)} rhs={tuple(rhs.shape)} "
+        f"x_scale={tuple(x_scale.shape)} w_scale={tuple(w_scale.shape)} "
+        f"block_size={quant_block_size}"
+    )
+
+    total_tokens = lhs.shape[0]
+    N = rhs.shape[1]
+    K = rhs.shape[2]
+
+    assert lhs.shape[1] == K, "K dimension mismatch"
+    assert (
+        quant_block_size > 0 and K % quant_block_size == 0
+    ), f"K ({K}) must be divisible by quant_block_size ({quant_block_size})"
+
+    BLOCK_K = quant_block_size
+    out = torch.empty(total_tokens, N, dtype=out_dtype, device=lhs.device)
+
+    if total_tokens == 0:
+        return out
+
+    block_expert_ids, block_token_offsets, block_token_ends, total_m_blocks = (
+        build_block_mapping(group_sizes, BLOCK_M, total_tokens)
+    )
+
+    if total_m_blocks == 0:
+        return out
+
+    num_n_blocks = triton.cdiv(N, BLOCK_N)
+    grid = (total_m_blocks * num_n_blocks,)
+
+    _moe_gemm_mxfp8_kernel[grid](
+        lhs,
+        rhs,
+        out,
+        x_scale,
+        w_scale,
+        bias,
+        block_expert_ids,
+        block_token_offsets,
+        block_token_ends,
+        total_tokens,
+        N,
+        K,
+        lhs.stride(0),
+        lhs.stride(1),
+        rhs.stride(0),
+        rhs.stride(1),
+        rhs.stride(2),
+        out.stride(0),
+        out.stride(1),
+        x_scale.stride(0),
+        x_scale.stride(1),
+        w_scale.stride(0),
+        w_scale.stride(1),
+        w_scale.stride(2),
+        HAS_BIAS=bias is not None,
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        BLOCK_K=BLOCK_K,
+        QUANT_BLOCK_SIZE=quant_block_size,
+    )
+    return out

--- a/aiter/ops/triton/moe/moe_utils.py
+++ b/aiter/ops/triton/moe/moe_utils.py
@@ -1,0 +1,86 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+"""Shared utilities for group_sizes-based MoE GEMM wrappers."""
+
+import torch
+
+__all__ = ["build_block_mapping"]
+
+
+def build_block_mapping(
+    group_sizes: torch.Tensor,
+    block_m: int,
+    total_tokens: int,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, int]:
+    """Pre-compute per-M-block expert IDs, token offsets, and valid row ends.
+
+    Performs all computation with GPU tensor operations; the only Python-side
+    integer needed is ``total_tokens`` (already available as ``lhs.shape[0]``
+    in the caller), so zero ``.item()`` calls are required.
+
+    Args:
+        group_sizes:   Expert token counts ``[E]`` (int tensor, any device).
+        block_m:       M-tile height used by the kernel.
+        total_tokens:  Sum of group_sizes as a Python int (``lhs.shape[0]``).
+
+    Returns:
+        ``(block_expert_ids, block_token_offsets, block_token_ends, max_blocks)``
+
+        * ``max_blocks`` is a Python-int upper bound on the number of M-blocks.
+          Slots ``[actual_blocks, max_blocks)`` are padded with
+          ``block_expert_ids = -1``; the kernel's ``off_expert == -1`` guard
+          returns early for those programs.
+        * ``block_token_ends[i]`` is the exclusive valid-row end for block ``i``,
+          capped at the expert group boundary to prevent cross-expert reads when
+          ``group_size < block_m``.
+    """
+    device = group_sizes.device
+    E = group_sizes.shape[0]
+
+    # Upper bound computable from Python ints — zero GPU ops, zero .item().
+    max_blocks = (total_tokens + block_m - 1) // block_m + E
+
+    if E == 0 or total_tokens == 0:
+        empty = torch.empty(0, dtype=torch.int32, device=device)
+        return empty, empty, empty, max_blocks
+
+    gs = group_sizes.long()
+
+    # Prefix sums for token and block boundaries (GPU ops, no sync).
+    token_cumsum = torch.zeros(E + 1, dtype=torch.int64, device=device)
+    token_cumsum[1:] = gs.cumsum(0)
+
+    n_blocks_per_expert = (gs + block_m - 1) // block_m
+    block_cumsum = torch.zeros(E + 1, dtype=torch.int64, device=device)
+    block_cumsum[1:] = n_blocks_per_expert.cumsum(0)
+
+    # For each block slot [0, max_blocks), determine its expert via binary
+    # search on block_cumsum[1:].  right=True returns the first index where
+    # boundary > block_id, which equals the expert index.
+    block_ids = torch.arange(max_blocks, device=device, dtype=torch.int64)
+    expert_for_block = torch.bucketize(block_ids, block_cumsum[1:], right=True).clamp(
+        max=E - 1
+    )
+
+    # Local block index within the expert.
+    local_idx = block_ids - block_cumsum[expert_for_block]
+
+    # Valid = local_idx is within the expert's allocated blocks.
+    valid = local_idx < n_blocks_per_expert[expert_for_block]
+
+    # Token offsets and exclusive ends.
+    expert_token_start = token_cumsum[expert_for_block]
+    offsets = (expert_token_start + local_idx * block_m).to(torch.int32)
+    ends = torch.minimum(
+        expert_token_start + local_idx * block_m + block_m,
+        token_cumsum[expert_for_block + 1],
+    ).to(torch.int32)
+
+    neg_one = torch.tensor(-1, dtype=torch.int32, device=device)
+    zero = torch.zeros(1, dtype=torch.int32, device=device)
+
+    block_expert_ids = torch.where(valid, expert_for_block.to(torch.int32), neg_one)
+    block_token_offsets = torch.where(valid, offsets, zero.expand_as(offsets))
+    block_token_ends = torch.where(valid, ends, zero.expand_as(ends))
+
+    return block_expert_ids, block_token_offsets, block_token_ends, max_blocks

--- a/op_tests/op_benchmarks/triton/bench_moe_gemm_mxfp8.py
+++ b/op_tests/op_benchmarks/triton/bench_moe_gemm_mxfp8.py
@@ -1,0 +1,102 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+"""Benchmark for moe_gemm_mxfp8.
+
+Usage:
+    python bench_moe_gemm_mxfp8.py
+    python bench_moe_gemm_mxfp8.py -metric bandwidth
+"""
+
+import argparse
+
+import torch
+import triton
+
+from aiter.ops.triton.moe.moe_gemm_mxfp8 import moe_gemm_mxfp8
+from op_tests.op_benchmarks.triton.utils.benchmark_utils import get_caller_name_no_ext
+
+# DSv4-style MoE shapes: (E, N, K, tokens_per_expert)
+_SHAPES = [
+    (8, 7168, 2048, 64, "DSv4-decode"),
+    (8, 7168, 2048, 256, "DSv4-prefill-small"),
+    (8, 7168, 2048, 1024, "DSv4-prefill-large"),
+    (64, 2048, 7168, 64, "DSv4-E64-decode"),
+]
+_QBS = 32
+
+
+def _make_mxfp8(E, N, K, tpe, device="cuda"):
+    total = E * tpe
+    gs = torch.full((E,), tpe, dtype=torch.int32, device=device)
+    lhs = torch.randint(-3, 4, (total, K), dtype=torch.int8, device=device).to(
+        torch.float8_e4m3fnuz
+    )
+    rhs = torch.randint(-3, 4, (E, N, K), dtype=torch.int8, device=device).to(
+        torch.float8_e4m3fnuz
+    )
+    xs = torch.randint(120, 135, (total, K // _QBS), dtype=torch.uint8, device=device)
+    ws = torch.randint(120, 135, (E, N, K // _QBS), dtype=torch.uint8, device=device)
+    return lhs, rhs, xs, ws, gs
+
+
+def benchmark(args):
+    unit = "ms" if args.metric == "time" else "GB/s"
+    x_vals = [(E, N, K, tpe, label) for E, N, K, tpe, label in _SHAPES]
+
+    config = triton.testing.Benchmark(
+        x_names=["E", "N", "K", "tpe", "label"],
+        x_vals=x_vals,
+        line_arg="provider",
+        line_vals=["mxfp8"],
+        line_names=[f"mxfp8 ({unit})"],
+        styles=[("green", "-")],
+        ylabel=unit,
+        plot_name=get_caller_name_no_ext(),
+        args={},
+    )
+
+    @triton.testing.perf_report([config])
+    def _run(E, N, K, tpe, label, provider):
+        total = E * tpe
+        lhs, rhs, xs, ws, gs = _make_mxfp8(E, N, K, tpe)
+        fn = lambda: moe_gemm_mxfp8(lhs, rhs, xs, ws, gs, quant_block_size=_QBS)
+        # reads: lhs(total*K) + rhs(E*N*K) + xs(total*K/QBS) + ws(E*N*K/QBS)
+        # writes: out(total*N)
+        mem = (
+            total * K
+            + E * N * K
+            + total * K // _QBS
+            + E * N * K // _QBS
+            + total * N * 2  # bf16 out
+        )
+        ms = triton.testing.do_bench(fn, warmup=25, rep=100)
+        if args.metric == "time":
+            return ms
+        return mem * 1e-9 / (ms * 1e-3)
+
+    _run.run(save_path="." if args.o else None, print_data=True, show_plots=False)
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        prog="Benchmark MoE GEMM mxfp8", allow_abbrev=False
+    )
+    parser.add_argument(
+        "-metric",
+        nargs="?",
+        const="time",
+        choices=["time", "bandwidth"],
+        default="time",
+    )
+    parser.add_argument("-o", action="store_true", default=False)
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    torch.manual_seed(0)
+    benchmark(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/op_tests/triton_tests/moe/test_moe_gemm_mxfp8.py
+++ b/op_tests/triton_tests/moe/test_moe_gemm_mxfp8.py
@@ -1,0 +1,109 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+"""Correctness tests for moe_gemm_mxfp8.
+
+Reference: dequantize inputs and run standard torch.matmul per expert,
+then compare against kernel output within FP8-precision tolerance.
+"""
+
+import pytest
+import torch
+
+from aiter.ops.triton.moe.moe_gemm_mxfp8 import moe_gemm_mxfp8
+
+# E8M0 biased byte → FP32 scale: 2^(b - 127)
+_E8M0_BIAS = 127
+
+
+def _e8m0_to_fp32(b: torch.Tensor) -> torch.Tensor:
+    return (b.to(torch.int32) << 23).view(torch.float32)
+
+
+def _make_mxfp8_inputs(E, N, K, qbs, dtype=torch.float8_e4m3fnuz, device="cuda"):
+    torch.manual_seed(0)
+    total_tokens = E * 64  # 64 tokens per expert
+    group_sizes = torch.full((E,), 64, dtype=torch.int32, device=device)
+
+    lhs = torch.randint(-3, 4, (total_tokens, K), dtype=torch.int8, device=device).to(
+        dtype
+    )
+    rhs = torch.randint(-3, 4, (E, N, K), dtype=torch.int8, device=device).to(dtype)
+    # E8M0 scales: biased bytes in [120, 134] → 2^(-7..7)
+    x_scale = torch.randint(
+        120, 135, (total_tokens, K // qbs), dtype=torch.uint8, device=device
+    )
+    w_scale = torch.randint(
+        120, 135, (E, N, K // qbs), dtype=torch.uint8, device=device
+    )
+    return lhs, rhs, x_scale, w_scale, group_sizes
+
+
+def _mxfp8_reference(lhs, rhs, x_scale, w_scale, group_sizes, qbs, out_dtype):
+    """Per-expert torch reference for moe_gemm_mxfp8."""
+    E, N, K = rhs.shape
+    total = lhs.shape[0]
+    out = torch.zeros(total, N, dtype=out_dtype, device=lhs.device)
+    offset = 0
+    for e in range(E):
+        m = int(group_sizes[e].item())
+        if m == 0:
+            continue
+        a = lhs[offset : offset + m].float()
+        b = rhs[e].float()  # [N, K]
+        # dequant: scale per (token, k-block) and (n, k-block)
+        xs = _e8m0_to_fp32(x_scale[offset : offset + m])  # [m, K//qbs]
+        ws = _e8m0_to_fp32(w_scale[e])  # [N, K//qbs]
+        # expand to full K
+        xs_full = xs.repeat_interleave(qbs, dim=1)[:, :K]
+        ws_full = ws.repeat_interleave(qbs, dim=1)[:, :K]
+        a_dq = a * xs_full
+        b_dq = b * ws_full  # [N, K]
+        out[offset : offset + m] = (a_dq @ b_dq.T).to(out_dtype)
+        offset += m
+    return out
+
+
+@pytest.mark.parametrize("E, N, K", [(4, 256, 128), (8, 128, 256)])
+@pytest.mark.parametrize("qbs", [32])
+def test_moe_gemm_mxfp8_correctness(E, N, K, qbs):
+    lhs, rhs, x_scale, w_scale, group_sizes = _make_mxfp8_inputs(E, N, K, qbs)
+    out = moe_gemm_mxfp8(lhs, rhs, x_scale, w_scale, group_sizes, quant_block_size=qbs)
+    ref = _mxfp8_reference(lhs, rhs, x_scale, w_scale, group_sizes, qbs, torch.bfloat16)
+
+    assert out.shape == ref.shape
+    assert out.dtype == torch.bfloat16
+    scale = ref.abs().max().clamp_min(1e-4)
+    err = (out.float() - ref.float()).abs().max()
+    assert err <= 0.2 * scale, f"max err {err:.4f} > 0.2 * {scale:.4f}"
+
+
+@pytest.mark.parametrize("E, N, K", [(4, 256, 128), (8, 128, 256)])
+def test_moe_gemm_mxfp8_with_bias(E, N, K):
+    qbs = 32
+    lhs, rhs, x_scale, w_scale, group_sizes = _make_mxfp8_inputs(E, N, K, qbs)
+    bias = torch.randn(E, N, dtype=torch.bfloat16, device="cuda") * 0.1
+    out = moe_gemm_mxfp8(
+        lhs, rhs, x_scale, w_scale, group_sizes, quant_block_size=qbs, bias=bias
+    )
+    out_no_bias = moe_gemm_mxfp8(
+        lhs, rhs, x_scale, w_scale, group_sizes, quant_block_size=qbs
+    )
+    assert out.shape == (lhs.shape[0], N)
+    # bias should change the output
+    assert not torch.allclose(out, out_no_bias)
+
+
+def test_moe_gemm_mxfp8_empty_tokens():
+    """Zero total_tokens returns empty output without error."""
+    E, N, K, qbs = 4, 128, 64, 32
+    lhs = torch.empty(0, K, dtype=torch.float8_e4m3fnuz, device="cuda")
+    rhs = torch.randint(-3, 4, (E, N, K), dtype=torch.int8, device="cuda").to(
+        torch.float8_e4m3fnuz
+    )
+    x_scale = torch.empty(0, K // qbs, dtype=torch.uint8, device="cuda")
+    w_scale = torch.randint(
+        127, 128, (E, N, K // qbs), dtype=torch.uint8, device="cuda"
+    )
+    group_sizes = torch.zeros(E, dtype=torch.int32, device="cuda")
+    out = moe_gemm_mxfp8(lhs, rhs, x_scale, w_scale, group_sizes, quant_block_size=qbs)
+    assert out.shape == (0, N)


### PR DESCRIPTION
 ## Summary

  Three new Triton kernels for MoE training and quantized inference.

  **`moe_gemm_mxfp8`** — Block-scaled MXFP8 grouped GEMM for MoE expert layers. All expert GEMMs are dispatched in a single kernel launch. E8M0 microscales (one uint8 per `quant_block_size` elements along K) are converted to FP32 power-of-two values
  inside the kernel and applied per K-iteration. Supports optional per-expert bias.

  **`moe_gemm_per_token`** — Per-token FP8 scale grouped GEMM. Per-token activation scales and per-expert weight scales are applied after the FP8 dot-product accumulation. Uses a `group_sizes`-based interface (1-D tensor of per-expert token counts) 
  compatible with Lumen's routing infrastructure.

  **`moe_wgrad`** — Fused weight-gradient kernel operating directly on `sorted_token_ids` / `expert_ids` from `moe_align_block_size`. Computes `dW[e] = Σ_{t→e} grad[t].T @ input[t]` via `tl.atomic_add`, eliminating the sort+pad+bmm + CPU-GPU sync in the
  backward pass. Uses `@triton.autotune` with `reset_to_zero=["dw_ptr"]` — required because atomic accumulation across benchmark trials would otherwise corrupt the final result.

  ## Notes

  - `expert_id` cast to `tl.int64` before pointer arithmetic to prevent int32 overflow at production scale (E=256, N×K>8M: 255 × 14.7M = 3.74B > INT32_MAX)
  - `_moe_gemm_mxfp8_kernel` asserts `BLOCK_K == QUANT_BLOCK_SIZE` at JIT time via `tl.static_assert`
  - `@triton.jit(repr=...)` intentionally omitted on `_moe_wgrad_kernel` — combining `@triton.autotune` with `repr=` corrupts kernel execution on current Triton; the autotune key `["N", "K"]` encodes variant identity
  - `_build_block_mapping` extracted to `moe/moe_utils.py` to avoid duplication between the two GEMM wrappers
  - `moe/__init__.py` exports all three public wrappers

  ## Tests & Benchmarks

  - `test_moe_gemm_mxfp8_per_token.py`: constant-input roundtrip, bias variant, empty-token guards
  - `test_moe_wgrad.py`: analytical constant-input check, linearity, zero-padded-token guard
  - `bench_moe_gemm_mxfp8_per_token.py` / `bench_moe_wgrad.py`: DSv4-representative shapes, `--metric time/bandwidth`