### PR TITLE
[Bugfix] Prevent resource leaks on repeated hipBLASLt extension initialization

### DIFF
--- a/aiter/ops/gradlib.py
+++ b/aiter/ops/gradlib.py
@@ -9,11 +9,23 @@ from ..jit.core import compile_ops
 
 
 @compile_ops("module_hipbsolgemm")
-def hipb_create_extension() -> None: ...
+def hipb_create_extension() -> None:
+    """Initialize hipBLASLt resources for the current device.
+
+    Repeated calls on that device are no-ops. To change devices, synchronize
+    outstanding work and destroy the existing extension before initializing
+    again. Only one device's resources can be active in the module at a time.
+    """
 
 
 @compile_ops("module_hipbsolgemm")
-def hipb_destroy_extension() -> None: ...
+def hipb_destroy_extension() -> None:
+    """Release hipBLASLt resources, allowing a later initialization.
+
+    Synchronize outstanding GEMMs before calling. Destruction uses the owning
+    device and restores the caller's current device. Without an active
+    extension this is a no-op, including after a previous destruction.
+    """
 
 
 def gen_hipb_mm_fake_tensor(

--- a/gradlib/csrc/hipbsolgemm.cu
+++ b/gradlib/csrc/hipbsolgemm.cu
@@ -70,6 +70,8 @@ hipblasLtMatmulPreference_t preference;
 size_t workspace_size = 2 * 128 * 1024 * 1024;
 // uint64_t workspace_size = 0;
 void* d_workspace;
+// One resource set per module. Lifecycle calls retain the Python GIL.
+int extension_device  = -1;
 int request_solutions = 1;
 int returnedAlgoCount = 0;
 
@@ -1377,6 +1379,18 @@ std::vector<int> hipb_findallsols(const aiter_tensor_t& mat1,
 
 void hipb_create_extension()
 {
+    aiter_detail::g_aiter_can_throw = true;
+    int device;
+    HIP_CALL(hipGetDevice(&device));
+    if(extension_device != -1)
+    {
+        AITER_CHECK(extension_device == device,
+                    "hipBLASLt extension is already initialized on device ",
+                    extension_device,
+                    "; destroy it before initializing on another device");
+        return;
+    }
+
     // CHECK_HIP_ERROR(hipStreamCreate(&weight_stream));
     // CHECK_HIP_ERROR(hipEventCreateWithFlags(&event, cudaEventDisableTiming));
 
@@ -1390,6 +1404,8 @@ void hipb_create_extension()
                                               &workspace_size,
                                               sizeof(workspace_size)));
 
+    extension_device = device;
+
     // CHECK_HIP_ERROR(hipEventCreate(&start));
     // CHECK_HIP_ERROR(hipEventCreate(&stop));
 }
