### PR TITLE
[FlyDSL] fix(flydsl): detach tensors before DLPack conversion

### DIFF
--- a/aiter/ops/flydsl/kernels/gemm_a16w16_gfx950.py
+++ b/aiter/ops/flydsl/kernels/gemm_a16w16_gfx950.py
@@ -1390,7 +1390,9 @@ def get_split_k_buffers(stream, device):
 
 
 def _dynamic_tensor_arg(tensor, leading_dim):
-    return flyc.from_dlpack(tensor.detach()).mark_layout_dynamic(leading_dim=leading_dim)
+    return flyc.from_dlpack(tensor.detach()).mark_layout_dynamic(
+        leading_dim=leading_dim
+    )
 
 
 def gemm_a16w16(

--- a/aiter/ops/flydsl/kernels/gemm_a16w16_gfx950.py
+++ b/aiter/ops/flydsl/kernels/gemm_a16w16_gfx950.py
@@ -1390,7 +1390,7 @@ def get_split_k_buffers(stream, device):
 
 
 def _dynamic_tensor_arg(tensor, leading_dim):
-    return flyc.from_dlpack(tensor).mark_layout_dynamic(leading_dim=leading_dim)
+    return flyc.from_dlpack(tensor.detach()).mark_layout_dynamic(leading_dim=leading_dim)
 
 
 def gemm_a16w16(


### PR DESCRIPTION
**Description**
```text
Detach input tensors in `_dynamic_tensor_arg` before converting them
via `flyc.from_dlpack` for FlyDSL.

This avoids DLPack export errors for tensors with `requires_grad=True`
while preserving shared storage and dynamic layout behavior.
```
