### PR TITLE
[Triton/Gluon] Fix memory access fault in `batched_gemm_a16wfp4` for `K` not aligned with `BLOCK_SIZE_K`

### DIFF
--- a/aiter/ops/triton/_triton_kernels/gemm/batched/batched_gemm_a16wfp4.py
+++ b/aiter/ops/triton/_triton_kernels/gemm/batched/batched_gemm_a16wfp4.py
@@ -179,17 +179,24 @@ def _batched_gemm_a16wfp4_kernel(
         accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
 
         for k in range(pid_k * num_k_iter, (pid_k + 1) * num_k_iter):
-            b_scales = tl.load(b_scale_ptrs)
             # a_scales = tl.full((BLOCK_SIZE_M, BLOCK_SIZE_K//SCALE_GROUP_SIZE), 127, dtype=tl.uint8)
             # b_scales = tl.full((BLOCK_SIZE_N, BLOCK_SIZE_K//SCALE_GROUP_SIZE), 127, dtype=tl.uint8)
             # Load the next block of A and B, generate a mask by checking the K dimension.
             # If it is out of bounds, set it to 0.
             if EVEN_K:
+                b_scales = tl.load(b_scale_ptrs)
                 a_bf16 = tl.load(a_ptrs)
                 b = tl.load(b_ptrs, cache_modifier=cache_modifier)
             else:
+                remaining_k = 2 * K - k * BLOCK_SIZE_K
+                scale_mask = tl.arange(
+                    0, BLOCK_SIZE_K // SCALE_GROUP_SIZE
+                ) < tl.cdiv(remaining_k, SCALE_GROUP_SIZE)
+                b_scales = tl.load(
+                    b_scale_ptrs, mask=scale_mask[None, :], other=127
+                )
                 a_bf16 = tl.load(
-                    a_ptrs, mask=offs_k_bf16[None, :] < K - k * BLOCK_SIZE_K, other=0
+                    a_ptrs, mask=offs_k_bf16[None, :] < remaining_k, other=0
                 )
                 b = tl.load(
                     b_ptrs, mask=offs_k[:, None] < K - k * (BLOCK_SIZE_K // 2), other=0

--- a/op_tests/triton_tests/gemm/batched/test_batched_gemm_a16wfp4.py
+++ b/op_tests/triton_tests/gemm/batched/test_batched_gemm_a16wfp4.py
@@ -121,6 +121,7 @@ def get_x_vals():
         for m in range(9)
         for (n, k) in [(512, 128), (128, 512)]
     ]
+    x_vals_with_batch.append((2, 3, 5, 192))
     # x_vals_with_batch = [(1, 1, 128, 512+128), ] # TODO check
     return x_vals_with_batch
 


### PR DESCRIPTION
## Disclosure

AI assistance was used. The changes were reviewed and tested manually.

## Purpose

Fix incorrect results and potential out-of-bounds scale reads in `batched_gemm_a16wfp4` when the logical K dimension does not fill `BLOCK_SIZE_K`, such as K=192 with `BLOCK_SIZE_K=256`.

The wrapper passes the packed FP4 weight extent as K to the Triton kernel: https://github.com/ROCm/aiter/blob/e8eac17259db6efcb48eba2aa0d9a3bf422e7b35/aiter/ops/triton/gemm/batched/batched_gemm_a16wfp4.py#L105-L112. One packed FP4 byte represents two BF16 activation elements, so a logical K of 192 is passed to the kernel as K=96.

The uneven-K path incorrectly used packed K directly as the BF16 activation bound: https://github.com/ROCm/aiter/blob/e8eac17259db6efcb48eba2aa0d9a3bf422e7b35/aiter/ops/triton/_triton_kernels/gemm/batched/batched_gemm_a16wfp4.py#L179-L199. For logical K=192, this loaded only activation elements 0-95 and silently omitted elements 96-191, producing incorrect GEMM results.

The same path loaded all `BLOCK_SIZE_K / 32` weight scales without a tail mask. With `BLOCK_SIZE_K=256`, the kernel loaded eight scales even though K=192 has only six scale groups. The final two loads were out of bounds and could cause a GPU memory access fault depending on the surrounding allocation.

## Proposed fix

Correct the mask of:

- `b_scales` (previously unmasked). Mask weight-scale tail loads to the number of remaining 32-element groups and fill inactive lanes with the neutral E8M0 scale.
- `a_bf16` (previously wrong mask). Compute the remaining logical K as twice the remaining packed K and use it to mask BF16 activation loads

Behavior change: partial-K inputs now consume the full BF16 K dimension and avoid out-of-bounds scale reads. The compile-time `EVEN_K` path and public API are unchanged.

## vLLM crash reproduction


vllm at https://github.com/vllm-project/vllm/tree/ffe3bb3c723d9e5e5f5a0c8aeab1d857a4975b8b:

```bash
VLLM_ROCM_USE_AITER_FP4BMM=1 VLLM_ROCM_USE_AITER=1 vllm serve zai-org/GLM-4.7-Flash \
    --tensor-parallel-size 1 \
    --enforce-eager
```

gives with `aiter==0.1.19`:

```
Memory access fault by GPU node-6 (Agent handle: 0x1be862f0) on address 0x7f4fb4e00000. Reason: Unknown.
GPU coredump: execvp failed: No such file or directory
Failed to write segment data to pipe: Broken pipe
GPU coredump: handler exited with error (status: 1)
GPU core dump failed
```

fixed with this PR.

## Test Plan

```bash
HIP_VISIBLE_DEVICES=6 HIP_LAUNCH_BLOCKING=1 python -m pytest op_tests/triton_tests/gemm/batched/test_batched_gemm_a16wfp4.py -k "192" -v
```

## Test Results

`8 passed, 2305 deselected in 7.79s` on MI350.