@@ -1398,6 +1414,11 @@ void hipb_create_extension()
 
 void hipb_destroy_extension()
 {
+    if(extension_device == -1)
+        return;
+
+    // Release resources on their owning device, preserving the caller's device.
+    HipDeviceGuard device_guard(extension_device);
     // CHECK_HIP_ERROR(hipStreamDestroy(weight_stream));
     // CHECK_HIP_ERROR(hipEventDestroy(event));
 
@@ -1405,6 +1426,11 @@ void hipb_destroy_extension()
     CHECK_HIPBLAS_ERROR(hipblasLtDestroy(hipblaslt_handle));
     CHECK_HIPBLAS_ERROR(hipblasLtMatmulPreferenceDestroy(preference));
     CHECK_HIP_ERROR(hipFree(d_workspace));
+
+    hipblaslt_handle = nullptr;
+    preference       = nullptr;
+    d_workspace      = nullptr;
+    extension_device = -1;
 
     // CHECK_HIP_ERROR(hipEventDestroy(start));
     // CHECK_HIP_ERROR(hipEventDestroy(stop));

--- a/op_tests/test_hipblaslt_lifecycle.py
+++ b/op_tests/test_hipblaslt_lifecycle.py
@@ -1,0 +1,129 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2026, Advanced Micro Devices, Inc. All rights reserved.
+
+"""Run in a fresh process on an idle GPU; --other-device opts into two GPUs."""
+
+import argparse
+
+import torch
+
+import aiter
+from aiter.test_common import checkAllclose
+
+MIB = 1024 * 1024
+WORKSPACE_BYTES = 256 * MIB
+MEMORY_TOLERANCE = 16 * MIB
+
+
+def free_memory() -> int:
+    torch.cuda.synchronize()
+    return torch.cuda.mem_get_info()[0]
+
+
+def check_gemm() -> None:
+    for dtype in (torch.float16, torch.bfloat16):
+        for m, n, k in ((16, 64, 64), (33, 128, 256)):
+            x = torch.randint(-2, 3, (m, k), device="cuda").to(dtype)
+            w = torch.randint(-2, 3, (n, k), device="cuda").to(dtype)
+            for use_bias in (False, True):
+                bias = torch.ones(n, dtype=dtype, device="cuda") if use_bias else None
+                ref = x.float() @ w.float().t()
+                if bias is not None:
+                    ref += bias.float()
+                ref = ref.to(dtype)
+                solutions = aiter.hipb_findallsols(x, w.t(), bias, dtype)
+                assert solutions, f"No hipBLASLt solutions for {(m, n, k, dtype)}"
+                for solution in (-1, solutions[0]):
+                    result = aiter.hipb_mm(x, w.t(), solution, bias, dtype)
+                    # Integer inputs make the accumulation exact before output casting.
+                    error = checkAllclose(ref, result, rtol=0, atol=0, printLog=False)
+                    assert error == 0, (m, n, k, dtype, use_bias, solution, error)
+    torch.cuda.synchronize()
+
+
+def test_repeated_init(iterations: int) -> None:
+    aiter.hipb_create_extension()
+    try:
+        # Exclude first-use HIP/hipBLASLt and torch allocator overhead.
+        check_gemm()
+        torch.cuda.empty_cache()
+        before = free_memory()
+        for _ in range(iterations):
+            aiter.hipb_create_extension()
+        after = free_memory()
+        print(f"Repeated init: before={before}, after={after}, loss={before - after}")
+        assert before - after < MEMORY_TOLERANCE, "Repeated init leaked device memory"
+        check_gemm()
+    finally:
+        torch.cuda.synchronize()
+        aiter.hipb_destroy_extension()
+
+
+def test_destroy_and_reinit() -> None:
+    # The preceding test has already destroyed the resource set.
+    aiter.hipb_destroy_extension()
+    torch.cuda.empty_cache()
+    for cycle in range(3):
+        before = free_memory()
+        aiter.hipb_create_extension()
+        initialized = free_memory()
+        assert before - initialized >= WORKSPACE_BYTES - MEMORY_TOLERANCE
+        try:
+            check_gemm()
+        finally:
+            torch.cuda.synchronize()
+            torch.cuda.empty_cache()
+            before_destroy = free_memory()
+            aiter.hipb_destroy_extension()
+        after_destroy = free_memory()
+        assert after_destroy - before_destroy >= WORKSPACE_BYTES - MEMORY_TOLERANCE
+        aiter.hipb_destroy_extension()
+        assert abs(free_memory() - after_destroy) < MEMORY_TOLERANCE
+        print(f"Destroy/re-init cycle {cycle + 1}: PASS")
+
+
+def test_device_change(device: int, other_device: int) -> None:
+    aiter.hipb_create_extension()
+    try:
+        check_gemm()
+        torch.cuda.set_device(other_device)
+        try:
+            aiter.hipb_create_extension()
+        except RuntimeError as error:
+            assert "destroy it before initializing on another device" in str(error)
+        else:
+            raise AssertionError("Changing devices with live resources must fail")
+        # Rejection must preserve the original resources.
+        torch.cuda.set_device(device)
+        check_gemm()
+        torch.cuda.set_device(other_device)
+    finally:
+        aiter.hipb_destroy_extension()
+    assert torch.cuda.current_device() == other_device
+    aiter.hipb_create_extension()
+    try:
+        check_gemm()
+    finally:
+        aiter.hipb_destroy_extension()
+        torch.cuda.set_device(device)
+    print("Device rejection, owner-device destruction, and device migration: PASS")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--device", type=int, default=0)
+    # Keep the regression bounded even when run against an unfixed build.
+    parser.add_argument("--iterations", type=int, default=4)
+    parser.add_argument("--other-device", type=int, default=None)
+    args = parser.parse_args()
+    if args.iterations < 2:
+        parser.error("--iterations must be at least 2")
+    if args.other_device == args.device:
+        parser.error("--other-device must differ from --device")
+    torch.cuda.set_device(args.device)
+    torch.manual_seed(42)
+    test_repeated_init(args.iterations)
+    test_destroy_and_reinit()
+    if args.other_device is not None:
+        test_device_change(args.device, args.other_device)
+    print("hipBLASLt lifecycle: PASS")


### PR DESCRIPTION
## Summary

Make hipBLASLt extension initialization idempotent on its owning device and
allow safe destruction followed by re-initialization. Repeated initialization
currently overwrites live global resources and leaks device memory.

## Motivation

`hipb_create_extension()` creates a hipBLASLt handle, allocates a 256 MiB device
workspace, and creates a matmul preference on every call. The previous pointers
are overwritten without being released, so a later `hipb_destroy_extension()`
can free only the most recent resource set.

A downstream tuning loop exposed this by initializing once per shape. The
problem also reproduces independently of that tuner on upstream AITER: four
additional initialization calls consumed 1,130 MiB on MI250. A separate minimal
probe of the installed build measured exactly 282 MiB per additional call,
including the explicit 256 MiB workspace and 26 MiB not separately attributed.

AITER's GEMM tuner and tuned GEMM runtime already guard their initialization
calls independently. Making the native resource owner handle repeated calls
prevents accidental resource loss without requiring every caller to maintain
its own initialization flag.

## Technical Details

### Changes

- Track the device owning the module's existing resource set, with `-1`
  representing the uninitialized state.
- Return without allocating on repeated initialization for that device.
- Raise `RuntimeError` if initialization is requested on another device while
  the existing resources are still live. The original resources remain usable.
- Make destruction a no-op when uninitialized, including after a prior destroy.
- Destroy resources on their owning device and restore the caller's current
  device with `HipDeviceGuard`.
- Clear resource pointers and reset the device state after successful teardown.
- Document lifecycle expectations in the Python API and add a standalone
  regression test in `op_tests/test_hipblaslt_lifecycle.py`.

The module continues to hold one resource set at a time. Lifecycle entry points
retain the Python GIL. Callers must synchronize outstanding GEMMs before
teardown. Existing fatal HIP/hipBLASLt allocation-error handling is unchanged;
this patch does not introduce recoverable allocation failures or a per-device
resource pool. GEMM kernel computation and solution selection are unchanged.

### The sibling entry point was checked and is not affected

`gradlib/csrc/rocsolgemm.cu` exposes the same shape of entry point,
`rocb_create_extension()`. It is not affected and is left unchanged: its body is
entirely commented out, so it creates no handle, allocates no workspace and owns
no state that a repeated call could overwrite. No other `*_create_extension`
entry point in `gradlib/csrc/` holds resources.

### Two implementation choices worth calling out

**`aiter_detail::g_aiter_can_throw` is set in `hipb_create_extension()`.** The
cross-device rejection is reported through `AITER_CHECK`, which reaches
`aiter_check_fatal`. That flag is `inline thread_local bool ... = false`, so
without setting it the rejection would abort the process instead of raising
`RuntimeError`, and the documented recovery path — destroy, switch device,
initialize again — would not be reachable from Python. The bare set matches the
existing usage in `csrc/opus_gemm/opus_gemm.cu`. It is deliberate, and it is a
side effect on the calling thread: after the first initialization on that thread,
subsequent AITER fatal checks raise rather than abort. If maintainers prefer the
save-and-restore discipline used by `aiter_safe_call()` in
`csrc/include/aiter_ctypes_error.h`, that would need a scope guard so the value
is restored on the throwing path as well; say the word and it will be changed.

**`HIP_CALL` is used for the new `hipGetDevice()` call** while the surrounding
pre-existing lines keep `CHECK_HIP_ERROR`. `HIP_CALL` routes into
`aiter_check_fatal`, the same error path as the `AITER_CHECK` immediately below
it, so the two new failure modes report consistently. `CHECK_HIP_ERROR` is
gradlib's local macro and is left untouched on every line that already used it.

## Test Plan

Run on an idle ROCm GPU in fresh processes, with separate JIT caches for the
baseline and patched builds. The test defaults to four repeated calls so that
running it on an unfixed build consumes about 1.1 GiB rather than exhausting VRAM.

```bash
# Regression and lifecycle tests, including FP16/BF16 and bias/no-bias.
python op_tests/test_hipblaslt_lifecycle.py

# Longer repeated-init check on the patched build.
python op_tests/test_hipblaslt_lifecycle.py --iterations 300

# Opt-in two-device coverage; indices refer to visible devices.
python op_tests/test_hipblaslt_lifecycle.py --device 0 --other-device 1

# Run the new test through AITER's CI test driver.
AITER_TEST=op_tests/test_hipblaslt_lifecycle.py bash .github/scripts/aiter_test.sh
```

Numerical checks build the reference in FP32 and cast it to the output dtype
before comparing, with `rtol=0, atol=0`. That is safe here rather than a
precision trap: inputs are integers in `[-2, 2]`, so every partial product and
every partial sum is exact in FP32, and both the reference and the hipBLASLt
result are therefore rounded exactly once from the same exact FP32 value when
they are written out in FP16/BF16. The comparison is not calibrated against a
higher-precision baseline; it compares two values that must be bit-identical.
The checks cover both heuristic selection (`solution_index=-1`) and an explicit
solution returned by `hipb_findallsols()`, before and after lifecycle
transitions.

## Test Result

Base: `ed5fc689b6a0872372d7010d0776e721e9ea9e56`. `gradlib/csrc/hipbsolgemm.cu`
and `aiter/ops/gradlib.py` are byte-identical at that commit and at
`9b410476af86cdd35328ba054b29827a64933b4b`, so these results still describe the
patch as it applies to current `main`.
Hardware: MI250 (`gfx90a`). Environment: ROCm 7.2.3 container,
PyTorch `2.11.0+gitd0c8b1f`, `torch.version.hip=7.2.53211`, Python 3.12.
Baseline and patched hipBLASLt modules were built from source with separate,
initially empty JIT caches and `GPU_ARCHS=gfx90a`.

| Check | Result |
|---|---|
| Upstream baseline, four additional init calls | Expected regression failure: 1,184,890,880 bytes (1,130 MiB) lost |
| Patched, four additional init calls via CI driver | PASS: 2 MiB difference, below the 16 MiB tolerance |
| Patched, 300 additional init calls | PASS: the same 2 MiB difference, without growth proportional to call count |
| FP16/BF16 GEMM, bias/no bias, heuristic/explicit solution | PASS with exact numerical comparison |
| Three destroy/re-init cycles and repeated destruction | PASS; workspace released and allocated again each cycle |
| Rejected cross-device init preserves original GEMM resources | PASS |
| Destruction from another current device preserves that current device | PASS |
| Initialization and GEMM on the second device after teardown | PASS |
| Repository pre-commit hook, Black, Ruff, whitespace check | PASS for the patch |

Representative regression output:

```text
# Upstream baseline (expected failure)
Repeated init: before=67926753280, after=66741862400, loss=1184890880
AssertionError: Repeated init leaked device memory

# Patched, --iterations 300
Repeated init: before=67926753280, after=67924656128, loss=2097152
Destroy/re-init cycle 1: PASS
Destroy/re-init cycle 2: PASS
Destroy/re-init cycle 3: PASS
hipBLASLt lifecycle: PASS

# Patched, two-device check
Device rejection, owner-device destruction, and device migration: PASS
hipBLASLt lifecycle: PASS

# Repository CI driver, AITER_TEST=op_tests/test_hipblaslt_lifecycle.py
All tests passed in shard 0.
```

The original 398-shape downstream tuning workload was not re-run. These tests
establish the isolated repeated-init leak and validate the native fix, without
claiming that the leak was the sole cause of the historical tuning OOM.

No gfx942 or gfx950 hardware was available locally, so no results on those
architectures are claimed here. `op_tests/test_hipblaslt_lifecycle.py` is placed
at the top level of `op_tests/`, which is where `.github/scripts/aiter_test.sh`
collects files with `find op_tests -maxdepth 1 -type f -name "*.py"`, so the
standard per-PR op-test job should exercise it on gfx942 and gfx950 without an
opt-in label. The test is single-GPU by default; the two-device path only runs
when `--other-device` is passed explicitly.

One property of the test is worth a reviewer's judgement: its memory assertions
read absolute free memory with `torch.cuda.mem_get_info()` and allow 16 MiB of
slack. `mem_get_info` is already used by `test_batch_prefill.py`,
`test_gated_delta_rule.py` and `test_moe_2stage.py`, but this test additionally
*asserts* on the delta, so it assumes the GPU is not shared with another process
for its duration. If CI runners can be shared, the tolerance should be raised or
the assertion scoped to the workspace-sized step rather than an absolute delta.

The existing `test_gemm_a16w16.py` also hit gfx90a limitations on both the
baseline and patched builds: shape `(16, 256, 256)` could not select an ASM
kernel, and `(16, 96, 256)` selected a skinny path whose `module_custom` build
uses an FP8 instruction unavailable on gfx90a. Shape `(33, 96, 256)` avoided
those paths but failed because the Triton GEMM default config for gfx90a is
absent. These failures are not counted as passing tests; these paths are not
modified by this patch. Full-suite success is not claimed.

### Testing checklist

- [x] Regression test added under `op_tests/`.
- [x] Patched hipBLASLt module built successfully from source.
- [x] Correctness, memory, lifecycle, and two-device tests passed on MI250.
- [x] Before/after performance measurements completed.
- [ ] Upstream CI on gfx942/gfx950 completed.

## Performance

BF16 GEMM on MI250, using the same shapes and inputs in separate baseline and
patched processes. Six processes were run in A/B/B/A/A/B order. Each process
reported the median of seven HIP-event samples, each timing ten replays of a
64-GEMM graph. The table reports the median of three process medians per variant.
Negative latency change means faster. These small differences do not establish
a speedup or a material GEMM regression.

| M, N, K | Baseline (µs) | Patched (µs) | Latency change |
|---|---:|---:|---:|
| 16, 256, 256 | 4.369 | 4.352 | -0.40% |
| 128, 1024, 1024 | 9.455 | 9.466 | +0.12% |
| 1024, 1024, 1024 | 26.538 | 26.512 | -0.10% |

A complete create/destroy pair measured 220.62 µs before and 214.34 µs after
(median of three process medians, ten cycles per process). These host timings
are noisy and no lifecycle speedup is claimed. The intended improvement is
bounded memory consumption on repeated initialization. Kernel bandwidth and
roofline analysis are not applicable to this resource-lifecycle change.

## Documentation

- [x] Updated create/destroy API docstrings, including synchronization and
  device-change expectations.
- User and performance guides: no changes needed for this lifecycle fix.

## Dependencies

- [x] No new third-party dependencies added.

## Breaking Changes

No Python function signatures change. Direct re-initialization on a different
device while the previous resource set is live now raises `RuntimeError`
instead of replacing and leaking those resources. To move to another device,
synchronize outstanding work, destroy the extension, select the new device,
and initialize again. Same-device repeated initialization and repeated
destruction are now no-ops.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
- [x] Follow AITER's `CONTRIBUTE.md` and prepare the change against `main`.
- [x] Pass applicable local pre-commit, formatting, and lint checks.
- [x] Include regression tests, test results, and applicable benchmarks.
- [x] Document the final lifecycle behavior and compatibility impact.
- [x] Author commits carry the DCO `Signed-off-by` line (`git commit -s`).
- [ ] Required upstream CI checks pass.
