### PR TITLE
[FlyDSL] [Feature] Precompile only the GEMM kernels the wheel is built for

### DIFF
--- a/aiter/aot/flydsl/README.md
+++ b/aiter/aot/flydsl/README.md
@@ -79,14 +79,17 @@ python -m aiter.aot.flydsl.chunk_gdn_h --csv /path/to/tuned.csv
 | `AITER_FLYDSL_AOT_TIMEOUT` | Per-kernel wall-clock cap (seconds). A worker stuck *alive* past this is killed (and retried); `0` disables. | `1200` |
 | `AITER_FLYDSL_AOT_MAX_RETRIES` | Retries for a worker that **died abnormally** (OOM-kill / segfault / timeout-kill). A clean compile error is never retried. `0` disables. | `2` |
 | `AITER_CONFIGS` | Resolves the default CSV lookup path (same as the runtime JIT) | repo built-in |
-| `ARCH` / `GPU_ARCHS` | **Banner/logging only** — printed as the "Target arch" line. Does **not** control the compiled target. | auto-detect |
+| `AITER_GPU_TARGETS` / `ARCH` / `GPU_ARCHS` | Filter **GEMM** AOT jobs by target; other kinds are unfiltered. The first one set wins, in that order. Unset builds every job. | unset |
 
-> **About the compile target arch.** The arch each kernel is actually compiled
-> for is derived per-job from the CSV's `cu_num` column (`cu_num_to_arch(...)`)
-> and applied internally via `FLYDSL_GPU_ARCH`. That internal var is overwritten
-> for every job, so setting `ARCH` / `GPU_ARCHS` / `FLYDSL_GPU_ARCH` in your shell
-> does **not** change what gets built. To cross-compile, edit the `cu_num`
-> column in the CSV.
+> **Compile target.** Each job is compiled for the arch in its `gfx` field, or
+> from the CSV `cu_num` via `cu_num_to_arch(...)` when `gfx` is empty. AOT
+> applies that through `FLYDSL_GPU_ARCH` and overwrites it per job, so setting
+> `FLYDSL_GPU_ARCH` in the shell does not change what gets built.
+
+`AITER_GPU_TARGETS=gfx950:128` is the exact `(gfx, cu_num)` form on both
+paths. `ARCH` always selects every GEMM job of that arch. `GPU_ARCHS` does
+that on the CLI (`CU_NUM` is ignored); packaging (`setup.py`) pairs it with
+`CU_NUM` into exact SKU pairs instead.
 
 Example:
 

--- a/aiter/aot/flydsl/README.md
+++ b/aiter/aot/flydsl/README.md
@@ -87,9 +87,10 @@ python -m aiter.aot.flydsl.chunk_gdn_h --csv /path/to/tuned.csv
 > `FLYDSL_GPU_ARCH` in the shell does not change what gets built.
 
 `AITER_GPU_TARGETS=gfx950:128` is the exact `(gfx, cu_num)` form on both
-paths. `ARCH` always selects every GEMM job of that arch. `GPU_ARCHS` does
-that on the CLI (`CU_NUM` is ignored); packaging (`setup.py`) pairs it with
-`CU_NUM` into exact SKU pairs instead.
+paths. The other two differ by path. Running `python -m aiter.aot.flydsl.gemm`
+directly, `ARCH` selects every GEMM job of that arch and `GPU_ARCHS` does the
+same (`CU_NUM` is ignored); packaging (`setup.py`) reads no `ARCH` and pairs
+`GPU_ARCHS` with `CU_NUM` into exact SKU pairs instead.
 
 Example:
 

--- a/aiter/aot/flydsl/common.py
+++ b/aiter/aot/flydsl/common.py
@@ -134,7 +134,7 @@ def override_env(var_name: str, value: str | None) -> Iterator[None]:
 def _filter_collected_aot_jobs(
     kind: OpKind, jobs: list[dict[str, Any]]
 ) -> list[dict[str, Any]]:
-    # GEMM only: parse_csv for the others keep just one of gfx/cu_num, 
+    # GEMM only: parse_csv for the others keep just one of gfx/cu_num,
     # so a (gfx, cu_num) filter would drop all of them.
     if kind is OpKind.GEMM:
         from .gemm import filter_jobs_for_build_targets

--- a/aiter/aot/flydsl/common.py
+++ b/aiter/aot/flydsl/common.py
@@ -131,6 +131,18 @@ def override_env(var_name: str, value: str | None) -> Iterator[None]:
             os.environ[var_name] = prev
 
 
