### PR TITLE
[uBench] Add MI355X gfx950 dense-operator benchmarks

### DIFF
--- a/op_tests/README_ubench.md
+++ b/op_tests/README_ubench.md
@@ -1,0 +1,78 @@
+# MI355X uBench
+
+This ports the dense-operator uBench workflow from `gfx1250/microbench` to
+`main`, where the gfx950 FlyDSL GEMM implementation is available.
+`bench_combo.py` currently dispatches gfx950 only. The gfx1250 suite remains
+on its source branch; this PR does not import unavailable gfx1250 kernels.
+
+## MI355X
+
+Install AITER and its pinned FlyDSL dependency. Clone ROCm/FlyDSL for the
+Softmax kernel sources (the compiler wheel alone does not install that checkout).
+
+```bash
+python op_tests/bench_combo.py --arch gfx950 --perf \
+  --ops softmax a16w16 --flydsl-root /path/to/FlyDSL \
+  --data-init norm --seed 0 --dtype bf16 fp16 fp32 \
+  --ubench-profiler --smi-monitor --output results.json
+```
+
+Omit `--arch` to detect the active GPU. Set device visibility before starting
+Python and reserve an idle GPU. The selected SMI ordinal must be the active
+benchmark device, and SMI maps HIP ordinal to PCI BDF rather than assuming SMI
+enumeration matches HIP enumeration.
+
+Supported gfx950 operators:
+
+- `softmax`: row-wise, out-of-place FlyDSL Softmax, with FP32 accumulation and
+  BF16/FP16/FP32 input/output. Includes AITER's 10 unit-test shapes and four
+  additional throughput/launch cases.
+- `a16w16`: BF16 `A[M,K] @ B[N,K].T`, no weight preshuffle. Imports the exact
+  `_TUNED` configurations from the installed AITER HGEMM test using AST parsing,
+  without executing that test module's import-time GPU work.
+
+The port covers these two operators only. gfx1250-specific operators such as
+Mega MoE are not advertised as working on gfx950.
+
+## Measurement and correctness
+
+Input generation, JSON table output, optional profiler timing and SMI replay
+reuse the `gfx1250/microbench` input/JSON helpers (in `ubench_common.py`),
+its unchanged `smi_monitor.py`, and main's `aiter.test_common.run_perftest`.
+The provenance commit is recorded in `ubench_common.py`.
+The additional HIP graph/event timer amortizes host dispatch over 64 operator
+calls and reports all samples from five rounds. Compilation, allocation and
+reference computation are outside timing. Preallocated output buffers are
+poisoned before replay to detect empty captures or incorrect stream selection.
+Validation runs both before capture and after replay. Invalid/zero profiler
+times are errors, not infinite-throughput results.
+
+`--ubench-profiler` adds the original `run_perftest(testGraph=True)` result as
+a separate field. Profiler instrumentation can materially perturb short
+kernels; compare the two timing methods separately. Default graph timing reuses
+inputs and therefore measures a resident working set, not guaranteed cold HBM.
+SMI replay occurs after latency measurement.
+
+Softmax checks normalized output error and row sums against FP32 softmax of the
+actual rounded input. The row-sum tolerance includes the row-sum error of the
+FP32 reference rounded to the output dtype (important for long FP16 rows). GEMM checks every element with a reference-RMS floor for
+cancellation and a normalized RMS bound. These checks are intentionally
+stricter than the existing GEMM unit test; a stock configuration can fail, and
+that failure is retained in JSON and reflected in the process exit status.
+
+Use `--configs file.json` to load a mapping such as
+`{"softmax:0:bf16": {"BLOCK_THREADS": 256, "THREADS_PER_ROW": 64, "ROWS_PER_BLOCK": 4}}`.
+`--case-index` selects explicitly indexed cases. `--variant` labels the result.
+Experimental implementation modules can be supplied with `--softmax-module`
+or `--gemm-module`; they must implement the same operator contract.
+
+## Verification
+
+```bash
+pytest -q op_tests/test_bench_combo_dispatch.py
+python op_tests/bench_combo.py --arch gfx950 --help
+```
+
+CPU tests cover argument forwarding, lazy dispatch, unsupported operators and
+help without GPU initialization. Actual gfx1250 runtime regression testing
+requires a gfx1250 machine; CPU dispatch tests do not substitute for it.

