### PR TITLE
[FlyDSL] Migrate mixed MoE 2-stage LDS to fly shared storage

### DIFF
--- a/aiter/ops/flydsl/kernels/mfma_epilogues.py
+++ b/aiter/ops/flydsl/kernels/mfma_epilogues.py
@@ -38,9 +38,8 @@ from collections.abc import Callable
 import flydsl.compiler as flyc
 import flydsl.expr as fx
 from flydsl._mlir import ir
-from flydsl.expr import arith, gpu, range_constexpr
+from flydsl.expr import gpu, range_constexpr
 from flydsl.expr.typing import T
-from flydsl.expr.typing import Vector as Vec
 
 
 def default_epilog(
@@ -243,30 +242,41 @@ def c_shuffle_epilog(
                     col_pair0_local = col_base_nr + (n_lane_s * c_evec)
                     lds_idx = row_base_lds + col_pair0_local
 
-                    # Select the per-group LDS source buffer, then issue a single
-                    # load. Both buffers share the same `lds_idx`, so selecting the
-                    # source (not the loaded value) keeps this to one ds_read;
-                    # loading from both and selecting the result would double LDS
-                    # traffic. A memref-typed ternary is a hard boundary with no
-                    # numeric-`fx` wrapper, so the raw `arith` select is localized
-                    # here (a value-returning `@flyc.jit` mis-merges the two
-                    # branches and drifts numerically on multi-row tiles).
-                    src = arith.ArithValue(_is_group_b.ir_value()).select(
-                        lds_out_split, lds_out
-                    )
-                    frag = Vec.load(vec_frag, src, [lds_idx]).ir_value()
-
-                    col_pair0 = col_pair0_local + _is_group_b.select(
-                        _half_n_idx, _zero_idx
-                    )
-                    store_pair(
-                        row_local=row_local,
+                    # Per-group LDS source is a distinct fly buffer (separate
+                    # global), so branch on the group predicate and issue the
+                    # load+store inside the taken arm (each thread belongs to one
+                    # group). This keeps one ds_read per thread without a
+                    # pointer-typed select or a value-merging region boundary.
+                    @flyc.jit
+                    def _grp_load_store(
+                        lds_idx=lds_idx,
+                        col_pair0_local=col_pair0_local,
                         row=row,
                         row_ctx=row_ctx,
-                        col_pair0=col_pair0,
-                        col_g0=by_n_v + col_pair0,
-                        frag=frag,
-                    )
+                        row_local=row_local,
+                    ):
+                        if _is_group_b:
+                            frag = fx.ptr_load(
+                                lds_out_split + fx.Int32(lds_idx),
+                                result_type=vec_frag,
+                            ).ir_value()
+                            col_pair0 = col_pair0_local + _half_n_idx
+                        else:
+                            frag = fx.ptr_load(
+                                lds_out + fx.Int32(lds_idx),
+                                result_type=vec_frag,
+                            ).ir_value()
+                            col_pair0 = col_pair0_local + _zero_idx
+                        store_pair(
+                            row_local=row_local,
+                            row=row,
+                            row_ctx=row_ctx,
+                            col_pair0=col_pair0,
+                            col_g0=by_n_v + col_pair0,
+                            frag=frag,
+                        )
+
+                    _grp_load_store()
 
             if row_pred is not None:
 
@@ -377,7 +387,9 @@ def c_shuffle_epilog(
                 col_pair0 = col_base_nr + (n_lane * c_evec)  # even col within tile
 
                 lds_idx_pair = row_base_lds + col_pair0
-                frag = Vec.load(vec_frag, lds_out, [lds_idx_pair]).ir_value()
+                frag = fx.ptr_load(
+                    lds_out + fx.Int32(lds_idx_pair), result_type=vec_frag
+                ).ir_value()
 
                 store_pair(
                     row_local=row_local,

--- a/aiter/ops/flydsl/kernels/mfma_preshuffle_pipeline.py
+++ b/aiter/ops/flydsl/kernels/mfma_preshuffle_pipeline.py
@@ -561,10 +561,8 @@ def buffer_copy_gmem16_dwordx4(
 
 
 def _lds_store_xor16(
-    vector,
     *,
-    lds_memref,
-    vec_ty,
+    lds_ptr,
     layout_lds,
     row_local: ir.Value,
     col_local_i32: ir.Value,
@@ -574,21 +572,20 @@ def _lds_store_xor16(
     vec_part: ir.Value,
     elem_bytes: int,
 ):
-    """Store one chunk into LDS with CK-style XOR16 swizzle on the K dimension."""
+    """Store one chunk into LDS (fly u8 ptr) with CK-style XOR16 K swizzle."""
     if elem_bytes not in (1, 2):
         raise ValueError(f"elem_bytes must be 1 or 2, got {elem_bytes!r}")
     col_swz_bytes = swizzle_xor16(row_local, col_local_i32 * tx_c4, k_blocks16)
     col_swz = col_swz_bytes if elem_bytes == 1 else col_swz_bytes // 2
     idx0 = crd2idx((fx.Int32(row_local), fx.Int32(col_swz)), layout_lds) + lds_base
-    vector.store(vector.bitcast(vec_ty, vec_part), lds_memref, [idx0])
+    byte_off = fx.Int64(idx0) if elem_bytes == 1 else fx.Int64(idx0) * elem_bytes
+    u8_ptr = fx.recast_iter(fx.Uint8, lds_ptr)
+    fx.ptr_store(fx.Vector(vec_part).bitcast(fx.Uint8), u8_ptr + byte_off)
 
 
 def lds_store_16b_xor16(
-    arith,
-    vector,
     *,
-    lds_memref,
-    vec16_ty,
+    lds_ptr,
     layout_lds,
     row_local: ir.Value,
     col_local_i32: ir.Value,
@@ -598,11 +595,9 @@ def lds_store_16b_xor16(
     vec_part_i32x4: ir.Value,
     elem_bytes: int = 1,
 ):
-    """Store one 16B chunk into LDS with CK-style XOR16 swizzle on the K dimension."""
+    """Store one 16B chunk into LDS (fly u8 ptr) with CK-style XOR16 K swizzle."""
     _lds_store_xor16(
-        vector,
-        lds_memref=lds_memref,
-        vec_ty=vec16_ty,
+        lds_ptr=lds_ptr,
         layout_lds=layout_lds,
         row_local=row_local,
         col_local_i32=col_local_i32,
@@ -615,11 +610,8 @@ def lds_store_16b_xor16(
 
 
 def lds_store_8b_xor16(
-    arith,
-    vector,
     *,
-    lds_memref,
-    vec8_ty,
+    lds_ptr,
     layout_lds,
     row_local: ir.Value,
     col_local_i32: ir.Value,
@@ -629,11 +621,9 @@ def lds_store_8b_xor16(
     vec_part_i32x2: ir.Value,
     elem_bytes: int = 1,
 ):
-    """Store one 8B chunk into LDS with CK-style XOR16 swizzle on the K dimension."""
+    """Store one 8B chunk into LDS (fly u8 ptr) with CK-style XOR16 K swizzle."""
     _lds_store_xor16(
-        vector,
-        lds_memref=lds_memref,
-        vec_ty=vec8_ty,
+        lds_ptr=lds_ptr,
         layout_lds=layout_lds,
         row_local=row_local,
         col_local_i32=col_local_i32,
@@ -646,11 +636,8 @@ def lds_store_8b_xor16(
 
 
 def lds_store_4b_xor16(
-    arith,
-    vector,
     *,
-    lds_memref,
-    vec4_ty,
+    lds_ptr,
     layout_lds,
     row_local: ir.Value,
     col_local_i32: ir.Value,
@@ -660,11 +647,9 @@ def lds_store_4b_xor16(
     vec_part_i32x1: ir.Value,
     elem_bytes: int = 1,
 ):
-    """Store one 4B chunk into LDS with CK-style XOR16 swizzle on the K dimension."""
+    """Store one 4B chunk into LDS (fly u8 ptr) with CK-style XOR16 K swizzle."""
     _lds_store_xor16(
-        vector,
-        lds_memref=lds_memref,
-        vec_ty=vec4_ty,
+        lds_ptr=lds_ptr,
         layout_lds=layout_lds,
         row_local=row_local,
         col_local_i32=col_local_i32,

--- a/aiter/ops/flydsl/kernels/mixed_moe_gemm_2stage_common.py
+++ b/aiter/ops/flydsl/kernels/mixed_moe_gemm_2stage_common.py
@@ -26,15 +26,12 @@ from contextlib import contextmanager
 import flydsl.compiler as flyc
 import flydsl.expr as fx
 from flydsl._mlir import ir
-from flydsl._mlir.dialects import llvm, memref, scf
+from flydsl._mlir.dialects import llvm, scf
 from flydsl._mlir.dialects.arith import CmpIPredicate
-from flydsl._mlir.extras import types as _mT
 from flydsl.compiler.kernel_function import CompilationContext
 from flydsl.expr import arith, const_expr, gpu, range_constexpr, rocdl
-from flydsl.expr.gpu import lds_space as _lds_space
 from flydsl.expr.typing import T
 from flydsl.runtime.device import get_rocm_arch as get_hip_arch
-from flydsl.utils.smem_allocator import SmemAllocator, SmemPtr
 
 from aiter.ops.flydsl.kernels import buffer_ops, vector
 from aiter.ops.flydsl.kernels.kernels_common import default_f8_type
@@ -152,8 +149,9 @@ def compile_mixed_moe_gemm1_common(
             f"got {shared_expert_id=} and {experts=}"
         )
     gpu_arch = get_hip_arch()
-    allocator_pong = SmemAllocator(None, arch=gpu_arch, global_sym_name="smem0")
-    allocator_ping = SmemAllocator(None, arch=gpu_arch, global_sym_name="smem1")
+
+    def _al(x, a):
+        return (int(x) + int(a) - 1) // int(a) * int(a)
 
     if a_dtype not in ("fp8", "fp4"):
         raise ValueError(f"a_dtype must be one of ('fp8','fp4'), got {a_dtype!r}")
@@ -290,15 +288,13 @@ def compile_mixed_moe_gemm1_common(
         cshuffle_elem_bytes * int(tile_m) * int(tile_n) if _use_cshuffle_epilog else 0
     )
     lds_tid_bytes = int(tile_m) * 4
-    input_elems = single_x_bytes if a_elem_bytes == 1 else (single_x_bytes // 2)
+    single_x_bytes if a_elem_bytes == 1 else (single_x_bytes // 2)
 
     GLOBAL_ALIGN = 1024
     std_pong = max(x_region_bytes, lds_out_bytes) + lds_tid_bytes
     std_ping = x_region_bytes
-    std_pong_aligned = allocator_pong._align(std_pong, 128)
-    std_total = allocator_pong._align(
-        std_pong_aligned, GLOBAL_ALIGN
-    ) + allocator_pong._align(std_ping, 128)
+    std_pong_aligned = _al(std_pong, 128)
+    std_total = _al(std_pong_aligned, GLOBAL_ALIGN) + _al(std_ping, 128)
     lds_limit = {"gfx950": 163840, "gfx942": 65536}.get(gpu_arch, 0)
 
     split_lds_out = (
@@ -320,22 +316,23 @@ def compile_mixed_moe_gemm1_common(
     def x_lds_elem():
         return default_f8_type()
 
-    lds_pong_offset = allocator_pong._align(allocator_pong.ptr, 16)
-    allocator_pong.ptr = lds_pong_offset + pong_buffer_bytes
-    lds_tid_offset_pong = allocator_pong._align(allocator_pong.ptr, 4)
-    allocator_pong.ptr = lds_tid_offset_pong + lds_tid_bytes
+    lds_pong_offset = 0
+    lds_tid_offset_pong = _al(lds_pong_offset + pong_buffer_bytes, 4)
+    pong_arena_bytes = lds_tid_offset_pong + lds_tid_bytes
 
-    lds_ping_offset = allocator_ping._align(allocator_ping.ptr, 16)
-    allocator_ping.ptr = lds_ping_offset + ping_buffer_bytes
+    lds_ping_offset = 0
+    ping_arena_bytes = lds_ping_offset + ping_buffer_bytes
 
+    # Reproduce the legacy two-arena occupancy padding exactly so total LDS
+    # bytes (and thus waves/EU) are unchanged after the fly-smem migration.
+    pong_field_bytes = _al(pong_arena_bytes, 128)
+    ping_field_bytes = _al(ping_arena_bytes, 128)
     if waves_per_eu is not None and waves_per_eu >= 1:
         total_cu_lds = 160 * 1024
         min_lds = total_cu_lds // (waves_per_eu + 1) + 1
-        pong_sz = allocator_pong._align(allocator_pong.ptr, 128)
-        ping_sz = allocator_ping._align(allocator_ping.ptr, 128)
-        cur_lds = pong_sz + ping_sz
+        cur_lds = pong_field_bytes + ping_field_bytes
         if cur_lds < min_lds:
-            allocator_ping.ptr += min_lds - cur_lds
+            ping_field_bytes += min_lds - cur_lds
 
     kpack_bytes = 16
     out_elem_bytes = 4 if out_is_f32 else 2
@@ -474,7 +471,7 @@ def compile_mixed_moe_gemm1_common(
             i64 = T.i64
             vec4_f32 = T.vec(4, f32)
             vec16_elems = 16 if a_elem_bytes == 1 else 8
-            vec16_x = T.vec(vec16_elems, x_elem)
+            T.vec(vec16_elems, x_elem)
             vec2_i64 = T.vec(2, i64)
 
             def ptr_buffer_resource(ptr, num_records_bytes):
@@ -575,46 +572,38 @@ def compile_mixed_moe_gemm1_common(
             layout_tx_wave_lane = fx.make_layout((num_waves_total, 64), stride=(64, 1))
             layout_lane16 = fx.make_layout((4, 16), stride=(16, 1))
 
-            base_ptr_pong = allocator_pong.get_base()
-            base_ptr_ping = allocator_ping.get_base()
-            lds_x_pong = SmemPtr(
-                base_ptr_pong, lds_pong_offset, x_lds_elem(), shape=(input_elems,)
-            ).get()
-            lds_x_ping = SmemPtr(
-                base_ptr_ping, lds_ping_offset, x_lds_elem(), shape=(input_elems,)
-            ).get()
             lds_out_elem_type = (
-                T.f32 if need_quant else (T.bf16 if out_is_bf16 else T.f16)
+                fx.Float32
+                if need_quant
+                else (fx.BFloat16 if out_is_bf16 else fx.Float16)
             )
-            if const_expr(split_lds_out and _use_cshuffle_epilog):
-                half_out_elems = int(tile_m) * (int(tile_n) // 2)
-                lds_out = SmemPtr(
-                    base_ptr_pong,
-                    lds_pong_offset,
-                    lds_out_elem_type,
-                    shape=(half_out_elems,),
-                ).get()
-                lds_out_B = SmemPtr(
-                    base_ptr_ping,
-                    lds_ping_offset,
-                    lds_out_elem_type,
-                    shape=(half_out_elems,),
-                ).get()
-            else:
-                lds_out = (
-                    SmemPtr(
-                        base_ptr_pong,
-                        lds_pong_offset,
-                        lds_out_elem_type,
-                        shape=(tile_m * tile_n,),
-                    ).get()
-                    if _use_cshuffle_epilog
+
+            # Two independent LDS arenas (ping/pong) as separate fly-shared byte
+            # fields; sub-buffers are carved by recast_iter at the same byte
+            # offsets the legacy allocator used, so the layout is unchanged.
+            @fx.struct
+            class _MoeGemm1Smem:
+                pong: fx.Array[fx.Uint8, pong_field_bytes, 16]
+                ping: fx.Array[fx.Uint8, ping_field_bytes, 16]
+
+            _lds = fx.SharedAllocator().allocate(_MoeGemm1Smem).peek()
+            lds_x_pong = _lds.pong.ptr
+            lds_x_ping = _lds.ping.ptr
+            base_ptr_pong = lds_x_pong
+            base_ptr_ping = lds_x_ping
+            if _use_cshuffle_epilog:
+                lds_out = fx.recast_iter(lds_out_elem_type, lds_x_pong)
+                lds_out_B = (
+                    fx.recast_iter(lds_out_elem_type, lds_x_ping)
+                    if split_lds_out
                     else None
                 )
+            else:
+                lds_out = None
                 lds_out_B = None
-            lds_tid = SmemPtr(
-                base_ptr_pong, lds_tid_offset_pong, T.i32, shape=(tile_m,)
-            ).get()
+            lds_tid = fx.recast_iter(fx.Int32, lds_x_pong) + fx.Int64(
+                lds_tid_offset_pong // 4
+            )
 
             c_a_pack = arith.constant(int(a_elem_vec_pack), index=True)
             c_elem_bytes = arith.constant(int(a_elem_bytes), index=True)
@@ -879,17 +868,10 @@ def compile_mixed_moe_gemm1_common(
                         klen, index=True
                     )
                     grp_x_bytes = wave_k_id * arith.constant(single_x_bytes, index=True)
-                    x_view_ty = _mT.memref(
-                        input_elems, x_lds_elem(), memory_space=_lds_space()
-                    )
                     pong_off = arith.constant(lds_pong_offset, index=True) + grp_x_bytes
                     ping_off = arith.constant(lds_ping_offset, index=True) + grp_x_bytes
-                    body_lds_x_pong = memref.view(
-                        x_view_ty, base_ptr_pong, pong_off, sizes=[]
-                    )
-                    body_lds_x_ping = memref.view(
-                        x_view_ty, base_ptr_ping, ping_off, sizes=[]
-                    )
+                    body_lds_x_pong = base_ptr_pong + fx.Int64(pong_off)
+                    body_lds_x_ping = base_ptr_ping + fx.Int64(ping_off)
                 else:
                     wave_k_id = arith.index(0)
 
@@ -1204,10 +1186,7 @@ def compile_mixed_moe_gemm1_common(
                         col_local_i32 = x_col_local_i32[i]
                         if const_expr(x_load_bytes == 16):
                             lds_store_16b_xor16(
-                                arith,
-                                vector,
-                                lds_memref=lds_buffer,
-                                vec16_ty=vec16_x,
+                                lds_ptr=lds_buffer,
                                 layout_lds=layout_lds,
                                 row_local=row_local,
                                 col_local_i32=col_local_i32,
@@ -1248,7 +1227,7 @@ def compile_mixed_moe_gemm1_common(
                             global_offset = arith.index_cast(T.i32, global_byte_idx)
 
                             if const_expr(i == 0):
-                                lds_addr = memref.extract_aligned_pointer_as_index(
+                                lds_addr = fx.ptrtoint(
                                     lds_buffer
                                 ) + wave_n_id * arith.constant(
                                     wave_size * dma_bytes, index=True
@@ -1289,8 +1268,11 @@ def compile_mixed_moe_gemm1_common(
                     idx_a16 = crd2idx(
                         [fx.Int32(curr_row_a_lds), fx.Int32(col_base_swz)], layout_lds
                     )
-                    loaded_a16 = vector.load_op(vec16_x, lds_buffer, [idx_a16])
-                    a_i64x2 = vector.bitcast(vec2_i64, loaded_a16)
+                    loaded_u8 = fx.ptr_load(
+                        fx.recast_iter(fx.Uint8, lds_buffer) + fx.Int64(idx_a16),
+                        result_type=fx.Vector.make_type(16, fx.Uint8),
+                    )
+                    a_i64x2 = fx.Vector(loaded_u8).bitcast(fx.Int64).ir_value()
                     a0 = vector.extract(
                         a_i64x2, static_position=[0], dynamic_position=[]
                     )
@@ -1873,8 +1855,10 @@ def compile_mixed_moe_gemm1_common(
                     tid_val = buffer_ops.buffer_load(
                         sorted_rsrc, tid_row, vec_width=1, dtype=T.i32
                     )
-                    tid_vec1 = vector.from_elements(T.vec(1, T.i32), [tid_val])
-                    vector.store(tid_vec1, lds_tid, [tx])
+                    fx.ptr_store(
+                        fx.Vector.from_elements([tid_val], fx.Int32),
+                        lds_tid + fx.Int32(tx),
+                    )
                     scf.YieldOp([])
 
                 acc_gate = [acc_init] * num_acc_n * m_repeat
@@ -2235,22 +2219,9 @@ def compile_mixed_moe_gemm1_common(
                     has_up = const_expr(acc_up is not None)
                     nm = num_acc_n * m_repeat
                     grp_stride = 64 * nm
-                    scr_ty = _mT.memref(
-                        num_waves_total * grp_stride * 4, f32, memory_space=_lds_space()
-                    )
-                    scr_g = memref.view(
-                        scr_ty,
-                        base_ptr_pong,
-                        arith.constant(lds_pong_offset, index=True),
-                        sizes=[],
-                    )
+                    scr_g = fx.recast_iter(fx.Float32, base_ptr_pong)
                     if const_expr(has_up):
-                        scr_u = memref.view(
-                            scr_ty,
-                            base_ptr_ping,
-                            arith.constant(lds_ping_offset, index=True),
-                            sizes=[],
-                        )
+                        scr_u = fx.recast_iter(fx.Float32, base_ptr_ping)
                     c_gs = arith.constant(grp_stride, index=True)
                     c4 = arith.constant(4, index=True)
                     c64 = arith.constant(64, index=True)
@@ -2258,9 +2229,9 @@ def compile_mixed_moe_gemm1_common(
                     gpu.barrier()
                     for ai in range_constexpr(nm):
                         sidx = (my_base + arith.constant(ai, index=True) * c64) * c4
-                        vector.store(acc_gate[ai], scr_g, [sidx], alignment=16)
+                        fx.ptr_store(fx.Vector(acc_gate[ai]), scr_g + fx.Int64(sidx))
                         if const_expr(has_up):
-                            vector.store(acc_up[ai], scr_u, [sidx], alignment=16)
+                            fx.ptr_store(fx.Vector(acc_up[ai]), scr_u + fx.Int64(sidx))
                     gpu.barrier()
                     for ai in range_constexpr(nm):
                         ai_off = arith.constant(ai, index=True) * c64 + lane_id
@@ -2271,9 +2242,17 @@ def compile_mixed_moe_gemm1_common(
                                 arith.constant(g * num_n_waves, index=True) + wave_n_id
                             )
                             pidx = (peer * c_gs + ai_off) * c4
-                            gvs.append(vector.load_op(vec4_f32, scr_g, [pidx]))
+                            gvs.append(
+                                fx.ptr_load(
+                                    scr_g + fx.Int64(pidx), result_type=vec4_f32
+                                ).ir_value()
+                            )
                             if const_expr(has_up):
-                                uvs.append(vector.load_op(vec4_f32, scr_u, [pidx]))
+                                uvs.append(
+                                    fx.ptr_load(
+                                        scr_u + fx.Int64(pidx), result_type=vec4_f32
+                                    ).ir_value()
+                                )
 
                         sg = gvs[0]
                         for g in range_constexpr(1, k_wave):
@@ -2411,15 +2390,18 @@ def compile_mixed_moe_gemm1_common(
                             v = v * tw
                         if const_expr(need_quant):
                             lds_idx = row_base_lds + col_local
-                            vec1_f32 = T.vec(1, f32)
-                            v1 = vector.from_elements(vec1_f32, [v])
-                            vector.store(v1, lds_out, [lds_idx], alignment=4)
+                            fx.ptr_store(
+                                fx.Vector.from_elements([v], fx.Float32),
+                                lds_out + fx.Int32(lds_idx),
+                            )
                         else:
                             v_out = arith.trunc_f(out_elem(), v)
                             lds_idx = row_base_lds + col_local
-                            vec1_out = T.vec(1, out_elem())
-                            v1 = vector.from_elements(vec1_out, [v_out])
-                            vector.store(v1, lds_out, [lds_idx], alignment=2)
+                            out_fly_dtype = fx.BFloat16 if out_is_bf16 else fx.Float16
+                            fx.ptr_store(
+                                fx.Vector.from_elements([v_out], out_fly_dtype),
+                                lds_out + fx.Int32(lds_idx),
+                            )
 
                 out_row_stride = (
                     inter_dim * 2 * out_elem_bytes
@@ -2432,7 +2414,7 @@ def compile_mixed_moe_gemm1_common(
                 )
 
                 def precompute_row(*, row_local, row):
-                    fused2 = memref.load(lds_tid, [row_local])
+                    fused2 = fx.ptr_load(lds_tid + fx.Int32(row_local)).ir_value()
                     row_i32 = arith.index_cast(T.i32, row)
                     row_valid0 = arith.cmpi(CmpIPredicate.ult, row_i32, num_valid_i32)
                     t = fused2 & mask24_i32
@@ -2759,25 +2741,11 @@ def compile_mixed_moe_gemm1_common(
 
                 if const_expr(kwave_fused):
                     slab_n = tile_m * tile_n
-                    slab_ty = _mT.memref(
-                        k_wave * slab_n, f32, memory_space=_lds_space()
-                    )
-                    gate_slab = memref.view(
-                        slab_ty,
-                        base_ptr_pong,
-                        arith.constant(lds_pong_offset, index=True),
-                        sizes=[],
-                    )
-                    up_slab = memref.view(
-                        slab_ty,
-                        base_ptr_ping,
-                        arith.constant(lds_ping_offset, index=True),
-                        sizes=[],
-                    )
+                    gate_slab = fx.recast_iter(fx.Float32, base_ptr_pong)
+                    up_slab = fx.recast_iter(fx.Float32, base_ptr_ping)
                     c_tn = arith.constant(tile_n, index=True)
                     c_slabn = arith.constant(slab_n, index=True)
                     kg_base = wave_k_id * c_slabn
-                    vec1_f32 = T.vec(1, f32)
                     vecev_f32 = T.vec(e_vec, f32)
 
                     gpu.barrier()
@@ -2800,17 +2768,13 @@ def compile_mixed_moe_gemm1_common(
                                 acc_up[aidx], static_position=[ii], dynamic_position=[]
                             )
                             idx = kg_base + rb + col
-                            vector.store(
-                                vector.from_elements(vec1_f32, [gv]),
-                                gate_slab,
-                                [idx],
-                                alignment=4,
+                            fx.ptr_store(
+                                fx.Vector.from_elements([gv], fx.Float32),
+                                gate_slab + fx.Int32(idx),
                             )
-                            vector.store(
-                                vector.from_elements(vec1_f32, [uv]),
-                                up_slab,
-                                [idx],
-                                alignment=4,
+                            fx.ptr_store(
+                                fx.Vector.from_elements([uv], fx.Float32),
+                                up_slab + fx.Int32(idx),
                             )
 
                     default_epilog(
@@ -2847,8 +2811,12 @@ def compile_mixed_moe_gemm1_common(
                                 usum = [None] * int(e_vec)
                                 for kg in range_constexpr(k_wave):
                                     ko = arith.constant(kg, index=True) * c_slabn + base
-                                    gvv = vector.load_op(vecev_f32, gate_slab, [ko])
-                                    uvv = vector.load_op(vecev_f32, up_slab, [ko])
+                                    gvv = fx.ptr_load(
+                                        gate_slab + fx.Int32(ko), result_type=vecev_f32
+                                    ).ir_value()
+                                    uvv = fx.ptr_load(
+                                        up_slab + fx.Int32(ko), result_type=vecev_f32
+                                    ).ir_value()
                                     for e in range_constexpr(int(e_vec)):
                                         ge = vector.extract(
                                             gvv,
@@ -3184,12 +3152,9 @@ def compile_mixed_moe_gemm1_common(
         stream: fx.Stream,
     ):
         _ = cache_tag
-        allocator_pong.finalized = False
-        allocator_ping.finalized = False
+        # LDS bytes are tracked automatically by the fly SharedAllocator; no
+        # manual finalize is needed.
         ctx = CompilationContext.get_current()
-        with ir.InsertionPoint(ctx.gpu_module_body):
-            allocator_pong.finalize()
-            allocator_ping.finalize()
 
         inter_dim_pad_total = arith.constant(2 * inter_dim_pad, index=True)
         tile2_pad = 0
@@ -3436,9 +3401,6 @@ def compile_mixed_moe_gemm2_common(
         and bool(accumulate)
     )
 
-    gpu_arch = get_hip_arch()
-    allocator = SmemAllocator(None, arch=gpu_arch, global_sym_name="smem0")
-
     if const_expr(a_dtype not in ("fp8", "fp4")):
         raise ValueError(f"a_dtype must be one of ('fp8','fp4'), got {a_dtype!r}")
     if const_expr(b_dtype not in ("fp8", "fp4")):
@@ -3616,8 +3578,6 @@ def compile_mixed_moe_gemm2_common(
         return default_f8_type()
 
     lds_alloc_bytes = int(lds_total_elems) * int(a_elem_bytes)
-    lds_alloc_offset = allocator._align(allocator.ptr, 16)
-    allocator.ptr = lds_alloc_offset + lds_alloc_bytes
 
     if const_expr(True):
 
@@ -3652,7 +3612,7 @@ def compile_mixed_moe_gemm2_common(
             vec16_elems = 16 if a_elem_bytes == 1 else 8
             vec8_elems = 8 if a_elem_bytes == 1 else 4
             vec4_elems = 4 if a_elem_bytes == 1 else 2
-            vec16_x = T.vec(vec16_elems, x_elem)
+            T.vec(vec16_elems, x_elem)
             vec2_i64 = T.vec(2, i64)
 
             def ptr_buffer_resource(ptr, num_records_bytes):
@@ -3739,40 +3699,30 @@ def compile_mixed_moe_gemm2_common(
             layout_tx_wave_lane = fx.make_layout((4, 64), stride=(64, 1))
             layout_lane16 = fx.make_layout((4, 16), stride=(16, 1))
 
-            base_ptr = allocator.get_base()
-            lds_x_ptr = SmemPtr(
-                base_ptr,
-                lds_alloc_offset,
-                x_lds_elem(),
-                shape=(lds_total_elems,),
-            )
-            lds_x = lds_x_ptr.get()
-            lds_out = (
-                SmemPtr(
-                    base_ptr,
-                    lds_x_ptr.byte_offset,
-                    (T.bf16 if out_is_bf16 else T.f16),
-                    shape=(tile_m * tile_n,),
-                ).get()
-                if _use_cshuffle_epilog
-                else None
-            )
-
+            # Single LDS slab as a fly-shared byte field; the double-buffered X
+            # halves (ping/pong) are addressed by an element `lds_base` offset,
+            # and lds_out / lds_tid / lds_tw are carved from the same base by
+            # recast_iter at the legacy byte offsets (layout unchanged).
+            lds_out_fly_dtype = fx.BFloat16 if out_is_bf16 else fx.Float16
             lds_x_b = 2 * int(tile_m) * int(lds_stride) * int(a_elem_bytes)
             lds_out_b = 2 * int(tile_m) * int(tile_n) if _use_cshuffle_epilog else 0
             lds_tid_off = max(lds_x_b, lds_out_b)
-            lds_tid = SmemPtr(
-                base_ptr, lds_x_ptr.byte_offset + lds_tid_off, T.i32, shape=(tile_m,)
-            ).get()
-            # lds_tw aliases the LDS slot immediately after
             lds_tw_off = lds_tid_off + int(tile_m) * 4
+
+            @fx.struct
+            class _MoeGemm2Smem:
+                slab: fx.Array[fx.Uint8, lds_alloc_bytes, 16]
+
+            _lds = fx.SharedAllocator().allocate(_MoeGemm2Smem).peek()
+            lds_x = _lds.slab.ptr
+            lds_out = (
+                fx.recast_iter(lds_out_fly_dtype, lds_x)
+                if _use_cshuffle_epilog
+                else None
+            )
+            lds_tid = fx.recast_iter(fx.Int32, lds_x) + fx.Int64(lds_tid_off // 4)
             lds_tw = (
-                SmemPtr(
-                    base_ptr,
-                    lds_x_ptr.byte_offset + lds_tw_off,
-                    T.f32,
-                    shape=(tile_m,),
-                ).get()
+                fx.recast_iter(fx.Float32, lds_x) + fx.Int64(lds_tw_off // 4)
                 if doweight_stage2
                 else None
             )
@@ -4393,8 +4343,8 @@ def compile_mixed_moe_gemm2_common(
                         load_b_scale_tile(base_k, k_shift_bits, by_n_p=by_n_p),
                     ]
 
-                vec8_x = T.vec(vec8_elems, x_elem)
-                vec4_x_lds = T.vec(vec4_elems, x_elem)
+                T.vec(vec8_elems, x_elem)
+                T.vec(vec4_elems, x_elem)
 
                 def store_x_tile_to_lds(vec_x_in_parts, lds_base):
                     for i in range_constexpr(num_x_loads):
@@ -4402,10 +4352,7 @@ def compile_mixed_moe_gemm2_common(
                         col_local_i32 = x_col_local_i32[i]
                         if const_expr(x_load_bytes == 16):
                             lds_store_16b_xor16(
-                                arith,
-                                vector,
-                                lds_memref=lds_x,
-                                vec16_ty=vec16_x,
+                                lds_ptr=lds_x,
                                 layout_lds=layout_lds,
                                 row_local=row_local,
                                 col_local_i32=col_local_i32,
@@ -4417,10 +4364,7 @@ def compile_mixed_moe_gemm2_common(
                             )
                         elif const_expr(x_load_bytes == 8):
                             lds_store_8b_xor16(
-                                arith,
-                                vector,
-                                lds_memref=lds_x,
-                                vec8_ty=vec8_x,
+                                lds_ptr=lds_x,
                                 layout_lds=layout_lds,
                                 row_local=row_local,
                                 col_local_i32=col_local_i32,
@@ -4432,10 +4376,7 @@ def compile_mixed_moe_gemm2_common(
                             )
                         else:
                             lds_store_4b_xor16(
-                                arith,
-                                vector,
-                                lds_memref=lds_x,
-                                vec4_ty=vec4_x_lds,
+                                lds_ptr=lds_x,
                                 layout_lds=layout_lds,
                                 row_local=row_local,
                                 col_local_i32=col_local_i32,
@@ -4478,7 +4419,7 @@ def compile_mixed_moe_gemm2_common(
 
                             if const_expr(i == 0):
                                 lds_addr = (
-                                    memref.extract_aligned_pointer_as_index(lds_x)
+                                    fx.ptrtoint(lds_x)
                                     + lds_base * c_a_elem_bytes_dma
                                     + wave_id * c_wave_dma_bytes
                                 )
@@ -4519,8 +4460,11 @@ def compile_mixed_moe_gemm2_common(
                         [fx.Int32(curr_row_a_lds), fx.Int32(col_base_swz)], layout_lds
                     )
                     idx_a16 = idx_a16 + lds_base
-                    loaded_a16 = vector.load_op(vec16_x, lds_x, [idx_a16])
-                    a_i64x2 = vector.bitcast(vec2_i64, loaded_a16)
+                    loaded_u8 = fx.ptr_load(
+                        fx.recast_iter(fx.Uint8, lds_x) + fx.Int64(idx_a16),
+                        result_type=fx.Vector.make_type(16, fx.Uint8),
+                    )
+                    a_i64x2 = fx.Vector(loaded_u8).bitcast(fx.Int64).ir_value()
                     a0 = vector.extract(
                         a_i64x2, static_position=[0], dynamic_position=[]
                     )
@@ -4573,14 +4517,15 @@ def compile_mixed_moe_gemm2_common(
                         if const_expr(doweight_stage2):
                             tw_pf = []
                             lane_div_16_mul4_pf = lane_div_16 * arith.index(4)
-                            vec4_f32_pf = T.vec(4, f32)
+                            T.vec(4, f32)
                             if const_expr(lds_tw is not None):
                                 for mi in range_constexpr(m_repeat):
                                     mi_base_pf = arith.constant(mi * 16, index=True)
                                     lds_row_pf = mi_base_pf + lane_div_16_mul4_pf
-                                    tw_v4 = vector.load_op(
-                                        vec4_f32_pf, lds_tw, [lds_row_pf]
-                                    )
+                                    tw_v4 = fx.ptr_load(
+                                        lds_tw + fx.Int32(lds_row_pf),
+                                        result_type=fx.Vector.make_type(4, fx.Float32),
+                                    ).ir_value()
                                     for ii in range_constexpr(4):
                                         tw_pf.append(
                                             vector.extract(
@@ -4862,11 +4807,15 @@ def compile_mixed_moe_gemm2_common(
                             )
                         else:
                             stored_val = tid_val
-                        tid_vec1 = vector.from_elements(T.vec(1, T.i32), [stored_val])
-                        vector.store(tid_vec1, lds_tid, [tx])
+                        fx.ptr_store(
+                            fx.Vector.from_elements([stored_val], fx.Int32),
+                            lds_tid + fx.Int32(tx),
+                        )
                         if const_expr(doweight_stage2):
-                            tw_vec1 = vector.from_elements(T.vec(1, T.f32), [tw_val_m])
-                            vector.store(tw_vec1, lds_tw, [tx], alignment=4)
+                            fx.ptr_store(
+                                fx.Vector.from_elements([tw_val_m], fx.Float32),
+                                lds_tw + fx.Int32(tx),
+                            )
                         scf.YieldOp([])
 
                 if const_expr(not r216_defer_tid):
@@ -5164,10 +5113,11 @@ def compile_mixed_moe_gemm2_common(
                         v_out = arith.trunc_f(out_elem(), v)
 
                         lds_idx = row_base_lds + col_local
-                        vec1_out = T.vec(1, out_elem())
-                        v1 = vector.from_elements(vec1_out, [v_out])
-
-                        vector.store(v1, lds_out, [lds_idx], alignment=2)
+                        out_fly_dtype = fx.BFloat16 if out_is_bf16 else fx.Float16
+                        fx.ptr_store(
+                            fx.Vector.from_elements([v_out], out_fly_dtype),
+                            lds_out + fx.Int32(lds_idx),
+                        )
 
                 row_stride_bytes_py = int(model_dim) * int(out_elem_bytes)
                 use_buf_atomic = bool(accumulate) and (row_stride_bytes_py <= 16384)
@@ -5179,12 +5129,14 @@ def compile_mixed_moe_gemm2_common(
 
                 def precompute_row(*, row_local, row):
                     if const_expr(use_buf_atomic):
-                        row_byte_off_i32 = memref.load(lds_tid, [row_local])
+                        row_byte_off_i32 = fx.ptr_load(
+                            lds_tid + fx.Int32(row_local)
+                        ).ir_value()
                         return (
                             (None, None, row_byte_off_i32),
                             None,
                         )
-                    fused2 = memref.load(lds_tid, [row_local])
+                    fused2 = fx.ptr_load(lds_tid + fx.Int32(row_local)).ir_value()
                     row_i32 = arith.index_cast(T.i32, row)
                     row_valid0 = arith.cmpi(CmpIPredicate.ult, row_i32, num_valid_i32)
                     t = fused2 & mask24_i32
@@ -5522,10 +5474,9 @@ def compile_mixed_moe_gemm2_common(
         stream: fx.Stream,
     ):
         _ = cache_tag
-        allocator.finalized = False
+        # LDS bytes are tracked automatically by the fly SharedAllocator; no
+        # manual finalize is needed.
         ctx = CompilationContext.get_current()
-        with ir.InsertionPoint(ctx.gpu_module_body):
-            allocator.finalize()
 
         n_in = arith.index_cast(ir.IndexType.get(), i32_n_in.ir_value())
         tile_n_idx = arith.constant(tile_n, index=True)


### PR DESCRIPTION
Replace legacy SmemAllocator/SmemPtr (builtin memref) with fly-shared storage (@fx.struct + SharedAllocator) and fly ptr_load/ptr_store/ recast_iter across both stage1 and stage2 builders. Rewrite the LDS consumers (lds_store_*_xor16, c_shuffle_epilog) to fly-dialect ops. Preserve the LDS byte layout and occupancy padding.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
