### PR TITLE
[Config] [GEMM] Tune GLM-5.2 native-MTP M=4 projections for gfx950

### DIFF
--- a/aiter/configs/model_configs/glm5_bf16_tuned_gemm.csv
+++ b/aiter/configs/model_configs/glm5_bf16_tuned_gemm.csv
@@ -283,7 +283,9 @@ gfx950,256,60,6144,1536,False,torch.bfloat16,torch.bfloat16,False,False,flydsl,2
 gfx950,256,10,3584,512,False,torch.bfloat16,torch.bfloat16,False,False,triton,0,0,3.3396,auto,0.0,10.99,1123.47
 gfx950,256,12,256,6144,False,torch.bfloat16,torch.bfloat16,False,False,flydsl,342,8,4.9611,flydsl_hgemm_abf16_wbf16_bf16_t16x32x128x5_ks8_w1x2x1_bias0_ktail0_gm0_pft_gfx950,0.0189,7.61,665.04
 gfx950,256,24,3072,6144,False,torch.bfloat16,torch.bfloat16,False,False,flydsl,2254,4,10.9995,flydsl_hgemm_abf16_wbf16_bf16_t32x64x128x4_ks4_w1x4x1_bias0_ktail0_gm0_pft_gfx950,0.0127,82.36,3472.08
-gfx950,256,4,2048,2048,False,torch.bfloat16,torch.bfloat16,False,False,triton,0,0,5.6903,auto,0.0,5.9,1479.95
+gfx950,256,4,512,6144,False,torch.bfloat16,torch.bfloat16,False,False,flydsl,173,6,5.8066,flydsl_hgemm_abf16_wbf16_bf16_t16x16x128x9_ks6_w1x1x1_bias0_ktail0_gm0_pft_gfx950,0.0146,4.33,1092.67
+gfx950,256,4,2048,2048,False,torch.bfloat16,torch.bfloat16,False,False,flydsl,345,4,5.9504,flydsl_hgemm_abf16_wbf16_bf16_t16x32x64x9_ks4_w1x1x1_bias0_ktail0_gm0_pft_gfx950,0.009,5.64,1415.26
+gfx950,256,4,3072,6144,False,torch.bfloat16,torch.bfloat16,False,False,flydsl,593,4,10.0285,flydsl_hgemm_abf16_wbf16_bf16_t16x64x128x4_ks4_w1x2x1_bias0_ktail0_gm0_pft_gfx950,0.0112,15.06,3771.5
 gfx950,256,48,6144,1536,False,torch.bfloat16,torch.bfloat16,False,False,flydsl,1846,1,8.08,flydsl_hgemm_abf16_wbf16_bf16_t48x32x128x5_ks1_w1x2x2_bias0_ktail0_gm0_pft_gfx950,0.0029,112.12,2427.18
 gfx950,256,8,3584,512,False,torch.bfloat16,torch.bfloat16,False,False,triton,0,0,4.033,auto,0.0,7.28,926.25
 gfx950,256,4,7168,512,False,torch.bfloat16,torch.bfloat16,False,False,flydsl,167,1,4.6154,flydsl_hgemm_abf16_wbf16_bf16_t16x32x64x9_ks1_w1x2x1_bias0_ktail0_gm0_pft_gfx950,0.0,6.36,1603.65
@@ -306,4 +308,5 @@ gfx950,256,10,6144,1536,False,torch.bfloat16,torch.bfloat16,False,False,flydsl,2
 gfx950,256,1,3584,512,False,torch.bfloat16,torch.bfloat16,False,False,triton,0,0,3.3906,auto,0.0,1.08,1084.83
 gfx950,256,1,6144,1536,False,torch.bfloat16,torch.bfloat16,False,False,flydsl,230,1,5.7665,flydsl_hgemm_abf16_wbf16_bf16_t16x32x128x7_ks1_w1x2x1_bias0_ktail0_gm0_pft_gfx950,0.0,3.27,3275.77
 gfx950,256,2,6144,1536,False,torch.bfloat16,torch.bfloat16,False,False,flydsl,263,1,5.8986,flydsl_hgemm_abf16_wbf16_bf16_t16x32x256x4_ks1_w1x2x1_bias0_ktail0_gm0_pft_gfx950,0.0,6.4,3205.01
+gfx950,256,4,6144,256,False,torch.bfloat16,torch.bfloat16,False,False,flydsl,82,1,3.9094,flydsl_hgemm_abf16_wbf16_bf16_t16x32x64x5_ks1_w1x2x1_bias0_ktail0_gm0_pft_gfx950,0.0,3.22,817.75
 gfx950,256,4,6144,1536,False,torch.bfloat16,torch.bfloat16,False,False,flydsl,222,1,5.8762,flydsl_hgemm_abf16_wbf16_bf16_t16x32x128x6_ks1_w1x1x2_bias0_ktail0_gm0_pft_gfx950,0.0021,12.85,3222.46

