### PR TITLE
[Triton/Gluon] [CI] [Bugfix] Fix stale MHA config-utils import

### DIFF
--- a/.github/workflows/triton-test.yaml
+++ b/.github/workflows/triton-test.yaml
@@ -262,7 +262,7 @@ jobs:
           docker exec -w /workspace triton_test mkdir -p test-reports
           # MI35X: skip the MHA-PE tests that fail an accuracy check on gfx950 with the coming Triton release.
           docker exec -w /workspace triton_test pytest -v ${TRITON_TEST} \
-            --deselect "op_tests/triton_tests/attention/test_mha_with_pe.py::test_mha_varlen_with_pe[True-0.17-96-64-8-1-64-128]" \
+            --deselect "op_tests/triton_tests/attention/test_mha_with_pe.py::test_mha_varlen_with_pe[triton-True-0.17-96-64-8-1-64-128]" \
             --junitxml=test-reports/triton.xml
 
       - name: Upload test logs

--- a/aiter/ops/triton/_gluon_kernels/gfx950/attention/mha.py
+++ b/aiter/ops/triton/_gluon_kernels/gfx950/attention/mha.py
@@ -32,7 +32,10 @@ from aiter.ops.triton.utils._triton.mha_kernel_utils import (
     _compute_fp8_scaling_factors,
 )
 from aiter.ops.triton.utils._triton.pid_preprocessing import remap_xcd
-from aiter.ops.triton.utils.core import AITER_TRITON_CONFIGS_PATH, load_config_json
+from aiter.ops.triton.utils.config_utils import (
+    AITER_TRITON_CONFIGS_PATH,
+    load_config_json,
+)
 
 
 @gluon.constexpr_function

--- a/op_tests/triton_tests/attention/test_mha.py
+++ b/op_tests/triton_tests/attention/test_mha.py
@@ -112,10 +112,9 @@ def _test_mha_impl(
     "SEQLEN_Q, SEQLEN_K",
     [(1, 1), (128, 128), (32, 16), (64, 128), (2048, 2048)],
 )
-@pytest.mark.parametrize("NUM_Q_HEADS, NUM_K_HEADS", [(1, 1), (8, 1), (64, 8)])
-@pytest.mark.parametrize("HEAD_SZ", [33, 64, 128])
+@pytest.mark.parametrize("NUM_Q_HEADS, NUM_K_HEADS", [(1, 1), (8, 8), (48, 8)])
+@pytest.mark.parametrize("HEAD_SZ", [64, 128])
 @pytest.mark.parametrize("CAUSAL", [(True), (False)])
