### PR TITLE
[Triton/Gluon] Fix int32 overflow in _gluon_deepgemm_fp8_paged_mqa_logits_preshuffle_varctx K/scale load offset

### DIFF
--- a/aiter/ops/triton/gluon/pa_mqa_logits.py
+++ b/aiter/ops/triton/gluon/pa_mqa_logits.py
@@ -1578,15 +1578,16 @@ def _gluon_deepgemm_fp8_paged_mqa_logits_preshuffle_varctx(
         mfma_q = gl.convert_layout(q, mfma_layout_a)
 
         context_kv_idx_next_0 = tl.where(mask_kv_next_0, context_kv_idx_next_0, 0)
-        k_next_0 = gl.amd.cdna3.buffer_load(
-            ptr=KV_buffer,
-            offsets=offset_k_fixed + context_kv_idx_next_0[None, :] * stride_k_seq,
+        k_next_0 = gl.load(
+            KV_buffer
+            + offset_k_fixed
+            + context_kv_idx_next_0.to(gl.int64)[None, :] * stride_k_seq
         )
-        k_scale_f_next_0 = gl.amd.cdna3.buffer_load(
-            ptr=scale_buffer,
-            offsets=context_kv_idx_next_0 * stride_scale_seq
+        k_scale_f_next_0 = gl.load(
+            scale_buffer
+            + context_kv_idx_next_0.to(gl.int64) * stride_scale_seq
             + gl.arange(0, ChunkKPerStage, layout=gl.SliceLayout(0, mfma_layout_b))
-            % KVBlockSize,
+            % KVBlockSize
         )
 
         _amd_iglp_sched_group_barrier(DS_READ, 4, 0)
@@ -1620,15 +1621,16 @@ def _gluon_deepgemm_fp8_paged_mqa_logits_preshuffle_varctx(
         #!=----------------------------
 
         context_kv_idx_next_1 = tl.where(mask_kv_next_1, context_kv_idx_next_1, 0)
-        k_next_1 = gl.amd.cdna3.buffer_load(
-            ptr=KV_buffer,
-            offsets=offset_k_fixed + context_kv_idx_next_1[None, :] * stride_k_seq,
+        k_next_1 = gl.load(
+            KV_buffer
+            + offset_k_fixed
+            + context_kv_idx_next_1.to(gl.int64)[None, :] * stride_k_seq
         )
-        k_scale_f_next_1 = gl.amd.cdna3.buffer_load(
-            ptr=scale_buffer,
-            offsets=context_kv_idx_next_1 * stride_scale_seq
+        k_scale_f_next_1 = gl.load(
+            scale_buffer
+            + context_kv_idx_next_1.to(gl.int64) * stride_scale_seq
             + gl.arange(0, ChunkKPerStage, layout=gl.SliceLayout(0, mfma_layout_b))
-            % KVBlockSize,
+            % KVBlockSize
         )
 
         _amd_s_set_prio(3)
@@ -1687,15 +1689,16 @@ def _gluon_deepgemm_fp8_paged_mqa_logits_preshuffle_varctx(
                 + gl.arange(0, ChunkKPerStage, layout=gl.SliceLayout(0, mfma_layout_b))
                 // KVBlockSize,
             )
-            k_next_0 = gl.amd.cdna3.buffer_load(
-                ptr=KV_buffer,
-                offsets=offset_k_fixed + context_kv_idx_next_0[None, :] * stride_k_seq,
+            k_next_0 = gl.load(
+                KV_buffer
+                + offset_k_fixed
+                + context_kv_idx_next_0.to(gl.int64)[None, :] * stride_k_seq
             )
-            k_scale_f_next_0 = gl.amd.cdna3.buffer_load(
-                ptr=scale_buffer,
-                offsets=context_kv_idx_next_0 * stride_scale_seq
+            k_scale_f_next_0 = gl.load(
+                scale_buffer
+                + context_kv_idx_next_0.to(gl.int64) * stride_scale_seq
                 + gl.arange(0, ChunkKPerStage, layout=gl.SliceLayout(0, mfma_layout_b))
-                % KVBlockSize,
+                % KVBlockSize
             )
 
             _amd_s_set_prio(3)
@@ -1758,15 +1761,16 @@ def _gluon_deepgemm_fp8_paged_mqa_logits_preshuffle_varctx(
                     )
                     // KVBlockSize,
                 )
-            k_next_1 = gl.amd.cdna3.buffer_load(
-                ptr=KV_buffer,
-                offsets=offset_k_fixed + context_kv_idx_next_1[None, :] * stride_k_seq,
+            k_next_1 = gl.load(
+                KV_buffer
+                + offset_k_fixed
+                + context_kv_idx_next_1.to(gl.int64)[None, :] * stride_k_seq
             )
-            k_scale_f_next_1 = gl.amd.cdna3.buffer_load(
-                ptr=scale_buffer,
-                offsets=context_kv_idx_next_1 * stride_scale_seq
+            k_scale_f_next_1 = gl.load(
+                scale_buffer
+                + context_kv_idx_next_1.to(gl.int64) * stride_scale_seq
                 + gl.arange(0, ChunkKPerStage, layout=gl.SliceLayout(0, mfma_layout_b))
-                % KVBlockSize,
+                % KVBlockSize
             )
             _amd_s_set_prio(2)
             mfma_k = gl.convert_layout(k, mfma_layout_b)

--- a/op_tests/test_pa_mqa_logits_varctx_overflow.py
+++ b/op_tests/test_pa_mqa_logits_varctx_overflow.py
@@ -32,8 +32,6 @@ This test uses distinct per-sequence blocks and a batch big enough to cross
 that no valid position was zeroed.
 """
 
-import math
-
 import pytest
 import torch
 
@@ -51,7 +49,9 @@ HEAD_DIM = 128
 KV_BLOCK = 64
 CHUNK_K = 256
 INDEX_DIM = HEAD_DIM + 4
-STRIDE_K_SEQ = KV_BLOCK * INDEX_DIM  # 8448 -> block_index*this overflows int32 at 254201
+STRIDE_K_SEQ = (
+    KV_BLOCK * INDEX_DIM
+)  # 8448 -> block_index*this overflows int32 at 254201
 FP8 = get_fp8_e4m3_dtype()
 
 
@@ -98,7 +98,15 @@ def _make_inputs(batch, ctx_list):
     flat[:, : KV_BLOCK * HEAD_DIM] = data.reshape(num_blocks, KV_BLOCK * HEAD_DIM)
 
     q_fp8 = q_bf16.to(FP8).contiguous()
-    return q_fp8, kvc, weights.contiguous(), context_lens, block_tables, t_max, num_blocks
+    return (
+        q_fp8,
+        kvc,
+        weights.contiguous(),
+        context_lens,
+        block_tables,
+        t_max,
+        num_blocks,
+    )
 
 
 def _run(q, kvc, w, ctx_lens, block_tables, t_max, vcs):
@@ -106,8 +114,17 @@ def _run(q, kvc, w, ctx_lens, block_tables, t_max, vcs):
         (q.shape[0], t_max), float("-inf"), dtype=torch.float32, device=dev
     )
     deepgemm_fp8_paged_mqa_logits(
-        q, kvc, w, out, ctx_lens, block_tables, t_max,
-        ChunkK=CHUNK_K, Preshuffle=True, KVBlockSize=KV_BLOCK, WavePerEU=2,
+        q,
+        kvc,
+        w,
+        out,
+        ctx_lens,
+        block_tables,
+        t_max,
+        ChunkK=CHUNK_K,
+        Preshuffle=True,
+        KVBlockSize=KV_BLOCK,
+        WavePerEU=2,
         VarCtxSchedule=vcs,
     )
     torch.cuda.synchronize()

--- a/op_tests/test_pa_mqa_logits_varctx_overflow.py
+++ b/op_tests/test_pa_mqa_logits_varctx_overflow.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+"""Regression test for the ``deepgemm_fp8_paged_mqa_logits`` VarCtx path 2**31
+KV-read-offset overflow (silent zeroed logits).
+
+Background
+----------
+The VarCtx gluon kernel
+``_gluon_deepgemm_fp8_paged_mqa_logits_preshuffle_varctx`` loaded K/scale with
+``gl.amd.cdna3.buffer_load(offsets=context_kv_idx * stride_k_seq + ...)``. The
+buffer-load voffset is a **32-bit** element offset, while ``context_kv_idx`` is an
+int32 block index. For a wide paged cache the product ``block_index * stride_k_seq``
+crosses ``2**31`` and wraps, so the load reads out of bounds and returns 0 -> the
+logits for those positions silently collapse to 0.
+
+``stride_k_seq = KVBlockSize * (head_dim + 4)`` (the +4 fp32-scale bytes make the
+row stride non-power-of-two, e.g. 64*(128+4)=8448). Overflow starts at
+``block_index >= 2**31 / 8448 = 254201``. The non-VarCtx (SplitKV / plain
+preshuffle) path never triggers this because it loads with 64-bit pointer
+arithmetic ``gl.load(KV_buffer + context_kv_idx.to(int64) * stride_k_seq)``.
+
+The bug only shows up when (a) the VarCtx schedule is used, and (b) the paged
+cache is wide enough that block indices reach the 2**31 boundary -- i.e. large
+batch with distinct per-sequence blocks. All existing pa-mqa tests either don't
+exercise the VarCtx path, or share a small block table across sequences, so they
+never cross the boundary.
+
+This test uses distinct per-sequence blocks and a batch big enough to cross
+2**31, then asserts the VarCtx output matches the known-good SplitKV output and
+that no valid position was zeroed.
+"""
+
+import math
+
+import pytest
+import torch
+
+from aiter.ops.shuffle import shuffle_weight
+from aiter.ops.triton.attention.pa_mqa_logits import (
+    deepgemm_fp8_paged_mqa_logits,
+    deepgemm_fp8_paged_mqa_logits_schedule,
+)
+from aiter.ops.triton.utils.types import get_fp8_e4m3_dtype
+
+dev = "cuda"
+SEED = 256
+HEADS = 64
+HEAD_DIM = 128
+KV_BLOCK = 64
+CHUNK_K = 256
+INDEX_DIM = HEAD_DIM + 4
+STRIDE_K_SEQ = KV_BLOCK * INDEX_DIM  # 8448 -> block_index*this overflows int32 at 254201
+FP8 = get_fp8_e4m3_dtype()
+
+
+def _variable_ctx(batch, lo=2048, hi=65536):
+    g = torch.Generator().manual_seed(SEED)
+    return [
+        max(KV_BLOCK, (c // KV_BLOCK) * KV_BLOCK)
+        for c in torch.randint(lo, hi, (batch,), generator=g).tolist()
+    ]
+
+
+def _make_inputs(batch, ctx_list):
+    """Distinct per-sequence paged fp8 KV cache (block_tables = arange) so global
+    block indices grow with batch and cross the 2**31 read-offset boundary."""
+    max_ctx = max(ctx_list)
+    max_blocks = max(
+        (max_ctx + CHUNK_K - 1) // CHUNK_K * (CHUNK_K // KV_BLOCK), CHUNK_K // KV_BLOCK
+    )
+    t_max = max_blocks * KV_BLOCK
+    num_blocks = max_blocks * batch
+    context_lens = torch.tensor(ctx_list, dtype=torch.int32, device=dev)
+
+    torch.manual_seed(0)
+    q_bf16 = torch.randn(batch, 1, HEADS, HEAD_DIM, dtype=torch.bfloat16, device=dev)
+    kv_bf16 = torch.randn(batch, t_max, HEAD_DIM, dtype=torch.bfloat16, device=dev)
+    weights = torch.randn(batch, HEADS, dtype=torch.float32, device=dev) * 0.1
+    block_tables = torch.arange(num_blocks, dtype=torch.int32, device=dev).reshape(
+        batch, max_blocks
+    )
+
+    kv_blocks = kv_bf16.reshape(num_blocks, KV_BLOCK, 1, HEAD_DIM)
+    sf = kv_blocks.abs().float().amax(dim=3, keepdim=True).clamp(1e-4) / 240.0
+    x_scaled = (kv_blocks * (1.0 / sf)).to(FP8)
+    kvc = torch.empty((num_blocks, KV_BLOCK * INDEX_DIM), dtype=torch.uint8, device=dev)
+    kvc[:, : KV_BLOCK * HEAD_DIM] = x_scaled.reshape(
+        num_blocks, KV_BLOCK * HEAD_DIM
+    ).view(torch.uint8)
+    kvc[:, KV_BLOCK * HEAD_DIM :] = sf.reshape(num_blocks, KV_BLOCK).view(torch.uint8)
+    kvc = kvc.view(num_blocks, KV_BLOCK, 1, INDEX_DIM)
+    flat = kvc.view(num_blocks, KV_BLOCK * INDEX_DIM)
+    data = shuffle_weight(
+        flat[:, : KV_BLOCK * HEAD_DIM].contiguous().view(num_blocks, KV_BLOCK, HEAD_DIM)
+    )
+    flat[:, : KV_BLOCK * HEAD_DIM] = data.reshape(num_blocks, KV_BLOCK * HEAD_DIM)
+
+    q_fp8 = q_bf16.to(FP8).contiguous()
+    return q_fp8, kvc, weights.contiguous(), context_lens, block_tables, t_max, num_blocks
+
+
+def _run(q, kvc, w, ctx_lens, block_tables, t_max, vcs):
+    out = torch.full(
+        (q.shape[0], t_max), float("-inf"), dtype=torch.float32, device=dev
+    )
+    deepgemm_fp8_paged_mqa_logits(
+        q, kvc, w, out, ctx_lens, block_tables, t_max,
+        ChunkK=CHUNK_K, Preshuffle=True, KVBlockSize=KV_BLOCK, WavePerEU=2,
+        VarCtxSchedule=vcs,
+    )
+    torch.cuda.synchronize()
+    return out
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires a ROCm GPU")
+@pytest.mark.parametrize("batch", [256])
+def test_varctx_kv_read_offset_no_overflow(batch):
+    ctx_list = _variable_ctx(batch)
+    q, kvc, w, ctx_lens, block_tables, t_max, num_blocks = _make_inputs(batch, ctx_list)
+
+    # the config must actually cross the 2**31 KV-read boundary, otherwise the
+    # test would pass even with the buggy (int32) kernel.
+    max_read_off = (num_blocks - 1) * STRIDE_K_SEQ
+    assert max_read_off >= (1 << 31), (
+        f"shape must cross 2**31 (max block-read offset={max_read_off} < 2**31); "
+        f"need a wider cache (num_blocks={num_blocks}, stride_k_seq={STRIDE_K_SEQ})"
+    )
+
+    # golden: SplitKV path (VarCtxSchedule=None) uses 64-bit pointer arithmetic
+    # and is always correct.
+    golden = _run(q, kvc, w, ctx_lens, block_tables, t_max, None)
+
+    sched = deepgemm_fp8_paged_mqa_logits_schedule(
+        batch, 1, ctx_lens, t_max, ChunkK=CHUNK_K, WavePerEU=2
+    )
+    var = _run(q, kvc, w, ctx_lens, block_tables, t_max, sched)
+
+    # (1) no valid position may be silently zeroed where the golden is non-zero
+    #     (the buffer_load OOB-returns-0 signature).
+    worst_row, worst_zeroed = -1, 0
+    for b in range(batch):
+        c = ctx_list[b]
+        g = golden[b, :c]
+        v = var[b, :c]
+        zeroed = int(((v == 0) & (g.abs() > 1e-3)).sum())
+        if zeroed > worst_zeroed:
+            worst_zeroed, worst_row = zeroed, b
+    assert worst_zeroed == 0, (
+        f"VarCtx zeroed {worst_zeroed} valid logits in row {worst_row} "
+        f"(ctx={ctx_list[worst_row]}): int32 overflow in the K/scale load offset."
+    )
+
+    # (2) per-row cosine vs the golden SplitKV output must be ~1.0 everywhere.
+    min_cos, min_row = 1.0, -1
+    for b in range(batch):
+        c = ctx_list[b]
+        g = golden[b, :c].double()
+        v = var[b, :c].double()
+        cos = float((g * v).sum() / (g.norm() * v.norm() + 1e-12))
+        if cos < min_cos:
+            min_cos, min_row = cos, b
+    assert min_cos > 0.999, (
+        f"VarCtx diverges from SplitKV: min per-row cos={min_cos:.6f} at row "
+        f"{min_row} (ctx={ctx_list[min_row]})."
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v", "-s"]))

--- a/op_tests/triton_tests/attention/test_pa_mqa_logits_varctx_overflow.py
+++ b/op_tests/triton_tests/attention/test_pa_mqa_logits_varctx_overflow.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # SPDX-License-Identifier: MIT
 # Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
 
@@ -35,12 +34,19 @@ that no valid position was zeroed.
 import pytest
 import torch
 
-from aiter.ops.shuffle import shuffle_weight
 from aiter.ops.triton.attention.pa_mqa_logits import (
     deepgemm_fp8_paged_mqa_logits,
     deepgemm_fp8_paged_mqa_logits_schedule,
 )
+from aiter.ops.triton.utils._triton import arch_info
+from aiter.ops.triton.utils.shuffle import shuffle_weight
 from aiter.ops.triton.utils.types import get_fp8_e4m3_dtype
+
+# The VarCtx Gluon branch (_gluon_..._preshuffle_varctx) runs only on CDNA
+# gfx942/gfx950. On gfx1250 the wrapper discards VarCtxSchedule and falls back to
+# the non-VarCtx path, so the regression would pass vacuously there.
+DEVICE_ARCH = arch_info.get_arch()
+_VARCTX_ARCHS = ("gfx942", "gfx950")
 
 dev = "cuda"
 SEED = 256
@@ -131,7 +137,10 @@ def _run(q, kvc, w, ctx_lens, block_tables, t_max, vcs):
     return out
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires a ROCm GPU")
+@pytest.mark.skipif(
+    not torch.cuda.is_available() or DEVICE_ARCH not in _VARCTX_ARCHS,
+    reason=f"VarCtx Gluon path requires gfx942/gfx950; got {DEVICE_ARCH}",
+)
 @pytest.mark.parametrize("batch", [256])
 def test_varctx_kv_read_offset_no_overflow(batch):
     ctx_list = _variable_ctx(batch)


### PR DESCRIPTION
## Motivation
The VarCtx gluon kernel `_gluon_deepgemm_fp8_paged_mqa_logits_preshuffle_varctx`
loads K/scale with `gl.amd.cdna3.buffer_load`, whose voffset is a **32-bit**
element offset. The block index (`context_kv_idx`, int32) is multiplied by
`stride_k_seq` while still int32, so for a wide paged cache the product
`block_index * stride_k_seq` crosses `2**31` and wraps. The load then reads out of
bounds and returns 0, so whole logit segments silently collapse to `0` for the
sequences that own high block indices (large batch). This PR loads K/scale with
64-bit pointer arithmetic via `gl.load`, matching the non-VarCtx preshuffle path.

### Issue
`deepgemm_fp8_paged_mqa_logits(..., Preshuffle=True, VarCtxSchedule=<schedule>)`
produces wrong output — whole segments become exactly `0.0` — at large batch with
variable context lengths on MI355X / gfx950. The non-VarCtx SplitKV path
(`VarCtxSchedule=None`) is always correct.

### Root cause
`stride_k_seq = kv_cache_fp8.stride(0) = KVBlockSize * index_dim`. The paged cache
row is `KVBlockSize * (head_dim + 4)` bytes — the extra 4 fp32-scale bytes per
block make the row stride **non-power-of-two**, e.g. `64 * (128 + 4) = 8448`
(not `64*128 = 8192`).

`context_kv_idx` is int32, and `gl.amd.cdna3.buffer_load` takes a **32-bit**
offset. The offset `context_kv_idx * stride_k_seq` therefore overflows once

```
block_index * 8448 >= 2**31  ->  block_index >= 2**31 / 8448 = 254201
```

The wrapped offset lands outside the buffer, the hardware buffer bound makes the
load return 0, and the resulting logits are `relu(q·0)·w = 0`.

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->
For each of the 4 K/scale load pairs in the `LoadBlockIndiceForEachStage == True`
branch (the `KVBlockSize=64` path used by the c4 indexer), switch from
`buffer_load(ptr=..., offsets=... int32 ...)` to `gl.load(ptr + ... int64 ...)`:

```python
# before (int32 offset -> overflow at block_index*stride_k_seq >= 2**31):
k_next_0 = gl.amd.cdna3.buffer_load(
    ptr=KV_buffer,
    offsets=offset_k_fixed + context_kv_idx_next_0[None, :] * stride_k_seq,
)
# after (64-bit pointer arithmetic, cannot overflow):
k_next_0 = gl.load(
    KV_buffer
    + offset_k_fixed
    + context_kv_idx_next_0.to(gl.int64)[None, :] * stride_k_seq
)
```

Same change for `k_next_1` and the two `k_scale_f_next_*`
(`context_kv_idx.to(gl.int64) * stride_scale_seq`). This mirrors exactly what the
non-VarCtx `_gluon_deepgemm_fp8_paged_mqa_logits_preshuffle` kernel already does.
## Test Plan
`op_tests/test_pa_mqa_logits_varctx_overflow.py` builds a distinct-per-sequence
paged cache (`block_tables = arange`) with `batch=256` and variable ctx so the
global block index crosses 254201, asserts the config actually reaches the
`2**31` boundary, then checks the VarCtx output against the known-good SplitKV
path: (1) no valid position is zeroed where SplitKV is non-zero, and (2) per-row
`cos(VarCtx, SplitKV) > 0.999`.
<!-- Explain any relevant testing done to verify this PR. -->

## Test Result
Test on (gfx950 / MI355X)
| kernel | test |
|---|---|
| before (buffer_load, int32) | **FAIL** — `VarCtx zeroed 51576 valid logits in row 254` |
| after (gl.load, int64) | **PASS** |

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
