### PR TITLE
[CK] [Bugfix] ck_batched_gemm_bf16: derive operand strides from the tensors

### DIFF
--- a/csrc/ck_batched_gemm_bf16/include/batched_gemm_bf16_common.cuh
+++ b/csrc/ck_batched_gemm_bf16/include/batched_gemm_bf16_common.cuh
@@ -1,4 +1,5 @@
 #pragma once
+#include <limits>
 // SPDX-License-Identifier: MIT
 // Copyright (C) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
 
@@ -143,13 +144,70 @@ __forceinline__ torch::Tensor batched_gemm_bf16_impl(
     int N = WQ.size(1);
     int K = XQ.size(2);
 
-    int StrideA = K;
-    int StrideB = K;
-    int StrideE = N;
+    // Derive every stride from the TENSOR, not from the logical shape.
+    //
+    // The original six expressions (StrideA = K, StrideB = K, StrideE = N,
+    // BatchStrideA = M*K, BatchStrideB = N*K, BatchStrideE = M*N) assume all three
+    // operands are contiguous in their logical shape. CK takes these as ordinary
+    // runtime scalars and supports arbitrary values, so the kernel was never the
+    // limitation -- the wrapper simply never asked the caller what it allocated.
+    //
+    // Two measured consequences of the old form:
+    //   * a non-contiguous Y was written AS IF contiguous -- no error, correct
+    //     arithmetic, wrong placement, and `return Y` handed back a view whose
+    //     strides described a layout the memory did not have;
+    //   * WQ in a (B, K, N) orientation made BatchStrideB = N*K read ~4x past the
+    //     end of the tensor, surfacing as a HIP illegal memory access rather than
+    //     a layout error.
+    //
+    // ALayout=Row  -> A is M x K, leading dim is the stride between M rows
+    // BLayout=Col  -> B is K x N column-major, leading dim is the stride between N columns
+    // ELayout=Row  -> E is M x N, leading dim is the stride between M rows
+    // In every case the INNERMOST dim must be unit-stride; anything else is a
+    // layout these descriptors cannot express and is rejected loudly below.
+    TORCH_CHECK(XQ.dim() == 3 && WQ.dim() == 3 && Y.dim() == 3,
+                "batched_gemm_bf16: XQ, WQ and Y must all be 3-D, got ",
+                XQ.dim(), ", ", WQ.dim(), ", ", Y.dim());
+    TORCH_CHECK(WQ.size(0) == B && Y.size(0) == B,
+                "batched_gemm_bf16: batch mismatch -- XQ ", B, ", WQ ", WQ.size(0),
+                ", Y ", Y.size(0));
+    TORCH_CHECK(WQ.size(2) == K,
+                "batched_gemm_bf16: contraction mismatch -- XQ K=", K, ", WQ K=",
+                WQ.size(2), ". WQ must be (batch, N, K); a (batch, K, N) operand is "
+                "the orientation that used to read past the end of the tensor.");
+    TORCH_CHECK(Y.size(1) == M && Y.size(2) == N,
+                "batched_gemm_bf16: output shape mismatch -- expected (", B, ", ", M,
+                ", ", N, "), got (", Y.size(0), ", ", Y.size(1), ", ", Y.size(2), ")");
+    TORCH_CHECK(XQ.stride(2) == 1,
+                "batched_gemm_bf16: XQ must be unit-stride in its innermost (K) dim, "
+                "got stride ", XQ.stride(2), ". CK's row-major A descriptor cannot "
+                "express this layout.");
+    TORCH_CHECK(WQ.stride(2) == 1,
+                "batched_gemm_bf16: WQ must be unit-stride in its innermost (K) dim, "
+                "got stride ", WQ.stride(2), ". CK's column-major B descriptor cannot "
+                "express this layout.");
+    TORCH_CHECK(Y.stride(2) == 1,
+                "batched_gemm_bf16: Y must be unit-stride in its innermost (N) dim, "
+                "got stride ", Y.stride(2), ". CK's row-major E descriptor cannot "
+                "express this layout -- refusing rather than mis-placing the result.");
 
-    int BatchStrideA = M * K;
-    int BatchStrideB = N * K;
-    int BatchStrideE = M * N;
+    // CK takes these as int; a stride that does not fit is a silent truncation.
+    auto fits_int = [](int64_t v) {
+        return v >= 0 && v <= static_cast<int64_t>(std::numeric_limits<int>::max());
+    };
+    TORCH_CHECK(fits_int(XQ.stride(0)) && fits_int(XQ.stride(1)) &&
+                fits_int(WQ.stride(0)) && fits_int(WQ.stride(1)) &&
+                fits_int(Y.stride(0)) && fits_int(Y.stride(1)),
+                "batched_gemm_bf16: a stride does not fit in int32 and would be "
+                "silently truncated");
+
+    int StrideA = static_cast<int>(XQ.stride(1));
+    int StrideB = static_cast<int>(WQ.stride(1));
+    int StrideE = static_cast<int>(Y.stride(1));
+
+    int BatchStrideA = static_cast<int>(XQ.stride(0));
+    int BatchStrideB = static_cast<int>(WQ.stride(0));
+    int BatchStrideE = static_cast<int>(Y.stride(0));
 
     const at::hip::OptionalHIPGuardMasqueradingAsCUDA device_guard(device_of(XQ));
     auto device_gemm = DeviceGemmInstance{};


### PR DESCRIPTION
### Motivation

The CK `batched_gemm_bf16` wrapper computes all six strides from the operands' logical
shapes:

```cpp
int StrideA = K;  int StrideB = K;  int StrideE = N;
int BatchStrideA = M * K;  int BatchStrideB = N * K;  int BatchStrideE = M * N;
```

That is correct only when all three operands are contiguous in those shapes. CK takes
these as ordinary runtime scalars and supports arbitrary values, so the kernel was never
the limitation — the wrapper simply did not ask the caller what it had allocated.

Two consequences, both reachable from Python with ordinary tensors:

- **A non-contiguous output is written as if it were contiguous.** No error is raised and
  the arithmetic is right, but the results land at the wrong addresses and the returned
  tensor's strides describe a layout the memory does not have. Silent, and it corrupts
  whatever the caller reads next.
- **A weight tensor in `(batch, K, N)` orientation** makes `BatchStrideB = N*K` read well
  past the end of the allocation, surfacing as a HIP illegal memory access rather than as
  a layout error. In our case that wedged the HIP context, which is a good deal harder to
  diagnose than a rejected argument.

This is already known in-tree, and documented as a limitation rather than fixed —
`op_tests/test_batched_gemm_bf16.py` skips the CK path for the transposed input with the
comment *"on the mbn (transposed mbk) input it returns wrong results"*.

### Technical details

Strides are read from the tensors. What the CK descriptors cannot express is rejected
loudly instead of being mis-placed: each operand must be unit-stride in its innermost
dimension, the batch and contraction dimensions must agree, and a stride that would not
fit in the `int` the descriptors take is refused rather than silently truncated.

Second commit: the test stops skipping. Both halves of the defect are reachable by
different calls, so there are two entries — `batched_gemm_bf16_CK` allocates its own
contiguous output and can therefore only exercise the input strides, while placement needs
the op called directly with a preallocated output whose outer strides are not those of a
contiguous `[b, m, n]`. That output is built the same way as the triton path's rather than
with `empty_like`, whose layout preservation depends on the source being non-overlapping
and dense, and its non-contiguity is asserted so a later change cannot quietly leave the
case testing nothing.

Note there are two implementations under the name `batched_gemm_bf16`: this is the CK one
under `csrc/`, not the Triton kernel (which is what #4075's int32 fix touched).

`csrc/ck_batched_gemm_a8w8` carries the same six expressions and the same exposure. It is
left alone here because this change is only verified for bf16; happy to extend it in this
PR if maintainers prefer one fix for both.

### Numerics statement

**Bitwise.** Not "within tolerance" — bitwise, and provable without a numerics argument:
the same kernel runs on the same inputs twice, once into a contiguous output and once into
the strided one, and the strided buffer read back through its intended layout is bitwise
identical to the contiguous result. It is identical arithmetic in identical order, differing
only in store addresses.

Oracle, re-run against **this branch's** header on MI355X (gfx950), one case per process:

| case | result |
|---|---|
| placement, 4 tokens — contiguous strides `[512,128,1]` vs strided `[128,16384,1]` | **bitwise identical**; the consumer's flatten is a view |
| placement, 1 token — `[128,128,1]` vs `[128,16384,1]` | **bitwise identical** |
| reject: `(batch, K, N)` orientation | `RuntimeError` naming the contraction mismatch — **not** a HIP illegal access |
| reject: non-unit innermost output stride | `RuntimeError` naming the layout — **not** a HIP illegal access |

At 1 token the strided destination reports contiguous because dim 1 is degenerate, so the
4-token case is the one that exercises a genuinely strided write. Both are reported rather
than only the stronger one.

The oracle was re-run rather than cited: this branch is a clean-room port, and a port that
quietly downgrades the oracle's tier would be a finding, not a footnote. The module was
rebuilt from this branch's header inside the container to make sure the measured binary is
the one being proposed.

### How the two arms were built, so the comparison can be checked

Both arms run the same digest-pinned container on the same GPU, one case per process. The
**patched** arm bind-mounts this branch's header over the image's copy and a writable AITER
JIT cache from which `module_batched_gemm_bf16` was removed, so that module is recompiled
from the branch's source; the **stock** arm mounts neither the header nor the branch test,
so it runs the image's own source, with a JIT cache whose `module_batched_gemm_bf16` is the
stock build (verified by checksum: stock `414d0c89`, patched `ae031409`).

One honest wrinkle in the stock arm: its JIT cache is a copy of a tree that also carries a
patched *unrelated* module (a KV-cache kernel from other work). This benchmark never calls
it — the test exercises only the CK batched GEMM, the Triton batched GEMM and
`torch.einsum` — so it cannot affect these numbers, but the tree is not a pristine one and
saying so is cheaper than implying it is.

### Test plan and result

`op_tests/test_batched_gemm_bf16.py`, the repo's own harness, on MI355X (gfx950).

`op_tests/test_batched_gemm_bf16.py`, the repo's own harness, on MI355X (gfx950).
24 processes, one case per process, run in randomized order; the first process of each arm
discarded; the figure is the median of the remaining three, and the spread is the full
range across them. `err` is the harness's own `checkAllclose` result.

**The contiguous path is unchanged.** This is the claim that matters for a correctness fix:
reading the strides costs nothing where the old code was already right.

| shape (b, m, n, k) | layout | patched `ck` µs | stock `ck` µs | delta | within-arm spread |
|---|---|---|---|---|---|
| 128, 4, 128, 512 | contiguous | 4.0912 | 4.0740 | **+0.0172 (+0.42%)** | up to 0.0256 |
| 16, 32, 1024, 4096 | contiguous | 27.4383 | 27.4339 | **+0.0044 (+0.02%)** | up to 0.0623 |

At both shapes the patched-versus-stock difference is **smaller than the run-to-run spread
within a single arm**, so this measurement does not resolve a difference — which is the
expected result, since the same kernel runs with the same strides on this path.

**The strided path now runs.** There is deliberately no stock column: upstream's own test
skips CK for this layout because it returns wrong results there, and a timing for a wrong
result is not a baseline.

| shape (b, m, n, k) | layout | patched `ck` µs | patched `ck_out` µs | err |
|---|---|---|---|---|
| 128, 4, 128, 512 | strided (transposed mbk) | 4.0884 | 3.8791 | 0 |
| 16, 32, 1024, 4096 | strided (transposed mbk) | 26.8948 | 26.9781 | 0 |

Every case, both arms, all 24 processes: `checkAllclose` passed with `err = 0`, and no
process exited non-zero.

`ck` is `batched_gemm_bf16_CK`, which allocates its own contiguous output; `ck_out` is the
op called directly with a preallocated output, which is the entry the second commit adds and
the only one that exercises placement. At the small shape `ck_out` is consistently the
faster of the two (3.86 against 4.09 µs) because the caller's buffer is reused rather than
allocated per call — an incidental observation, not a claim this PR makes.