+def _filter_collected_aot_jobs(
+    kind: OpKind, jobs: list[dict[str, Any]]
+) -> list[dict[str, Any]]:
+    # GEMM only: the other kinds record half a target each, cu_num without gfx
+    # or gfx without cu_num, so a (gfx, cu_num) filter would drop all of them.
+    if kind is OpKind.GEMM:
+        from .gemm import filter_jobs_for_build_targets
+
+        return filter_jobs_for_build_targets(jobs)
+    return jobs
+
+
 def _collect_aot_jobs_for(kind: OpKind) -> list[dict[str, Any]]:
     """Load DEFAULT_CSVS + parse_csv for the named kind and return its
     job list. Note: importing .gemm / .moe / .chunk_gdn_h here also
@@ -153,7 +165,8 @@ def _collect_aot_jobs_for(kind: OpKind) -> list[dict[str, Any]]:
         from .chunk_gdn_h import DEFAULT_CSVS, parse_csv
     else:
         raise ValueError(f"unknown FlyDSL AOT kind: {kind!r}")
-    return collect_aot_jobs(DEFAULT_CSVS, parse_csv)
+    jobs = collect_aot_jobs(DEFAULT_CSVS, parse_csv)
+    return _filter_collected_aot_jobs(kind, jobs)
 
 
 def _compile_one_config_for(kind: OpKind) -> Callable[..., dict[str, Any]]:

--- a/aiter/aot/flydsl/common.py
+++ b/aiter/aot/flydsl/common.py
@@ -134,8 +134,8 @@ def override_env(var_name: str, value: str | None) -> Iterator[None]:
 def _filter_collected_aot_jobs(
     kind: OpKind, jobs: list[dict[str, Any]]
 ) -> list[dict[str, Any]]:
-    # GEMM only: the other kinds record half a target each, cu_num without gfx
-    # or gfx without cu_num, so a (gfx, cu_num) filter would drop all of them.
+    # GEMM only: parse_csv for the others keep just one of gfx/cu_num, 
+    # so a (gfx, cu_num) filter would drop all of them.
     if kind is OpKind.GEMM:
         from .gemm import filter_jobs_for_build_targets
 

--- a/aiter/aot/flydsl/gemm.py
+++ b/aiter/aot/flydsl/gemm.py
@@ -27,7 +27,10 @@ Usage:
 
 Environment variables:
     FLYDSL_RUNTIME_CACHE_DIR  Cache directory (default: ~/.flydsl/cache)
-    GPU_ARCHS / ARCH          Target GPU architecture information for logging.
+    AITER_GPU_TARGETS         ';'/','-separated 'gfx' or 'gfx:cu_num' build
+                              targets; missing pairs retain runtime fallback.
+    GPU_ARCHS                 Legacy arch-wide filter.
+    ARCH                      Legacy bare-arch filter.
 """
 
 from __future__ import annotations
@@ -52,6 +55,8 @@ from aiter.aot.flydsl.common import (
     run_jobs_parallel,
 )
 from aiter.jit.core import AITER_CONFIGS
+from aiter.jit.utils.build_targets import KNOWN_GFX, _parse_gpu_targets_env
+from aiter.jit.utils.chip_info import get_gfx_runtime
 from aiter.ops.flydsl.bpreshuffle_gemm_gfx1250 import (
     parse_wmma_kernel_name as parse_ptpc_wmma_kernel_name,
 )
@@ -180,7 +185,7 @@ def parse_csv(csv_path: str):
             m = int(row["M"])
             n = int(row["N"])
             k = int(row["K"])
-            cu_num = int(row.get("cu_num", "0"))
+            cu_num = int(row.get("cu_num") or 0)
             gfx = row.get("gfx", "").strip()
 
             if kernel_name.startswith("flydsl_bpreshuflle_"):
@@ -654,6 +659,113 @@ def job_arch(cu_num: int = 0, gfx: str = "") -> str:
     return gfx or cu_num_to_arch(cu_num, default=GEMM_AOT_ARCH_DEFAULT)
 
 
