### PR TITLE
[FlyDSL] gfx950 fp8 FMHA: fix the all-masked-tile NaN

### DIFF
--- a/aiter/ops/flydsl/kernels/fmha_gfx950/flash_attn_fp8_gfx950.py
+++ b/aiter/ops/flydsl/kernels/fmha_gfx950/flash_attn_fp8_gfx950.py
@@ -230,8 +230,7 @@ def build_flash_attn_dualwave_swp_fp8_module(
             m_tile = softmax_helper.max2(
                 softmax_helper.reduce_max(v_s_a), softmax_helper.reduce_max(v_s_b)
             )
-            if const_expr(traits.CAUSAL):
-                m_tile = softmax_helper.floor_masked_max(m_tile)
+            m_tile = softmax_helper.floor_masked_max(m_tile)
             return m_tile
 
         def _load_q_regs():


### PR DESCRIPTION
Rebased onto the current `binding_fa_gfx950`, which now provides `return_lse` itself. The LSE half of this PR is therefore dropped; what remains is the one-line NaN fix.

## Motivation

A tile in which every column is masked leaves `m_tile` at `-inf`. On the **first** tile `m_row` is `-inf` too, so `rescale_from_tile_max` computes `(-inf - -inf) * logit_scale = NaN`, and `exp2(NaN) = NaN` scales the O accumulator to NaN. The epilogue's guarded reciprocal does not save it: the guard correctly yields `inv_l = 0`, but `0 * NaN = NaN`.

Under `CAUSAL` the existing floor already covered this. Non-causal was left exposed, and a varlen entry with `seqlen_kv == 0` hits it on every call — which MLA chunked prefill emits routinely, whenever a batch has unequal cached lengths, since the chunk-meta builder yields `max(seq_hi - seq_lo, 0)` per sequence. CK writes exact `0.0` for those rows; this kernel wrote NaN, and the merge then spread it across the whole layer output.

## Technical Details

Floor the tile max unconditionally rather than only under `CAUSAL`. The floor is `-3.0e38`, below any real logit, so no non-degenerate result changes. `_merge_tile_max` is the only tile-max site in the gfx950 fp8 family.

## Test Plan / Test Result

gfx950 (MI355X), K3 MLA shapes H=12 D=192 Dv=128, fresh FlyDSL JIT cache:

- `op_tests/test_flydsl_fmha.py -k head_dim_192` — **52 passed**, unchanged from the base.
- Zero-KV probe — the 147456 affected elements were NaN before this patch and are exact `0.0` after, with the `-inf` LSE mask (1152/1152 rows) intact and all live rows unchanged. A fully-masked causal case (`Sq=128, Skv=4`, 1488/1488 rows `-inf`) and an `sk=1` control are clean too.
- `return_lse` parity against a torch reference, now that the base provides it — max abs err **2.9e-06** over five shapes including split-K (`splits=1` and `splits=4`), unchanged by this patch.

### Is the floor safe in the non-causal case?

The floor only binds while `m_row` is still `-inf`, i.e. before any unmasked column has been seen: once `m_row` is finite, `maxnumf(m_row, -3e38) == maxnumf(m_row, -inf)`, same value and same rescale. In non-causal the masked columns are a suffix (`col >= seqlen_kv`), so a fully-masked tile is always preceded by a real one -- unlike causal, where early Q rows have whole later tiles masked, which is why the floor was written for `CAUSAL` originally. Split-K does not break this: `split_nonempty = split_t0 + 4 <= max_num_tiles` and varlen-inactive rows get `split_t_end = split_t0`, so an empty split never enters the loop (probed: kv=1/16/255 against 8 and 16 splits, 0 NaN on the unpatched base).

Verified rather than assumed -- unpatched base vs this patch, separate JIT caches, `torch.equal` (not a tolerance):

| case | |
|---|---|
| non-causal kv=16384 / 16383 / 16385 (tile-aligned, one short, one past) | bit-identical |
| non-causal kv=1, kv=255 (sub-tile) | bit-identical |
| non-causal bs4 and bs3 ragged, unaligned | bit-identical |
| non-causal split-K=4, kv=16384 / 16383 | bit-identical |
| causal 2048^2, causal cross sq<<sk, causal sq=128 sk=129 | bit-identical |

12/12. So the floor is a no-op for every row with at least one unmasked column, and the only behaviour it changes is `seqlen_kv == 0`.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
