### PR TITLE
[MLA] Add pre-allocated scratch buffers for CUDA-graph-safe non-persistent decode

### DIFF
--- a/aiter/mla.py
+++ b/aiter/mla.py
@@ -546,6 +546,8 @@ def mla_decode_fwd(
     g_kv_indptr=None,
     cp_world_size=1,
     cp_rank=0,
+    logits_buf=None,
+    attn_lse_buf=None,
     causal=True,
 ):
     device = q.device
@@ -631,15 +633,17 @@ def mla_decode_fwd(
                     )
                 )
             )
-            else torch.empty(
-                (total_s, num_kv_splits, nhead, v_head_dim),
-                dtype=dtypes.fp32,
-                device=device,
+            else (
+                logits_buf[:total_s * num_kv_splits].view(total_s, num_kv_splits, nhead, v_head_dim)
+                if logits_buf is not None and logits_buf.numel() >= total_s * num_kv_splits * nhead * v_head_dim
+                else torch.empty((total_s, num_kv_splits, nhead, v_head_dim), dtype=dtypes.fp32, device=device)
             )
         )
 
-        attn_lse = torch.empty(
-            (total_s, num_kv_splits, nhead, 1), dtype=dtypes.fp32, device=device
+        attn_lse = (
+            attn_lse_buf[:total_s * num_kv_splits].view(total_s, num_kv_splits, nhead, 1)
+            if attn_lse_buf is not None and attn_lse_buf.numel() >= total_s * num_kv_splits * nhead
+            else torch.empty((total_s, num_kv_splits, nhead, 1), dtype=dtypes.fp32, device=device)
         )
         final_lse = (
             torch.empty((total_s, nhead), dtype=dtypes.fp32, device=device)
@@ -683,7 +687,7 @@ def mla_decode_fwd(
             cp_rank,
             valid_split_count,
             use_valid_split_count_reduce,
-            causal,
+
         )
 
         if num_kv_splits == 1 and (
@@ -912,7 +916,7 @@ def mla_decode_fwd(
                 final_lse,
                 q_scale,
                 kv_scale,
-                causal,
+
             )
         elif use_hk:
             aiter.hk_mla_decode_fwd(
@@ -957,7 +961,7 @@ def mla_decode_fwd(
                 cp_rank,
                 None,
                 0,
-                causal,
+
             )
 
         _mla_decode_reduce_v1_dispatch(


### PR DESCRIPTION
## Motivation

Enable the AITER ASM MLA persistent decode kernel to work inside CUDA graphs on ROCm/HIP. Currently, `mla_decode_fwd`'s non-persistent split-KV path allocates scratch buffers (`logits`, `attn_lse`) via `torch.empty` on every call. During HIP CUDA graph capture, these allocations trigger `hipErrorStreamCaptureUnsupported` because `torch.empty` with runtime-computed sizes is illegal on a capture stream.

This blocks using `--dsa-decode-backend aiter` with EAGLE speculative decoding and CUDA graphs on SGLang, leaving the 1.6x faster ASM kernel (11.6µs vs TileLang 18.57µs at seq=1) unusable in production.

Also fixes 3 call sites that pass a `causal` argument to `mla_decode_stage1_asm_fwd` — the C++ op accepts 25 parameters and `causal` was passed as a 26th, causing `RuntimeError` on newer builds.

## Technical Details

### `aiter/mla.py`

**Change 1: Pre-allocated scratch buffer params**

Add optional `logits_buf` and `attn_lse_buf` parameters to `mla_decode_fwd`:

```python
def mla_decode_fwd(
    ...,
    logits_buf=None,    # [max_partials, 1, nhead, v_head_dim] fp32
    attn_lse_buf=None,  # [max_partials, 1, nhead, 1] fp32
    causal=True,
):
```

In the non-persistent path, when these buffers are provided and have sufficient capacity, they are sliced into instead of allocating fresh tensors. When `None` or too small, falls back to `torch.empty` (fully backward compatible).

The caller (SGLang `dsa_backend.py`) pre-allocates these once at `init_cuda_graph_state` time, sized for `max_batch * max_splits * nhead * dim`. Companion SGLang PR: https://github.com/nehaprakriya/sglang/tree/fix/aiter-eagle-cuda-graph

**Change 2: Remove `causal` from ASM kernel calls**

3 call sites in `mla_decode_fwd` passed `causal` as a positional argument to `mla_decode_stage1_asm_fwd`. The C++ binding does not declare this parameter. Removed from all 3 sites (non-persistent path, opus path, and the gfx950 persistent path).

## Test Plan

1. Standalone kernel test: `op_tests/test_mla_sparse.py --block_size 1 --dtype fp8 --kv_dtype fp8 --ctxLen 62000 --batchSize 1 --nhead 16,6 --max_split_per_batch 32`
2. E2E serving: GLM-5.2-MXFP4 / MI355X / TP=4 with EAGLE 5-step speculative decoding, CUDA graphs, CONC=14, `max_running_requests=18`
3. Backward compatibility: default `logits_buf=None` preserves existing behavior — no change to any existing caller

## Test Result

- Standalone kernel: all production shapes (seq 1-96, topk=2048, context=62000) pass correctness and 1000-call stress test
- E2E: server healthy, `cuda graph: True` in decode, EAGLE `accept_rate=0.53`, `accept_length=3.65`, 14 concurrent requests stable, "Paris" correctness pass
- No regression for callers that don't pass the new params

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/TheRock/blob/main/GOVERNANCE.md#pull-requests.