+def _job_target(job: dict) -> tuple[str, int]:
+    gfx = str(job.get("gfx") or "").strip().lower()
+    cu_num = int(job.get("cu_num") or 0)
+    return gfx or job_arch(cu_num), cu_num
+
+
+def _legacy_cu_nums(jobs: list[dict]) -> list[int]:
+    return sorted(
+        {
+            int(job.get("cu_num") or 0)
+            for job in jobs
+            if not str(job.get("gfx") or "").strip()
+        }
+    )
+
+
+def _select_for_targets(
+    jobs: list[dict], targets: list[tuple[str, int]]
+) -> tuple[list[dict], list[str]]:
+    """Jobs matching any target, and the targets nothing matched."""
+    wanted = set(targets)
+    selected: list[dict] = []
+    covered: set[tuple[str, int]] = set()
+    for job in jobs:
+        gfx, cu_num = _job_target(job)
+        # cu_num 0 means no count was recorded, so the row stays in for
+        # every target of its arch.
+        hits = {t for t in wanted if t[0] == gfx and (t[1] == cu_num or cu_num == 0)}
+        if hits:
+            selected.append(job)
+            covered |= hits
+    return selected, [f"{gfx}:{cu}" for gfx, cu in sorted(wanted - covered)]
+
+
+def _select_for_archs(
+    jobs: list[dict], archs: set[str]
+) -> tuple[list[dict], list[str]]:
+    """Jobs whose arch was requested, and the arches nothing matched."""
+    selected = [job for job in jobs if _job_target(job)[0] in archs]
+    present = {_job_target(job)[0] for job in selected}
+    return selected, sorted(archs - present)
+
+
+def _warn_legacy_rows(jobs: list[dict]) -> None:
+    for cu_num in _legacy_cu_nums(jobs):
+        # Inferring the arch from a CU count is ambiguous for arches sharing one.
+        print(
+            f"  [WARN] FlyDSL GEMM row has no gfx; inferring {job_arch(cu_num)} "
+            f"from legacy cu_num={cu_num}. Re-run the tuner to record gfx."
+        )
+
+
+def _warn_unmatched(missing: list[str]) -> None:
+    if missing:
+        print(
+            f"  [WARN] The configured GEMM CSVs have no FlyDSL GEMM jobs for "
+            f"{', '.join(missing)}; those targets will use their existing "
+            "runtime fallback."
+        )
+
+
+def _archs_from_env(value: str) -> set[str]:
+    """Arch names in an ARCH/GPU_ARCHS value. Raises ValueError on a bad one."""
+    archs = {a.strip().lower() for a in re.split(r"[;,]", value) if a.strip()}
+    if not archs:
+        raise ValueError("contains no valid architecture names")
+    if "native" in archs:
+        if len(archs) != 1:
+            raise ValueError("'native' cannot be combined with other targets")
+        archs = {get_gfx_runtime()}
+    unknown = archs - KNOWN_GFX
+    if unknown:
+        raise ValueError(f"contains unknown target(s): {sorted(unknown)}")
+    return archs
+
+
+def active_target_env() -> tuple[str, str] | None:
+    """The env var driving target selection, and its value."""
+    for var_name in ("AITER_GPU_TARGETS", "ARCH", "GPU_ARCHS"):
+        value = (os.environ.get(var_name) or "").strip()
+        if value:
+            return var_name, value
+    return None
+
+
+def filter_jobs_for_build_targets(jobs: list[dict]) -> list[dict]:
+    """Apply the same target selection to CLI and packaging AOT paths."""
+    active = active_target_env()
+    if active is None:
+        return jobs
+    var_name, value = active
+    if var_name == "AITER_GPU_TARGETS":
+        # Not get_build_targets_env: it folds GPU_ARCHS in, and the two are
+        # separate contracts here.
+        selected, missing = _select_for_targets(jobs, _parse_gpu_targets_env())
+    else:
+        # ARCH and GPU_ARCHS stay arch-wide, including when CU_NUM is set.
+        try:
+            archs = _archs_from_env(value)
+        except ValueError as e:
+            raise RuntimeError(f"{var_name} {e}.") from None
+        selected, missing = _select_for_archs(jobs, archs)
+    _warn_legacy_rows(jobs)
+    _warn_unmatched(missing)
+    return selected
+
+
 def compile_one_config(
     kernel_name: str,
     kind: str,
@@ -736,17 +848,17 @@ def main():
     cache_dir = os.path.expanduser(
         os.environ.get("FLYDSL_RUNTIME_CACHE_DIR", "~/.flydsl/cache")
     )
-    arch = os.environ.get("ARCH") or os.environ.get("GPU_ARCHS")
-
     all_jobs = collect_aot_jobs(csv_paths, parse_csv)
-    if arch:
-        # GPU_ARCHS may be a ';'- or ','-separated list (e.g. "gfx942;gfx950").
-        arch_set = {a.strip() for a in re.split(r"[;,]", arch) if a.strip()}
-        n_before = len(all_jobs)
-        all_jobs = [
-            j for j in all_jobs if job_arch(j["cu_num"], j.get("gfx", "")) in arch_set
-        ]
-        print(f"[aiter] ARCH={arch}: {len(all_jobs)}/{n_before} jobs match")
+    n_before = len(all_jobs)
+    try:
+        all_jobs = filter_jobs_for_build_targets(all_jobs)
+    except RuntimeError as e:
+        print(f"Error: {e}")
+        sys.exit(1)
+    active = active_target_env()
+    target_spec = active[1] if active else ""
+    if target_spec:
+        print(f"[aiter] targets={target_spec}: {len(all_jobs)}/{n_before} jobs match")
 
     hgemm_jobs = [j for j in all_jobs if j["kind"] == "hgemm"]
     preshuffle_jobs = [j for j in all_jobs if j["kind"] == "preshuffle"]
@@ -766,7 +878,7 @@ def main():
     print(f"  PTPC wmma jobs:   {len(ptpc_wmma_jobs)}")
     print(f"  Total jobs:       {len(all_jobs)}")
     print(f"  Cache dir:        {cache_dir}")
-    print(f"  Target arch:      {arch or '(all archs found in CSVs)'}")
+    print(f"  Target arch:      {target_spec or '(all archs found in CSVs)'}")
     print("=" * 72)
 
     total_t0 = time.time()

--- a/aiter/aot/flydsl/gemm.py
+++ b/aiter/aot/flydsl/gemm.py
@@ -29,7 +29,9 @@ Environment variables:
     FLYDSL_RUNTIME_CACHE_DIR  Cache directory (default: ~/.flydsl/cache)
     AITER_GPU_TARGETS         ';'/','-separated 'gfx' or 'gfx:cu_num' build
                               targets; missing pairs retain runtime fallback.
-    GPU_ARCHS                 Legacy arch-wide filter.
+    GPU_ARCHS                 Arch list. Packaging resolves it with CU_NUM into
+                              exact targets; the CLI keeps every job of that arch.
+    CU_NUM                    Compute-unit count paired with GPU_ARCHS.
     ARCH                      Legacy bare-arch filter.
 """
 
@@ -55,7 +57,11 @@ from aiter.aot.flydsl.common import (
     run_jobs_parallel,
 )
 from aiter.jit.core import AITER_CONFIGS
-from aiter.jit.utils.build_targets import KNOWN_GFX, _parse_gpu_targets_env
+from aiter.jit.utils.build_targets import (
+    KNOWN_GFX,
+    _parse_gpu_targets_env,
+    get_build_targets_env,
+)
 from aiter.jit.utils.chip_info import get_gfx_runtime
 from aiter.ops.flydsl.bpreshuffle_gemm_gfx1250 import (
     parse_wmma_kernel_name as parse_ptpc_wmma_kernel_name,
@@ -744,8 +750,22 @@ def active_target_env() -> tuple[str, str] | None:
     return None
 
 
-def filter_jobs_for_build_targets(jobs: list[dict]) -> list[dict]:
-    """Apply the same target selection to CLI and packaging AOT paths."""
+def _targets_from_archs_env(value: str) -> list[tuple[str, int]]:
+    """The (gfx, cu_num) pairs GPU_ARCHS and CU_NUM resolve to."""
+    # get_build_targets_env reads no live GPU, so expand 'native' first.
+    archs = _archs_from_env(value)
+    with override_env("GPU_ARCHS", ";".join(sorted(archs))):
+        return get_build_targets_env()
+
+
+def filter_jobs_for_build_targets(
+    jobs: list[dict], *, arch_wide: bool = False
+) -> list[dict]:
+    """Select the jobs to bake for the configured targets.
+
+    arch_wide selects on arch alone and ignores CU_NUM; otherwise GPU_ARCHS and
+    CU_NUM resolve to exact (gfx, cu_num) pairs.
+    """
     active = active_target_env()
     if active is None:
         return jobs
@@ -754,13 +774,19 @@ def filter_jobs_for_build_targets(jobs: list[dict]) -> list[dict]:
         # Not get_build_targets_env: it folds GPU_ARCHS in, and the two are
         # separate contracts here.
         selected, missing = _select_for_targets(jobs, _parse_gpu_targets_env())
-    else:
-        # ARCH and GPU_ARCHS stay arch-wide, including when CU_NUM is set.
+    elif arch_wide or var_name == "ARCH":
+        # ARCH names a bare arch and carries no CU count.
         try:
             archs = _archs_from_env(value)
         except ValueError as e:
             raise RuntimeError(f"{var_name} {e}.") from None
         selected, missing = _select_for_archs(jobs, archs)
+    else:
+        try:
+            targets = _targets_from_archs_env(value)
+        except ValueError as e:
+            raise RuntimeError(f"{var_name} {e}.") from None
+        selected, missing = _select_for_targets(jobs, targets)
     _warn_legacy_rows(jobs)
     _warn_unmatched(missing)
     return selected
@@ -851,7 +877,7 @@ def main():
     all_jobs = collect_aot_jobs(csv_paths, parse_csv)
     n_before = len(all_jobs)
     try:
-        all_jobs = filter_jobs_for_build_targets(all_jobs)
+        all_jobs = filter_jobs_for_build_targets(all_jobs, arch_wide=True)
     except RuntimeError as e:
         print(f"Error: {e}")
         sys.exit(1)

--- a/aiter/aot/flydsl/gemm.py
+++ b/aiter/aot/flydsl/gemm.py
@@ -32,7 +32,7 @@ Environment variables:
     GPU_ARCHS                 Arch list. Packaging resolves it with CU_NUM into
                               exact targets; the CLI keeps every job of that arch.
     CU_NUM                    Compute-unit count paired with GPU_ARCHS.
-    ARCH                      Legacy bare-arch filter.
+    ARCH                      Bare-arch filter on the CLI; packaging ignores it.
 """
 
 from __future__ import annotations
@@ -741,9 +741,16 @@ def _archs_from_env(value: str) -> set[str]:
     return archs
 
 
-def active_target_env() -> tuple[str, str] | None:
-    """The env var driving target selection, and its value."""
-    for var_name in ("AITER_GPU_TARGETS", "ARCH", "GPU_ARCHS"):
+def active_target_env(*, cli: bool = True) -> tuple[str, str] | None:
+    """The env var driving target selection, and its value.
+
+    ARCH is part of main()'s existing filter and is left there; the packaging
+    path reads only the two variables this filter introduces.
+    """
+    names = ["AITER_GPU_TARGETS", "GPU_ARCHS"]
+    if cli:
+        names.insert(1, "ARCH")
+    for var_name in names:
         value = (os.environ.get(var_name) or "").strip()
         if value:
             return var_name, value
@@ -763,10 +770,10 @@ def filter_jobs_for_build_targets(
 ) -> list[dict]:
     """Select the jobs to bake for the configured targets.
 
-    arch_wide selects on arch alone and ignores CU_NUM; otherwise GPU_ARCHS and
-    CU_NUM resolve to exact (gfx, cu_num) pairs.
+    arch_wide is main()'s selection: on arch alone, ignoring CU_NUM. Otherwise
+    GPU_ARCHS and CU_NUM resolve to exact (gfx, cu_num) pairs.
     """
-    active = active_target_env()
+    active = active_target_env(cli=arch_wide)
     if active is None:
         return jobs
     var_name, value = active
@@ -774,8 +781,8 @@ def filter_jobs_for_build_targets(
         # Not get_build_targets_env: it folds GPU_ARCHS in, and the two are
         # separate contracts here.
         selected, missing = _select_for_targets(jobs, _parse_gpu_targets_env())
-    elif arch_wide or var_name == "ARCH":
-        # ARCH names a bare arch and carries no CU count.
+    elif arch_wide:
+        # ARCH and a bare GPU_ARCHS name an arch and carry no CU count.
         try:
             archs = _archs_from_env(value)
         except ValueError as e:

--- a/op_tests/test_gemm_codegen.py
+++ b/op_tests/test_gemm_codegen.py
@@ -30,6 +30,7 @@ import os
 import sys
 import tempfile
 import textwrap
+from unittest import mock
 
 # Ensure the repo-local aiter is imported, not any system/site-packages install.
 _REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -1027,6 +1028,126 @@ def test_unmatched_targets():
     )
 
 
+def test_flydsl_aot_target_filter():
+    _section("1d. production FlyDSL AOT — compatible target filtering")
+
+    import aiter.aot.flydsl.common as aot_common
+    from aiter.aot.flydsl.common import OpKind, _filter_collected_aot_jobs
+
+    env_names = ("AITER_GPU_TARGETS", "GPU_ARCHS", "CU_NUM", "ARCH")
+    original = {name: os.environ.pop(name, None) for name in env_names}
+    jobs = [
+        {"kernel_name": "k128", "gfx": "gfx950", "cu_num": 128},
+        {"kernel_name": "k256", "gfx": "gfx950", "cu_num": 256},
+        # Same CU as k128, so gfx must participate in the filter.
+        {"kernel_name": "other_arch", "gfx": "gfx942", "cu_num": 128},
+    ]
+    try:
+        os.environ["AITER_GPU_TARGETS"] = "gfx950:256;gfx950:128"
+        with mock.patch.object(aot_common, "collect_aot_jobs", return_value=jobs):
+            selected = aot_common._collect_aot_jobs_for(OpKind.GEMM)
+        _check(
+            "production packaging collector filters targets and same-CU other gfx",
+            {job["kernel_name"] for job in selected} == {"k128", "k256"},
+            str(selected),
+        )
+
+        os.environ["AITER_GPU_TARGETS"] = "gfx950:128;gfx950:64"
+        selected = _filter_collected_aot_jobs(OpKind.GEMM, jobs)
+        _check(
+            "partial requested target coverage preserves available jobs",
+            [job["kernel_name"] for job in selected] == ["k128"],
+            str(selected),
+        )
+
+        os.environ["AITER_GPU_TARGETS"] = "gfx950:128"
+        selected = _filter_collected_aot_jobs(
+            OpKind.GEMM,
+            [{"kernel_name": "legacy", "gfx": "", "cu_num": 128}],
+        )
+        _check(
+            "targeted AOT preserves legacy rows missing gfx identity",
+            [job["kernel_name"] for job in selected] == ["legacy"],
+            str(selected),
+        )
+
+        del os.environ["AITER_GPU_TARGETS"]
+        os.environ["GPU_ARCHS"] = "gfx950"
+        os.environ["CU_NUM"] = "128"
+        selected = _filter_collected_aot_jobs(OpKind.GEMM, jobs)
+        _check(
+            "legacy GPU_ARCHS remains arch-wide when CU_NUM is set",
+            [job["kernel_name"] for job in selected] == ["k128", "k256"],
+            str(selected),
+        )
+        del os.environ["CU_NUM"]
+        os.environ["GPU_ARCHS"] = "gfx942"
+        selected = _filter_collected_aot_jobs(OpKind.GEMM, jobs)
+        _check(
+            "legacy GPU_ARCHS without CU_NUM remains an arch-wide filter",
+            [job["kernel_name"] for job in selected] == ["other_arch"],
+            str(selected),
+        )
+        del os.environ["GPU_ARCHS"]
+        os.environ["AITER_GPU_TARGETS"] = "gfx950:256"
+        selected = _filter_collected_aot_jobs(
+            OpKind.GEMM,
+            jobs + [{"kernel_name": "no_cu", "gfx": "gfx950", "cu_num": 0}],
+        )
+        _check(
+            "a row with no recorded CU count is kept for its arch",
+            "no_cu" in {job["kernel_name"] for job in selected},
+            str(selected),
+        )
+        del os.environ["AITER_GPU_TARGETS"]
+
+        def _only(var, value):
+            for name in ("AITER_GPU_TARGETS", "ARCH", "GPU_ARCHS"):
+                os.environ.pop(name, None)
+            os.environ[var] = value
+
+        def _rejects(var, value):
+            _only(var, value)
+            try:
+                _filter_collected_aot_jobs(OpKind.GEMM, jobs)
+            except RuntimeError:
+                return True
+            return False
+
+        def _selects(var, value):
+            _only(var, value)
+            return [
+                job["kernel_name"]
+                for job in _filter_collected_aot_jobs(OpKind.GEMM, jobs)
+            ]
+
+        _check("separator-only GPU_ARCHS is rejected", _rejects("GPU_ARCHS", " ; "))
+        _check("separator-only ARCH is rejected", _rejects("ARCH", " , "))
+        _check("unknown GPU_ARCHS arch is rejected", _rejects("GPU_ARCHS", "gfx9999"))
+        _check("unknown ARCH arch is rejected", _rejects("ARCH", "gfx9999"))
+        _check(
+            "GPU_ARCHS native combined with another target is rejected",
+            _rejects("GPU_ARCHS", "native;gfx942"),
+        )
+        _check(
+            "ARCH native combined with another target is rejected",
+            _rejects("ARCH", "native,gfx942"),
+        )
+        # GPU_ARCHS accepted ',' before the filter moved here; keep it that way.
+        comma = _selects("GPU_ARCHS", "gfx942,gfx950")
+        _check(
+            "comma-separated GPU_ARCHS selects both arches",
+            comma == ["k128", "k256", "other_arch"],
+            str(comma),
+        )
+    finally:
+        for name, value in original.items():
+            if value is None:
+                os.environ.pop(name, None)
+            else:
+                os.environ[name] = value
+
+
 # ---------------------------------------------------------------------------
 # Entry point
 # ---------------------------------------------------------------------------
@@ -1034,6 +1155,7 @@ def test_unmatched_targets():
 if __name__ == "__main__":
     test_get_build_targets()
     test_unmatched_targets()
+    test_flydsl_aot_target_filter()
     test_gen_instances_filter(
         csv_path=REPRO_CSV,
         target_a=TARGET_C,

--- a/op_tests/test_gemm_codegen.py
+++ b/op_tests/test_gemm_codegen.py
@@ -1132,16 +1132,10 @@ def test_flydsl_aot_target_filter():
             ]
 
         _check("separator-only GPU_ARCHS is rejected", _rejects("GPU_ARCHS", " ; "))
-        _check("separator-only ARCH is rejected", _rejects("ARCH", " , "))
         _check("unknown GPU_ARCHS arch is rejected", _rejects("GPU_ARCHS", "gfx9999"))
-        _check("unknown ARCH arch is rejected", _rejects("ARCH", "gfx9999"))
         _check(
             "GPU_ARCHS native combined with another target is rejected",
             _rejects("GPU_ARCHS", "native;gfx942"),
-        )
-        _check(
-            "ARCH native combined with another target is rejected",
-            _rejects("ARCH", "native,gfx942"),
         )
         # GPU_ARCHS accepted ',' before the filter moved here; keep it that way.
         comma = _selects("GPU_ARCHS", "gfx942,gfx950")

--- a/op_tests/test_gemm_codegen.py
+++ b/op_tests/test_gemm_codegen.py
@@ -1033,6 +1033,7 @@ def test_flydsl_aot_target_filter():
 
     import aiter.aot.flydsl.common as aot_common
     from aiter.aot.flydsl.common import OpKind, _filter_collected_aot_jobs
+    from aiter.aot.flydsl.gemm import filter_jobs_for_build_targets
 
     env_names = ("AITER_GPU_TARGETS", "GPU_ARCHS", "CU_NUM", "ARCH")
     original = {name: os.environ.pop(name, None) for name in env_names}
@@ -1076,16 +1077,25 @@ def test_flydsl_aot_target_filter():
         os.environ["CU_NUM"] = "128"
         selected = _filter_collected_aot_jobs(OpKind.GEMM, jobs)
         _check(
-            "legacy GPU_ARCHS remains arch-wide when CU_NUM is set",
-            [job["kernel_name"] for job in selected] == ["k128", "k256"],
+            "packaging pairs GPU_ARCHS with CU_NUM instead of baking the arch",
+            [job["kernel_name"] for job in selected] == ["k128"],
             str(selected),
         )
+        cli = [
+            job["kernel_name"]
+            for job in filter_jobs_for_build_targets(jobs, arch_wide=True)
+        ]
+        _check(
+            "the CLI mode still selects arch-wide, ignoring CU_NUM",
+            cli == ["k128", "k256"],
+            str(cli),
+        )
         del os.environ["CU_NUM"]
-        os.environ["GPU_ARCHS"] = "gfx942"
+        os.environ["GPU_ARCHS"] = "gfx950"
         selected = _filter_collected_aot_jobs(OpKind.GEMM, jobs)
         _check(
-            "legacy GPU_ARCHS without CU_NUM remains an arch-wide filter",
-            [job["kernel_name"] for job in selected] == ["other_arch"],
+            "GPU_ARCHS without CU_NUM takes the arch's default count",
+            [job["kernel_name"] for job in selected] == ["k256"],
             str(selected),
         )
         del os.environ["GPU_ARCHS"]
@@ -1136,8 +1146,8 @@ def test_flydsl_aot_target_filter():
         # GPU_ARCHS accepted ',' before the filter moved here; keep it that way.
         comma = _selects("GPU_ARCHS", "gfx942,gfx950")
         _check(
-            "comma-separated GPU_ARCHS selects both arches",
-            comma == ["k128", "k256", "other_arch"],
+            "comma-separated GPU_ARCHS resolves each arch to its default count",
+            comma == ["k256"],
             str(comma),
         )
     finally:


### PR DESCRIPTION
Stops a released wheel from precompiling FlyDSL GEMM kernels for architectures it is not built for. The packaging path compiled every job in the tuned CSVs regardless of the wheel's targets; it now filters by build target, the way the standalone entry point already did.

Stacked on #5340, which introduces `AITER_GPU_TARGETS`: build targets written as `gfx:cu_num` pairs. The filter here resolves through that machinery, so packaging selects AOT jobs the way the rest of the build selects tuned rows.

## Motivation

`setup.py` → `run_aot()` → `_collect_aot_jobs_for()` called `collect_aot_jobs()` with no target filter, so approximately 220 gfx1250 kernels were built into every gfx942/gfx950 wheel, which never reaches them. The same gap shows up on MI350P: FlyDSL dispatch keys on `(gfx, cu_num)` from the live device, and every tuned FlyDSL row records 256 CUs, so on a 128-CU part every lookup misses, yet a `gfx950:128` build was precompiling all of those kernels anyway. It now selects none of them, and once rows are tuned for 128 CUs it will select exactly those. 


### Scope

GEMM only. Each other `OpKind` reads its own CSVs and keeps only one of the two fields a target needs: MoE and chunk_gdn_h carry `cu_num` and recover an arch later through `cu_num_to_arch`, grouped MoE carries `gfx` alone, mxfp4 MoE hardcodes `FLYDSL_GPU_ARCH` to gfx950, and mega MoE builds its jobs without a CSV. Matching those jobs against a `(gfx, cu_num)` pair would drop every one. Filtering them means widening each `parse_csv` to carry both fields, plus a `gfx` column for the mxfp4 model CSVs that lack one, which is out of scope here.


## Technical Details


**1. Packaging now resolves targets the way CK does; the standalone entry point still does not.** CK's codegen resolves `GPU_ARCHS` and `CU_NUM` into exact `(gfx, cu_num)` pairs and keeps only the tuned rows matching them. FlyDSL packaging did none of that, baking every row in the CSVs whatever the build targeted. It now resolves the same pairs, so both halves of a build select for the same SKU.

The standalone entry point is unchanged: it still matches on architecture alone and ignores `CU_NUM`. Only that divergence is now visible. Under `GPU_ARCHS=gfx950 CU_NUM=128` packaging selects nothing, since every FlyDSL GEMM row records 256 CUs, while the CLI selects every gfx950 job. Neither result is wrong on its own, and an AOT miss only falls back to a runtime JIT compile, but one environment now means two different things depending on which entry point reads it. 

**2. An unknown arch now fails the build.** `GPU_ARCHS=gfx9999` raises, aborting the wheel build where packaging previously ignored the variable and baked everything. Intended, but it is a hard failure on a free-form `workflow_dispatch` input. Every in-tree caller passes a valid value and `gpu_archs` has a default, so no automated path can hit it.

**3. The filter reads `AITER_GPU_TARGETS` and `GPU_ARCHS` only.** `ARCH` stays on the standalone entry point: build images export it as a machine type such as `x86_64`, and an unrecognised value raises, so routing packaging through it would kill the wheel build on those hosts.

**4. Uppercase now matches where it previously matched nothing.** Case-folding means `GFX950` selects every gfx950 job where it used to select none. On the packaging path that is a narrowing, since it baked every job in the CSVs before reading no target variable at all; on the standalone entry point it is the opposite, since an unmatched arch there selected nothing and fell back to runtime JIT.


### Also in here

A release build gains one warning line naming gfx942, correct since no `libtype=flydsl` GEMM rows exist for it. `parse_csv` no longer raises on an empty `cu_num` cell; it parses as 0, which the filter treats as a wildcard. No shipped CSV trips this today.

## Test Plan

`op_tests/test_gemm_codegen.py`, covering the packaging collector end to end, partial target coverage, legacy rows with no `gfx`, both separator forms, and each rejected `GPU_ARCHS` input.

## Test Result

Passes; `ruff` and `black` clean. An AOT miss is not a failure, it falls back to a runtime JIT compile, so `AITER_GPU_TARGETS=gfx950:128` selecting 0 jobs today is safe.