### PR TITLE
[HIP] [Bugfix] Fix gfx90a module_custom builds by guarding FP8 MFMA kernels

### DIFF
--- a/csrc/kernels/custom_kernels.cu
+++ b/csrc/kernels/custom_kernels.cu
@@ -30,6 +30,11 @@
 #define __HIP__MI350_MI300_MI250__
 #endif
 
+// FP8 MFMA is available on MI300/MI350, but not on MI250.
+#if defined(__HIPCC__) && (defined(__gfx942__) || defined(__gfx950__))
+#define __HIP__MI350_MI300__
+#endif
+
 #if defined(NDEBUG)
 #undef NDEBUG
 #include <assert.h>
@@ -1769,7 +1774,7 @@ void wvSplitK_(void* in_a,
     });
 }
 
-#if defined(__HIP__MI350_MI300_MI250__) // TODO: Add NAVI support
+#if defined(__HIP__MI350_MI300__) // TODO: Add NAVI support
 template <typename scalar_t,
           typename fp8_t,
           int THRDS,
@@ -1966,7 +1971,7 @@ __global__ void __launch_bounds__(WvPrGrp* THRDS) wvSplitKQ_hf_sml_(const int K,
         m += CuCount * _WvPrGrp * YTILE;
     }
 }
-#else  // !defined(__HIP__MI350_MI300_MI250__) TODO: Add NAVI support
+#else  // !defined(__HIP__MI350_MI300__) TODO: Add NAVI support
 template <typename scalar_t,
           typename fp8_t,
           int THRDS,
@@ -1988,9 +1993,9 @@ __global__ void wvSplitKQ_hf_sml_(const int K,
 {
     UNREACHABLE_CODE
 }
-#endif // defined(__HIP__MI350_MI300_MI250__) TODO: Add NAVI support
+#endif // defined(__HIP__MI350_MI300__) TODO: Add NAVI support
 
-#if defined(__HIP__MI350_MI300_MI250__) // TODO: Add NAVI support
+#if defined(__HIP__MI350_MI300__) // TODO: Add NAVI support
 template <typename scalar_t,
           typename fp8_t,
           int THRDS,
@@ -2183,7 +2188,7 @@ __global__ void __launch_bounds__(WvPrGrp* THRDS) wvSplitKQ_hf_(const int K,
         m += CuCount * _WvPrGrp * YTILE;
     }
 }
-#else  // !defined(__HIP__MI350_MI300_MI250__) TODO: Add NAVI support
+#else  // !defined(__HIP__MI350_MI300__) TODO: Add NAVI support
 template <typename scalar_t,
           typename fp8_t,
           int THRDS,
