### PR TITLE
[HIP] [OPUS] fix: single-source opus's half-precision dtype spellings

### DIFF
--- a/csrc/include/opus/dtypes.hpp
+++ b/csrc/include/opus/dtypes.hpp
@@ -1,0 +1,37 @@
+/***************************************************************************************************
+ * OPUS, AI (O)(P)erator Micro(U) (S)TD
+ *
+ * MIT License
+ * Copyright (C) 2025-2026 carlus.huang@amd.com
+ *
+ **************************************************************************************************/
+#pragma once
+
+// Scalar spellings of the half-precision types opus registers as dtypes.
+//
+// This is the single source of truth: opus.hpp feeds these to REGISTER_DTYPE,
+// and headers that need the spellings in a translation unit that deliberately
+// does not pull in all of opus.hpp alias them from here. Hardcoding __fp16 or
+// _Float16 anywhere else silently breaks opus::cast on the compilers where the
+// two differ.
+//
+// clang>=24 types the half operands of the fp16 matrix-core builtins
+// (wmma_*_f16, mfma_*f16) and of raw_ptr_buffer_atomic_fadd_v2f16 as _Float16,
+// and an __fp16 ext_vector no longer converts to a _Float16 one. Keeping
+// __fp16 on clang 20-23 preserves their fp32-intermediate fp16 fma
+// (v_fma_mixlo_f16) rather than shifting to a native half fma (v_fma_f16).
+
+namespace opus::dtypes {
+
+#if __clang_major__ >= 24
+using bf16 = __bf16;
+using fp16 = _Float16;
+#elif __clang_major__ >= 20   // enable for rocm 7.0+
+using bf16 = __bf16;
+using fp16 = __fp16;
+#else
+using bf16 = unsigned short;
+using fp16 = _Float16;
+#endif
+
+} // namespace opus::dtypes

--- a/csrc/include/opus/opus.hpp
+++ b/csrc/include/opus/opus.hpp
@@ -13,6 +13,8 @@
 #include <type_traits>
 #include <utility>
 
+#include "dtypes.hpp"
+
 #ifndef OPUS_ENABLE_RUNTIME_QUERY
 #define OPUS_ENABLE_RUNTIME_QUERY 0
 #endif
@@ -1007,17 +1009,8 @@ template<typename T> struct is_dtype : false_type {};
 template<typename T> constexpr bool is_dtype_v = is_dtype<remove_cvref_t<T>>::value;    // use this!
 
 REGISTER_DTYPE(fp32, float)
-// clang>=24 types the half operands of the fp16 matrix-core builtins (wmma_*_f16, mfma_*f16) and of raw_ptr_buffer_atomic_fadd_v2f16 as _Float16, and an __fp16 ext_vector no longer converts to a _Float16 one -- every fp16 mfma/wmma dispatch below is a hard error under __fp16 there. _Float16 is what opus used before clang 20 and what ck_tile still uses; the cost of respelling it is that arithmetic on fp16_t becomes a native half fma (v_fma_f16) instead of the fp32-intermediate v_fma_mixlo_f16, so keep __fp16 on the older compilers rather than shifting their numerics.
-#if __clang_major__ >= 24
-REGISTER_DTYPE(bf16, __bf16)
-REGISTER_DTYPE(fp16, _Float16)
-#elif __clang_major__ >= 20   // enable for rocm 7.0+
-REGISTER_DTYPE(bf16, __bf16)
-REGISTER_DTYPE(fp16, __fp16)
-#else
-REGISTER_DTYPE(bf16, unsigned short)
-REGISTER_DTYPE(fp16, _Float16)
-#endif
+REGISTER_DTYPE(bf16, dtypes::bf16)
+REGISTER_DTYPE(fp16, dtypes::fp16)
 REGISTER_DTYPE(fp8 , _BitInt(8))
 REGISTER_DTYPE(bf8 , unsigned _BitInt(8))
 REGISTER_DTYPE(i32 , int)

--- a/csrc/include/pa_sparse_prefill_opus.h
+++ b/csrc/include/pa_sparse_prefill_opus.h
@@ -11,6 +11,7 @@
 
 #pragma once
 #include "aiter_tensor.h"
+#include <opus/dtypes.hpp>
 
 // Public API: prefill attention over two CSR ranges (prefix + extend).
 //