-@pytest.mark.parametrize("backend", ["triton", "gluon"])
 def test_mha(
     BATCH: int,
     SEQLEN_Q: int,
@@ -124,7 +123,6 @@ def test_mha(
     NUM_K_HEADS: int,
     HEAD_SZ: int,
     CAUSAL: bool,
-    backend: str,
     dtype=torch.bfloat16,
 ):
     _test_mha_impl(
@@ -138,7 +136,41 @@ def test_mha(
         RETURN_LSE=False,
         RETURN_SOFTMAX=False,
         CAUSAL=CAUSAL,
-        backend=backend,
+        backend="triton",
+        dtype=dtype,
+    )
+
+
+@pytest.mark.parametrize("BATCH", [1, 30, 50])
+@pytest.mark.parametrize(
+    "SEQLEN_Q, SEQLEN_K",
+    [(1, 1), (128, 128), (32, 16), (64, 128), (2048, 2048)],
+)
+@pytest.mark.parametrize("NUM_Q_HEADS, NUM_K_HEADS", [(1, 1), (8, 1), (64, 8)])
+@pytest.mark.parametrize("HEAD_SZ", [33, 64, 128])
+@pytest.mark.parametrize("CAUSAL", [(True), (False)])
+def test_mha_gluon(
+    BATCH: int,
+    SEQLEN_Q: int,
+    SEQLEN_K: int,
+    NUM_Q_HEADS: int,
+    NUM_K_HEADS: int,
+    HEAD_SZ: int,
+    CAUSAL: bool,
+    dtype=torch.bfloat16,
+):
+    _test_mha_impl(
+        BATCH,
+        SEQLEN_Q,
+        SEQLEN_K,
+        NUM_Q_HEADS,
+        NUM_K_HEADS,
+        HEAD_SZ,
+        DROPOUT=0.0,
+        RETURN_LSE=False,
+        RETURN_SOFTMAX=False,
+        CAUSAL=CAUSAL,
+        backend="gluon",
         dtype=dtype,
     )
 
@@ -568,11 +600,10 @@ def _test_mha_varlen_impl(
     [(1, 1), (128, 128), (32, 16), (64, 128), (2048, 2048)],
 )
 @pytest.mark.parametrize(
-    "NUM_Q_HEADS, NUM_K_HEADS", [(1, 1), (8, 1), (16, 16), (64, 8)]
+    "NUM_Q_HEADS, NUM_K_HEADS", [(1, 1), (16, 16), (2, 1), (48, 8)]
 )
-@pytest.mark.parametrize("HEAD_SZ", [8, 32, 33, 128])
+@pytest.mark.parametrize("HEAD_SZ", [8, 32, 128])
 @pytest.mark.parametrize("CAUSAL", [(True), (False)])
-@pytest.mark.parametrize("backend", ["triton", "gluon"])
 def test_mha_varlen(
     BATCH: int,
     SEQLEN_Q: int,
@@ -581,7 +612,6 @@ def test_mha_varlen(
     NUM_K_HEADS: int,
     HEAD_SZ: int,
     CAUSAL: bool,
-    backend: str,
     dtype=torch.bfloat16,
 ):
     _test_mha_varlen_impl(
@@ -595,7 +625,43 @@ def test_mha_varlen(
         RETURN_LSE=False,
         RETURN_SOFTMAX=False,
         CAUSAL=CAUSAL,
-        backend=backend,
+        backend="triton",
+        dtype=dtype,
+    )
+
+
+@pytest.mark.parametrize("BATCH", [1, 4, 30, 50])
+@pytest.mark.parametrize(
+    "SEQLEN_Q, SEQLEN_K",
+    [(1, 1), (128, 128), (32, 16), (64, 128), (2048, 2048)],
+)
+@pytest.mark.parametrize(
+    "NUM_Q_HEADS, NUM_K_HEADS", [(1, 1), (8, 1), (16, 16), (64, 8)]
+)
+@pytest.mark.parametrize("HEAD_SZ", [8, 32, 33, 128])
+@pytest.mark.parametrize("CAUSAL", [(True), (False)])
+def test_mha_varlen_gluon(
+    BATCH: int,
+    SEQLEN_Q: int,
+    SEQLEN_K: int,
+    NUM_Q_HEADS: int,
+    NUM_K_HEADS: int,
+    HEAD_SZ: int,
+    CAUSAL: bool,
+    dtype=torch.bfloat16,
+):
+    _test_mha_varlen_impl(
+        BATCH,
+        SEQLEN_Q,
+        SEQLEN_K,
+        NUM_Q_HEADS,
+        NUM_K_HEADS,
+        HEAD_SZ,
+        DROPOUT=0.0,
+        RETURN_LSE=False,
+        RETURN_SOFTMAX=False,
+        CAUSAL=CAUSAL,
+        backend="gluon",
         dtype=dtype,
     )
 


### PR DESCRIPTION
## Summary

- fix the broken gfx950 Gluon MHA config import after the Triton utils reorganization
- keep the original Triton MHA parameter matrices and exercise the expanded shapes in dedicated Gluon tests
- update the MI35X MHA-PE deselect for the backend-prefixed pytest node ID

## Root cause

[#4147](https://github.com/ROCm/aiter/pull/4147), merged on September 8, imported `AITER_TRITON_CONFIGS_PATH` and `load_config_json` from `aiter.ops.triton.utils.core`, but [#5061](https://github.com/ROCm/aiter/pull/5061) had already moved those helpers to `aiter.ops.triton.utils.config_utils` and removed `core.py`. This causes a deterministic `ModuleNotFoundError` during pytest collection.

After that import was corrected, the next CI run exposed two additional regressions introduced by #4147:

1. Its expanded Gluon MHA shape matrices were shared with the existing Triton tests. The newly added odd-head cases produce 14 Triton accuracy failures. This PR separates the backend matrices, retaining the original Triton coverage and the expanded Gluon coverage.
2. Adding the `backend` parameter prefixed the MHA-PE pytest node IDs with `triton-`, but the workflow's known-failure deselect still used the old ID and no longer matched.

## CI evidence

- [Triton Test failure on current `main`](https://github.com/ROCm/aiter/actions/runs/34246454827)
- [`main` MI35X shard 3 collection failure](https://github.com/ROCm/aiter/actions/runs/34246454827/job/102132338976)
- [`main` MI300X shard 3 collection failure](https://github.com/ROCm/aiter/actions/runs/34246454827/job/102132339181)
- [Independent reproduction on PR #4761 after merging current `main`](https://github.com/ROCm/aiter/actions/runs/34257169809)
- [Initial #5352 CI run exposing the remaining shard 4 failures](https://github.com/ROCm/aiter/actions/runs/34260549117/job/102179514759)

The stale import affected shards 3, 4, 5, and 7. With collection restored, shard 4 exposed the test-matrix and deselect regressions addressed by the two follow-up commits.

## Test plan

- [x] `python3 -m compileall -q aiter/ops/triton/_gluon_kernels/gfx950/attention/mha.py`
- [x] `python3 -m compileall -q op_tests/triton_tests/attention/test_mha.py`
- [x] `git diff --check`
- [ ] upstream Triton CI