@@ -2205,7 +2210,7 @@ __global__ void wvSplitKQ_hf_(const int K,
 {
     UNREACHABLE_CODE
 }
-#endif // defined(__HIP__MI350_MI300_MI250__) TODO: Add NAVI support
+#endif // defined(__HIP__MI350_MI300__) TODO: Add NAVI support
 
 void wvSplitKQ_(void* in_a,
                 void* in_b,

--- a/op_tests/test_custom_gemm_arch.py
+++ b/op_tests/test_custom_gemm_arch.py
@@ -1,0 +1,52 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2026, Advanced Micro Devices, Inc. All rights reserved.
+
+"""Check that FP8 kernels do not prevent supported FP16/BF16 custom GEMMs."""
+
+import argparse
+
+import torch
+
+import aiter
+from aiter.jit.utils.chip_info import get_cu_num, get_gfx_runtime
+from aiter.test_common import checkAllclose, perftest
+
+
+@perftest(num_iters=50, num_rotate_args=1, use_cuda_event=True)
+def benchmark_custom(
+    weight: torch.Tensor, x: torch.Tensor, out: torch.Tensor, cu_num: int
+) -> torch.Tensor:
+    aiter.wv_splitk_small_fp16_bf16(weight, x, out, x.shape[0], cu_num)
+    return out
+
+
+def test_custom_gemm(dtype: torch.dtype, m: int, n: int, k: int, timing: bool) -> None:
+    x = torch.randint(-1, 2, (m, k), device="cuda").to(dtype)
+    weight = torch.randint(-1, 2, (n, k), device="cuda").to(dtype)
+    out = torch.full((m, n), float("nan"), device="cuda", dtype=dtype)
+    ref = (x.float() @ weight.float().t()).to(dtype)
+    # All entry points share module_custom, including the unrelated FP8 kernels.
+    # Use the supported 16-bit entry point directly, without tuned CSV dispatch.
+    aiter.wv_splitk_small_fp16_bf16(weight, x, out, m, get_cu_num())
+    torch.cuda.synchronize()
+    error = checkAllclose(ref, out, rtol=0, atol=0, printLog=False)
+    assert error == 0, f"Incorrect custom GEMM: {dtype}, {(m, n, k)}, {error=}"
+    print(f"PASS {dtype} {(m, n, k)}", flush=True)
+    if timing:
+        _, latency = benchmark_custom(weight, x, out, get_cu_num())
+        print(f"BENCH {dtype} {(m, n, k)}: {latency:.3f} us", flush=True)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--benchmark", action="store_true")
+    args = parser.parse_args()
+    gfx = get_gfx_runtime()
+    if gfx not in ("gfx90a", "gfx942", "gfx950"):
+        print(f"SKIP: custom 16-bit GEMM kernels are not supported on {gfx}")
+    else:
+        torch.manual_seed(42)
+        for dtype in (torch.float16, torch.bfloat16):
+            for shape in ((16, 96, 256), (1, 128, 256), (4, 96, 512), (8, 96, 5120)):
+                test_custom_gemm(dtype, *shape, timing=args.benchmark)
+        print(f"custom GEMM architecture regression: PASS ({gfx})", flush=True)


### PR DESCRIPTION
## Summary

Related to #4389. cc @rlrs. This PR overlaps with its FP8 architecture guard fix
and adds a standalone regression and hardware/build validation.

Exclude gfx90a from the two FP8 MFMA kernel implementations in `module_custom`,
so supported FP16/BF16 custom GEMMs can compile and run on MI250. Keep their
existing gfx942/gfx950 implementations and the gfx90a FP16/BF16 kernels enabled.

## Motivation

A valid FP16/BF16 call to `wv_splitk_small_fp16_bf16()` triggers a JIT build of
`module_custom`, which also contains FP8 kernels. Those kernels currently use
`__HIP__MI350_MI300_MI250__`, a guard that includes gfx90a, even though their
`__builtin_amdgcn_mfma_f32_32x32x16_fp8_fp8` calls require `fp8-insts`.

The complete module fails to compile on gfx90a, even when the caller does not
use FP8. This also blocks `aiter.tuned_gemm.tgemm.mm()` when it selects the
affected skinny GEMM path. The failure reproduces directly in AITER without
vLLM or downstream capture patches.

Baseline diagnostic, from both FP8 kernel implementations:

```text
custom_kernels.cu:1892:41: error: '__builtin_amdgcn_mfma_f32_32x32x16_fp8_fp8' needs target feature fp8-insts
custom_kernels.cu:2107:41: error: '__builtin_amdgcn_mfma_f32_32x32x16_fp8_fp8' needs target feature fp8-insts
```

This is independent of #5325, which addresses hipBLASLt resource lifecycle.
This patch is based directly on main and does not require that PR.

### Related work

[PR #4389 by @rlrs](https://github.com/ROCm/aiter/pull/4389) already addresses
this same guard bug as part of a broader gfx90a fix covering OPUS and
all-reduce as well. Its `__HIP__FP8_MFMA__` guard and this PR's
`__HIP__MI350_MI300__` guard select the same targets and protect the same two
kernel implementations. This is not a distinct discovery or a new fix beyond
that guard change. This PR supplies a narrower patch with a standalone
regression, MI250 execution checks, and gfx942/gfx950 build validation.

## Changes

- Add a gfx942/gfx950-only guard, `__HIP__MI350_MI300__`, with a comment explaining
  why FP8 MFMA excludes MI250.
- Apply it to `wvSplitKQ_hf_sml_` and `wvSplitKQ_hf_`, including their corresponding
  conditional comments.
- Preserve the gfx90a-inclusive guard for the four other kernel implementations.
- Add `op_tests/test_custom_gemm_arch.py`, a standalone regression exercising
  FP16/BF16 custom GEMM directly, with optional benchmarks using `@perftest()`.

No kernel arithmetic, launch configuration, or Python signature changes.
On gfx90a the two FP8 kernels now use the existing unsupported-architecture
stubs. This does not add FP8 emulation or make `wvSplitKQ()` supported on MI250;
those stubs assert if executed. The fix restores supported 16-bit operations
that previously could not build because they share the module with FP8 code.

## Testing

Base: `eec768a47c1da52e175f9089c640e695f8b572a3`.
Environment: MI250/gfx90a, Python 3.12, PyTorch `2.11.0+gitd0c8b1f`,
`torch.version.hip=7.2.53211`. Builds use separate source trees and initially
empty JIT caches for each variant/target, with `GPU_ARCHS` set explicitly.
The installed AITER package was not modified.

### Commands

```bash
# From the source checkout, on an idle visible MI250 device:
PYTHONPATH="$PWD" GPU_ARCHS=gfx90a AITER_JIT_DIR=/tmp/aiter-fp8-regression \
    python op_tests/test_custom_gemm_arch.py

# Optional timing using AITER's benchmark helper:
PYTHONPATH="$PWD" GPU_ARCHS=gfx90a AITER_JIT_DIR=/tmp/aiter-fp8-regression \
    python op_tests/test_custom_gemm_arch.py --benchmark

# Run the new regression through the repository CI driver:
PYTHONPATH="$PWD" GPU_ARCHS=gfx90a AITER_JIT_DIR=/tmp/aiter-fp8-regression \
    AITER_TEST=op_tests/test_custom_gemm_arch.py bash .github/scripts/aiter_test.sh
```

To reproduce the baseline failure, copy only the test into the unmodified base
and use a different empty `AITER_JIT_DIR`. The first test case triggers the
complete `module_custom` build through the supported 16-bit entry point.

### Results

| Check | Baseline | Patched |
|---|---|---|
| Complete module_custom JIT build, gfx90a | FAIL: missing fp8-insts | PASS |
| Direct FP16/BF16 custom GEMM, four shapes per dtype | Blocked by build failure | PASS, all eight cases |
| tgemm.mm, FP16/BF16, bias/no bias, shape (16, 96, 256) | Affected path cannot build | PASS, all four cases |
| New regression via AITER CI driver on MI250 | — | PASS |
| Complete module_custom build targeting gfx942 | PASS | PASS |
| Complete module_custom build targeting gfx950 | PASS | PASS |

The gfx942/gfx950 rows are **cross-compilation**, not execution on those GPUs.
The build helper does not load or launch those modules on the gfx90a host.
Device preprocessing with the JIT compiler flags also verifies that the two
FP8 MFMA bodies are removed only on gfx90a:

| Device target | FP8 MFMA bodies before | FP8 MFMA bodies after |
|---|---:|---:|
| gfx90a | 2 | 0 |
| gfx942 | 2 | 2 |
| gfx950 | 2 | 2 |

The numerical regression uses integer inputs in `[-1, 1]`, compares against an
FP32 accumulation reference cast to the output dtype, and asserts zero
mismatches with `checkAllclose(rtol=0, atol=0)`. Shapes are `(M, N, K)`:
`(16, 96, 256)`, `(1, 128, 256)`, `(4, 96, 512)`, and `(8, 96, 5120)`.

The test is collected from the top level of `op_tests/`. It runs on gfx90a,
gfx942, and gfx950, and explicitly skips other architectures where these
custom 16-bit kernels have no implementation. No runtime results on gfx942 or
gfx950 are claimed locally; those are left to upstream CI.

- [x] Standalone regression test added, with CLI and explicit pass/fail checks.
- [x] Source build and correctness verified on MI250.
- [x] gfx942/gfx950 cross-compilation and device preprocessing checked.
- [x] Benchmark run using `@perftest()`.
- [x] Repository pre-commit, Black, Ruff, changed C++ formatting, and whitespace checks passed.
- [ ] Runtime checks on gfx942/gfx950 completed by upstream CI.

## Performance

The baseline does not build on gfx90a, so it has no usable latency to compare
against. This is a build/correctness fix; no percentage speedup is claimed.
For a timing smoke test, `@perftest(num_iters=50, num_rotate_args=1,
use_cuda_event=True)` reports these mean HIP-event times on the patched MI250
build. Single-call event timing can include submission gaps and is not a
measurement of peak kernel throughput.

| M, N, K | Baseline | Patched FP16 (µs) | Patched BF16 (µs) |
|---|---|---:|---:|
| 16, 96, 256 | Compile failure | 35.171 | 33.645 |
| 1, 128, 256 | Compile failure | 35.033 | 33.667 |
| 4, 96, 512 | Compile failure | 34.147 | 33.776 |
| 8, 96, 5120 | Compile failure | 36.688 | 39.145 |

Bandwidth/roofline optimization is outside this change: the existing kernel
bodies and memory access patterns are unchanged.

## Documentation

- [x] Added an architecture-capability comment next to the new guard.
- No API or user-guide changes required; this does not add supported FP8 hardware.

## Dependencies

- [x] No new third-party dependencies.

## Breaking Changes

None for supported calls. FP8 custom GEMM remains unsupported on gfx90a.

## Submission Checklist

- [x] Reviewed AITER's CONTRIBUTE.md and ROCm contribution guidance.
- [x] Descriptive `[Bugfix]` title; component tags may be added by the repo bot.
- [x] Relevant tests, reproducible compiler failure, successful build logs, and timing results included.
- [x] Formatting/lint checks completed for the patch.
- [x] Author commits signed off under the DCO (`git commit -s`).
- [ ] Required upstream CI checks and maintainer review completed.