@@ -104,8 +105,8 @@ void pa_sparse_prefill_fp8_gfx1250_opus_fwd(aiter_tensor_t& q_nope,
 // Implementation section - only compiled in the .cu translation unit
 // ============================================================================
 
-using bf16_t = __bf16;
-using fp16_t = __fp16;
+using bf16_t = opus::dtypes::bf16;
+using fp16_t = opus::dtypes::fp16;
 // 8-bit float storage types, aliased to match opus's dtype registration.
 using fp8_t  = _BitInt(8);
 using bf8_t  = unsigned _BitInt(8);

--- a/csrc/kernels/mla/opus/defs.h
+++ b/csrc/kernels/mla/opus/defs.h
@@ -2,8 +2,10 @@
 
 #include <algorithm>
 
-using bf16_t = __bf16;
-using fp16_t = __fp16;
+#include <opus/dtypes.hpp>
+
+using bf16_t = opus::dtypes::bf16;
+using fp16_t = opus::dtypes::fp16;
 using fp8_t  = _BitInt(8);
 using bf8_t  = unsigned _BitInt(8);
 


### PR DESCRIPTION
## Problem

`module_pa_sparse_prefill_opus` fails to build on ROCm 10.1 nightly (AMD clang 24.0.0git). The same source builds fine on ROCm 10.0 (AMD clang 23.0.0git).

```
csrc/include/opus/opus.hpp:1498:49: error: no matching function for call to 'cast'
csrc/include/pa_sparse_prefill_opus.h:2083:24: note: in instantiation of function template
      specialization 'opus::cast<__fp16, float __attribute__((ext_vector_type(4))), true>'
      requested here
csrc/include/opus/opus.hpp:1258:1: note: candidate template ignored: requirement
      'std::is_same_v<__fp16, _Float16>' was not satisfied [with D = __fp16]
fatal error: too many errors emitted, stopping now [-ferror-limit=]
```

## Cause

`opus.hpp` already picks the right spelling per compiler — `_Float16` on clang>=24, `__fp16` on clang 20-23 (the latter deliberately, to keep their fp32-intermediate fp16 fma). Any header that hands a `fp16_t` to opus has to agree with that choice.

Two do not — both hardcode `using fp16_t = __fp16`:

- `csrc/include/pa_sparse_prefill_opus.h` — breaks the ROCm 10.1 build today
- `csrc/kernels/mla/opus/defs.h` — same latent break in `module_opus_mla`, not reached yet because the build dies earlier

On clang 20-23 the two spellings coincide, which is why this only surfaces now.

## Fix

Move the conditional into a new `csrc/include/opus/dtypes.hpp` and have everyone read it from there: `opus.hpp` feeds the aliases to `REGISTER_DTYPE`, consumers alias them directly. `opus.hpp` gets 4 lines shorter, each consumer becomes two `using` lines with no `#if` and no comment, and the next compiler bump is one edit instead of one per consumer.

Consumers cannot simply say `opus::fp16_t` the way `csrc/include/rmsnorm.h:14` does: `pa_sparse_prefill_opus.h` includes `<opus/opus.hpp>` only on the gfx950 device pass (line ~494), so the spellings must be available without pulling in the full header. That is what makes a separate, dependency-free `dtypes.hpp` the right shape here.

`fmha_fwd_hd128_bf16_opus_defs.h` and `fmha_fwd_hd192_v128_bf16_opus_defs.h` are left alone: they spell only `bf16_t = __bf16`, which agrees with opus on every clang>=20 branch. They could follow later for consistency.

## Verification

On ROCm 10.1 nightly (AMD clang 24.0.0git), replaying the exact failing `hipcc` command from the build (`--offload-arch=gfx942 --offload-arch=gfx950`):

| | `fp16_t` | result |
|---|---|---|
| before | `__fp16` | `no matching function for call to 'cast'` ×5, no object file |
| after | from `opus::dtypes` | compiles clean, object produced |

That translation unit pulls in `opus.hpp` on the gfx950 device pass, so it covers the `dtypes.hpp` split as well as the consumer change.

A full `PREBUILD_KERNELS=1 GPU_ARCHS='gfx942;gfx950' setup.py develop` on ROCm 10.1 nightly then went all the way through with the patch applied:

```
modules built          121
failed jit builds        0
'no matching function'   0
  module_pa_sparse_prefill_opus   ok (39.2s)
  module_opus_mla                 ok (12.7s)
```

So this was the only thing standing between aiter and clang 24, and `module_opus_mla` does get compiled — its hardcoded `__fp16` would have been the next failure.

Ruled out source drift: `csrc/include/opus/` and `pa_sparse_prefill_opus.*` are byte-identical between `d67211faa` (builds on ROCm 10.0) and `eec768a4` (fails on ROCm 10.1), so the compiler version is the only variable.

The clang 20-23 and pre-20 branches are moved verbatim; CI on this PR covers them (ROCm 7.2.4 wheel builds for py3.10/py3.12, plus OPUS tests on MI300X and MI35X) and is green.
