### PR TITLE
[Triton/Gluon] [CI] Consolidate MHA backend test parameterization

### DIFF
--- a/op_tests/triton_tests/attention/test_mha.py
+++ b/op_tests/triton_tests/attention/test_mha.py
@@ -30,6 +30,48 @@ logger = logging.getLogger(__name__)
 DEBUG_MODE = False
 
 
+# Keep backend-specific head domains coupled to avoid unsupported cross-products.
+def _backend_head_cases(backend, head_pairs, head_sizes):
+    return [
+        pytest.param(
+            backend,
+            num_q_heads,
+            num_k_heads,
+            head_size,
+            id=f"{backend}-{num_q_heads}-{num_k_heads}-{head_size}",
+        )
+        for num_q_heads, num_k_heads in head_pairs
+        for head_size in head_sizes
+    ]
+
+
+_MHA_BACKEND_HEAD_CASES = [
+    *_backend_head_cases(
+        "triton",
+        ((1, 1), (8, 8), (48, 8)),
+        (64, 128),
+    ),
+    *_backend_head_cases(
+        "gluon",
+        ((1, 1), (8, 1), (64, 8)),
+        (33, 64, 128),
+    ),
+]
+
+_MHA_VARLEN_BACKEND_HEAD_CASES = [
+    *_backend_head_cases(
+        "triton",
+        ((1, 1), (16, 16), (2, 1), (48, 8)),
+        (8, 32, 128),
+    ),
+    *_backend_head_cases(
+        "gluon",
+        ((1, 1), (8, 1), (16, 16), (64, 8)),
+        (8, 32, 33, 128),
+    ),
+]
+
+
 def _test_mha_impl(
     BATCH: int,
     SEQLEN_Q: int,
@@ -112,9 +154,11 @@ def _test_mha_impl(
     "SEQLEN_Q, SEQLEN_K",
     [(1, 1), (128, 128), (32, 16), (64, 128), (2048, 2048)],
 )
-@pytest.mark.parametrize("NUM_Q_HEADS, NUM_K_HEADS", [(1, 1), (8, 8), (48, 8)])
-@pytest.mark.parametrize("HEAD_SZ", [64, 128])
 @pytest.mark.parametrize("CAUSAL", [(True), (False)])
+@pytest.mark.parametrize(
+    "backend, NUM_Q_HEADS, NUM_K_HEADS, HEAD_SZ",
+    _MHA_BACKEND_HEAD_CASES,
+)
 def test_mha(
     BATCH: int,
     SEQLEN_Q: int,
@@ -123,6 +167,7 @@ def test_mha(
     NUM_K_HEADS: int,
     HEAD_SZ: int,
     CAUSAL: bool,
+    backend: str,
     dtype=torch.bfloat16,
 ):
     _test_mha_impl(
@@ -136,41 +181,7 @@ def test_mha(
         RETURN_LSE=False,
         RETURN_SOFTMAX=False,
         CAUSAL=CAUSAL,
-        backend="triton",
-        dtype=dtype,
-    )
-
-
-@pytest.mark.parametrize("BATCH", [1, 30, 50])
-@pytest.mark.parametrize(
-    "SEQLEN_Q, SEQLEN_K",
-    [(1, 1), (128, 128), (32, 16), (64, 128), (2048, 2048)],
-)
-@pytest.mark.parametrize("NUM_Q_HEADS, NUM_K_HEADS", [(1, 1), (8, 1), (64, 8)])
-@pytest.mark.parametrize("HEAD_SZ", [33, 64, 128])
-@pytest.mark.parametrize("CAUSAL", [(True), (False)])
-def test_mha_gluon(
-    BATCH: int,
-    SEQLEN_Q: int,
-    SEQLEN_K: int,
-    NUM_Q_HEADS: int,
-    NUM_K_HEADS: int,
-    HEAD_SZ: int,
-    CAUSAL: bool,
-    dtype=torch.bfloat16,
-):
-    _test_mha_impl(
-        BATCH,
-        SEQLEN_Q,
-        SEQLEN_K,
-        NUM_Q_HEADS,
-        NUM_K_HEADS,
-        HEAD_SZ,
-        DROPOUT=0.0,
-        RETURN_LSE=False,
-        RETURN_SOFTMAX=False,
-        CAUSAL=CAUSAL,
-        backend="gluon",
+        backend=backend,
         dtype=dtype,
     )
 
@@ -599,11 +610,11 @@ def _test_mha_varlen_impl(
     "SEQLEN_Q, SEQLEN_K",
     [(1, 1), (128, 128), (32, 16), (64, 128), (2048, 2048)],
 )
-@pytest.mark.parametrize(
-    "NUM_Q_HEADS, NUM_K_HEADS", [(1, 1), (16, 16), (2, 1), (48, 8)]
-)
-@pytest.mark.parametrize("HEAD_SZ", [8, 32, 128])
 @pytest.mark.parametrize("CAUSAL", [(True), (False)])
+@pytest.mark.parametrize(
+    "backend, NUM_Q_HEADS, NUM_K_HEADS, HEAD_SZ",
+    _MHA_VARLEN_BACKEND_HEAD_CASES,
+)
 def test_mha_varlen(
     BATCH: int,
     SEQLEN_Q: int,
@@ -612,6 +623,7 @@ def test_mha_varlen(
     NUM_K_HEADS: int,
     HEAD_SZ: int,
     CAUSAL: bool,
+    backend: str,
     dtype=torch.bfloat16,
 ):
     _test_mha_varlen_impl(
@@ -625,43 +637,7 @@ def test_mha_varlen(
         RETURN_LSE=False,
         RETURN_SOFTMAX=False,
         CAUSAL=CAUSAL,
-        backend="triton",
-        dtype=dtype,
-    )
-
-
-@pytest.mark.parametrize("BATCH", [1, 4, 30, 50])
-@pytest.mark.parametrize(
-    "SEQLEN_Q, SEQLEN_K",
-    [(1, 1), (128, 128), (32, 16), (64, 128), (2048, 2048)],
-)
-@pytest.mark.parametrize(
-    "NUM_Q_HEADS, NUM_K_HEADS", [(1, 1), (8, 1), (16, 16), (64, 8)]
-)
-@pytest.mark.parametrize("HEAD_SZ", [8, 32, 33, 128])
-@pytest.mark.parametrize("CAUSAL", [(True), (False)])
-def test_mha_varlen_gluon(
-    BATCH: int,
-    SEQLEN_Q: int,
-    SEQLEN_K: int,
-    NUM_Q_HEADS: int,
-    NUM_K_HEADS: int,
-    HEAD_SZ: int,
-    CAUSAL: bool,
-    dtype=torch.bfloat16,
-):
-    _test_mha_varlen_impl(
-        BATCH,
-        SEQLEN_Q,
-        SEQLEN_K,
-        NUM_Q_HEADS,
-        NUM_K_HEADS,
-        HEAD_SZ,
-        DROPOUT=0.0,
-        RETURN_LSE=False,
-        RETURN_SOFTMAX=False,
-        CAUSAL=CAUSAL,
-        backend="gluon",
+        backend=backend,
         dtype=dtype,
     )
 


### PR DESCRIPTION
## Summary

- restore a single pytest entry point for fixed-length MHA and one for varlen MHA
- couple each backend to its supported head-pair/head-size matrix so pytest does not form cross-backend Cartesian products
- preserve the exact post-#5352 coverage: 450 fixed-length cases and 1,120 varlen cases

## Why

#4147 added `backend=["triton", "gluon"]` as an independent parameter on shape matrices expanded for Gluon. That made Triton run every Gluon shape too. The [initial #5352 shard-4 run](https://github.com/ROCm/aiter/actions/runs/34260549117/job/102179514759) had 14 MHA failures; every one was a Triton causal case with sequence length 2048, head size 33, and `(Q, K)` heads `(1, 1)` or `(8, 1)`.

#5352 fixed that accidental cross-product by splitting the backend tests and restoring the original Triton matrices. The shape isolation was necessary, but separate test functions were not. This PR expresses the backend distinction in the parameter data while keeping shared batches, sequence lengths, causal modes, implementation, and assertions in one test function per API.

The fifteenth failure in that CI job was the known MHA-PE case whose node ID changed after backend parameterization. Its workflow deselect was corrected separately by #5352 and is unchanged here.

## Test plan

- [x] `python3 -m compileall -q op_tests/triton_tests/attention/test_mha.py`
- [x] `black --check op_tests/triton_tests/attention/test_mha.py`
- [x] `ruff check op_tests/triton_tests/attention/test_mha.py`
- [x] `git diff --check`
- [x] validate unique backend/head tuples and exact totals (450 fixed + 1,120 varlen)
- [ ] upstream GPU CI
