### PR TITLE
[CI] fix auditwheel excludes: versioned ROCm SONAMEs were grafting ~890MB into the wheel

### DIFF
--- a/.github/workflows/aiter-release.yaml
+++ b/.github/workflows/aiter-release.yaml
@@ -444,25 +444,20 @@ jobs:
               # ROCm libs ship in the consumer container; torch libs are
               # provided by the user-installed PyTorch wheel.
               EXCLUDES=(
-                --exclude libamdhip64.so.7
-                --exclude libamdhip64.so
-                --exclude libhsa-runtime64.so.1
-                --exclude libhsa-runtime64.so
-                --exclude librocblas.so
-                --exclude librocsparse.so
-                --exclude librocsolver.so
-                --exclude libhipblas.so
-                --exclude libhipblaslt.so
-                --exclude librccl.so.1
-                --exclude librccl.so
-                --exclude libMIOpen.so.1
-                --exclude libMIOpen.so
-                --exclude libtorch.so
-                --exclude libtorch_cpu.so
-                --exclude libtorch_hip.so
-                --exclude libtorch_python.so
-                --exclude libc10.so
-                --exclude libc10_hip.so
+                --exclude "libamdhip64.so*"
+                --exclude "libhsa-runtime64.so*"
+                --exclude "libamd_comgr.so*"
+                --exclude "librocblas.so*"
+                --exclude "librocsparse.so*"
+                --exclude "librocsolver.so*"
+                --exclude "librocroller.so*"
+                --exclude "libroctx64.so*"
+                --exclude "libhipblas.so*"
+                --exclude "libhipblaslt.so*"
+                --exclude "librccl.so*"
+                --exclude "libMIOpen.so*"
+                --exclude "libtorch*.so*"
+                --exclude "libc10*.so*"
               )
               for whl in dist/*.whl; do
                 echo "=== auditwheel show (raw) ==="
@@ -473,6 +468,20 @@ jobs:
               done
               echo "=== Repaired wheels ==="
               ls -lh dist-repaired/
+              # Guard: nothing should have been grafted. auditwheel copies any
+              # non-excluded external lib into <pkg>.libs/ inside the wheel, so
+              # a non-empty .libs/ means an exclude pattern stopped matching
+              # (e.g. a de-torched module gained a direct ROCm DT_NEEDED, or a
+              # ROCm bump changed a SONAME major).
+              for whl in dist-repaired/*.whl; do
+                grafted=$(${PYBIN}/python -m zipfile -l "${whl}" | grep "\.libs/" || true)
+                if [ -n "${grafted}" ]; then
+                  echo "ERROR: auditwheel grafted external libs into ${whl}:"
+                  echo "${grafted}"
+                  echo "Add the missing SONAME glob to EXCLUDES above."
+                  exit 1
+                fi
+              done
               # Replace original dist with repaired copies (keeps existing
               # downstream upload logic untouched).
               rm -f dist/*.whl


### PR DESCRIPTION
## Problem

The released wheel is ~890 MB larger than it needs to be: `auditwheel repair` grafts ROCm BLAS libraries, and their dependency closure, into `amd_aiter.libs/`.

## Root cause

auditwheel matches `--exclude` patterns against the raw `DT_NEEDED` soname with `fnmatch` (`src/auditwheel/lddtree.py`). The exclude list used unversioned names, which never match the real sonames:

| exclude pattern | actual SONAME | matched? |
|---|---|---|
| `librocblas.so` | `librocblas.so.5` | no |
| `librocsolver.so` | `librocsolver.so.0` | no |
| `libhipblas.so` | `libhipblas.so.3` | no |
| `libhipblaslt.so` | `libhipblaslt.so.1` | no |
| `libamdhip64.so.7` | `libamdhip64.so.7` | yes |

The versioned form was only spelled out for libs that were already direct dependencies (`libamdhip64`, `libhsa-runtime64`, `librccl`, `libMIOpen`). The BLAS family was unreachable at the time, so the wrong patterns went unnoticed.

They became reachable after #4850. Before it, `module_hipbsolgemm.so` depended on `libtorch_hip.so` and picked up hipBLASLt transitively. `libtorch_hip.so` *is* matched by an exclude, and an exclude also stops the recursion into that lib's own dependencies, so the BLAS libs were never visited. De-torching removed the torch dependency, and the modules now link the BLAS libs directly:

```
module_hipbsolgemm.so  ->  libhipblaslt.so.1, libhipblas.so.3
module_rocsolgemm.so   ->  librocblas.so.5
```

Neither soname matches an exclude, so auditwheel walks in and grafts the closure.

## Fix

- Make every exclude a glob (`"librocblas.so*"`), so versioned sonames match and a ROCm major bump does not silently reopen this.
- Add `librocroller`, `libroctx64`, `libamd_comgr`, newly reachable through hipBLASLt.
- After `repair`, fail the build if anything landed in `.libs/`. This growth was silent; now it is not.

## Measurements

Same base wheel, same container, only the exclude list differs (ROCm 7.2.3, py3.12):

| | wheel size |
|---|---|
| base (before repair) | 130.1 MB |
| repair, old excludes | **1019.6 MB** |
| repair, new excludes | **130.5 MB** |

What the old list let through:

```
amd_aiter.libs/librocsolver-*.so.0.7.70203    827.7 MB
amd_aiter.libs/libamd_comgr-*.so.3.0.0        152.7 MB
amd_aiter.libs/librocroller-*.so.1.0.0         84.2 MB
amd_aiter.libs/librocblas-*.so.5.2.70203       53.4 MB
amd_aiter.libs/libhipblaslt-*.so.1.2.70203      9.1 MB
amd_aiter.libs/libhipblas-*.so.3.2.70203        1.0 MB
amd_aiter.libs/libzstd-*.so.1.5.5               0.7 MB
amd_aiter.libs/libroctx64-*.so.4.1.70203        0.0 MB
```

With the new list `.libs/` is empty and the guard passes; replayed against the old-exclude wheel, the guard exits 1 as intended.

Size is not the only concern: the grafted `librocblas` / `librocsolver` came from the build container and would shadow the host ROCm via RPATH at runtime.

## Not covered here

`auditwheel repair --plat manylinux_2_28_x86_64` could not run in my container (Ubuntu 24.04 / glibc 2.39 does not meet the 2.28 baseline), so both runs fell back to the auto platform (`manylinux_2_39`). That affects only the wheel's platform tag, not the grafting behaviour, and both runs used the same fallback. The end-to-end result on the real manylinux2_28 builder still needs one release run to confirm; the new guard is the acceptance criterion for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
