### PR TITLE
[Config] Retune gpt-oss N=2880,K=4096 off hipBLASLt so CUDAGraph capture succeeds

### DIFF
--- a/aiter/configs/model_configs/gptoss_bf16_tuned_gemm.csv
+++ b/aiter/configs/model_configs/gptoss_bf16_tuned_gemm.csv
@@ -84,9 +84,9 @@ gfx950,256,80,2880,4096,True,torch.bfloat16,torch.bfloat16,False,False,flydsl,36
 gfx950,256,96,2880,4096,True,torch.bfloat16,torch.bfloat16,False,False,flydsl,4021,4,13.4578,flydsl_hgemm_abf16_wbf16_bf16_t96x64x128x3_ks4_w2x2x2_bias1_ktail0_gm0_pft_gfx950,0.0201,168.3,1852.63
 gfx950,256,112,2880,4096,True,torch.bfloat16,torch.bfloat16,False,False,flydsl,3447,2,14.2545,flydsl_hgemm_abf16_wbf16_bf16_t64x64x64x6_ks2_w4x2x1_bias1_ktail0_gm0_pft_gfx950,0.0067,185.37,1764.75
 gfx950,256,128,2880,4096,True,torch.bfloat16,torch.bfloat16,False,False,flydsl,3571,2,14.8665,flydsl_hgemm_abf16_wbf16_bf16_t64x64x64x6_ks2_w4x2x1_bias1_ktail0_gm0_pft_gfx950,0.0067,203.13,1707.11
-gfx950,256,192,2880,4096,True,torch.bfloat16,torch.bfloat16,False,False,torch,0,0,17.6739,native,0.0,256.3,1486.47
-gfx950,256,256,2880,4096,True,torch.bfloat16,torch.bfloat16,False,False,torch,0,0,18.6333,native,0.0,324.14,1457.86
-gfx950,256,320,2880,4096,True,torch.bfloat16,torch.bfloat16,False,False,torch,0,0,20.4656,native,0.0,368.9,1370.96
+gfx950,256,192,2880,4096,True,torch.bfloat16,torch.bfloat16,False,False,flydsl,3074,2,18.4618,flydsl_hgemm_abf16_wbf16_bf16_t96x64x128x3_ks2_w2x2x2_bias1_ktail0_gm0_pft_gfx950,0.0138,245.36,1423.03
+gfx950,256,256,2880,4096,True,torch.bfloat16,torch.bfloat16,False,False,triton,0,0,20.523,auto,0.0,294.29,1323.62
+gfx950,256,320,2880,4096,True,torch.bfloat16,torch.bfloat16,False,False,flydsl,1971,1,22.5042,flydsl_hgemm_abf16_wbf16_bf16_t64x64x64x5_ks1_w1x4x1_bias1_ktail0_gm0_pft_gfx950,0.0,335.48,1246.77
 gfx950,256,512,2880,4096,True,torch.bfloat16,torch.bfloat16,False,False,flydsl,2063,1,25.3644,flydsl_hgemm_abf16_wbf16_bf16_t64x96x128x3_ks1_w2x2x2_bias1_ktail0_gm0_pft_gfx950,0.0049,476.24,1211.79
 gfx950,256,1024,2880,4096,True,torch.bfloat16,torch.bfloat16,False,False,flydsl,328,1,36.7809,flydsl_hgemm_abf16_wbf16_bf16_t128x96x64x4_ks1_w2x2x1_bias1_ktail0_gm0_pft_gfx950,0.0,656.84,1029.88
 gfx950,256,2048,2880,4096,True,torch.bfloat16,torch.bfloat16,False,False,torch,0,0,61.2613,native,0.0,788.73,851.54


### PR DESCRIPTION
## What breaks

`gpt-oss-120b` on gfx950 with TP2 + DP-attention + EP + two-batch overlap never starts:

```
HIP error: operation not permitted when stream is capturing
Search for `hipErrorStreamCaptureUnsupported' ...
[atom] Engine Core: load model runner failed
```

Three rows of `gptoss_bf16_tuned_gemm.csv` — `N=2880, K=4096` at `M=192/256/320` — carry `libtype=torch`, which dispatches to hipBLASLt (`tuned_gemm.py`'s own comment says so). hipBLASLt allocates its workspace on first use, and that allocation is illegal on a capturing stream, so CUDAGraph capture aborts.

TBO is what reaches these M: capture at `bs=512` runs ubatches of 256, where `bs=256` would have landed on `M=128` and its flydsl row. Every neighbouring M on this shape is already flydsl — only these three fell to torch.

## Fix

Re-tuned with the existing tuner, excluding the capture-hostile backend:

```
python3 csrc/gemm_a16w16/gemm_a16w16_tune.py \
    --input_file <the three shapes> \
    --libtype flydsl,triton,asm,skinny,opus
```

| M | libtype | us | vs hipBLASLt |
|---|---|---|---|
| 192 | flydsl | 18.46 | +5.4% |
| 256 | triton | 20.52 | +19.8% |
| 320 | flydsl | 22.50 | +31.4% |

hipBLASLt baseline measured on the same box: 17.51 / 17.13 / 17.12 us. The gap is the price of these shapes being capturable at all; there is no faster capture-safe option in the tuner's search space.

## Verification

- **Positive control**: reverting only these three rows to `torch` reproduces `operation not permitted when stream is capturing` at capture, twice, and the server fails to start. With them, capture completes.
- gpt-oss-120b TP2 + DP2 + EP + TBO, GSM8K flexible-extract **0.906** (baseline 0.90, threshold 0.88), 1319/1319, no faults. `M=192` tunes with `err_ratio=0.0138`, inside the tuner's 0.05 gate and not visible in the score.

## Note

`N=100544, K=2880` (lm_head at TP2) has no tuned row at all and falls back to hipBLASLt the same way, which is why capture also fails with TBO **off**. Out of scope here — this PR only covers the rows that already exist and pick a backend that cannot be captured.
