### PR TITLE
[Triton/Gluon] [HIP] Fix large tensor addressing-quant & inverse_rope

### DIFF
--- a/aiter/ops/triton/rope/rope.py
+++ b/aiter/ops/triton/rope/rope.py
@@ -697,6 +697,46 @@ def _rope_cached_bwd(
 ) -> torch.Tensor:
     s, b, h, d = x.shape
 
+    # The Triton kernel forms x/out offsets in signed 32-bit element units.
+    # Slice very large sequence-major views on the host so each launch receives
+    # an already advanced base pointer and only uses representable offsets.
+    index_limit = (1 << 31) - 1
+    fixed_x_elems = (
+        (b - 1) * abs(x.stride(1))
+        + (h - 1) * abs(x.stride(2))
+        + (d - 1) * abs(x.stride(3))
+    )
+    fixed_out_elems = (
+        (out.shape[1] - 1) * abs(out.stride(1))
+        + (out.shape[2] - 1) * abs(out.stride(2))
+        + (out.shape[3] - 1) * abs(out.stride(3))
+    )
+    x_row_elems = abs(x.stride(0))
+    out_row_elems = abs(out.stride(0))
+    rows_per_launch = min(
+        (index_limit - fixed_x_elems) // x_row_elems + 1,
+        (index_limit - fixed_out_elems) // out_row_elems + 1,
+    )
+    if s > rows_per_launch:
+        if rows_per_launch < 1:
+            raise RuntimeError("RoPE row span exceeds the 32-bit element-index limit")
+        for start in range(0, s, rows_per_launch):
+            end = min(start + rows_per_launch, s)
+            _rope_cached_bwd(
+                x[start:end],
+                out[start:end],
+                cos,
+                sin,
+                positions[start:end] if positions is not None else None,
+                offsets[start:end] if offsets is not None else None,
+                rotate_style,
+                reuse_freqs_front_part,
+                nope_first,
+                inplace,
+                transpose_output,
+            )
+        return out
+
     if cos.shape[-1] == d // 2:
         if reuse_freqs_front_part:
             have_nope = False

--- a/csrc/kernels/quant_kernels.cu
+++ b/csrc/kernels/quant_kernels.cu
@@ -125,9 +125,15 @@ dynamic_per_group_scaled_quant_kernel(DTYPE_O* __restrict__ out,
     {
         inverted_scale = absMax * inverted_DTYPE_MAX;
     }
-    row_offset           = std::is_same_v<DTYPE_O, opus::fp4_t>
-                               ? groupId * group_size / 2 + (threadIdx.x % num_thread_per_group) * vec_size_o
-                               : groupId * group_size + (threadIdx.x % num_thread_per_group) * vec_size_o;
+    const int64_t out_row_offset =
+        std::is_same_v<DTYPE_O, opus::fp4_t> ? x * ori_cols / 2 : x * ori_cols;
+    const int32_t out_thread_offset =
+        (std::is_same_v<DTYPE_O, opus::fp4_t> ? y * group_size / 2
+                                              : y * group_size) +
+        (threadIdx.x % num_thread_per_group) * vec_size_o;
+    const int64_t out_linear_offset = out_row_offset + out_thread_offset;
+    // Fallback descriptor base for outputs beyond the global descriptor's
+    // 32-bit byte reach. Normal-size tensors retain the original global base.
     if(threadIdx.x % num_thread_per_group == 0)
     {
         if constexpr(use_e8m0_scale)
@@ -166,9 +172,24 @@ dynamic_per_group_scaled_quant_kernel(DTYPE_O* __restrict__ out,
 
     using DTYPE_STORE = std::conditional_t<std::is_same_v<DTYPE_O, opus::fp4_t>, uint8_t, DTYPE_O>;
     auto* out_ptr     = reinterpret_cast<DTYPE_STORE*>(out);
-    auto buffer_o = opus::make_gmem<DTYPE_STORE>(out_ptr, oob_size);
-
-    store_vector<DTYPE_STORE, DTYPE_I, thread_data_size, RT, false, WARP_SIZE, 1, DTYPE_O>(buffer_o, thread_data, row_offset, inverted_scale);
+    constexpr int64_t kDescriptorReach = (int64_t{1} << 32) - 1;
+    if(oob_size <= kDescriptorReach)
+    {
+        auto buffer_o = opus::make_gmem<DTYPE_STORE>(out_ptr, oob_size);
+        store_vector<DTYPE_STORE, DTYPE_I, thread_data_size, RT, false, WARP_SIZE, 1, DTYPE_O>(
+            buffer_o, thread_data, out_linear_offset, inverted_scale);
+    }
+    else
+    {
+        auto buffer_o = opus::make_gmem<DTYPE_STORE>(
+            out_ptr + out_row_offset,
+            static_cast<int64_t>(std::is_same_v<DTYPE_O, opus::fp4_t>
+                                     ? ori_cols / 2
+                                     : ori_cols) *
+                sizeof(DTYPE_STORE));
+        store_vector<DTYPE_STORE, DTYPE_I, thread_data_size, RT, false, WARP_SIZE, 1, DTYPE_O>(
+            buffer_o, thread_data, out_thread_offset, inverted_scale);
+    }
 }
 
 __global__ void initializeScale(float *d_data, int size, float value)


### PR DESCRIPTION
## Motivation
test fail when running` python op_tests/test_inverse_rope_group_quant.py -s 65536 --hg 128,16 --group-size 128` 
coredump in rope and mismatch in quant_kernels.cu


## Technical Details

support int64_t addressing

## Test Plan

python op_tests/test_inverse_rope_group_quant.py -s 65536 --hg 128,16 --group-size 128

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