--- a/op_tests/bench_combo.py
+++ b/op_tests/bench_combo.py
@@ -1,0 +1,49 @@
+# SPDX-License-Identifier: MIT
+"""Architecture dispatcher for the existing uBench combo infrastructure.
+
+The main-branch backend supports gfx950. Architecture-specific suites can be
+added without importing their GPU modules on unsupported hardware.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib
+import sys
+
+BACKENDS = {"gfx950": "bench_gfx950_combo"}
+
+
+def backend_for(arch):
+    try:
+        return BACKENDS[arch]
+    except KeyError:
+        raise ValueError(
+            f"Unsupported architecture {arch!r}; supported: {', '.join(BACKENDS)}"
+        ) from None
+
+
+def main(argv=None):
+    argv = list(sys.argv[1:] if argv is None else argv)
+    parser = argparse.ArgumentParser(add_help=False)
+    parser.add_argument("--arch", choices=list(BACKENDS))
+    args, remaining = parser.parse_known_args(argv)
+    if args.arch is None:
+        if "--help" in remaining or "-h" in remaining:
+            print(
+                "Usage: bench_combo.py --arch {gfx950} [backend options]\n"
+                "Omit --arch to detect the current GPU. Use --arch gfx950 --help for operator options."
+            )
+            return
+        from aiter.jit.utils.chip_info import get_gfx
+
+        arch = get_gfx()
+    else:
+        arch = args.arch
+    backend = importlib.import_module(backend_for(arch))
+    sys.argv = [sys.argv[0], *remaining]
+    backend.main()
+
+
+if __name__ == "__main__":
+    main()

--- a/op_tests/bench_gfx950_combo.py
+++ b/op_tests/bench_gfx950_combo.py
@@ -1,0 +1,346 @@
+# SPDX-License-Identifier: MIT
+"""MI355X uBench: FlyDSL row softmax and BF16 A @ B.T.
+
+Reuses uBench's input generators, profiler timer, JSON tables and SMI monitor.
+Graph-event samples additionally expose launch amortization and run-to-run noise.
+FlyDSL kernel sources are supplied explicitly via --flydsl-root.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import importlib
+import json
+import math
+import os
+import statistics
+import sys
+from pathlib import Path
+
+SOFTMAX_SHAPES = [
+    (1823, 781),
+    (1, 1),
+    (128, 1),
+    (1, 128),
+    (8192, 8192),
+    (4096, 8192),
+    (359, 1),
+    (1, 359),
+    (1, 131072),
+    (1, 89999),
+    (32768, 8192),
+    (128, 1024),
+    (4096, 1024),
+    (4096, 4096),
+]
+
+
+def gemm_cases(source):
+    tree = ast.parse(Path(source).read_text())
+    for node in tree.body:
+        if isinstance(node, ast.Assign) and any(
+            isinstance(t, ast.Name) and t.id == "_TUNED" for t in node.targets
+        ):
+            rows = ast.literal_eval(node.value)
+            keys = (
+                "block_m",
+                "block_n",
+                "block_k",
+                "stages",
+                "split_k",
+                "m_waves",
+                "n_waves",
+                "k_waves",
+                "group_m",
+                "hti",
+            )
+            cases = []
+            for row in rows:
+                cfg = dict(zip(keys, row[3:]))
+                cfg["policy"] = "hti" if cfg.pop("hti") else "ft"
+                cases.append((tuple(row[:3]), cfg))
+            return cases
+    raise ValueError("No _TUNED cases found in the HGEMM unit test")
+
+
+def graph_samples(fn, *, iters, rounds, output=None):
+    import torch
+
+    for _ in range(10):
+        fn()
+    torch.cuda.synchronize()
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        for _ in range(iters):
+            fn()
+    # Poison output outside capture. An empty/wrong-stream graph must not pass
+    # by leaving the result of the eager correctness call in the buffer.
+    if output is not None:
+        output.fill_(float("nan"))
+    graph.replay()
+    torch.cuda.synchronize()
+    samples = []
+    for _ in range(rounds):
+        start = torch.cuda.Event(enable_timing=True)
+        end = torch.cuda.Event(enable_timing=True)
+        start.record()
+        graph.replay()
+        end.record()
+        end.synchronize()
+        samples.append(start.elapsed_time(end) * 1000 / iters)
+    if any(not math.isfinite(x) or x <= 0 for x in samples):
+        raise RuntimeError(f"Invalid GPU timing: {samples}")
+    return samples
+
+
+def correctness(out, ref, op, dtype):
+    import torch
+
+    yf = out.float()
+    rf = ref.float()
+    if not torch.isfinite(yf).all():
+        raise AssertionError("nonfinite output")
+    delta = (yf - rf).abs()
+    if op == "softmax":
+        scale = rf.abs() + rf.amax(-1, keepdim=True)
+        scaled = (delta / scale.clamp_min(1e-30)).max().item()
+        bound = {"fp32": 1e-5, "fp16": 5e-3, "bf16": 2e-2}[dtype]
+        row_error = (yf.sum(-1) - 1).abs().max().item()
+        rounding_row_error = (rf.to(out.dtype).float().sum(-1) - 1).abs().max().item()
+        if (
+            scaled > bound
+            or row_error
+            > rounding_row_error + {"fp32": 1e-5, "fp16": 2e-3, "bf16": 1e-2}[dtype]
+        ):
+            raise AssertionError(
+                f"softmax scaled_error={scaled}, row_sum_error={row_error}"
+            )
+        return {
+            "max_abs_error": delta.max().item(),
+            "scaled_error": scaled,
+            "row_sum_error": row_error,
+            "reference_rounding_row_sum_error": rounding_row_error,
+        }
+    # BF16 output rounding alone is ~0.4%; use an all-element, reference-scale
+    # floor for cancellation, plus a normalized RMS gate. No % pass allowance.
+    rms = rf.square().mean().sqrt().item()
+    nrmse = delta.square().mean().sqrt().item() / max(rms, 1e-20)
+    tol = 0.02 * rf.abs() + 0.01 * max(rms, 1e-6)
+    violations = (delta > tol).sum().item()
+    if violations or nrmse > 0.01:
+        raise AssertionError(f"GEMM violations={violations}, normalized_RMSE={nrmse}")
+    return {
+        "max_abs_error": delta.max().item(),
+        "normalized_rmse": nrmse,
+        "violations": violations,
+    }
+
+
+def main():
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--perf", action="store_true", help="compatibility with combo CLI")
+    p.add_argument(
+        "--ops", nargs="+", choices=["softmax", "a16w16"], default=["softmax", "a16w16"]
+    )
+    p.add_argument("--flydsl-root", type=Path, default=None)
+    p.add_argument(
+        "--data-init",
+        nargs="+",
+        choices=["zero", "constant", "uniform", "norm"],
+        default=["norm"],
+    )
+    p.add_argument("--seed", type=int, default=0)
+    p.add_argument(
+        "--dtype", nargs="+", choices=["bf16", "fp16", "fp32"], default=["bf16"]
+    )
+    p.add_argument("--case-index", type=int, nargs="+", default=None)
+    p.add_argument("--iters", type=int, default=64)
+    p.add_argument("--rounds", type=int, default=5)
+    p.add_argument("--output", type=Path, required=True)
+    p.add_argument(
+        "--configs", type=Path, help="JSON mapping case key to candidate config"
+    )
+    p.add_argument("--variant", default="baseline")
+    p.add_argument("--softmax-module", default="kernels.norm.softmax_kernel")
+    p.add_argument(
+        "--gemm-module",
+        help="optional FlyDSL GEMM implementation module for A/B experiments",
+    )
+    p.add_argument(
+        "--ubench-profiler",
+        action="store_true",
+        help="cross-check via upstream run_perftest",
+    )
+    p.add_argument("--smi-monitor", action="store_true")
+    p.add_argument("--smi-device", type=int, default=0)
+    p.add_argument("--smi-interval", type=float, default=0.05)
+    p.add_argument("--smi-duration", type=float, default=0.5)
+    args = p.parse_args()
+    if args.iters < 2 or args.rounds < 1:
+        p.error("iters >=2 and rounds >=1 required")
+    if args.smi_interval <= 0 or args.smi_duration <= 0:
+        p.error("SMI durations must be positive")
+    if args.flydsl_root:
+        sys.path.insert(0, str(args.flydsl_root.resolve()))
+    import torch
+    from ubench_common import fill, make_generator, print_json_table
+
+    import aiter
+    from aiter.jit.utils.chip_info import get_gfx
+    from aiter.test_common import run_perftest
+
+    if get_gfx() != "gfx950":
+        p.error(f"gfx950 required; detected {get_gfx()}")
+    if args.smi_device != torch.cuda.current_device():
+        p.error("SMI device must match the active benchmark GPU")
+    torch.backends.cuda.matmul.allow_tf32 = False
+    overrides = json.loads(args.configs.read_text()) if args.configs else {}
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    rows = []
+    failures = []
+    for op in args.ops:
+        if op == "softmax":
+            module = importlib.import_module(args.softmax_module)
+            cases = [(s, {}) for s in SOFTMAX_SHAPES]
+            dtypes = args.dtype
+        else:
+            from aiter.ops.flydsl import flydsl_hgemm
+
+            if args.gemm_module:
+                from aiter.ops.flydsl import gemm_kernels
+
+                gemm_kernels.gemm_a16w16 = importlib.import_module(
+                    args.gemm_module
+                ).gemm_a16w16
+            source = (
+                Path(aiter.__file__).resolve().parents[1]
+                / "op_tests/test_flydsl_hgemm.py"
+            )
+            cases = gemm_cases(source)
+            dtypes = ["bf16"]
+        for ci, (shape, base_cfg) in enumerate(cases):
+            if args.case_index is not None and ci not in args.case_index:
+                continue
+            for dtype in dtypes:
+                for dist in args.data_init:
+                    key = f"{op}:{ci}:{dtype}"
+                    cfg = overrides.get(key, base_cfg)
+                    row = {
+                        "arch": "gfx950",
+                        "op": op,
+                        "case_index": ci,
+                        "shape": list(shape),
+                        "dtype": dtype,
+                        "data_init": dist,
+                        "seed": args.seed,
+                        "variant": args.variant,
+                        "config": cfg,
+                    }
+                    print("CASE " + json.dumps(row), flush=True)
+                    try:
+                        gen = make_generator(args.seed)
+                        dt = {
+                            "bf16": torch.bfloat16,
+                            "fp16": torch.float16,
+                            "fp32": torch.float32,
+                        }[dtype]
+                        if op == "softmax":
+                            m, n = shape
+                            a = fill((m, n), dist, gen, dtype=dt)
+                            out = torch.empty_like(a)
+                            ref = torch.softmax(a.float(), dim=-1)
+                            launch = module.build_softmax_module(
+                                m,
+                                n,
+                                {"bf16": "bf16", "fp16": "f16", "fp32": "f32"}[dtype],
+                                **cfg,
+                            )
+
+                            def fn(launch=launch, a=a, out=out, m=m):
+                                launch(a, out, m, stream=torch.cuda.current_stream())
+                                return out
+                        else:
+                            m, n, k = shape
+                            a = fill((m, k), dist, gen, dtype=dt)
+                            b = fill((n, k), dist, gen, dtype=dt)
+                            out = torch.empty((m, n), device="cuda", dtype=dt)
+                            ref = a.float() @ b.float().T
+
+                            def fn(a=a, b=b, out=out, cfg=cfg):
+                                return flydsl_hgemm(a, b, out=out, **cfg)
+
+                        fn()
+                        torch.cuda.synchronize()
+                        row.update(correctness(out, ref, op, dtype))
+                        samples = graph_samples(
+                            fn, iters=args.iters, rounds=args.rounds, output=out
+                        )
+                        row.update(correctness(out, ref, op, dtype))
+                        row.update(
+                            {
+                                "samples_us": samples,
+                                "median_us": statistics.median(samples),
+                                "min_us": min(samples),
+                                "max_us": max(samples),
+                                "timing": "hipgraph_events",
+                            }
+                        )
+                        if args.ubench_profiler:
+                            _, us = run_perftest(
+                                fn,
+                                num_iters=33,
+                                num_warmup=5,
+                                num_rotate_args=1,
+                                testGraph=True,
+                            )
+                            if not math.isfinite(us) or us <= 0:
+                                raise RuntimeError(
+                                    f"invalid uBench profiler latency {us}"
+                                )
+                            row["ubench_profiler_us"] = float(us)
+                        if op == "softmax":
+                            row["effective_gbs"] = (
+                                2 * m * n * a.element_size() / row["median_us"] / 1e3
+                            )
+                        else:
+                            row["tflops"] = 2 * m * n * k / row["median_us"] / 1e6
+                        if args.smi_monitor:
+                            from smi_monitor import replay_with_smi
+
+                            os.environ.update(
+                                AITER_SMI_MONITOR="1",
+                                AITER_SMI_DEVICE=str(args.smi_device),
+                                AITER_SMI_INTERVAL=str(args.smi_interval),
+                                AITER_SMI_DURATION=str(args.smi_duration),
+                            )
+                            try:
+                                row["smi"] = replay_with_smi(
+                                    fn,
+                                    label=key,
+                                    synchronize=torch.cuda.synchronize,
+                                    estimated_us=row["median_us"],
+                                )
+                            finally:
+                                os.environ.pop("AITER_SMI_MONITOR", None)
+                        row["status"] = "passed"
+                    except Exception as exc:  # noqa: BLE001 - retain per-case failure and exit nonzero
+                        import traceback
+
+                        traceback.print_exc()
+                        row.update(
+                            status="failed", error=f"{type(exc).__name__}: {exc}"
+                        )
+                        failures.append(key)
+                    rows.append(row)
+                    print_json_table(op, [row])
+                    args.output.write_text(json.dumps(rows, indent=2) + "\n")
+                    torch.cuda.empty_cache()
+    if not rows:
+        p.error("no test cases selected")
+    if failures:
+        raise SystemExit(f"{len(failures)} cases failed: {failures}")
+
+
+if __name__ == "__main__":
+    main()

