### PR TITLE
[Triton/Gluon] Restore shared MHA backend parameterization

### DIFF
--- a/op_tests/triton_tests/attention/mha_test_utils.py
+++ b/op_tests/triton_tests/attention/mha_test_utils.py
@@ -21,6 +21,8 @@ def skip_if_triton_padded_head_miscompiled(
 ):
     """
     Skip Triton forward tests miscompiled by the pinned ROCm Triton build.
+
+    Remove this function once the Triton compiler pinned by AITER CI is updated.
     """
     if (
         backend == "triton"

--- a/op_tests/triton_tests/attention/mha_test_utils.py
+++ b/op_tests/triton_tests/attention/mha_test_utils.py
@@ -2,6 +2,7 @@ import pytest
 import torch
 
 from aiter.ops.triton.attention.mha import gluon_forward_unsupported_reason
+from aiter.ops.triton.utils._triton import arch_info
 
 
 def skip_if_gluon_unsupported(backend: str, **feature_flags):
@@ -13,6 +14,27 @@ def skip_if_gluon_unsupported(backend: str, **feature_flags):
     reason = gluon_forward_unsupported_reason(**feature_flags)
     if reason:
         pytest.skip(reason)
+
+
+def skip_if_triton_padded_head_miscompiled(
+    backend: str, HEAD_SZ: int, CAUSAL: bool, SEQLEN_K: int, NUM_K_HEADS: int
+):
+    """
+    Skip Triton forward tests miscompiled by the pinned ROCm Triton build.
+    """
+    if (
+        backend == "triton"
+        and HEAD_SZ == 33
+        and CAUSAL
+        and SEQLEN_K >= 2048
+        and NUM_K_HEADS == 1
+        and arch_info.get_arch() == "gfx950"
+    ):
+        pytest.skip(
+            "gfx950: padded head size 33 is miscompiled by the pinned ROCm "
+            "Triton build for causal long-sequence single-KV-head cases; "
+            "passes on triton-lang/triton@2074a1b"
+        )
 
 
 def pad_rearrange_dropout_mask(

--- a/op_tests/triton_tests/attention/test_mha.py
+++ b/op_tests/triton_tests/attention/test_mha.py
@@ -113,7 +113,7 @@ def _test_mha_impl(
     "SEQLEN_Q, SEQLEN_K",
     [(1, 1), (128, 128), (32, 16), (64, 128), (2048, 2048)],
 )
-@pytest.mark.parametrize("NUM_Q_HEADS, NUM_K_HEADS", [(1, 1), (8, 1), (64, 8)])
+@pytest.mark.parametrize("NUM_Q_HEADS, NUM_K_HEADS", [(1, 1), (8, 1), (48, 8)])
 @pytest.mark.parametrize("HEAD_SZ", [33, 64, 128])
 @pytest.mark.parametrize("CAUSAL", [(True), (False)])
 @pytest.mark.parametrize("backend", ["triton", "gluon"])
@@ -572,7 +572,7 @@ def _test_mha_varlen_impl(
     [(1, 1), (128, 128), (32, 16), (64, 128), (2048, 2048)],
 )
 @pytest.mark.parametrize(
-    "NUM_Q_HEADS, NUM_K_HEADS", [(1, 1), (8, 1), (16, 16), (64, 8)]
+    "NUM_Q_HEADS, NUM_K_HEADS", [(1, 1), (8, 1), (16, 16), (48, 8)]
 )
 @pytest.mark.parametrize("HEAD_SZ", [8, 32, 33, 128])
 @pytest.mark.parametrize("CAUSAL", [(True), (False)])

--- a/op_tests/triton_tests/attention/test_mha.py
+++ b/op_tests/triton_tests/attention/test_mha.py
@@ -23,6 +23,7 @@ from aiter.test_mha_common import (
 from op_tests.triton_tests.attention.mha_test_utils import (
     pad_rearrange_dropout_mask,
     skip_if_gluon_unsupported,
+    skip_if_triton_padded_head_miscompiled,
 )
 
 logging.basicConfig(level=logging.DEBUG)
@@ -127,6 +128,9 @@ def test_mha(
     backend: str,
     dtype=torch.bfloat16,
 ):
+    skip_if_triton_padded_head_miscompiled(
+        backend, HEAD_SZ, CAUSAL, SEQLEN_K, NUM_K_HEADS
+    )
     _test_mha_impl(
         BATCH,
         SEQLEN_Q,
@@ -584,6 +588,9 @@ def test_mha_varlen(
     backend: str,
     dtype=torch.bfloat16,
 ):
+    skip_if_triton_padded_head_miscompiled(
+        backend, HEAD_SZ, CAUSAL, SEQLEN_K, NUM_K_HEADS
+    )
     _test_mha_varlen_impl(
         BATCH,
         SEQLEN_Q,

--- a/op_tests/triton_tests/attention/test_mha.py
+++ b/op_tests/triton_tests/attention/test_mha.py
@@ -112,9 +112,10 @@ def _test_mha_impl(
     "SEQLEN_Q, SEQLEN_K",
     [(1, 1), (128, 128), (32, 16), (64, 128), (2048, 2048)],
 )
-@pytest.mark.parametrize("NUM_Q_HEADS, NUM_K_HEADS", [(1, 1), (8, 8), (48, 8)])
-@pytest.mark.parametrize("HEAD_SZ", [64, 128])
+@pytest.mark.parametrize("NUM_Q_HEADS, NUM_K_HEADS", [(1, 1), (8, 1), (64, 8)])
+@pytest.mark.parametrize("HEAD_SZ", [33, 64, 128])
 @pytest.mark.parametrize("CAUSAL", [(True), (False)])
+@pytest.mark.parametrize("backend", ["triton", "gluon"])
 def test_mha(
     BATCH: int,
     SEQLEN_Q: int,
@@ -123,6 +124,7 @@ def test_mha(
     NUM_K_HEADS: int,
     HEAD_SZ: int,
     CAUSAL: bool,
+    backend: str,
     dtype=torch.bfloat16,
 ):
     _test_mha_impl(
@@ -136,41 +138,7 @@ def test_mha(
         RETURN_LSE=False,
         RETURN_SOFTMAX=False,
         CAUSAL=CAUSAL,
-        backend="triton",
-        dtype=dtype,
-    )
-
-
-@pytest.mark.parametrize("BATCH", [1, 30, 50])
-@pytest.mark.parametrize(
-    "SEQLEN_Q, SEQLEN_K",
-    [(1, 1), (128, 128), (32, 16), (64, 128), (2048, 2048)],
-)
-@pytest.mark.parametrize("NUM_Q_HEADS, NUM_K_HEADS", [(1, 1), (8, 1), (64, 8)])
-@pytest.mark.parametrize("HEAD_SZ", [33, 64, 128])
-@pytest.mark.parametrize("CAUSAL", [(True), (False)])
-def test_mha_gluon(
-    BATCH: int,
-    SEQLEN_Q: int,
-    SEQLEN_K: int,
-    NUM_Q_HEADS: int,
-    NUM_K_HEADS: int,
-    HEAD_SZ: int,
-    CAUSAL: bool,
-    dtype=torch.bfloat16,
-):
-    _test_mha_impl(
-        BATCH,
-        SEQLEN_Q,
-        SEQLEN_K,
-        NUM_Q_HEADS,
-        NUM_K_HEADS,
-        HEAD_SZ,
-        DROPOUT=0.0,
-        RETURN_LSE=False,
-        RETURN_SOFTMAX=False,
-        CAUSAL=CAUSAL,
-        backend="gluon",
+        backend=backend,
         dtype=dtype,
     )
 
@@ -600,10 +568,11 @@ def _test_mha_varlen_impl(
     [(1, 1), (128, 128), (32, 16), (64, 128), (2048, 2048)],
 )
 @pytest.mark.parametrize(
-    "NUM_Q_HEADS, NUM_K_HEADS", [(1, 1), (16, 16), (2, 1), (48, 8)]
+    "NUM_Q_HEADS, NUM_K_HEADS", [(1, 1), (8, 1), (16, 16), (64, 8)]
 )
-@pytest.mark.parametrize("HEAD_SZ", [8, 32, 128])
+@pytest.mark.parametrize("HEAD_SZ", [8, 32, 33, 128])
 @pytest.mark.parametrize("CAUSAL", [(True), (False)])
+@pytest.mark.parametrize("backend", ["triton", "gluon"])
 def test_mha_varlen(
     BATCH: int,
     SEQLEN_Q: int,
@@ -612,6 +581,7 @@ def test_mha_varlen(
     NUM_K_HEADS: int,
     HEAD_SZ: int,
     CAUSAL: bool,
+    backend: str,
     dtype=torch.bfloat16,
 ):
     _test_mha_varlen_impl(
@@ -625,43 +595,7 @@ def test_mha_varlen(
         RETURN_LSE=False,
         RETURN_SOFTMAX=False,
         CAUSAL=CAUSAL,
-        backend="triton",
-        dtype=dtype,
-    )
-
-
-@pytest.mark.parametrize("BATCH", [1, 4, 30, 50])
-@pytest.mark.parametrize(
-    "SEQLEN_Q, SEQLEN_K",
-    [(1, 1), (128, 128), (32, 16), (64, 128), (2048, 2048)],
-)
-@pytest.mark.parametrize(
-    "NUM_Q_HEADS, NUM_K_HEADS", [(1, 1), (8, 1), (16, 16), (64, 8)]
-)
-@pytest.mark.parametrize("HEAD_SZ", [8, 32, 33, 128])
-@pytest.mark.parametrize("CAUSAL", [(True), (False)])
-def test_mha_varlen_gluon(
-    BATCH: int,
-    SEQLEN_Q: int,
-    SEQLEN_K: int,
-    NUM_Q_HEADS: int,
-    NUM_K_HEADS: int,
-    HEAD_SZ: int,
-    CAUSAL: bool,
-    dtype=torch.bfloat16,
-):
-    _test_mha_varlen_impl(
-        BATCH,
-        SEQLEN_Q,
-        SEQLEN_K,
-        NUM_Q_HEADS,
-        NUM_K_HEADS,
-        HEAD_SZ,
-        DROPOUT=0.0,
-        RETURN_LSE=False,
-        RETURN_SOFTMAX=False,
-        CAUSAL=CAUSAL,
-        backend="gluon",
+        backend=backend,
         dtype=dtype,
     )
 


### PR DESCRIPTION
## Summary

- revert the duplicated Triton/Gluon MHA test functions introduced by #5352
- restore #4147's shared `test_mha` and `test_mha_varlen` backend parameterization
- run the same head-count and head-size matrices, including head size 33, for both backends
- use `(48, 8)` rather than #4147's `(64, 8)` for the largest head count, so the shared matrix fits in gfx942 memory
- remove `_backend_mha_cases()` because the backends no longer use different matrices
- add a narrow conditional skip for the 14 cases miscompiled by the pinned ROCm Triton build, so they stay collected instead of being deleted from the matrix

The stale-import and MHA-PE deselect fixes from #5352 remain correct and are not changed here.

## Why the split was the wrong fix

After the import fix restored collection, the initial #5352 run exposed 14 failures in one narrow traditional-Triton configuration. #5352 made CI green by moving #4147's expanded matrix into separate Gluon-only test functions, which removed **all** Triton head-size-33 coverage and duplicated the test wrappers. That hid the defect rather than recording it, and it also silently changed the Triton head-count matrix.

Head size 33 is a valid shape. Of the 250 Triton head-size-33 cases in the shared matrix, 236 pass — including every non-causal case, every shorter sequence length, and the `(48, 8)` and `(16, 16)` head configurations.

## The 14 failing cases

All 14 share the same signature:

| Axis | Value |
|---|---|
| backend | `triton` (Gluon is unaffected) |
| `HEAD_SZ` | 33 |
| `CAUSAL` | `True` |
| `SEQLEN_Q, SEQLEN_K` | 2048, 2048 |
| `NUM_Q_HEADS, NUM_K_HEADS` | `(1, 1)` and `(8, 1)` |
| architecture | gfx950 |

`NUM_K_HEADS == 1` is the discriminator, not the GQA group size: `(1, 1)` and `(8, 8)` are both group-1, but only `(1, 1)` fails.

## This is a compiler defect, not a kernel or shape defect

The failure is fully deterministic. Two runs on different days and different runner instances produced identical results — the same 14 node IDs, and all 11 distinct `Greatest absolute difference` values at identical tensor indices with identical multiplicities. Re-running does not help.

CI installs `triton-3.8.0+amd.rocm7.2.0.git111ff227`. That commit is **not** upstream. Compared against `triton-lang/triton@2074a1b`, the two have diverged, and the pinned build carries five AMD-only commits that upstream does not:

```
a1845dccc5  2026-05-18  Fix compatible issue for pyotrch2.10
f6a045ff63  2026-07-06  Add budget-aware SGPR kernarg preload, enable by default for all arches
c528593ab9  2026-08-28  Revert "[AMD][GFX9] Enable amdgpu-use-amdgpu-trackers LLVM flag (#11285)"
8ac9305870  2026-08-28  Revert "Only anchor efficient layout reshapes (#11275)"
111ff22753  2026-08-28  Force amdgpu-agpr-alloc=0 to work around AGPR over-allocation
```

@brunomazzottiamd independently confirmed the affected cases pass on gfx950 when Triton is built from `triton-lang/triton@2074a1b`, which isolates the defect to the pinned build rather than to Triton in general.

The leading hypothesis involves the interaction of padded head lanes (`33 -> 40 -> 64`) with the gfx950 software-pipelined loop. `small_head` is defined **only** in the gfx950 config and sets `num_stages: 3`; gfx942 has no such entry and falls through to `default` with `num_stages: 1`, so it never enters the pipelined path. `Revert "Only anchor efficient layout reshapes"` and the forced `amdgpu-agpr-alloc=0` are the most plausible suspects. The precise mechanism is not yet proven.

## The conditional skip

`skip_if_triton_padded_head_miscompiled()` guards exactly the failing combination and nothing else:

```python
if (
    backend == "triton"
    and HEAD_SZ == 33
    and CAUSAL
    and SEQLEN_K >= 2048
    and NUM_K_HEADS == 1
    and arch_info.get_arch() == "gfx950"
):
```

The cases remain collected and report as skipped with an explanation pointing at the compiler, so the coverage gap is visible in CI output instead of invisible. Removing the guard once CI moves to a fixed Triton build is a one-line change.

## Head counts: `(48, 8)` instead of #4147's `(64, 8)`

This is the one place where the restored matrix deliberately departs from #4147.

#4147 used `(64, 8)` for the largest head count, but that value was never actually executed on Triton. #4147 also shipped a `_gluon_kernels/gfx950/attention/mha.py` that imported the `utils.core` module deleted by #5061, so `test_mha.py` failed at collection on every architecture for the entire window it was on main. #5352 fixed the import and reverted Triton to `(48, 8)` in the same change, so `(64, 8)` went straight from uncollectable to removed without ever running.

Restoring it here ran it for the first time, and it exhausted MI300X:

```
torch.OutOfMemoryError: Tried to allocate 50.00 GiB.
GPU 0 has a total capacity of 191.98 GiB of which 17.12 GiB is free
```

The cause is the PyTorch reference in `attention_ref()`, not the kernels. It upcasts to fp32 and materializes several full `(batch, heads, seqlen_q, seqlen_k)` tensors at once. At `BATCH=50`, `SEQLEN=2048`:

| Head config | Per tensor | Peak | Fits in 191.98 GiB |
|---|---|---|---|
| `(64, 8)` | 50.0 GiB | ~150 GiB | no — 9 OOMs, observed peak 151.74 GiB |
| `(48, 8)` | 37.5 GiB | ~112.5 GiB | yes — this is what main sustains today |

gfx950 has enough HBM to absorb `(64, 8)`, which is why only MI300X failed.

Both `test_mha` and `test_mha_varlen` use `(48, 8)`, not just the varlen one that OOM'd. `test_mha` did technically pass `(64, 8)` on gfx942, but only because it runs first on a clean device, and at roughly 150 GiB of 191.98 GiB it had no headroom. Changing only varlen would also break the alignment between the two matrices that #4147 established. `(48, 8)` preserves the same GQA shape being exercised — 8 KV heads with a >1 group size — at a group size of 6 instead of 8.

`test_mha_backward` keeps its own independent `NUM_Q_HEADS [32, 64]` / `NUM_K_HEADS [8]` lists, unchanged by this PR. Its batch size caps at 4, so its worst case is about 4.3 GiB per tensor and it never approaches the limit.

## Coverage

Case counts are unchanged by the head-count value; only the shape exercised by that axis differs.

| Test | #5352 (split) | This PR | Skipped |
|---|---|---|---|
| `test_mha` | 450 | 540 | 6 |
| `test_mha_varlen` | 1,120 | 1,280 | 8 |

Gluon coverage is untouched — zero Gluon cases match the skip condition. Triton retains 236 of its 250 head-size-33 cases.

## Evidence

- [#4147 introduced the shared matrices](https://github.com/ROCm/aiter/pull/4147)
- [Initial #5352 shard-4 run showing the 14 failures](https://github.com/ROCm/aiter/actions/runs/34260549117/job/102179514759)
- [This branch reproducing the identical 14 failures before the skip](https://github.com/ROCm/aiter/actions/runs/34374699211/job/102546324215)
- [Triton 3.7 shard-4 control that passed](https://github.com/ROCm/aiter/actions/runs/32304449893/job/96235360533)
- [#5152 upgraded the CI pin to Triton 3.8](https://github.com/ROCm/aiter/pull/5152)
- [#5352 split-matrix run that passed after dropping those Triton cases](https://github.com/ROCm/aiter/actions/runs/34311085615/job/102338846451)
- [MI300X shard 4 OOM run at `(64, 8)`](https://github.com/ROCm/aiter/actions/runs/34397685440/job/102935544640)
- [MI300X shard 4 green at `(48, 8)`](https://github.com/ROCm/aiter/actions/runs/34518758723/job/103012863221)
- [MI35X shard 4 green with the 14 cases skipped](https://github.com/ROCm/aiter/actions/runs/34518758723/job/103012863008)

## Test plan

- [x] test sections match commit `2e682f2dd` from #4147, apart from the documented `(48, 8)` head count
- [x] `black --check` and `ruff check` on both changed files
- [x] skip predicate simulated against the full matrix: matches the 14 failing node IDs exactly, no over-skip, zero Gluon cases affected
- [x] MI35X shard 4 green with the 14 cases reported as skipped — 4,204 passed, 770 skipped
- [x] MI300X shard 4 green with zero `OutOfMemoryError` — 2,580 passed, 2,395 skipped
- [x] full PR check suite green on `0b1237ab7`: all 8 MI300X shards and all 8 MI35X shards pass
