### PR TITLE
[Triton/Gluon] [tune][gfx1100]

### DIFF
--- a/aiter/ops/triton/attention/unified_attention.py
+++ b/aiter/ops/triton/attention/unified_attention.py
@@ -120,10 +120,18 @@ def use_2d_kernel(params: _UAParams):
     if params.head_size >= 512 and not get_arch().is_rdna and not params.all_decode:
         return True
 
+    gate = params.target_num_prgms
+    if get_arch().is_rdna:
+        # on RDNA the 3D split-KV kernel only pays off while the 2D launch is too
+        # small to fill the machine; past that the extra segment traffic and the
+        # reduce pass cost more than the added parallelism. On gfx1100 the
+        # crossover sits at cu_count/4, i.e. target_num_prgms (cu_count*4) // 16.
+        gate = params.target_num_prgms // 16
+
     return (
         (params.sliding_window > 0)
         or (params.max_seqlen_k <= 512)
-        or (params.num_2d_prgms > params.target_num_prgms)
+        or (params.num_2d_prgms > gate)
     )
 
 

--- a/aiter/ops/triton/configs/gfx1100/triton/attention/unified_attention/DEFAULT.json
+++ b/aiter/ops/triton/configs/gfx1100/triton/attention/unified_attention/DEFAULT.json
@@ -30,8 +30,8 @@
       "num_warps": 4,
       "num_stages": 1,
       "waves_per_eu": 6,
-      "TILE_SIZE_MIN": 16,
-      "TILE_SIZE_MAX": 16
+      "TILE_SIZE_MIN": 32,
+      "TILE_SIZE_MAX": 32
     },
     "Q_LEQ_1": {
       "BLOCK_M": 16,
@@ -39,7 +39,7 @@
       "num_stages": 1,
       "waves_per_eu": 6,
       "TILE_SIZE_MIN": 1,
-      "TILE_SIZE_MAX": 64
+      "TILE_SIZE_MAX": 32
     },
     "DT_fp8_fp8": {
       "BLOCK_M": 16,
@@ -54,14 +54,14 @@
       "num_warps": 2,
       "num_stages": 1,
       "waves_per_eu": 6,
-      "TILE_SIZE_MIN": 16,
-      "TILE_SIZE_MAX": 16
+      "TILE_SIZE_MIN": 32,
+      "TILE_SIZE_MAX": 32
     }
   },
   "attn_3d": {
     "BLOCK_M": 16,
-    "num_warps": 2,
-    "num_stages": 2,
+    "num_warps": 8,
+    "num_stages": 1,
     "waves_per_eu": 2
   },
   "reduce": {


### PR DESCRIPTION
- attn_2d prefill and chunked prefill: TILE_SIZE 16 -> 32, matching gfx1201.
- attn_2d decode: TILE_SIZE_MAX 64 -> 32. Also a correctness fix -- at head_size=256 / block_size=64 a 64-wide tile overruns gfx1100's 64 KB LDS and aborts with triton OutOfResources.
- attn_3d: num_warps 2 -> 8, num_stages 2 -> 1. The split-KV kernel is latency-bound on the paged KV gather, so a wider workgroup pays.
- use_2d_kernel(): on RDNA, switch to 2D at target_num_prgms // 16; the 3D kernel only helps while the 2D launch cannot fill the machine.

Test Models (1 GPU, W7900): granite-4.1-8b, Qwen3-4B, Olmo-3-7B-Instruct,
     Meta-Llama-3-8B-Instruct