--- a/op_tests/bench_gfx950_combo.py
+++ b/op_tests/bench_gfx950_combo.py
@@ -260,6 +260,7 @@ def main():
                             def fn(launch=launch, a=a, out=out, m=m):
                                 launch(a, out, m, stream=torch.cuda.current_stream())
                                 return out
+
                         else:
                             m, n, k = shape
                             a = fill((m, k), dist, gen, dtype=dt)
@@ -324,7 +325,8 @@ def main():
                             finally:
                                 os.environ.pop("AITER_SMI_MONITOR", None)
                         row["status"] = "passed"
-                    except Exception as exc:  # noqa: BLE001 - retain per-case failure and exit nonzero
+                    # Retain each case failure and exit nonzero after reporting.
+                    except Exception as exc:  # noqa: BLE001
                         import traceback
 
                         traceback.print_exc()

--- a/op_tests/smi_monitor.py
+++ b/op_tests/smi_monitor.py
@@ -1,0 +1,445 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+# ruff: noqa: BLE001, PYI034, S110, UP035, UP037
+"""AMD GPU metrics monitor using amdsmi.
+
+ROCm ships the binding without a setup.py. If the normal import fails, this
+module temporarily searches ``/opt/rocm/share/amd_smi`` while importing it.
+Neither ``PYTHONPATH`` nor the caller's lasting ``sys.path`` is changed.
+The amdsmi session and HIP-device handle mapping are initialized lazily once
+per process and reused by every monitor instance.
+
+Usage (context manager):
+    with GpuMonitor(device_index=0, interval_s=0.05) as mon:
+        run_workload()
+    samples = mon.samples   # list[dict]
+
+Usage (explicit start/stop):
+    mon = GpuMonitor(device_index=0, interval_s=0.05)
+    mon.start()
+    run_workload()
+    mon.stop()
+    samples = mon.samples
+"""
+
+from __future__ import annotations
+
+import atexit
+import ctypes
+import importlib
+import json
+import os
+import sys
+import threading
+import time
+from contextlib import contextmanager
+from functools import cache
+from typing import Generator
+
+SMI_RESULT_PREFIX = "AITER_SMI_RESULT "
+_ROCM_AMDSMI_PATH = "/opt/rocm/share/amd_smi"
+
+
+def _import_amdsmi():
+    """Import amdsmi, temporarily searching ROCm's unpackaged binding."""
+    try:
+        return importlib.import_module("amdsmi")
+    except ImportError:
+        if not os.path.isdir(_ROCM_AMDSMI_PATH):
+            raise
+
+    added_path = _ROCM_AMDSMI_PATH not in sys.path
+    if added_path:
+        sys.path.insert(0, _ROCM_AMDSMI_PATH)
+    try:
+        return importlib.import_module("amdsmi")
+    finally:
+        if added_path:
+            sys.path.remove(_ROCM_AMDSMI_PATH)
+
+try:
+    amdsmi = _import_amdsmi()
+
+    _AMDSMI_AVAILABLE = True
+except ImportError:
+    _AMDSMI_AVAILABLE = False
+
+
+_AMDSMI_LOCK = threading.Lock()
+_AMDSMI_INITIALIZED = False
+_AMDSMI_HANDLES_BY_BDF = {}
+_AMDSMI_HANDLES_BY_HIP_DEVICE = {}
+
+
+# ------------------------------------------------------------------
+# HIP device -> amdsmi handle via PCIe BDF
+# ------------------------------------------------------------------
+
+
+@cache
+def _hip_runtime_library():
+    """Load and cache the HIP runtime used for device-to-BDF lookup."""
+    import glob as _glob
+
+    candidates = ["libamdhip64.so"] + sorted(
+        _glob.glob("/opt/rocm/lib/libamdhip64.so.*"), reverse=True
+    )
+    for name in candidates:
+        try:
+            return ctypes.CDLL(name)
+        except OSError:
+            continue
+    raise RuntimeError(
+        "libamdhip64.so not found (tried unversioned and /opt/rocm/lib/libamdhip64.so.*); "
+        "is ROCm installed?"
+    )
+
+
+@cache
+def _hip_device_bdf(hip_device: int) -> str:
+    """Return the PCIe BDF string for a HIP device index, e.g. '0000:03:00.0'.
+
+    Calls ``hipDeviceGetPCIBusId`` via ctypes so there is no hard dependency on
+    PyTorch or the hip-python package.
+    """
+    libhip = _hip_runtime_library()
+    buf = ctypes.create_string_buffer(64)
+    ret = libhip.hipDeviceGetPCIBusId(buf, ctypes.c_int(64), ctypes.c_int(hip_device))
+    if ret != 0:
+        raise RuntimeError(f"hipDeviceGetPCIBusId failed with error code {ret}")
+    return buf.value.decode().lower().strip()
+
+
+def _amdsmi_bdf_str(handle) -> str:
+    """Normalise the BDF returned by amdsmi into 'dddd:bb:dd.f' lowercase."""
+    raw = amdsmi.amdsmi_get_gpu_device_bdf(handle)
+    if isinstance(raw, str):
+        return raw.lower().strip()
+    # Some amdsmi versions return a dict: {'domain': 0, 'bus': 3, 'device': 0, 'function': 0}
+    return (
+        f"{raw['domain']:04x}:{raw['bus']:02x}:{raw['device']:02x}.{raw['function']:x}"
+    )
+
+
+def _ensure_amdsmi_initialized() -> None:
+    """Initialize amdsmi and enumerate processor handles once per process."""
+    global _AMDSMI_INITIALIZED, _AMDSMI_HANDLES_BY_BDF
+
+    if not _AMDSMI_AVAILABLE:
+        raise ImportError("amdsmi is not installed or not importable")
+    with _AMDSMI_LOCK:
+        if _AMDSMI_INITIALIZED:
+            return
+        amdsmi.amdsmi_init()
+        try:
+            _AMDSMI_HANDLES_BY_BDF = {
+                _amdsmi_bdf_str(handle): handle
+                for handle in amdsmi.amdsmi_get_processor_handles()
+            }
+        except BaseException:
+            amdsmi.amdsmi_shut_down()
+            raise
+        _AMDSMI_INITIALIZED = True
+
+
+def _shutdown_amdsmi() -> None:
+    """Release the process-wide amdsmi session during interpreter shutdown."""
+    global _AMDSMI_INITIALIZED
+
+    with _AMDSMI_LOCK:
+        if not _AMDSMI_INITIALIZED:
+            return
+        try:
+            amdsmi.amdsmi_shut_down()
+        finally:
+            _AMDSMI_INITIALIZED = False
+            _AMDSMI_HANDLES_BY_BDF.clear()
+            _AMDSMI_HANDLES_BY_HIP_DEVICE.clear()
+
+
+atexit.register(_shutdown_amdsmi)
+
+
+def hip_device_to_amdsmi_handle(hip_device: int):
+    """Return the amdsmi processor handle that corresponds to a HIP device index.
+
+    Uses PCIe BDF as the stable identifier linking the two numbering schemes.
+
+    Args:
+        hip_device: HIP device ordinal (as used by ``torch.cuda`` / HIP runtime).
+
+    Returns:
+        The amdsmi processor handle for that GPU.
+
+    Raises:
+        RuntimeError: if no amdsmi handle matches the HIP device's BDF.
+        ImportError: if amdsmi is not available.
+    """
+    _ensure_amdsmi_initialized()
+    with _AMDSMI_LOCK:
+        cached = _AMDSMI_HANDLES_BY_HIP_DEVICE.get(hip_device)
+        if cached is not None:
+            return cached
+        target_bdf = _hip_device_bdf(hip_device)
+        handle = _AMDSMI_HANDLES_BY_BDF.get(target_bdf)
+        if handle is None:
+            raise RuntimeError(
+                f"No amdsmi handle found with BDF {target_bdf!r} "
+                f"(HIP device {hip_device})"
+            )
+        _AMDSMI_HANDLES_BY_HIP_DEVICE[hip_device] = handle
+        return handle
+
+
+def _collect_sample(handle) -> dict:
+    """Collect one snapshot from a single GPU handle."""
+    sample: dict = {"timestamp_s": time.perf_counter()}
+    try:
+        metrics = amdsmi.amdsmi_get_gpu_metrics_info(handle)
+        sample["gfx_clk_mhz"] = metrics.get("current_gfxclk", None)
+        sample["soc_clk_mhz"] = metrics.get("current_socclk", None)
+        sample["power_w"] = metrics.get("current_socket_power", None)
+        sample["temp_hotspot_c"] = metrics.get("temperature_hotspot", None)
+    except Exception:
+        pass
+    try:
+        info = amdsmi.amdsmi_get_gpu_activity(handle)
+        sample["gfx_activity_pct"] = info.get("gfx_activity", None)
+        sample["umc_activity_pct"] = info.get("umc_activity", None)
+    except Exception:
+        pass
+    try:
+        mem = amdsmi.amdsmi_get_gpu_memory_usage(handle, amdsmi.AmdSmiMemoryType.VRAM)
+        sample["vram_used_mb"] = mem / 1024 / 1024
+    except Exception:
+        pass
+    return sample
+
+
+class GpuMonitor:
+    """Poll AMD GPU metrics on a background thread.
+
+    Args:
+        device_index: Integer ordinal of the GPU to monitor (default 0), or a
+                      pre-resolved amdsmi processor handle (e.g. from
+                      ``hip_device_to_amdsmi_handle``).
+        interval_s:   Polling interval in seconds (default 0.05 = 50 ms).
+    """
+
+    def __init__(self, device_index: int = 0, interval_s: float = 0.05) -> None:
+        if not _AMDSMI_AVAILABLE:
+            raise ImportError("amdsmi is not installed or not importable")
+        self._device_index = device_index
+        self._interval_s = interval_s
+        self._samples: list[dict] = []
+        self._thread: threading.Thread | None = None
+        self._stop_event = threading.Event()
+        self._ready_event = threading.Event()
+        self._error: BaseException | None = None
+        self._handle = None
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def start(self) -> None:
+        """Begin background polling. Safe to call only once per instance."""
+        if self._thread is not None and self._thread.is_alive():
+            raise RuntimeError("GpuMonitor is already running")
+        self._samples = []
+        self._error = None
+        self._stop_event.clear()
+        self._ready_event.clear()
+        try:
+            if isinstance(self._device_index, int):
+                self._handle = hip_device_to_amdsmi_handle(self._device_index)
+            else:
+                _ensure_amdsmi_initialized()
+                self._handle = self._device_index
+        except BaseException as error:
+            raise RuntimeError(f"failed to initialize amdsmi monitor: {error}") from error
+        self._thread = threading.Thread(target=self._poll_loop, daemon=True)
+        self._thread.start()
+        if not self._ready_event.wait(timeout=10.0):
+            self._stop_event.set()
+            raise RuntimeError("timed out while initializing amdsmi monitor")
+        if self._error is not None:
+            error = self._error
+            self.stop()
+            raise RuntimeError(f"failed to initialize amdsmi monitor: {error}")
+
+    def stop(self) -> None:
+        """Stop background polling and wait for the thread to finish."""
+        self._stop_event.set()
+        if self._thread is not None:
+            self._thread.join()
+            self._thread = None
+
+    @property
+    def samples(self) -> list[dict]:
+        """Collected samples; each is a dict with 'timestamp_s' plus metric keys."""
+        return list(self._samples)
+
+    def summary(
+        self, *, start_s: float | None = None, end_s: float | None = None
+    ) -> dict:
+        """Return metric summaries, optionally restricted to a timestamp window."""
+        samples = [
+            sample
+            for sample in self._samples
+            if (start_s is None or sample["timestamp_s"] >= start_s)
+            and (end_s is None or sample["timestamp_s"] <= end_s)
+        ]
+        if not samples:
+            return {}
+        keys = {key for sample in samples for key in sample if key != "timestamp_s"}
+        result: dict = {}
+        for key in sorted(keys):
+            vals = sorted(
+                s[key]
+                for s in samples
+                if s.get(key) is not None and s[key] != "N/A"
+            )
+            if not vals:
+                continue
+            n = len(vals)
+            mid = n // 2
+            median = vals[mid] if n % 2 else (vals[mid - 1] + vals[mid]) / 2
+            result[key] = {
+                "min": vals[0],
+                "mean": sum(vals) / n,
+                "median": median,
+                "max": vals[-1],
+                "n": n,
+            }
+        return result
+
+    # ------------------------------------------------------------------
+    # Context manager
+    # ------------------------------------------------------------------
+
+    def __enter__(self) -> "GpuMonitor":
+        self.start()
+        return self
+
+    def __exit__(self, *_) -> None:
+        self.stop()
+
+    # ------------------------------------------------------------------
+    # Internal
+    # ------------------------------------------------------------------
+
+    def _poll_loop(self) -> None:
+        try:
+            self._ready_event.set()
+            while not self._stop_event.is_set():
+                t0 = time.perf_counter()
+                self._samples.append(_collect_sample(self._handle))
+                elapsed = time.perf_counter() - t0
+                remaining = self._interval_s - elapsed
+                if remaining > 0:
+                    self._stop_event.wait(timeout=remaining)
+        except BaseException as error:
+            self._error = error
+            self._ready_event.set()
+        finally:
+            self._ready_event.set()
+
+
+# ------------------------------------------------------------------
+# Module-level convenience functions
+# ------------------------------------------------------------------
+
+
+@contextmanager
+def monitor_gpu(
+    device_index: int = 0, interval_s: float = 0.05
+) -> Generator[GpuMonitor, None, None]:
+    """Context manager that yields a running GpuMonitor.
+
+    Example::
+
+        with monitor_gpu(device_index=0) as mon:
+            run_workload()
+        print(mon.summary())
+    """
+    mon = GpuMonitor(device_index=device_index, interval_s=interval_s)
+    with mon:
+        yield mon
+
+
+def smi_replay_enabled() -> bool:
+    """Whether the benchmark requested an isolated SMI replay window."""
+    return os.environ.get("AITER_SMI_MONITOR", "0") == "1"
+
+
+def emit_smi_result(result: dict) -> None:
+    """Write one structured result to the combo JSONL sink or stdout."""
+    line = SMI_RESULT_PREFIX + json.dumps(result, sort_keys=True)
+    output_path = os.environ.get("AITER_SMI_OUTPUT_PATH")
+    if output_path:
+        with open(output_path, "a", encoding="utf-8") as output:
+            output.write(line + "\n")
+    else:
+        print(line, flush=True)
+
+
+def replay_with_smi(
+    fn,
+    *,
+    label: str,
+    synchronize,
+    estimated_us: float | None = None,
+) -> dict | None:
+    """Repeat one already-prepared benchmark case under the GPU monitor.
+
+    Input creation, compilation, correctness and the latency measurement happen
+    before this function is called.  Batching launches between synchronizations
+    keeps short kernels busy while still checking the wall-clock deadline often
+    enough for slow kernels.
+    """
+    if not smi_replay_enabled():
+        return None
+
+    device = int(os.environ.get("AITER_SMI_DEVICE", "0"))
+    interval_s = float(os.environ.get("AITER_SMI_INTERVAL", "0.05"))
+    duration_s = float(os.environ.get("AITER_SMI_DURATION", "1.0"))
+    if interval_s <= 0 or duration_s <= 0:
+        raise ValueError("AITER_SMI_INTERVAL and AITER_SMI_DURATION must be positive")
+
+    # Aim for roughly one synchronization per monitor tick.  The cap prevents a
+    # near-zero/invalid latency estimate from enqueueing an unbounded amount of
+    # work, while a slow case is synchronized after every launch.
+    if estimated_us is not None and estimated_us > 0:
+        batch_iters = max(1, min(1024, int(interval_s * 1e6 / estimated_us)))
+    else:
+        batch_iters = 1
+
+    synchronize()
+    launches = 0
+    start = time.perf_counter()
+    with monitor_gpu(device_index=device, interval_s=interval_s) as monitor:
+        while launches == 0 or time.perf_counter() - start < duration_s:
+            for _ in range(batch_iters):
+                fn()
+            launches += batch_iters
+            synchronize()
+    elapsed_s = time.perf_counter() - start
+
+    result = {
+        "label": label,
+        "device": device,
+        "interval_s": interval_s,
+        "duration_s": elapsed_s,
+        "launches": launches,
+        "samples": len(monitor.samples),
+        "metrics": monitor.summary(),
+    }
+    expected_samples = max(1, int(duration_s / interval_s))
+    result["sample_status"] = (
+        "ok" if len(monitor.samples) >= max(2, expected_samples // 2) else "insufficient"
+    )
+    # A shared JSONL sink survives fd silencing and child processes. Standalone
+    # UT runs without a sink still get a machine-readable stdout record.
+    emit_smi_result(result)
+    return result

--- a/op_tests/smi_monitor.py
+++ b/op_tests/smi_monitor.py
@@ -57,6 +57,7 @@ def _import_amdsmi():
         if added_path:
             sys.path.remove(_ROCM_AMDSMI_PATH)
 
+
 try:
     amdsmi = _import_amdsmi()
 
@@ -257,7 +258,9 @@ class GpuMonitor:
                 _ensure_amdsmi_initialized()
                 self._handle = self._device_index
         except BaseException as error:
-            raise RuntimeError(f"failed to initialize amdsmi monitor: {error}") from error
+            raise RuntimeError(
+                f"failed to initialize amdsmi monitor: {error}"
+            ) from error
         self._thread = threading.Thread(target=self._poll_loop, daemon=True)
         self._thread.start()
         if not self._ready_event.wait(timeout=10.0):
@@ -296,9 +299,7 @@ class GpuMonitor:
         result: dict = {}
         for key in sorted(keys):
             vals = sorted(
-                s[key]
-                for s in samples
-                if s.get(key) is not None and s[key] != "N/A"
+                s[key] for s in samples if s.get(key) is not None and s[key] != "N/A"
             )
             if not vals:
                 continue
@@ -437,7 +438,9 @@ def replay_with_smi(
     }
     expected_samples = max(1, int(duration_s / interval_s))
     result["sample_status"] = (
-        "ok" if len(monitor.samples) >= max(2, expected_samples // 2) else "insufficient"
+        "ok"
+        if len(monitor.samples) >= max(2, expected_samples // 2)
+        else "insufficient"
     )
     # A shared JSONL sink survives fd silencing and child processes. Standalone
     # UT runs without a sink still get a machine-readable stdout record.

--- a/op_tests/test_bench_combo_dispatch.py
+++ b/op_tests/test_bench_combo_dispatch.py
@@ -1,0 +1,78 @@
+# SPDX-License-Identifier: MIT
+"""CPU tests: unsupported architectures must not run or import GPU backends."""
+
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+import pytest
+
+ROOT = Path(__file__).parent
+spec = importlib.util.spec_from_file_location("combo_dispatch", ROOT / "bench_combo.py")
+combo = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(combo)
+
+
+@pytest.mark.parametrize(
+    "arch,expected",
+    [("gfx950", "bench_gfx950_combo")],
+)
+def test_dispatch_preserves_backend_arguments(arch, expected):
+    backend = Mock()
+    with (
+        patch.object(combo.importlib, "import_module", return_value=backend) as load,
+        patch.object(sys, "argv", ["bench_combo.py"]),
+    ):
+        combo.main(["--arch", arch, "--perf", "--ops", "a16w16"])
+        load.assert_called_once_with(expected)
+        backend.main.assert_called_once_with()
+        assert sys.argv[1:] == ["--perf", "--ops", "a16w16"]
+
+
+def test_unknown_arch_is_error():
+    with pytest.raises(ValueError, match="Unsupported architecture"):
+        combo.backend_for("gfx942")
+
+
+def test_help_without_gpu_imports():
+    result = subprocess.run(
+        [sys.executable, str(ROOT / "bench_combo.py"), "--help"],
+        capture_output=True,
+        check=False,
+        text=True,
+    )
+    assert result.returncode == 0
+    assert "gfx950" in result.stdout
+
+
+def test_gfx950_help_without_gpu_imports():
+    result = subprocess.run(
+        [sys.executable, str(ROOT / "bench_combo.py"), "--arch", "gfx950", "--help"],
+        capture_output=True,
+        check=False,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "softmax" in result.stdout
+
+
+def test_gfx950_rejects_unsupported_operator():
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(ROOT / "bench_combo.py"),
+            "--arch",
+            "gfx950",
+            "--ops",
+            "mega_moe",
+            "--output",
+            "unused.json",
+        ],
+        capture_output=True,
+        check=False,
+        text=True,
+    )
+    assert result.returncode != 0
+    assert "invalid choice" in result.stderr

--- a/op_tests/test_ubench_common.py
+++ b/op_tests/test_ubench_common.py
@@ -1,0 +1,32 @@
+# SPDX-License-Identifier: MIT
+import json
+
+import pytest
+import torch
+
+from op_tests.ubench_common import fill, make_generator, print_json_table
+
+
+@pytest.mark.parametrize("dist", ["zero", "constant", "uniform", "norm"])
+def test_repeatable_input(dist):
+    a = fill(
+        (3, 17), dist, make_generator(42, "cpu"), dtype=torch.bfloat16, device="cpu"
+    )
+    b = fill(
+        (3, 17), dist, make_generator(42, "cpu"), dtype=torch.bfloat16, device="cpu"
+    )
+    assert a.dtype == torch.bfloat16
+    torch.testing.assert_close(a, b, rtol=0, atol=0)
+
+
+def test_invalid_input_distribution():
+    with pytest.raises(ValueError, match="dist"):
+        fill((1, 2), "invalid", None, device="cpu")
+
+
+def test_json_records(capsys):
+    print_json_table("softmax", [{"shape": [1, 17], "latency_us": 2.5}])
+    assert json.loads(capsys.readouterr().out) == {
+        "name": "softmax",
+        "rows": [{"shape": [1, 17], "latency_us": 2.5}],
+    }

--- a/op_tests/ubench_common.py
+++ b/op_tests/ubench_common.py
@@ -1,0 +1,116 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+"""uBench data and JSON helpers, ported from gfx1250/microbench.
+
+Source commit: e566d682a90108ca1babf9d8f5ba3ec13c32aa10
+Only the dense floating-point data helpers needed by gfx950 are included.
+"""
+
+import json
+
+import pandas as pd
+import torch
+
+DATA_DISTS = ("zero", "constant", "uniform", "norm")
+_STAGE_ELEMS = 1 << 28
+
+
+def print_json_table(name, rows, keep=None):
+    """Print benchmark rows as one record-oriented JSON object.
+
+    A single-line object is intentional: parent benchmark drivers can validate
+    and forward it without parsing pandas' human-readable table formats.
+    """
+    if isinstance(rows, pd.DataFrame):
+        df = rows.copy()
+    else:
+        df = pd.DataFrame([row for row in rows if row is not None])
+    if not df.empty:
+        df = df.replace("", pd.NA).dropna(axis=1, how="all")
+        if keep is not None:
+            cols = [column for column in keep if column in df.columns]
+            cols += [
+                column
+                for column in df.columns
+                if "err_msg" in column and column not in cols
+            ]
+            df = df[cols]
+    records = json.loads(df.to_json(orient="records"))
+    print(json.dumps({"name": name, "rows": records}), flush=True)
+
+
+def make_generator(seed, device="cuda"):
+    """Seeded ``torch.Generator`` -- same seed => bit-identical buffers."""
+    return torch.Generator(device=device).manual_seed(int(seed))
+
+
+def _row_chunks(rows, cols):
+    """Row slices whose f32 staging stays around _STAGE_ELEMS elements."""
+    step = max(_STAGE_ELEMS // max(cols, 1), 1)
+    for start in range(0, rows, step):
+        yield start, min(start + step, rows)
+
+
+def _canon_dist(dist, allowed):
+    if dist == "gaussian":
+        dist = "norm"
+    if dist not in allowed:
+        raise ValueError(f"dist {dist!r}; choose from {allowed}")
+    return dist
+
+
+def _sample_data_f32(shape, dist, gen, *, lo, hi, device):
+    if dist == "uniform":
+        return torch.empty(shape, dtype=torch.float32, device=device).uniform_(
+            lo, hi, generator=gen
+        )
+    if dist == "norm":
+        return torch.empty(shape, dtype=torch.float32, device=device).normal_(
+            0.0, 1.0, generator=gen
+        )
+    raise ValueError(f"data dist {dist!r} is not continuous; use fill dispatch")
+
+
+def _fill_sampled(shape, dist, gen, *, dtype, device, uniform, constant, sample_fn):
+    if dist == "zero":
+        return torch.zeros(shape, dtype=dtype, device=device)
+    if dist == "constant":
+        return torch.full(shape, constant, dtype=dtype, device=device)
+    lo, hi = uniform
+    if len(shape) != 2:
+        return sample_fn(shape, dist, gen, lo=lo, hi=hi, device=device).to(dtype)
+    rows, cols = shape
+    out = torch.empty(shape, dtype=dtype, device=device)
+    for r0, r1 in _row_chunks(rows, cols):
+        v = sample_fn((r1 - r0, cols), dist, gen, lo=lo, hi=hi, device=device)
+        out[r0:r1] = v.to(dtype)
+        del v
+    return out
+
+
+def fill(
+    shape,
+    dist,
+    gen,
+    *,
+    dtype=torch.float32,
+    device="cuda",
+    uniform=(-1.0, 1.0),
+    constant=1.0,
+):
+    """Return a ``dtype`` DATA tensor of ``shape``.
+
+    ``dist`` in {zero, constant, uniform, norm}. ``uniform`` is U(lo, hi);
+    ``norm`` / ``gaussian`` is N(0, 1). ``zero`` / ``constant`` ignore ``gen``.
+    """
+    dist = _canon_dist(dist, DATA_DISTS)
+    return _fill_sampled(
+        shape,
+        dist,
+        gen,
+        dtype=dtype,
+        device=device,
+        uniform=uniform,
+        constant=constant,
+        sample_fn=_sample_data_f32,
+    )


### PR DESCRIPTION
The operator uBench on `gfx1250/microbench` imports gfx1250-only kernels and cannot run on MI355X. This ports the dense-operator workflow to `main`, where the gfx950 FlyDSL HGEMM implementation exists.

Adds an architecture-gated entry point for FlyDSL row Softmax (BF16/FP16/FP32) and BF16 GEMM, ports the required upstream input/JSON helpers and unchanged SMI monitor, and reuses `aiter.test_common.run_perftest`. Softmax baseline source is selected explicitly with `--flydsl-root`. The gfx1250 suite remains on its source branch; other gfx1250 operators are not advertised as supported.

The additional HIP graph/event timer records raw samples, excludes compilation/allocation, and poisons output before replay to catch empty captures. Profiler and SMI measurements are separate. Per-case failures are retained in JSON and produce a nonzero exit. Accuracy gates are intentionally stricter than the existing HGEMM test; some stock configurations fail those gates rather than being silently accepted.

Validation on MI355X/gfx950 with the AITER CI ROCm 7.2.4 / PyTorch 2.10 image and FlyDSL 0.3.2:

- 11 CPU tests passed (dispatch, unsupported arguments, input generation, JSON output).
- Both operators passed on the exact PR checkout with profiler timing and successful SMI collection.
- A stock GEMM case that exceeds the stricter gate correctly produced a recorded failure and nonzero exit.
- Ruff and `git diff --check` passed for new code. The upstream SMI implementation is carried unchanged.

The README contains runnable commands and the source commit is recorded in `ubench_common.py`. This is independent of the split-kernel optimization PR.