--- a/aiter/configs/model_configs/glm5_bf16_untuned_gemm.csv
+++ b/aiter/configs/model_configs/glm5_bf16_untuned_gemm.csv
@@ -7,6 +7,11 @@ M,N,K,bias,dtype,outdtype,scaleAB,bpreshuffle
 2,38720,6144,False,torch.bfloat16,torch.bfloat16,False,False
 4,160,6144,False,torch.bfloat16,torch.bfloat16,False,False
 4,256,6144,False,torch.bfloat16,torch.bfloat16,False,False
+4,512,6144,False,torch.bfloat16,torch.bfloat16,False,False
+4,2048,2048,False,torch.bfloat16,torch.bfloat16,False,False
+4,3072,6144,False,torch.bfloat16,torch.bfloat16,False,False
+4,6144,256,False,torch.bfloat16,torch.bfloat16,False,False
+4,6144,1536,False,torch.bfloat16,torch.bfloat16,False,False
 4,38720,6144,False,torch.bfloat16,torch.bfloat16,False,False
 8,160,6144,False,torch.bfloat16,torch.bfloat16,False,False
 8,256,6144,False,torch.bfloat16,torch.bfloat16,False,False


### PR DESCRIPTION
## Motivation

GLM-5.2's native-MTP target verification pass uses `M=4` at the
single-request serving point. A production TP8 graph showed five BF16
projection shapes that were absent from the model's tuning input. Current
AITER `main`, including ROCm/AITER#5328, already has exact tuned rows for two
of them, but the other three still fall back to the generic Torch path.

This change records all five production shapes in the GLM-5.2 tuning input,
adds the three missing gfx950 winners, and updates one existing row only after
it clears the tuner's 3% current-main comparison gate. The newer upstream
`(4, 6144, 1536)` row is retained because its fresh candidate was only 0.5%
faster.

No model-specific dispatch logic is added; this is tuning data consumed by
AITER's existing GEMM selector.

## Technical details

The multi-backend tuner evaluated 4,704 correctness-filtered candidates on an
MI355X against AITER `0923a53ea6c4609fa85a165ccc8b3236b43d0d4e`. The accepted
rows all resolve to FlyDSL.

| M, N, K | Current-main state | Runtime before | Runtime after | Change | Result |
|---|---|---:|---:|---:|---|
| 4, 512, 6144 | Torch fallback | 10.17 us | 5.87 us | -42.30% | add |
| 4, 2048, 2048 | tuned Triton | 6.34 us | 6.01 us | -5.29% | replace |
| 4, 3072, 6144 | Torch fallback | 11.62 us | 10.38 us | -10.70% | add |
| 4, 6144, 256 | Torch fallback | 5.37 us | 3.91 us | -27.15% | add |
| 4, 6144, 1536 | tuned FlyDSL | 6.47 us | 6.43 us | -0.51% | keep current |

These are the tuner's end-to-end runtime measurements through
`gemm_a16w16`, not the kernel-only `us` field stored in the CSV. Pre- and
post-tune arms used the same process and inputs; every accepted result clears
`--min_improvement_pct 3.0`.

## Correctness and graph capture

- The tuner checked every selected output against an FP32 reference before
  admitting it.
- All five final runtime selections were captured and replayed 20 times through
  `torch.cuda.CUDAGraph`; every shape remained within AITER's 5% BF16
  mismatched-element oracle.
- `python3 -m unittest op_tests.tuning_tests.test_config_shape_collision -v`
  passed all 17 tests, including the real 18-file BF16 config merge and its
  positive/negative self-checks.

Environment: AMD Instinct MI355X, ROCm 7.2.26015, PyTorch
`2.11.0+rocm7.2`.

## Serving context

The earlier two-replay SGLang screening on the AITER 95 baseline found that
the complete M=4 dense configuration improved output throughput from 211.048
to 214.805 tok/s (+1.78%) and median TPOT from 4.312 to 4.269 ms (-1.01%).
That result motivated this contribution, but it is not presented as the
incremental current-main serving claim: ROCm/AITER#5328 landed two of these
five exact rows after that screening. The table above is the new incremental
comparison against current AITER `main`.

## Submission checklist

- [x] Changes are limited to GLM-5.2 model tuning inputs and gfx950 results.
- [x] Fresh tuning and runtime comparison were run against current `main`.
- [x] Graph capture/replay was validated on MI355X.
- [x] Merged-config collision tests pass.