### PR TITLE
[CI] fix: fix the conflict of cpu isolation and sglang cpu affinity

### DIFF
--- a/.github/scripts/kimi_sglang_accuracy.sh
+++ b/.github/scripts/kimi_sglang_accuracy.sh
@@ -37,6 +37,8 @@ SLOG="$OUT/server.log"
 export SGLANG_USE_AITER=${SGLANG_USE_AITER:-1}
 export AITER_QUICK_REDUCE_QUANTIZATION=${AITER_QUICK_REDUCE_QUANTIZATION:-INT4}
 export SGLANG_AITER_FP8_PREFILL_ATTN=${SGLANG_AITER_FP8_PREFILL_ATTN:-0}
+# The CI container can expose only a restricted subset of the host CPUs.
+export SGLANG_SET_CPU_AFFINITY=0
 
 if [ -d "/models/${MODEL_PATH}" ]; then MODEL="/models/${MODEL_PATH}"; else MODEL="${MODEL_PATH}"; fi
 echo "== Kimi SGLang accuracy =="; echo "model=$MODEL tp=$TP"

--- a/.github/scripts/kimi_sglang_perf.sh
+++ b/.github/scripts/kimi_sglang_perf.sh
@@ -36,6 +36,8 @@ SLOG="$OUT/server.log"
 export SGLANG_USE_AITER=${SGLANG_USE_AITER:-1}
 export AITER_QUICK_REDUCE_QUANTIZATION=${AITER_QUICK_REDUCE_QUANTIZATION:-INT4}
 export SGLANG_AITER_FP8_PREFILL_ATTN=${SGLANG_AITER_FP8_PREFILL_ATTN:-0}
+# The CI container can expose only a restricted subset of the host CPUs.
+export SGLANG_SET_CPU_AFFINITY=0
 
 # Prefer a /models mount if the weights are pre-cached there, else use the path
 # as given (e.g. a local /data mount).

--- a/.github/workflows/sglang_downstream.yaml
+++ b/.github/workflows/sglang_downstream.yaml
@@ -173,6 +173,7 @@ jobs:
           bash scripts/ci/amd/amd_ci_exec.sh -w "/sglang-checkout/test" \
             -e GITHUB_STEP_SUMMARY="/sglang-checkout/github_summary.md" \
             -e AITER_USE_SYSTEM_TRITON=1 \
+            -e SGLANG_SET_CPU_AFFINITY=0 \
             "${MODEL_ENV_ARGS[@]}" \
             ${EXTRA_EXEC_ARGS} \
             ${TEST_COMMAND} || TEST_EXIT_CODE=$?


### PR DESCRIPTION
## Motivation

  Fix the SGLang downstream MI35x CI failure caused by CPU affinity settings that are incompatible with the container CPU set.

  The SGLang ROCm image enables CPU affinity by default. SGLang derives GPU-local CPU IDs from the host topology, but the CI container may only have access to
  a restricted subset of those CPUs. Attempting to bind scheduler processes to unavailable CPUs causes psutil to raise a ValueError, terminating scheduler
  initialization.

  For example:

  ValueError: CPU number 96 is not eligible; choose between [6, ..., 25]

  ## Technical Details

  Disable SGLang CPU affinity for the Aiter downstream test command by passing:

  SGLANG_SET_CPU_AFFINITY=0

  through the existing amd_ci_exec.sh environment interface.

  This overrides the ROCm container image default without modifying or patching SGLang source code. The change is limited to the SGLang checkout and test
  processes used by Aiter downstream CI.

  Using a CI-level environment override also avoids depending on the implementation or layout of SGLang's CPU affinity code.

  ## Test Plan

  - Run git diff --check.
  - Validate the updated GitHub Actions workflow.
  - Verify that amd_ci_exec.sh passes SGLANG_SET_CPU_AFFINITY=0 into the test container.
  - Verify that SGLang parses SGLANG_SET_CPU_AFFINITY=0 as disabled.
  - Run the affected 8-GPU MI35x DeepSeek-R1-MXFP4 downstream test in CI.

  ## Test Result

  Local static checks passed:

  - git diff --check: passed.
  - Workflow syntax validation: passed.
  - Confirmed that amd_ci_exec.sh forwards the environment override to docker exec.
  - Confirmed that SGLang recognizes 0 as a valid false value for SGLANG_SET_CPU_AFFINITY.
  - Confirmed that the currently selected downstream test suites do not override the setting.

  The full 8-GPU MI35x test requires CI hardware and is pending CI validation.

  ## Submission Checklist

  - [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.