### PR TITLE
[Bugfix][MLA] Make _fold_seqlen_indptr CUDA-graph-capturable

### DIFF
--- a/aiter/mla.py
+++ b/aiter/mla.py
@@ -402,14 +402,12 @@ def _fold_seqlen_indptr(indptr, fold_factor):
     """Repeat each batch's seqlen ``fold_factor`` times (head-folding pseudo-batches)."""
     lens = indptr[1:] - indptr[:-1]
     folded_lens = lens.repeat_interleave(fold_factor)
-    out = torch.empty(
-        indptr.shape[0] + (fold_factor - 1) * (indptr.shape[0] - 1),
-        dtype=indptr.dtype,
-        device=indptr.device,
-    )
-    out[0] = 0
-    out[1:] = torch.cumsum(folded_lens, dim=0).to(indptr.dtype)
-    return out
+    cumsum = torch.cumsum(folded_lens, dim=0).to(indptr.dtype)
+    # Prepend the leading 0 on device. Writing it as ``out[0] = 0`` stages the
+    # Python scalar through unpinned host memory, which is illegal under CUDA-
+    # graph capture ("Cannot copy between CPU and CUDA tensors during CUDA graph
+    # capture unless the CPU tensor is pinned").
+    return torch.nn.functional.pad(cumsum, (1, 0))
 
 
 def _use_persistent_mla_decode(bs, nhead, max_seqlen_q, q_dtype, kv_dtype):

--- a/op_tests/test_mla_fold_indptr.py
+++ b/op_tests/test_mla_fold_indptr.py
@@ -1,0 +1,68 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+import torch
+
+import aiter
+from aiter.mla import _fold_seqlen_indptr
+
+torch.set_default_device("cuda")
+
+
+def _reference_fold(indptr, fold_factor):
+    """Host-side reference for the head-folded indptr."""
+    lens = (indptr[1:] - indptr[:-1]).tolist()
+    out, acc = [0], 0
+    for n in lens:
+        for _ in range(fold_factor):
+            acc += n
+            out.append(acc)
+    return torch.tensor(out, dtype=indptr.dtype, device=indptr.device)
+
+
+def test_fold_seqlen_indptr_values():
+    for lens in ([3, 4, 5], [0, 7, 0, 2], [1]):
+        indptr = torch.tensor(
+            [0, *torch.tensor(lens).cumsum(0).tolist()], dtype=torch.int32
+        )
+        for fold_factor in (1, 2, 4, 8):
+            got = _fold_seqlen_indptr(indptr, fold_factor)
+            want = _reference_fold(indptr, fold_factor)
+            assert got.dtype == indptr.dtype, f"{got.dtype=} != {indptr.dtype=}"
+            assert torch.equal(got, want), f"{lens=} {fold_factor=} {got=} {want=}"
+    aiter.logger.info("_fold_seqlen_indptr values: passed")
+
+
+def test_fold_seqlen_indptr_cuda_graph_capture():
+    """Capture _fold_seqlen_indptr under a real torch.cuda.graph().
+
+    Regression test for the capture-safety fix: seeding the leading zero with
+    ``out[0] = 0`` staged a host scalar into device memory, which raises
+    "Cannot copy between CPU and CUDA tensors during CUDA graph capture unless
+    the CPU tensor is pinned" and made persistent MLA decode uncapturable for
+    any head count that takes the head-folding path (nhead 32..128 step 16).
+    """
+    indptr = torch.tensor([0, 3, 7, 12], dtype=torch.int32)
+    fold_factor = 4
+
+    # Warm-up on a side stream (standard torch.cuda.graph() prerequisite).
+    side = torch.cuda.Stream()
+    side.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(side):
+        _fold_seqlen_indptr(indptr, fold_factor)
+    torch.cuda.current_stream().wait_stream(side)
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        out = _fold_seqlen_indptr(indptr, fold_factor)
+
+    graph.replay()
+    torch.cuda.synchronize()
+    want = _reference_fold(indptr, fold_factor)
+    assert torch.equal(out, want), f"{out=} {want=}"
+    aiter.logger.info("_fold_seqlen_indptr cuda-graph capture/replay: passed")
+
+
+if __name__ == "__main__":
+    test_fold_seqlen_indptr_values()
+    test_fold_seqlen_indptr_cuda_graph_capture()


### PR DESCRIPTION
The head-folding path of the persistent MLA decode (nhead 32..128 step 16, persistent_mode) rebuilds qo_indptr/kv_indptr via _fold_seqlen_indptr, which seeded the leading zero with `out[0] = 0`. Assigning a Python scalar into a device tensor stages it through unpinned host memory, so any capture of that path fails with:

    RuntimeError: Cannot copy between CPU and CUDA tensors during CUDA graph
    capture unless the CPU tensor is pinned.

That makes persistent MLA decode uncapturable for every head count that folds, which is the common configuration for DeepSeek-style MLA on gfx942 -- callers that capture decode (e.g. vLLM's full-decode CUDA graphs) have to monkey-patch this function to boot at all.

Build the leading zero on device with a pad instead. Values, dtype and shape are unchanged; only the host round-trip goes away.

Adds op_tests/test_mla_fold_indptr.py covering the folded values against a host reference and a real torch.cuda.graph() capture + replay.
