### PR TITLE
[FlyDSL] [gfx950] Ragged MXFP4 grouped GEMM and wgrad

### DIFF
--- a/aiter/ops/flydsl/__init__.py
+++ b/aiter/ops/flydsl/__init__.py
@@ -42,6 +42,14 @@ _LAZY_IMPORTS = {
         ".kernels.mqa_logits.fp8_mqa_logits",
         "flydsl_fp8_mqa_logits",
     ),
+    "flydsl_grouped_gemm_a4w4_ragged": (
+        ".grouped_gemm_mxfp4_gfx950",
+        "flydsl_grouped_gemm_a4w4_ragged",
+    ),
+    "flydsl_grouped_wgrad_a4w4_ragged": (
+        ".grouped_gemm_mxfp4_gfx950",
+        "flydsl_grouped_wgrad_a4w4_ragged",
+    ),
     "flydsl_hgemm": (".gemm_kernels", "flydsl_hgemm"),
     "flydsl_hstu_attention_fwd": (
         ".hstu_attention_kernels",
@@ -79,6 +87,8 @@ __all__ = [
     "compute_varqlen_windows",
     "flydsl_flash_attn_func",
     "flydsl_fp8_mqa_logits",
+    "flydsl_grouped_gemm_a4w4_ragged",
+    "flydsl_grouped_wgrad_a4w4_ragged",
     "flydsl_hgemm",
     "flydsl_hstu_attention_fwd",
     "flydsl_mla_reduce_v1",

--- a/aiter/ops/flydsl/grouped_gemm_mxfp4_gfx950.py
+++ b/aiter/ops/flydsl/grouped_gemm_mxfp4_gfx950.py
@@ -1,0 +1,344 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+"""Ragged MXFP4 (a4w4) grouped GEMM launchers for gfx950.
+
+Groups partition a token axis with **unequal, device-resident** sizes: each
+block reads its own bounds from ``group_end_offsets`` and the host never syncs
+to learn them. That is the difference from every other grouped MXFP4 path in
+aiter -- ``flydsl_grouped_gemm_a8w4_masked`` is gfx1250 + contiguous-M, the MoE
+``flydsl_mxfp4_gemm1/gemm2`` need ``moe_sorting`` output and fuse an activation,
+and ``flydsl_batched_gemm_mxfp4`` is strided-batched with equal M per batch.
+
+Both kernels take plain per-1x32 cast output: **no preshuffled weights and no
+shuffled scales**. One e8m0 is broadcast to 4 bytes so the MFMA ``op_sel`` is a
+don't-care, which is what removes the preshuffle requirement that the dense fp4
+paths carry.
+
+    flydsl_grouped_gemm_a4w4_ragged   out[group_g] = X[group_g] @ W[g]^T
+    flydsl_grouped_wgrad_a4w4_ragged  grad_W[g]    = go[group_g]^T @ ia[group_g]
+
+The wgrad is the transpose-contraction direction: there the groups partition the
+CONTRACTION rather than the output rows.
+"""
+
+from __future__ import annotations
+
+import os
+
+import torch
+
+from aiter.jit.utils.chip_info import get_gfx
+
+from .kernels.mxfp4_grouped_gemm_ragged import (
+    BLOCK_R,
+    FP4_PER_BYTE,
+    SCALE_BLOCK,
+    cached_launch as _cached_launch_gemm,
+    pick_block_c,
+)
+from .kernels.mxfp4_grouped_wgrad_ragged import (
+    BLOCK_C,
+    BLOCK_M,
+    LPT_MAX_E,
+    ORDER_MODES,
+    cached_launch as _cached_launch_wgrad,
+)
+from .kernels.mxfp4_grouped_wgrad_ragged import BLOCK_R as WGRAD_BLOCK_R
+from .kernels.tensor_shim import _run_compiled
+
+
+def _require_gfx950(what: str) -> None:
+    gfx = get_gfx()
+    if gfx != "gfx950":
+        raise NotImplementedError(
+            f"[FlyDSL] {what} requires gfx950 (CDNA4 scaled MFMA), got {gfx}"
+        )
+
+
+def ceildiv(a: int, b: int) -> int:
+    return -(-a // b)
+
+
+def flydsl_grouped_gemm_a4w4_ragged(
+    input_act,
+    weight,
+    input_act_scales,
+    weight_scales,
+    group_end_offsets,
+    out_dtype=torch.bfloat16,
+    block_c=None,
+    out=None,
+):
+    """MXFP4 forward/dgrad grouped GEMM over RAGGED token groups.
+
+        out[group_g] = input_act[group_g] @ weight[g]^T
+
+    Groups partition the token (output row) dim with device-resident, unequal
+    sizes. Because the ragged axis is NOT the contraction, the whole pipelined
+    K-walk carries over from the even-groups body untouched -- only the
+    block->(group, tile) mapping and the epilogue mask change.
+
+    input_act         (M, K//2)      packed fp4 e2m1, 2 per byte, row-major
+    weight            (E, N, K//2)   packed fp4 e2m1, row-major
+    input_act_scales  (M, K//32)     e8m0 as uint8
+    weight_scales     (E, N, K//32)
+    group_end_offsets (E,) int32  cumulative group ends along M, ON DEVICE.
+                                         Read by the block itself -- never synced here.
+    block_c           column tile width; None picks it from N (see pick_block_c)
+    out               optional (M, N) bf16 destination to write in place.
+
+    K is passed as the LOGICAL element count, derived from the packed width, so
+    every caller-visible shape is in elements and only the kernel's internals
+    deal in bytes.
+
+    Pass ``out`` when you already have the destination -- it skips both an
+    allocation and the zero-fill. That matters: the zero-fill is a full memset of
+    M*N, 805 MB at the e2e shape, measured at 0.117 ms against a 1.225 ms kernel,
+    i.e. **9.5%** -- almost the entire cost of ragged support over the even body.
+
+    When we allocate, we zero. Rows at and past ``group_end_offsets[-1]`` are
+    written by no block (the dispatcher pads M past the last group), and handing
+    back uninitialised memory there is the worse default. Callers matching ATen's
+    grouped-mm contract can skip it: ATen's own reference leaves that tail
+    untouched too, so it is not part of the result.
+    """
+    _require_gfx950("grouped MXFP4 GEMM")
+    M, KP = input_act.shape
+    E, N, KP2 = weight.shape
+    assert KP == KP2, f"packed-K mismatch: A={KP}, B={KP2}"
+    K = KP * FP4_PER_BYTE
+    assert input_act_scales.shape == (
+        M,
+        K // SCALE_BLOCK,
+    ), f"x scales {tuple(input_act_scales.shape)} != {(M, K // SCALE_BLOCK)}"
+    assert weight_scales.shape == (
+        E,
+        N,
+        K // SCALE_BLOCK,
+    ), f"w scales {tuple(weight_scales.shape)} != {(E, N, K // SCALE_BLOCK)}"
+    assert (
+        group_end_offsets.numel() == E
+    ), f"offsets {group_end_offsets.numel()} != E {E}"
+
+    # Same int32 ceiling the wgrad carries, and for two reasons at once here.
+    # FlyDSL's CABI packs a tensor's flattened element count as int32 and the
+    # operands go over as 1-D views; separately, the epilogue store offset is
+    # `r_ * out_n + col`, an i32 element index into `out`. An overflow there
+    # does NOT fault: the bounded buffer descriptor clamps out-of-range, but a
+    # wrapped index lands back INSIDE the allocation and silently corrupts a
+    # row, which is the worse failure of the two.
+    #
+    # M*N is the binding term: at N=2048 it is reached at M = 1,048,576 tokens
+    # on one rank -- unreachable under balanced routing, but real routing
+    # concentrates enough tokens on a single rank to cross it.
+    #
+    # UNDER torch.compile this cannot be a Python branch: M is the routed token
+    # count, an unbacked SymInt, so a data-dependent `>` guard kills the whole
+    # compiled path. torch._check registers a deferred runtime assert (an
+    # over-limit shape still fails loudly rather than wrapping) and teaches the
+    # shape env the fact. Eager keeps the graceful fallback so a caller can drop
+    # to another kernel instead of losing the run.
+    INT32_MAX = 2**31 - 1
+    biggest = max(M * N, M * KP, E * N * KP)
+    if torch.compiler.is_compiling():
+        torch._check(biggest <= INT32_MAX)
+    elif biggest > INT32_MAX:
+        raise NotImplementedError(
+            f"largest operand has {biggest} elements, over the int32 limit "
+            f"FlyDSL's argument packing and this kernel's epilogue offset "
+            f"impose ({INT32_MAX}); M={M} N={N} K={K} E={E}"
+        )
+
+    BLOCK_C = pick_block_c(N) if block_c is None else int(block_c)
+    n_c = ceildiv(N, BLOCK_C)
+    # Worst-case row tiles: a full cover of M plus at most one partial tile per
+    # group. Computed from M and E alone -- deriving it from the actual group
+    # sizes would need them on the host, i.e. the sync this kernel avoids.
+    # Slots past the real tile count predicate themselves off via `active`.
+    n_slots = ceildiv(M, BLOCK_R) + E
+    n_blocks = n_slots * n_c
+
+    if out is None:
+        # zeros, not empty: rows at and past the last group's end are written by
+        # no block, so torch.empty would hand back uninitialised memory there.
+        out = torch.zeros(M, N, dtype=torch.bfloat16, device=input_act.device)
+    else:
+        assert (
+            out.shape == (M, N) and out.dtype == torch.bfloat16
+        ), f"out {tuple(out.shape)}/{out.dtype} != {(M, N)}/torch.bfloat16"
+        assert out.is_contiguous(), "out must be contiguous"
+    launch = _cached_launch_gemm(K, N, E, BLOCK_C)
+    _run_compiled(
+        launch,
+        input_act.contiguous().view(torch.int8).reshape(-1),
+        weight.contiguous().view(torch.int8).reshape(-1),
+        out.view(-1),
+        input_act_scales.contiguous().view(torch.uint8).view(-1),
+        weight_scales.contiguous().view(torch.uint8).view(-1),
+        group_end_offsets.to(torch.int32).contiguous(),
+        n_blocks,
+        n_c,
+        M,
+        N,
+        torch.cuda.current_stream(),
+    )
+    return out if out_dtype == torch.bfloat16 else out.to(out_dtype)
+
+
+def flydsl_grouped_wgrad_a4w4_ragged(
+    go_t,
+    go_scale,
+    ia_t,
+    ia_scale,
+    group_end_offsets,
+    out_dtype=torch.bfloat16,
+    m_total=None,
+    _order=None,
+):
+    """Ragged MXFP4 wgrad, tuned body.
+
+           grad_W[g] = go[group_g]^T @ ia[group_g]
+
+       go_t   (R, M//2) packed fp4, dim1-quantized (tokens contiguous)
+       ia_t   (C, M//2) packed fp4
+       scales (R, M//32) / (C, M//32) e8m0 -- FULL-WIDTH planes at the operand's
+              row stride, not pre-sliced to the routed token count.
+    One block per (group, output tile); each block
+       reads its own group bounds from ``group_end_offsets`` on device.
+
+       ``m_total`` is unused by the body -- the grid is E * n_r * n_c regardless of
+       the token count, and every boundary comes from the offsets. It is accepted
+       for signature compatibility with the caller's integration.
+    """
+    _require_gfx950("grouped MXFP4 wgrad")
+    del m_total
+
+    R, M_PACKED = go_t.shape
+    C, M2 = ia_t.shape
+    assert M_PACKED == M2, f"token-dim mismatch: {M_PACKED} vs {M2}"
+    # Callers see logical token counts; only the kernel body deals in bytes.
+    M_ROW = M_PACKED * FP4_PER_BYTE
+    E = group_end_offsets.shape[0]
+
+    # The cooperative dwordx2 scale load needs an even element index; with a
+    # 256-aligned window base that reduces to SCALE_I32_ROW = M_ROW/128 being
+    # even. The MoE caller already row-pads its operands for the dim1 cast, so
+    # this is a pad-multiple change (128 -> 256) rather than a copy it was not
+    # already paying. NotImplementedError so the integration falls back instead
+    # of crashing.
+    # 128, not 256: the scale plane packs 4 e8m0 per i32, so a row must be a whole
+    # number of i32 (M_ROW/32 divisible by 4). Whether the cooperative scale load
+    # can use a dwordx2 or needs two dwords then depends on M_ROW % 256, which is
+    # passed to the compiler as `sc_pair` rather than demanded of the caller --
+    # see the SC_PAIR note in _compile. Requiring 256 here would decline 7 of 8
+    # shapes the MoE dispatcher actually produces.
+    if M_ROW % BLOCK_M != 0:
+        raise NotImplementedError(
+            f"row stride {M_ROW} must be a multiple of {BLOCK_M} so a scale-plane "
+            f"row is a whole number of i32"
+        )
+    sc_pair = (M_ROW % (2 * BLOCK_M)) == 0
+
+    # FlyDSL's CABI packs a tensor's flattened element count as int32, and the
+    # operands go over as 1-D views (the kernel addresses them flat), so an
+    # operand with >= 2**31 elements raises `struct.error` from inside the
+    # dispatch -- which kills the whole training job rather than failing one op.
+    # Raise NotImplementedError instead: the integration catches it and falls
+    # back to the Triton wgrad, so the run survives at reduced speed.
+    #
+    # Measured threshold: R*M_ROW == 2**31 exactly. At R=2048 that is
+    # M_ROW = 1,048,576 tokens on a single rank -- unreachable under balanced
+    # routing, but real routing at bs8/seq8192 concentrates enough tokens on one
+    # rank to cross it (it took down that sweep cell twice).
+    #
+    # Passing the operands 2-D instead does NOT fix it: tested, and the result
+    # is garbage (SQNR -2.26 dB), because every offset in the body is a flat
+    # element index. A real fix needs the addressing reworked to 2-D, or the
+    # contraction split so no single launch sees 2**31 elements.
+    #
+    # UNDER torch.compile this cannot be a Python branch: M_ROW is the routed
+    # token count, an unbacked SymInt, so `biggest > INT32_MAX` is a
+    # data-dependent guard Dynamo cannot resolve and the whole compiled path
+    # dies. Assert the precondition instead -- torch._check registers a deferred
+    # runtime assert (an over-limit operand still fails loudly rather than
+    # wrapping) and teaches the shape env the fact, so the comparison resolves
+    # statically. Eager keeps the graceful fallback.
+    INT32_MAX = 2**31 - 1
+    # The operands go over as int8 (BYTE) views, so the packed width is what the
+    # CABI actually counts -- fp4 buys back a factor of 2 of headroom here.
+    biggest = max(R, C) * M_PACKED
+    if torch.compiler.is_compiling():
+        torch._check(biggest <= INT32_MAX)
+    elif biggest > INT32_MAX:
+        raise NotImplementedError(
+            f"operand has {biggest} elements, over the int32 limit FlyDSL's "
+            f"argument packing imposes ({INT32_MAX}); R={R} C={C} "
+            f"M_ROW={M_ROW}"
+        )
+
+    # The scale rows are indexed at the *operand's* row stride, so they must be
+    # the matching full-width e8m0 planes, not ones pre-sliced to m_total.
+    assert go_scale.shape == (
+        R,
+        M_ROW // SCALE_BLOCK,
+    ), f"go_scale {tuple(go_scale.shape)} != {(R, M_ROW // SCALE_BLOCK)}"
+    assert ia_scale.shape == (
+        C,
+        M_ROW // SCALE_BLOCK,
+    ), f"ia_scale {tuple(ia_scale.shape)} != {(C, M_ROW // SCALE_BLOCK)}"
+
+    n_r = ceildiv(R, WGRAD_BLOCK_R)
+    n_c = ceildiv(C, BLOCK_C)
+    n_blocks = E * n_r * n_c
+
+    # torch.empty, not zeros: one block owns each (g, tile) and stores every valid
+    # (row, col) exactly once, including zeros for empty groups. A chunked
+    # schedule needs zeros
+    # because its atomic epilogue accumulates onto the buffer; this one does not.
+    out = torch.empty(E, R, C, dtype=torch.float32, device=go_t.device)
+    # Read per call, not at import: the bench flips it between interleaved arms
+    # inside one process, and lru_cache keys on it so every variant coexists.
+    order = (
+        _order
+        if _order is not None
+        else (
+            "lpt"
+            if os.environ.get("AITER_FLYDSL_MXFP4_WGRAD_LPT", "1") != "0"
+            else "id"
+        )
+    )
+    # The remap ranks every group against every other -- E*E selects and E scalar
+    # loads in every block's prologue. At E=8 that is tens of SALU ops
+    # against a 100+ iteration K-walk and one 32-byte line of
+    # offsets. At E in the hundreds it is a large unrolled prologue, a slow
+    # compile, and E loads per block, for a benefit that shrinks anyway (more
+    # groups per CU averages the imbalance out on its own).
+    #
+    # Falls back to `id`, not `idsel`: `idsel` is also O(E) loads, and its
+    # measured gain is ~1%, so it is not worth 256 scalar loads per block. `id`
+    # is the O(1) mapping and is what every number before 2026-07-31 was taken
+    # on. All of this is unmeasured above E=8 -- the cutoff is a guard against
+    # a shape nobody has run, not a tuned value.
+    if order not in ORDER_MODES:
+        raise ValueError(f"order must be one of {ORDER_MODES}, got {order!r}")
+    if order == "lpt" and E > LPT_MAX_E:
+        order = "id"
+    launch = _cached_launch_wgrad(R, C, E, sc_pair, order)
+    _run_compiled(
+        launch,
+        go_t.contiguous().view(torch.int8).reshape(-1),
+        ia_t.contiguous().view(torch.int8).reshape(-1),
+        out.view(-1),
+        go_scale.contiguous().view(torch.uint8).view(-1),
+        ia_scale.contiguous().view(torch.uint8).view(-1),
+        group_end_offsets.to(torch.int32).contiguous(),
+        n_blocks,
+        n_r,
+        n_c,
+        R,
+        C,
+        M_ROW,
+        torch.cuda.current_stream(),
+    )
+    return out.to(out_dtype)

--- a/aiter/ops/flydsl/kernels/mxfp4_grouped_gemm_ragged.py
+++ b/aiter/ops/flydsl/kernels/mxfp4_grouped_gemm_ragged.py
@@ -168,6 +168,12 @@ def pick_block_c(N: int) -> int:
 # AITER_FLYDSL_MXFP4_GEMM_INTERLEAVE=0 for the plain cluster.
 _INTERLEAVE = os.environ.get("AITER_FLYDSL_MXFP4_GEMM_INTERLEAVE", "1") != "0"
 
+# gfx950 XCD count, and the band width in TILES an XCD owns contiguously.
+# AITER_FLYDSL_MXFP4_GEMM_XCD_SPAN is in M-blocks; the band is that times the
+# column-tile count, so a band is a run of whole row tiles. 0 disables the remap.
+N_XCD = 8
+_XCD_SPAN = int(os.environ.get("AITER_FLYDSL_MXFP4_GEMM_XCD_SPAN", "4"))
+
 
 def _mfma_scale_agpr(a, b, sa, sb, acc):
     """fp4 16x16x128 scaled MFMA with the accumulator pinned in AGPR (=a,...,0)
@@ -238,6 +244,10 @@ def _compile(K: int, N: int, E: int, BLOCK_C: int):
     """
     assert K % 128 == 0, f"K ({K}) must be a multiple of 128 (MFMA K-sub-block)"
     assert BLOCK_C in (128, 256), f"BLOCK_C {BLOCK_C} not supported"
+
+    # An XCD's contiguous run, in TILES: _XCD_SPAN row-tiles' worth of column
+    # tiles, so a band is whole row tiles and an XCD's A reads stay together.
+    _XCD_BAND = _XCD_SPAN * (-(-N // BLOCK_C))
 
     K_BYTES = K // FP4_PER_BYTE
     # Steps of 256 fp4. A trailing 128 (K % 256 == 128, e.g. DSV3's 1408)
@@ -345,6 +355,7 @@ def _compile(K: int, N: int, E: int, BLOCK_C: int):
         A_scale: fx.Tensor,
         B_scale: fx.Tensor,
         OFFS: fx.Tensor,
+        n_blocks_rt: fx.Int32,
         n_c_tiles: fx.Int32,
         out_m: fx.Int32,
         out_n: fx.Int32,
@@ -357,6 +368,27 @@ def _compile(K: int, N: int, E: int, BLOCK_C: int):
         # uniform across experts. Only this mapping and the epilogue mask
         # care that the groups are ragged.
         bid = fx.block_idx.x
+        # XCD band remap. gfx950 has 8 XCDs with a private L2 each, and blocks
+        # go to XCDs round-robin by index. A plain `bid // n_c` mapping puts
+        # consecutive column tiles of ONE row tile on DIFFERENT XCDs, so every
+        # XCD pulls the same A rows and each expert's B slab is smeared across
+        # all eight L2s. Banding gives an XCD a contiguous run of `band` tiles,
+        # which for a band that divides a group's tile count keeps that XCD's
+        # reads inside one expert slab.
+        #
+        # This is a permutation of block -> tile and nothing else: the identity
+        # tail keeps it a bijection, so every (slot, c_base) pair is still
+        # covered exactly once and the result cannot change.
+        if const_expr(_XCD_BAND > 0 and N_XCD > 1):
+            _span = const_expr(N_XCD * _XCD_BAND)
+            _local = ArithValue(bid) // fx.Int32(N_XCD)
+            _xcd = ArithValue(bid) - _local * fx.Int32(N_XCD)
+            _rnd = ArithValue(_local) // fx.Int32(_XCD_BAND)
+            _mapped = (ArithValue(_rnd) * fx.Int32(N_XCD) + _xcd) * fx.Int32(
+                _XCD_BAND
+            ) + (ArithValue(_local) - ArithValue(_rnd) * fx.Int32(_XCD_BAND))
+            _whole = (ArithValue(n_blocks_rt) // fx.Int32(_span)) * fx.Int32(_span)
+            bid = arith.select(ArithValue(bid) < _whole, _mapped, bid)
         slot = ArithValue(bid) // n_c_tiles  # which row tile overall
         c_base = (ArithValue(bid) % n_c_tiles) * fx.Int32(BLOCK_C)
 
@@ -851,6 +883,7 @@ def _compile(K: int, N: int, E: int, BLOCK_C: int):
             A_scale,
             B_scale,
             OFFS,
+            n_blocks,
             n_c_tiles,
             out_m,
             out_n,

--- a/aiter/ops/flydsl/kernels/mxfp4_grouped_gemm_ragged.py
+++ b/aiter/ops/flydsl/kernels/mxfp4_grouped_gemm_ragged.py
@@ -1,0 +1,868 @@
+# SPDX-License-Identifier: MIT
+#
+# RAGGED MXFP4 FORWARD/DGRAD grouped GEMM, 4-wave AGPR body, gfx950 (CDNA4).
+#
+#     out[group_g] = X[group_g] @ W[g]^T        X(M,K), W(E,N,K) -> (M,N)
+#
+# ---------------------------------------------------------------------------
+# The ragged machinery -- device-resident offsets, the block -> (group, row
+# tile, col tile) walk, the overhang mask, the over-provisioned grid -- does not
+# depend on the element type, so it is identical to the MXFP8 form of this body.
+#
+# WHAT AN FP4 ELEMENT TYPE CHANGES, and why each change is what it is:
+#
+#   1. **The LDS K-step stays 128 BYTES and becomes 256 ELEMENTS.** Every piece
+#      of the data path -- ``compute_global_swizzle``, ``swizzle_128``, the
+#      ``BufferCopyLDS128b`` G2S atom, the S2R column formula -- addresses
+#      bytes, not elements, so all of it is reused VERBATIM. What changes is
+#      that one LDS row now feeds TWO K=128 MFMA sub-blocks (``ksub`` 0 and 1)
+#      instead of one. The K-loop trip count halves and the MFMA count per step
+#      doubles, which raises the MFMA-per-ds_read ratio from 2.0 to 4.0.
+#
+#   2. **S2R keeps the two 16-byte halves separate.** The MXFP8 loader packs
+#      them with ``pack_i32x4_i32x8`` because an fp8 K=128 operand is 32 bytes.
+#      An fp4 K=128 operand is 16 bytes, so each half IS an operand. Packing and
+#      re-splitting would cost the round-trip FlyDSL's own fp4 reference calls
+#      out by name (``fp4_gemm_4wave.py:45``): ~64 VGPR of split temporaries on
+#      top of the i32x8 fragments, pushing arch VGPR to 256 and spilling scale.
+#
+#   3. **The MFMA is the same instruction with cbsz:4 blgp:4.**
+#      ``v_mfma_scale_f32_16x16x128_f8f6f4`` selects fp4 e2m1 by operand-format
+#      field, not by opcode. The accumulator stays pinned in AGPR.
+#
+#   4. **The scale plane is UNCHANGED and stays broadcast.** One E8M0 per 32
+#      elements either way, so ``SCALE_I32_ROW = K // 128`` still holds: an i32
+#      is 4 e8m0 = 128 elements = one MFMA K-sub-block. K-step ``s`` consumes
+#      scale i32 ``2s + ksub``, which means the MXFP8 kernel's paired dwordx2
+#      chunk load -- written to cover two of ITS K-steps -- now covers exactly
+#      one of ours. The cooperative load + ds_bpermute redistribution and the
+#      one-e8m0-broadcast-to-4-bytes trick carry over untouched, so this kernel
+#      needs NO ``shuffle_scale_w4`` preshuffle and NO opsel plumbing, unlike
+#      FlyDSL's dense fp4 reference.
+#
+#   5. **Byte offsets halve.** A row is K//2 bytes. Every global offset, buffer
+#      bound and ``num_records_bytes`` is in bytes and was audited for this.
+#
+#   6. **K need not be a multiple of 256.** At K % 256 == 128 (DSV3's 1408) the
+#      last K-step is a HALF step: the G2S still copies a full 128-byte row --
+#      harmless, it reads into the next row and the bounded buffer resource
+#      clamps the final one -- but only ksub 0 is issued to the MFMA.
+# ---------------------------------------------------------------------------
+#
+# This body and its sibling ``mxfp4_grouped_wgrad_ragged`` are the same pipeline
+# pointed in two directions, because the two problems have the SAME operand
+# layout: both are `C = A @ B^T` with A and B row-major and the contraction
+# running along the contiguous axis. What differs is only what the axes mean:
+#
+#                    wgrad                           forward (here)
+#   A                go_t   (R=N, M_TOTAL)           X      (M_tok, K)
+#   B                ia_t   (C=K, M_TOTAL)           W[g]   (N, K)
+#   contraction      tokens, length m_g              K, length K (fixed)
+#   groups partition the CONTRACTION                 the OUTPUT ROWS
+#   per-group offset a column offset (m_start)       a row offset on A, a plane on B
+#   output           (E, R, C) f32                   (M_tok, N) bf16
+#
+# So the group index moves from the K-walk into the tile's base addresses, the
+# contraction becomes short and uniform (K/128 = 16 or 11 steps, versus the
+# wgrad's 192), and the epilogue writes bf16 into one 2-D matrix instead of f32
+# into a per-expert stack.
+#
+# Two structural consequences of the short contraction:
+#   * The K-loop is fully unrolled at compile time. wgrad needed `scf.for`
+#     because a 192-step constexpr loop hung the JIT; at 6-8 fp4 steps the
+#     rolled form only costs scheduling freedom, and the loop-carried a0/b0
+#     fragments and scale chunk disappear.
+#   * Pipeline fill and drain are a much larger fraction of the kernel, and MORE
+#     so at fp4 than at fp8: halving the step count to 6-8 leaves 2 prologue
+#     steps and 2 tail steps out of 6, so half the kernel is fill/drain at
+#     K=1408. That is the main structural risk in this port.
+#
+# The vmcnt accounting is derived, not transcribed. A hand-computed set of four
+# constants (W1A/W2A/W1B/W2B) covers a periodic steady state; with the loop
+# unrolled the issue pattern is not perfectly periodic (the last steps stop
+# prefetching scales), so `_VmCounter` tracks issued vector-memory ops and each
+# barrier waits for exactly "everything up to the op I depend on". It reproduces
+# the hand-computed constants in the steady state.
+
+# NOTE: no `from __future__ import annotations` -- fx.struct needs real types.
+
+import functools
+import os
+
+import flydsl.compiler as flyc
+import flydsl.expr as fx
+from flydsl._mlir.dialects import llvm as _llvm
+from flydsl.expr import arith, const_expr, range_constexpr, rocdl
+from flydsl.expr.arith import ArithValue
+from flydsl.expr.typing import T
+from flydsl.expr.typing import Vector as Vec
+
+from . import buffer_ops
+
+# These six are the FlyDSL fp8-GEMM helper set, already vendored into aiter by
+# the 8-wave CDNA4 GEMM. They address BYTES, not elements, which is exactly why
+# an fp4 kernel can reuse them unchanged -- see the LDS K-step note in the module
+# docstring above.
+from .gemm_a8w8_8wave import (
+    G2SLoader,
+    S2RLoader,
+    compute_global_swizzle,
+    make_fp8_buffer_tensor,
+    swizzle_128,
+    wait_barrier,
+)
+
+SCALE_BLOCK = 32
+
+BLOCK_R = 256  # output rows (tokens) per tile
+BLOCK_C_DEFAULT = 256  # output cols (N) per tile; 128 also supported, see pick_block_c
+# One pipeline step stages 128 BYTES of K per operand row -- the same LDS
+# geometry the MXFP8 body uses, and the reason its whole data path is reusable.
+# At 2 fp4 per byte that is 256 elements, i.e. two K=128 MFMA sub-blocks.
+BLOCK_K_BYTES = 128
+FP4_PER_BYTE = 2
+BLOCK_K_ELEMS = BLOCK_K_BYTES * FP4_PER_BYTE  # 256
+KSUBS = 2  # MFMA K=128 sub-blocks per staged LDS row
+
+
+def pick_block_c(N: int) -> int:
+    """Column tile width. Always 256 -- the narrow tile was measured and lost.
+
+    The motivation for a narrow tile is real: a tile that overhangs N is not
+    free, because the MFMAs run on the overhang and the results are discarded at
+    the store. At K=2048, M=196608, N=1408 (6x256 = 1536 columns) and N=1536 take
+    the SAME 0.83 ms, so the 9.1% overhang is paid in full, and the kernel's
+    29.8% of peak on useful FLOPs is really 32.3% of the hardware.
+
+    1408 = 2^7 x 11 and a legal BLOCK_C is 64 x N_TILES_B, so 128 is the only
+    sane width that divides it. Measured (median of 3, interleaved):
+
+        K=2048 N=1408   256: 0.831 ms 1365 TF/s   128: 0.979 ms 1158   0.849x
+        K=1408 N=2048   256: 0.833 ms 1361 TF/s   128: 1.034 ms 1097   0.806x
+        K=2048 N=2048   256: 1.105 ms 1493 TF/s   128: 1.326 ms 1244   0.833x
+
+    So the narrow tile removes the whole overhang at N=1408 and is still 15%
+    slower. Why: per K-step a wave issues 4*NA*NB MFMAs against 4*(NA+NB) LDS
+    reads, so the MFMA-per-ds_read ratio is NA*NB/(NA+NB) -- 2.0 at 4x4, 1.33 at
+    4x2. Hardware efficiency drops 32.3% -> 25.1%, a 22% loss to save 9% of work.
+
+    There is no better tile available: the accumulators already fill all 256
+    AGPRs at NA*NB = 16 per quadrant, so no shape with a higher ratio fits. The
+    NA=8, NB=2 corner (ratio 1.6, and exactly 160 KB of LDS) interpolates to
+    ~28% hardware, still below the 29.8% useful the wide tile delivers.
+
+    Conclusion: the overhang at N=1408 is not recoverable by retiling. Pass
+    ``block_c=128`` explicitly to re-run the comparison.
+
+    fp4 note: those numbers are the MXFP8 body's. fp4 doubles the MFMAs per LDS
+    read (each staged row feeds two K=128 sub-blocks), so the ratio argument
+    moves 2.0 -> 4.0 and the narrow tile's 1.33 -> 2.67. Whether that changes
+    the verdict is a measurement, not an inference -- re-run it with block_c.
+    """
+    return BLOCK_C_DEFAULT
+
+
+# Interleave each quadrant's MFMAs with the g2s/s2r loads of the NEXT
+# fragment so they co-issue in the MFMA execute shadow. Worth +6.6% in wgrad
+# once its scale loads stopped saturating the L1 address path. Set
+# AITER_FLYDSL_MXFP4_GEMM_INTERLEAVE=0 for the plain cluster.
+_INTERLEAVE = os.environ.get("AITER_FLYDSL_MXFP4_GEMM_INTERLEAVE", "1") != "0"
+
+
+def _mfma_scale_agpr(a, b, sa, sb, acc):
+    """fp4 16x16x128 scaled MFMA with the accumulator pinned in AGPR (=a,...,0)
+    so the f32x4 accumulates in place and the compiler does not shuffle it
+    between AGPR slots.
+
+    ``a``/``b`` are i32x4 -- 16 bytes = 32 fp4 per lane = the K=128 operand.
+    The MXFP8 body passes i32x8 here; same instruction, the operand format
+    field ``cbsz``/``blgp`` (0 = fp8 e4m3, 4 = fp4 e2m1) is what changes the
+    element width, not the opcode.
+
+    ``sa``/``sb`` are broadcast-i32 E8M0 scales (one e8m0 replicated to 4
+    bytes), so ``op_sel`` is a don't-care and is left at its default. That is
+    why this kernel needs neither preshuffled scales nor opsel bookkeeping."""
+    asm = "v_mfma_scale_f32_16x16x128_f8f6f4 $0, $1, $2, $0, $3, $4 cbsz:4 blgp:4"
+    return _llvm.inline_asm(
+        Vec.make_type(4, fx.Float32),
+        [
+            arith._to_raw(a),
+            arith._to_raw(b),
+            arith._to_raw(sa),
+            arith._to_raw(sb),
+            arith._to_raw(acc),
+        ],
+        asm,
+        "=a,v,v,v,v,0",
+        has_side_effects=True,
+    )
+
+
+class _VmCounter:
+    """Issue-order bookkeeping for `s_waitcnt vmcnt(n)`.
+
+    vmcnt retires IN ORDER, so "wait until op X has landed" is spelled
+    "allow at most (ops issued after X) to be outstanding". Every vector
+    memory op the kernel issues is counted here; `mark()` records a
+    watermark right after the ops a later barrier will depend on, and
+    `wait(mark)` emits the barrier with the exact count.
+
+    Getting this wrong in the unsafe direction is silent: too LARGE a count
+    under-waits and reads LDS the copy has not filled yet. Deriving it from
+    the issue order removes the chance to mis-transcribe a constant.
+    """
+
+    def __init__(self):
+        self.n = 0
+
+    def issue(self, k):
+        self.n += k
+        return self.n
+
+    def mark(self):
+        return self.n
+
+    def wait(self, mark):
+        wait_barrier(self.n - mark)
+
+
+def _compile(K: int, N: int, E: int, BLOCK_C: int):
+    """Compile a RAGGED forward grouped GEMM for one (K, N, E) shape.
+
+    Deliberately absent from the key: the token count and every group size.
+    Both are runtime. Under real MoE routing they change every step, and a
+    shape-keyed compile leaks a JIT compile plus a retained GPU module per
+    step per layer -- the same defect the dim1 cast had, where it cost 618x.
+    The even-groups parent keyed on (K, N, M_G, M_TOTAL, BLOCK_C) and so
+    recompiled per token count; only balanced routing hid it.
+    """
+    assert K % 128 == 0, f"K ({K}) must be a multiple of 128 (MFMA K-sub-block)"
+    assert BLOCK_C in (128, 256), f"BLOCK_C {BLOCK_C} not supported"
+
+    K_BYTES = K // FP4_PER_BYTE
+    # Steps of 256 fp4. A trailing 128 (K % 256 == 128, e.g. DSV3's 1408)
+    # becomes a HALF step: the G2S still stages a whole 128-byte row and
+    # only ksub 0 reaches the MFMA.
+    K_ITERS = (K + BLOCK_K_ELEMS - 1) // BLOCK_K_ELEMS
+    HALF_TAIL = (K % BLOCK_K_ELEMS) != 0
+    assert (
+        K_ITERS >= 4
+    ), f"K {K} gives {K_ITERS} steps; need >= 4 (2 prologue + 2 tails)"
+
+    # i32 of e8m0 per operand row. One i32 is 4 E8M0 = 128 elements = one
+    # MFMA K-sub-block, so this count is IDENTICAL to the MXFP8 body's even
+    # though the step size doubled: K-step s consumes i32 2s and 2s+1.
+    SCALE_I32_ROW = K // 128
+
+    N_TILES_A = BLOCK_R // 4 // 16
+    N_TILES_B = BLOCK_C // 4 // 16
+    N_ACCUMS = N_TILES_A * N_TILES_B
+    N_LDS_ROUNDS = max(N_TILES_A, N_TILES_B)
+
+    # A dwordx2 scale load needs an even element index. The index is
+    # lane*SCALE_I32_ROW + row_base*SCALE_I32_ROW + 2s; the 2s term is always
+    # even, so the row stride alone decides. K=2048 -> 16 (paired);
+    # K=1408 -> 11 (two dword loads instead; same cache lines, one extra
+    # instruction).
+    SC_PAIR = SCALE_I32_ROW % 2 == 0
+    N_SC_OPS = 4 if SC_PAIR else 8  # scale vm ops per chunk (= one K-step)
+    # One chunk per K-step now, where the MXFP8 body needed one per two: its
+    # paired dwordx2 covered two of its 128-element steps, and covers exactly
+    # one of our 256-element ones.
+    N_CHUNKS = K_ITERS
+
+    LDS_BLOCK_R = BLOCK_R // 2  # each wave-dim half owns 128 rows
+    LDS_BLOCK_C = BLOCK_C // 2
+
+    def _interleave_plan(n_mfma, n_g2s, n_tiles):
+        """Where to slot each load into the cluster's MFMA stream.
+
+        Returns three lists indexed by MFMA position: the g2s steps, the
+        first-half s2r tiles and the second-half s2r tiles to issue just
+        before that MFMA. Generated rather than written out because the
+        counts move with the tile -- BLOCK_C=256 is 16 MFMAs against 4 g2s
+        steps and 4x2 s2r reads, BLOCK_C=128 is 8 against 4 and 2x2.
+
+        Computed HERE, outside the kernel body, on purpose: FlyDSL's AST
+        rewriter turns an `if` inside a nested kernel-body function into a
+        separate `__then_N` function that cannot see the enclosing closure,
+        so schedule logic has to be plain Python that runs before tracing.
+        The kernel body then walks the plan with no branches at all.
+        """
+        acts = []
+        for r in range(max(n_g2s, n_tiles)):
+            if r < n_g2s:
+                acts.append(("g", r))
+            if r < n_tiles:
+                acts.append(("s0", r))
+                acts.append(("s1", r))
+        g_at = [[] for _ in range(n_mfma)]
+        s0_at = [[] for _ in range(n_mfma)]
+        s1_at = [[] for _ in range(n_mfma)]
+        for n_, act in enumerate(acts):
+            # Strictly < n_mfma for every n_, so no load is ever dropped.
+            pos = int(round((n_ + 1) * n_mfma / (len(acts) + 1)))
+            {"g": g_at, "s0": s0_at, "s1": s1_at}[act[0]][pos].append(act[1])
+        return g_at, s0_at, s1_at
+
+    # (tile_i, tile_j, ksub). Two MFMAs per accumulator per step, because a
+    # staged 128-byte row is two K=128 sub-blocks. ksub is the OUTER loop so
+    # both MFMAs of an accumulator are not back-to-back on the same AGPR.
+    MFMA_SEQ = [
+        (i, j, ks)
+        for ks in range(KSUBS)
+        for i in range(N_TILES_A)
+        for j in range(N_TILES_B)
+    ]
+    # Keyed by (g2s steps, s2r tiles): clusters 1 and 4 push A and pull B,
+    # clusters 2 and 3 the other way round. Keys collide harmlessly when the
+    # tile is square.
+    PLANS = {
+        (N_TILES_A, N_TILES_B): _interleave_plan(len(MFMA_SEQ), N_TILES_A, N_TILES_B),
+        (N_TILES_B, N_TILES_A): _interleave_plan(len(MFMA_SEQ), N_TILES_B, N_TILES_A),
+    }
+    a_lds_size = LDS_BLOCK_R * BLOCK_K_BYTES
+    b_lds_size = LDS_BLOCK_C * BLOCK_K_BYTES
+
+    # Int8, not Float8E4M3FN: LDS holds packed fp4 BYTES and nothing in the
+    # data path interprets them until the MFMA does.
+    @fx.struct
+    class SharedStorage:
+        A_lds_cur_0: fx.Array[fx.Int8, a_lds_size, 16]
+        A_lds_cur_1: fx.Array[fx.Int8, a_lds_size, 16]
+        A_lds_next_0: fx.Array[fx.Int8, a_lds_size, 16]
+        A_lds_next_1: fx.Array[fx.Int8, a_lds_size, 16]
+        B_lds_cur_0: fx.Array[fx.Int8, b_lds_size, 16]
+        B_lds_cur_1: fx.Array[fx.Int8, b_lds_size, 16]
+        B_lds_next_0: fx.Array[fx.Int8, b_lds_size, 16]
+        B_lds_next_1: fx.Array[fx.Int8, b_lds_size, 16]
+
+    @flyc.kernel(known_block_size=[256, 1, 1])
+    def kernel_fwd(
+        A: fx.Tensor,
+        B: fx.Tensor,
+        OUT: fx.Tensor,
+        A_scale: fx.Tensor,
+        B_scale: fx.Tensor,
+        OFFS: fx.Tensor,
+        n_c_tiles: fx.Int32,
+        out_m: fx.Int32,
+        out_n: fx.Int32,
+    ):
+        I8_IR_t = fx.Int8.ir_type
+
+        # ── Block -> (group, row tile, col tile), resolved ON DEVICE ──
+        # Groups partition the OUTPUT ROWS here, not the contraction, so
+        # unlike the wgrad kernel nothing about the K-walk changes: K is
+        # uniform across experts. Only this mapping and the epilogue mask
+        # care that the groups are ragged.
+        bid = fx.block_idx.x
+        slot = ArithValue(bid) // n_c_tiles  # which row tile overall
+        c_base = (ArithValue(bid) % n_c_tiles) * fx.Int32(BLOCK_C)
+
+        offs_rsrc = buffer_ops.create_buffer_resource(
+            OFFS, max_size=False, num_records_bytes=E * 4
+        )
+        # Uniform (SGPR) loads: every lane in the block wants the same
+        # boundaries, so this is E scalar loads, not E per-lane loads.
+        ends = [
+            ArithValue(
+                buffer_ops.buffer_load(
+                    offs_rsrc, fx.Int32(i), vec_width=1, dtype=T.i32, is_scalar=True
+                )
+            )
+            for i in range(E)
+        ]
+        starts = [ArithValue(fx.Int32(0))] + ends[:-1]
+
+        # Walk the groups accumulating row tiles until the slot lands in one.
+        # E is constexpr, so this unrolls to E selects on the SALU against a
+        # K-walk of many iterations -- the same O(E) prologue the wgrad
+        # kernel pays. `active` is false for slots past the last group's
+        # tiles, which predicates those blocks off in the epilogue.
+        g = ArithValue(fx.Int32(0))
+        r_base = ArithValue(fx.Int32(0))
+        m_start = ArithValue(fx.Int32(0))
+        m_end = ArithValue(fx.Int32(0))
+        active = fx.Int32(0) > fx.Int32(0)  # false
+        cum = ArithValue(fx.Int32(0))
+        # range_constexpr, not range: the AST rewriter turns a plain `range`
+        # into a device-side scf.for, whose induction variable is an
+        # ArithValue and cannot index the `ends`/`starts` Python lists. This
+        # loop must unroll at trace time.
+        for i in range_constexpr(E):
+            m_i = ends[i] - starts[i]
+            t_i = (m_i + fx.Int32(BLOCK_R - 1)) // fx.Int32(BLOCK_R)
+            hit = (slot >= cum) & (slot < cum + t_i)
+            g = arith.select(hit, fx.Int32(i), g)
+            r_base = arith.select(hit, (slot - cum) * fx.Int32(BLOCK_R), r_base)
+            m_start = arith.select(hit, starts[i], m_start)
+            m_end = arith.select(hit, ends[i], m_end)
+            active = active | hit
+            cum = cum + t_i
+
+        # A is offset by the group's first token row, B by the expert's
+        # weight plane. Both are plain row offsets at the same stride K --
+        # the "dynamic per-group stride" problem the MXFP8-MoE post
+        # describes does not arise on this axis.
+        row0 = m_start + r_base
+        wrow0 = ArithValue(g) * fx.Int32(N) + c_base
+
+        lds = fx.SharedAllocator().allocate(SharedStorage).peek()
+        a_cur0, a_cur1 = lds.A_lds_cur_0, lds.A_lds_cur_1
+        a_next0, a_next1 = lds.A_lds_next_0, lds.A_lds_next_1
+        b_cur0, b_cur1 = lds.B_lds_cur_0, lds.B_lds_cur_1
+        b_next0, b_next1 = lds.B_lds_next_0, lds.B_lds_next_1
+
+        lane_id = fx.thread_idx.x % 64
+        wave_id = fx.thread_idx.x // 64
+        wave_i = wave_id // 2
+        wave_j = wave_id % 2
+
+        m_lane = lane_id % fx.Int32(16)
+        k_grp = lane_id // fx.Int32(16)
+        kshift = k_grp * fx.Int32(8)
+        mask_ff = fx.Int32(0xFF)
+        bcast = fx.Int32(0x01010101)
+
+        # BYTES, not elements: an fp4 row is K//2 bytes wide.
+        A0_gl = row0 * fx.Int32(K_BYTES)
+        A1_gl = (row0 + fx.Int32(LDS_BLOCK_R)) * fx.Int32(K_BYTES)
+        B0_gl = wrow0 * fx.Int32(K_BYTES)
+        B1_gl = (wrow0 + fx.Int32(LDS_BLOCK_C)) * fx.Int32(K_BYTES)
+
+        gA = make_fp8_buffer_tensor(A, I8_IR_t)
+        gB = make_fp8_buffer_tensor(B, I8_IR_t)
+        a_div = fx.logical_divide(gA, fx.make_layout(1, 1))
+        b_div = fx.logical_divide(gB, fx.make_layout(1, 1))
+
+        sa_rsrc = buffer_ops.create_buffer_resource(A_scale, max_size=True)
+        sb_rsrc = buffer_ops.create_buffer_resource(B_scale, max_size=True)
+
+        # K_BYTES: this is the global ROW STRIDE the swizzle walks, in bytes.
+        gl_off_a = compute_global_swizzle(
+            lane_id, wave_id, K_BYTES, N_LDS_ROUNDS, preshuffled=False
+        )
+        gl_off_b = compute_global_swizzle(
+            lane_id, wave_id, K_BYTES, N_LDS_ROUNDS, preshuffled=False
+        )
+
+        a_g2s = G2SLoader(a_div, gl_off_a, N_TILES_A, I8_IR_t, wave_id)
+        b_g2s = G2SLoader(b_div, gl_off_b, N_TILES_B, I8_IR_t, wave_id)
+        a_s2r = S2RLoader(wave_i, N_TILES_A)
+        b_s2r = S2RLoader(wave_j, N_TILES_B)
+
+        vm = _VmCounter()
+
+        # ── MXFP4 scales: cooperative wide load + ds_bpermute ──
+        # UNCHANGED from the MXFP8 body, and it costs nothing to keep: the MX
+        # scale plane does not depend on the element format. One i32 per row
+        # is 4 E8M0 = 128 elements = exactly one MFMA K-sub-block, fp8 or fp4
+        # alike. What moved is only the INDEX: our K-step spans two i32
+        # (2s, 2s+1) where the MXFP8 body's spanned one, so its dwordx2 pair
+        # -- built to cover two of its steps -- covers exactly one of ours.
+        #
+        # Each operand-half needs the e8m0 byte of 64 consecutive rows (4 MFMA
+        # tiles x 16 rows) at this sub-block; lane group k_grp takes byte
+        # k_grp and broadcasts it to all 4 bytes, which is why op_sel can stay
+        # at its default and no scale preshuffle is needed.
+        #
+        # The naive form -- one buffer_load per (half, tile) -- issues 16 dword
+        # loads per K-step that touch the SAME 16 cache lines four times over,
+        # because lanes m_lane..m_lane+48 share an address. That is the same L1
+        # request count as all of the step's data traffic, and it, not the
+        # matrix core, sets the pace (measured in wgrad: stubbing the scales
+        # out took it 822 -> 1486 TFLOP/s).
+        #
+        # Instead: ONE cooperative load per half, lane L taking row
+        # (half_base + L), so 64 lanes cover 64 rows with no duplicate address,
+        # widened to a dwordx2 spanning two K-steps. 8x fewer scale L1
+        # requests. Each lane then pulls the tile it actually needs with
+        # ds_bpermute (lane L from lane t*16 + L%16) -- LDS crossbar, not HBM.
+        #
+        # A half spans N_TILES*16 rows, so 64 lanes cover it exactly at
+        # N_TILES=4 and cover it twice over at N_TILES=2 (BLOCK_C=128). The
+        # duplicate half of that load is wasted address bandwidth but stays
+        # ONE instruction, and the rows it touches are the next 32 of the same
+        # weight plane -- already-warm cache lines, or an in-bounds read the
+        # bpermute never selects.
+        assert N_TILES_A <= 4 and N_TILES_B <= 4, "a half must fit in 64 lanes"
+
+        sa0_base = row0 + wave_i * fx.Int32(N_TILES_A * 16)
+        sa1_base = row0 + fx.Int32(LDS_BLOCK_R) + wave_i * fx.Int32(N_TILES_A * 16)
+        sb0_base = wrow0 + wave_j * fx.Int32(N_TILES_B * 16)
+        sb1_base = wrow0 + fx.Int32(LDS_BLOCK_C) + wave_j * fx.Int32(N_TILES_B * 16)
+
+        # Only the row term is per-lane; the half base and the K index are
+        # wave-uniform and ride the buffer instruction's SGPR soffset, so the
+        # address costs no per-step VALU and exactly one VGPR.
+        sc_voff = lane_id * fx.Int32(SCALE_I32_ROW)
+        sc_sbase = [
+            (_rs, _base * fx.Int32(SCALE_I32_ROW * 4))
+            for _rs, _base in (
+                (sa_rsrc, sa0_base),
+                (sa_rsrc, sa1_base),
+                (sb_rsrc, sb0_base),
+                (sb_rsrc, sb1_base),
+            )
+        ]
+        sc_perm = [
+            fx.Int32(t_ * 64) + m_lane * fx.Int32(4)
+            for t_ in range_constexpr(max(N_TILES_A, N_TILES_B))
+        ]
+        # Tiles per half, in the order the chunk stores them: A0, A1, B0, B1.
+        sc_tiles = (N_TILES_A, N_TILES_A, N_TILES_B, N_TILES_B)
+
+        def issue_chunk(k_i32):
+            """Cooperative scale loads for scale-i32 pair (k_i32, k_i32+1),
+            i.e. the two K=128 sub-blocks of ONE 256-element K-step.
+
+            Returns 2 raw i32 per operand-half, flat: [a0_lo, a0_hi, a1_lo, ...].
+            A chunk for a K-step past the end reads the next row's scales (or
+            out of bounds, which the buffer resource returns as 0) and is never
+            consumed -- cheaper than predicating the last prefetch.
+            """
+            out = []
+            for _rs, _sb in sc_sbase:
+                soff = _sb + fx.Int32(k_i32 * 4)
+                # const_expr, not a bare `if`: 0.3.0's AST rewriter
+                # routes an `if` in a kernel body through scf_if_dispatch.
+                # For a Python-constant condition that still calls only the
+                # taken branch -- so this is about intent, not correctness:
+                # const_expr says "compile-time" at the call site instead of
+                # leaving a reader to check _is_dynamic.
+                if const_expr(SC_PAIR):
+                    v = fx.Vector(
+                        buffer_ops.buffer_load(
+                            _rs, sc_voff, vec_width=2, dtype=T.i32, soffset_bytes=soff
+                        )
+                    )
+                    out.append(v[0])
+                    out.append(v[1])
+                else:
+                    out.append(
+                        buffer_ops.buffer_load(
+                            _rs, sc_voff, vec_width=1, dtype=T.i32, soffset_bytes=soff
+                        )
+                    )
+                    out.append(
+                        buffer_ops.buffer_load(
+                            _rs,
+                            sc_voff,
+                            vec_width=1,
+                            dtype=T.i32,
+                            soffset_bytes=soff + fx.Int32(4),
+                        )
+                    )
+            vm.issue(N_SC_OPS)
+            return out
+
+        def use_chunk(chunk, p):
+            """Redistribute + consume the chunk's sub-block `p` (= ksub)
+            -> (sa0, sa1, sb0, sb1), each a list of broadcast-i32 per tile."""
+            groups = []
+            for h_ in range_constexpr(4):
+                src = chunk[2 * h_ + p]
+                grp = []
+                for t_ in range_constexpr(sc_tiles[h_]):
+                    v = rocdl.ds_bpermute(res=T.i32, index=sc_perm[t_], src=src)
+                    grp.append(((ArithValue(v) >> kshift) & mask_ff) * bcast)
+                groups.append(grp)
+            return groups
+
+        def use_step(chunk, n_ksub=KSUBS):
+            """Both sub-blocks of one K-step: sa[ks][tile], sb[ks][tile]."""
+            sa0, sa1, sb0, sb1 = [], [], [], []
+            for ks in range_constexpr(n_ksub):
+                g0, g1, g2, g3 = use_chunk(chunk, ks)
+                sa0.append(g0)
+                sa1.append(g1)
+                sb0.append(g2)
+                sb1.append(g3)
+            return sa0, sa1, sb0, sb1
+
+        def mma(a, b, c, sa, sb, n_ksub=KSUBS):
+            """``a[tile][ksub]`` / ``b[tile][ksub]`` are i32x4 K=128 operands;
+            ``sa[ksub][tile]`` / ``sb[ksub][tile]`` the matching scales."""
+            for ks in range_constexpr(n_ksub):
+                for i in range_constexpr(N_TILES_A):
+                    for j in range_constexpr(N_TILES_B):
+                        idx = i * N_TILES_B + j
+                        c[idx] = _mfma_scale_agpr(
+                            a[i][ks], b[j][ks], sa[ks][i], sb[ks][j], c[idx]
+                        )
+            return c
+
+        zero = Vec.filled(4, 0.0, fx.Float32)
+        c00 = [zero] * N_ACCUMS
+        c01 = [zero] * N_ACCUMS
+        c10 = [zero] * N_ACCUMS
+        c11 = [zero] * N_ACCUMS
+
+        def _lds_swizzle(s2r):
+            """Byte offsets of a tile's two K=128 sub-blocks in the staged
+            128-byte row. Identical formula to the MXFP8 body's -- the LDS
+            geometry is in bytes and did not change; what changed is that
+            these two offsets are now two OPERANDS rather than two halves of
+            one."""
+            out = []
+            for row_off in range_constexpr(s2r.n_tiles):
+                row = (
+                    s2r.wave_idx * fx.Int32(s2r.n_tiles * 16)
+                    + fx.Int32(row_off * 16)
+                    + (lane_id % fx.Int32(16))
+                )
+                swz = []
+                for ii in range_constexpr(KSUBS):
+                    col = (lane_id // fx.Int32(16)) * fx.Int32(16) + fx.Int32(ii * 64)
+                    r_, c_ = swizzle_128(row, col)
+                    swz.append(r_ * fx.Int32(BLOCK_K_BYTES) + c_)
+                out.append(swz)
+            return out
+
+        def s2r_load_fp4(s2r, lds_src):
+            """Per tile: ``[i32x4_ksub0, i32x4_ksub1]``, NOT packed."""
+            swz = _lds_swizzle(s2r)
+            return [
+                [s2r.load_one(lds_src, swz[t_][ks]) for ks in range_constexpr(KSUBS)]
+                for t_ in range_constexpr(s2r.n_tiles)
+            ]
+
+        def _cluster_plain(lds_dst, g2s, k_off, s2r, lds_src, a, b, c, sa, sb):
+            g2s.load(lds_dst, k_off)
+            vm.issue(g2s.n_load_steps)
+            rt = s2r_load_fp4(s2r, lds_src)
+            c = mma(a, b, c, sa, sb)
+            return c, rt
+
+        def _cluster_il(lds_dst, g2s, k_off, s2r, lds_src, a, b, c, sa, sb):
+            # Interleave this quadrant's MFMAs with the g2s and s2r loads of
+            # the NEXT fragment, so the loads co-issue in the MFMA execute
+            # shadow. Mirrors fp8_gemm_4wave's _interleaved_cluster; the MFMA
+            # is scaled + AGPR-pinned here. The schedule comes from
+            # `_interleave_plan` (computed before tracing), so this walks it
+            # with no branches -- see that function on why.
+            #
+            # fp4 has 2x the MFMAs per cluster and the same number of loads,
+            # so every load lands in a wider shadow than it did at fp8.
+            swz = _lds_swizzle(s2r)
+            rt = [[None, None] for _ in range(s2r.n_tiles)]
+            g_at, s0_at, s1_at = PLANS[(g2s.n_load_steps, s2r.n_tiles)]
+
+            for idx in range_constexpr(len(MFMA_SEQ)):
+                for gi in range_constexpr(len(g_at[idx])):
+                    g2s.load_one(lds_dst, k_off, g_at[idx][gi])
+                for si in range_constexpr(len(s0_at[idx])):
+                    t_ = s0_at[idx][si]
+                    rt[t_][0] = s2r.load_one(lds_src, swz[t_][0])
+                for si in range_constexpr(len(s1_at[idx])):
+                    t_ = s1_at[idx][si]
+                    rt[t_][1] = s2r.load_one(lds_src, swz[t_][1])
+                i_, j_, ks_ = MFMA_SEQ[idx]
+                c[i_ * N_TILES_B + j_] = _mfma_scale_agpr(
+                    a[i_][ks_],
+                    b[j_][ks_],
+                    sa[ks_][i_],
+                    sb[ks_][j_],
+                    c[i_ * N_TILES_B + j_],
+                )
+
+            vm.issue(g2s.n_load_steps)
+            return c, rt
+
+        _cluster = _cluster_il if _INTERLEAVE else _cluster_plain
+
+        # ── Prologue: pre-fill the 8-buffer LDS pipeline (2 K-steps) ──
+        # Chunks 0 and 1 go first so they are the oldest things in flight and
+        # the prologue barriers retire them for free. TWO chunks, where the
+        # MXFP8 body needed one: a chunk is one K-step's scales here, and the
+        # prefetch horizon is two steps.
+        chunks = [None] * N_CHUNKS
+        chunks[0] = issue_chunk(0)
+        if N_CHUNKS > 1:
+            chunks[1] = issue_chunk(2)
+
+        a_g2s.load(a_cur0, A0_gl + 0 * BLOCK_K_BYTES)
+        mk_ac0 = vm.issue(N_TILES_A)
+        b_g2s.load(b_cur0, B0_gl + 0 * BLOCK_K_BYTES)
+        mk_bc0 = vm.issue(N_TILES_B)
+        b_g2s.load(b_cur1, B1_gl + 0 * BLOCK_K_BYTES)
+        vm.issue(N_TILES_B)
+        a_g2s.load(a_cur1, A1_gl + 0 * BLOCK_K_BYTES)
+        mk_a = vm.issue(N_TILES_A)
+
+        a_g2s.load(a_next0, A0_gl + 1 * BLOCK_K_BYTES)
+        vm.issue(N_TILES_A)
+        b_g2s.load(b_next0, B0_gl + 1 * BLOCK_K_BYTES)
+        mk_b = vm.issue(N_TILES_B)
+        b_g2s.load(b_next1, B1_gl + 1 * BLOCK_K_BYTES)
+        vm.issue(N_TILES_B)
+        a_g2s.load(a_next1, A1_gl + 1 * BLOCK_K_BYTES)
+        mk_c = vm.issue(N_TILES_A)
+
+        vm.wait(mk_ac0)
+        a0 = s2r_load_fp4(a_s2r, a_cur0)
+        vm.wait(mk_bc0)
+        b0 = s2r_load_fp4(b_s2r, b_cur0)
+
+        # ── Main K-steps 0 .. K_ITERS-3, fully unrolled ──
+        # Each step consumes the LDS buffers holding step k, loads step k+2
+        # into them, and reads step k+1's leading fragments. Which watermark
+        # each barrier waits on follows from the ping-pong depth:
+        #   * clusters 1-2 read the halves written by step k-2's SECOND half,
+        #   * clusters 3-4 read the halves written by step k-1's FIRST half.
+        # The two prologue groups stand in for steps -2 and -1: `mk_a` closes
+        # the k=0 group (step 0's second-half operands), `mk_b` sits right
+        # after b_next0 (step 1's leading fragments) and `mk_c` closes the
+        # k=1 group (step 1's second-half operands).
+        bufs = (a_cur0, a_cur1, a_next0, a_next1, b_cur0, b_cur1, b_next0, b_next1)
+        sec = {-2: mk_a, -1: mk_c}  # second-half watermark, by step index
+        fst = {-1: mk_b}  # first-half watermark, by step index
+
+        for kk in range_constexpr(K_ITERS - 2):
+            ac0, ac1, an0, an1, bc0, bc1, bn0, bn1 = bufs
+            k2 = (kk + 2) * BLOCK_K_BYTES
+
+            # The scales for this step came off HBM two steps ago; the only
+            # HBM touch is the prefetch for the step two out -- the same
+            # horizon the data ping-pong runs at.
+            vm.wait(sec[kk - 2])
+            if kk + 2 < N_CHUNKS:
+                chunks[kk + 2] = issue_chunk(2 * (kk + 2))
+            sa0, sa1, sb0, sb1 = use_step(chunks[kk])
+
+            c00, b1 = _cluster(
+                ac0, a_g2s, A0_gl + k2, b_s2r, bc1, a0, b0, c00, sa0, sb0
+            )
+            c01, a1 = _cluster(
+                bc0, b_g2s, B0_gl + k2, a_s2r, ac1, a0, b1, c01, sa0, sb1
+            )
+            fst[kk] = vm.mark()
+
+            vm.wait(fst[kk - 1])
+            c10, a0 = _cluster(
+                bc1, b_g2s, B1_gl + k2, a_s2r, an0, a1, b0, c10, sa1, sb0
+            )
+            c11, b0 = _cluster(
+                ac1, a_g2s, A1_gl + k2, b_s2r, bn0, a1, b1, c11, sa1, sb1
+            )
+            sec[kk] = vm.mark()
+
+            bufs = (an0, an1, ac0, ac1, bn0, bn1, bc0, bc1)
+
+        a_cur0, a_cur1, a_next0, a_next1, b_cur0, b_cur1, b_next0, b_next1 = bufs
+
+        # ── Tail step K_ITERS-2: drain, no more g2s ──
+        k_tail0 = K_ITERS - 2
+        vm.wait(sec[k_tail0 - 2])
+        sa0, sa1, sb0, sb1 = use_step(chunks[k_tail0])
+        b1 = s2r_load_fp4(b_s2r, b_cur1)
+        c00 = mma(a0, b0, c00, sa0, sb0)
+        a1 = s2r_load_fp4(a_s2r, a_cur1)
+        c01 = mma(a0, b1, c01, sa0, sb1)
+        vm.wait(fst[k_tail0 - 1])
+        a0 = s2r_load_fp4(a_s2r, a_next0)
+        c10 = mma(a1, b0, c10, sa1, sb0)
+        b0 = s2r_load_fp4(b_s2r, b_next0)
+        c11 = mma(a1, b1, c11, sa1, sb1)
+
+        a_cur0, a_next0 = a_next0, a_cur0
+        a_cur1, a_next1 = a_next1, a_cur1
+        b_cur0, b_next0 = b_next0, b_cur0
+        b_cur1, b_next1 = b_next1, b_cur1
+
+        # ── Tail step K_ITERS-1 ──
+        # When K % 256 == 128 this is a HALF step: the G2S staged a whole
+        # 128-byte row (reading 64 bytes into the next row, which the bounded
+        # buffer resource clamps on the last one), but only ksub 0 -- the
+        # first 64 bytes, K elements 0..127 -- is real, so only it is issued.
+        NK_TAIL = 1 if HALF_TAIL else KSUBS
+        k_tail1 = K_ITERS - 1
+        vm.wait(sec[k_tail1 - 2])
+        sa0, sa1, sb0, sb1 = use_step(chunks[k_tail1], NK_TAIL)
+        b1 = s2r_load_fp4(b_s2r, b_cur1)
+        a1 = s2r_load_fp4(a_s2r, a_cur1)
+        c00 = mma(a0, b0, c00, sa0, sb0, NK_TAIL)
+        c01 = mma(a0, b1, c01, sa0, sb1, NK_TAIL)
+        c10 = mma(a1, b0, c10, sa1, sb0, NK_TAIL)
+        c11 = mma(a1, b1, c11, sa1, sb1, NK_TAIL)
+
+        # ── Epilogue: bf16 into out(M, N); the MFMA already applied the scales ──
+        # Storing f32 and converting outside would cost a full extra pass over
+        # M*N (553 MB at the e2e forward shape) -- more than half the kernel.
+        out_m_i = arith.index_cast(T.index, out_m)
+        out_n_i = arith.index_cast(T.index, out_n)
+        nbytes = arith.index_cast(T.i64, out_m_i * out_n_i * fx.Index(2))
+        o_rsrc = buffer_ops.create_buffer_resource(
+            OUT, max_size=False, num_records_bytes=nbytes
+        )
+        base_row = row0 + wave_i * fx.Int32(N_TILES_A * 16)
+        base_col = c_base + wave_j * fx.Int32(N_TILES_B * 16)
+        oob = out_m * out_n
+
+        def store_group(frag, br, bc):
+            for ti in range_constexpr(N_TILES_A):
+                row = br + fx.Int32(ti * 16) + k_grp * fx.Int32(4)
+                for tj in range_constexpr(N_TILES_B):
+                    col = bc + fx.Int32(tj * 16) + m_lane
+                    col_ok = col < out_n
+                    vec = Vec(frag[ti * N_TILES_B + tj])
+                    for e in range_constexpr(4):
+                        r_ = row + fx.Int32(e)
+                        # `r_ < m_end` is the ragged part. A row tile may
+                        # overhang its group, in which case the overhanging
+                        # rows hold this expert's weights applied to the
+                        # NEXT group's tokens -- correct arithmetic, wrong
+                        # expert -- so they must not be stored. `active`
+                        # kills whole slots past the last group's tiles.
+                        # Reading those A rows is harmless: each output
+                        # element is one A row dotted with one B column, so
+                        # nothing leaks across rows, and any fp8 NaN in the
+                        # pad region past m_total lands only in rows we drop.
+                        ok = active & (r_ < m_end) & (r_ < out_m) & col_ok
+                        off = arith.select(ok, r_ * out_n + col, oob)
+                        buffer_ops.buffer_store(vec[e].to(fx.BFloat16), o_rsrc, off)
+
+        store_group(c00, base_row, base_col)
+        store_group(c01, base_row, base_col + fx.Int32(LDS_BLOCK_C))
+        store_group(c10, base_row + fx.Int32(LDS_BLOCK_R), base_col)
+        store_group(
+            c11, base_row + fx.Int32(LDS_BLOCK_R), base_col + fx.Int32(LDS_BLOCK_C)
+        )
+
+    @flyc.jit
+    def launch_fwd(
+        A,
+        B,
+        OUT,
+        A_scale,
+        B_scale,
+        OFFS,
+        n_blocks: fx.Int32,
+        n_c_tiles: fx.Int32,
+        out_m: fx.Int32,
+        out_n: fx.Int32,
+        stream: fx.Stream,
+    ):
+        kernel_fwd(
+            A,
+            B,
+            OUT,
+            A_scale,
+            B_scale,
+            OFFS,
+            n_c_tiles,
+            out_m,
+            out_n,
+            value_attrs={
+                "rocdl.waves_per_eu": 1,
+                "rocdl.flat_work_group_size": "256,256",
+            },
+        ).launch(grid=(n_blocks, 1, 1), block=(256, 1, 1), stream=stream)
+
+    return launch_fwd
+
+
+@functools.lru_cache(maxsize=None)
+def cached_launch(K: int, N: int, E: int, BLOCK_C: int):
+    return _compile(K, N, E, BLOCK_C)

--- a/aiter/ops/flydsl/kernels/mxfp4_grouped_wgrad_ragged.py
+++ b/aiter/ops/flydsl/kernels/mxfp4_grouped_wgrad_ragged.py
@@ -1,0 +1,1059 @@
+# SPDX-License-Identifier: MIT
+#
+# RAGGED MXFP4 WGRAD grouped GEMM, gfx950 (CDNA4).
+#
+#     grad_W[g] = go[group_g]^T @ ia[group_g]
+#
+# Here the groups partition the CONTRACTION, not the output rows -- the opposite
+# of the sibling ``mxfp4_grouped_gemm_ragged``, and the reason this body needs
+# its own ragged machinery rather than reusing that one's.
+#
+# The pipeline is the tuned equal-groups shape -- 4-wave 2x2 geometry, AGPR-pinned
+# scaled MFMA, 8-buffer LDS ping-pong with a depth-2 K pipeline, cooperative scale
+# load + ds_bpermute + a one-body scale prefetch riding the scf.for state -- driven
+# from device-resident ragged group sizes.
+#
+# Why the tuned body and not a simpler ragged one (E=8, N=1408, K=2048, 24576
+# tok/expert, even groups so both see identical work): a non-pipelined ragged body
+# runs at 630 TF/s (13.6% of peak) against this pipeline's 1349 TF/s (29.2%). The
+# gap is the body, not the raggedness.
+#
+# ── The three things that made that pipeline equal-groups, and how each is paid ──
+#
+# 1. CONSTEXPR CONTRACTION LENGTH. The equal-groups form keys its compile on M_G
+#    and derives
+#    K_ITERS = M_G/128 as a Python int, which drives the prologue/rolled-loop/tail
+#    split and the constexpr peel of the odd remainder.
+#
+#    Here the group length is a device value. Two moves make the same schedule
+#    work with a runtime trip count:
+#      * The window is EXTENDED, never shortened, to an even number of K-steps
+#        >= 4 (`K_eff`). MAIN = K_eff - 2 is then even, so `N_ROLLED == MAIN`
+#        and the constexpr odd-step peel disappears entirely -- one fewer
+#        moving part than the equal-groups form, not one more.
+#      * Everything outside the group is masked (see 3), so extending is free of
+#        correctness consequences and costs at most 3 dead K-steps per block.
+#
+# 2. 128-ALIGNED GROUP STARTS. The cooperative scale load is a dwordx2 whose
+#    element index is (half_base + lane)*SCALE_I32_ROW + m_start_i32 + k. It needs
+#    that index EVEN, and it needs the lane's e8m0 to sit at byte k_grp of the
+#    loaded i32 -- both of which hold only when the group starts on a 128 (really
+#    256) boundary. Ragged group boundaries are only 32-aligned, which is why a
+#    naive ragged body carries per-lane `a_e8`/`k_carry` index arithmetic and
+#    cannot use the wide cooperative load at all.
+#
+#    Rather than widen the load (3 distinct i32 per unrolled body once a carry is
+#    possible => dwordx4 and +8 live VGPRs against 12 of headroom), the window
+#    BASE is rounded DOWN to 256: `lo0 = (start/256)*256`. Then m_start_i32 is
+#    even and the per-lane byte is k_grp again, so **the entire equal-groups
+#    scale path is reused verbatim** -- cooperative load, ds_bpermute, the
+#    one-body prefetch and its vmcnt accounting. The up-to-224 leading elements
+#    that rounding pulls in belong to the previous group and are masked off by
+#    (3). Requires SCALE_I32_ROW even, i.e. M_ROW % 256 == 0 (see wgrad_ragged).
+#
+# 3. NO PARTIAL K-STEPS. An equal-groups body contracts exactly M_G elements,
+#    all of them real.
+#
+#    Here a block's window [lo0, lo0 + K_eff*128) both starts before the group
+#    (leading round-down) and ends after it (trailing partial + the extension
+#    from 1). Both, plus empty groups, plus the dead extension steps, are handled
+#    by ONE predicate on the A-operand scale:
+#
+#        e  = k*128 + k_grp*32          (this lane's 32-element sub-block)
+#        ok = (e >= head) & (e < span)
+#
+#    where `head = start - lo0` and `span = end - lo0` are block-uniform. Forcing
+#    the A e8m0 to 0x00 (= 2**-127, NOT NaN) makes a*scale*b underflow to ~1e-33
+#    against accumulators of order 1e2. Masking rides the SCALE and not the MFMA
+#    fragment because the scale path maps k_grp -> sub-block directly, while the
+#    fragment's K layout is opaque and not lane//16.
+#
+#    Applied to A only: a == 0 kills the product for any FINITE b. That "finite"
+#    is load-bearing and is why both scale descriptors are bounded below -- an
+#    out-of-range e8m0 read of 0xFF is NaN, and 0 * NaN = NaN would survive the
+#    mask. `max_size=False` ALONE DOES NOT BOUND a dynamic memref; it silently
+#    falls back to 0xFFFFFFFF. Verify in the generated IR, not in this source.
+#
+# ── What this grid choice gains over a chunked ragged schedule ──
+#
+# The grid is E * n_r_tiles * n_c_tiles: exactly one block per (group, output
+# tile), each walking its whole group. There is no split of a group across
+# chunks, and therefore **no atomic epilogue** -- the block owns its output tile
+# outright and stores it directly onto an uninitialised buffer, as the
+# equal-groups form does. That also makes this body bit-reproducible at a fixed
+# stride, which a chunked schedule is not, and removes the zero-init memset of
+# the (E, R, C) f32 output.
+#
+# The cost of that choice is load balance: 384 blocks over 256 CUs means a skewed
+# group is a straggler, where a chunked schedule would spread the work over
+# ~5000 blocks. Equal groups accept the same 384-block grid.
+#
+# ── What the straggler actually costs, measured (2026-07-31) ──
+#
+# It is a SCHEDULING problem, not a chunking one, at the skew that occurs:
+#
+#   * The block -> group map IS the dispatch order (the hardware issues
+#     workgroups in increasing block id). Ordering the groups longest-first --
+#     `slot_to_group` below, computed on device from the offsets every block
+#     already reads -- is worth a MEDIAN +10.8% (range +4.5%..+22.9%) over seven
+#     group-size lists taken from real routed DSV3-16B steps. No atomics, no
+#     extra launch, no host sync.
+#   * With the remap on, the ragged path at those real sizes runs at 27.2-29.5%
+#     of peak and is FASTER than equal groups at the same total work (0.88-0.96x)
+#     -- so at real skew there is no straggler deficit left to chunk away.
+#   * A synthetic ragged draw (flat Dirichlet split) has max/mean K_eff of
+#     2.4-3.6. Real routing lands at 1.17-1.69. In the synthetic regime one group
+#     IS the critical path, reordering can only reach +1.2% median, and chunking
+#     would be the only remaining lever -- but that regime is an artifact of the
+#     draw, not something routing produces.
+#
+# So a chunked variant that re-introduces the atomic epilogue is NOT worth
+# building for this workload.
+#
+# NAMING / stride split:
+#     A := go_t (R, M_ROW)   B := ia_t (C, M_ROW)   out[g] = A[:,s:e] @ B[:,s:e]^T
+# M is the contraction (tokens); M_ROW is the HBM row stride and is a RUNTIME
+# argument, never a constexpr: under real routing the routed token count changes
+# every step, and a constexpr stride keys a fresh JIT compile -- and retains a
+# fresh GPU module -- per step per layer. The compile key is (R, C, E) only.
+
+# NOTE: no `from __future__ import annotations` -- fx.struct Storable needs real
+# types at class-definition time.
+
+import functools
+import os
+
+import flydsl.compiler as flyc
+import flydsl.expr as fx
+from flydsl._mlir.dialects import llvm as _llvm
+from flydsl.expr import arith, const_expr, range_constexpr, rocdl
+from flydsl.expr.arith import ArithValue
+from flydsl.expr.typing import T
+from flydsl.expr.typing import Vector as Vec
+
+from . import buffer_ops
+
+# These six are the FlyDSL fp8-GEMM helper set, already vendored into aiter by
+# the 8-wave CDNA4 GEMM. They address BYTES, not elements, which is exactly why
+# an fp4 kernel can reuse them unchanged -- see the LDS K-step note in the module
+# docstring above.
+from .gemm_a8w8_8wave import (
+    G2SLoader,
+    S2RLoader,
+    compute_global_swizzle,
+    make_fp8_buffer_tensor,
+    swizzle_128,
+    wait_barrier,
+)
+
+SCALE_BLOCK = 32
+
+BLOCK_R = 256  # output rows per tile
+BLOCK_C = 256  # output cols per tile
+# One pipeline step stages 128 BYTES of the contraction per operand row -- the
+# same LDS geometry the MXFP8 body uses. At 2 fp4 per byte that is 256 tokens,
+# i.e. TWO K=128 MFMA sub-blocks (ksub 0/1). See the fp4 note in the header.
+BLOCK_K_BYTES = 128
+FP4_PER_BYTE = 2
+BLOCK_K_ELEMS = BLOCK_K_BYTES * FP4_PER_BYTE  # 256 tokens
+KSUBS = 2
+BLOCK_M = 128  # elements covered by ONE scale i32 / one MFMA K-sub-block
+SCALE_BLOCK = 32
+# Window base rounding. Unchanged at 256: it is set by the scale index needing
+# to be even (lo0/128 even), which is the same constraint at fp4, and 256 is
+# also exactly one fp4 K-step so the step addressing lands on a row boundary.
+WINDOW_ALIGN = 256
+LPT_MAX_E = 32  # above this the dispatch remap falls back to `id`
+
+# Block -> (group, bounds) mappings. Only "lpt" ships; the other two are here to
+# be timed against it, because the difference between them splits `lpt`'s gain
+# into a scheduling part and a codegen part. See slot_to_group.
+#   id     -- group = dispatch slot, offsets read at a COMPUTED index (original)
+#   idsel  -- group = dispatch slot, offsets read at constant indices
+#   lpt    -- slot d takes the d-th longest group, constant-index reads
+ORDER_MODES = ("id", "idsel", "lpt")
+
+
+# Interleave each quadrant's 16 MFMAs with the g2s/s2r loads of the NEXT
+# fragment so they co-issue in the MFMA execute shadow. Worth +6.6% here
+# (and +5.1% on the sibling forward kernel) -- but only AFTER the scale
+# delivery came off the L1 critical path; it measured neutral before that.
+_INTERLEAVE = os.environ.get("AITER_FLYDSL_MXFP4_WGRAD_INTERLEAVE", "1") != "0"
+
+
+def _mfma_scale_agpr(a, b, sa, sb, acc):
+    """fp4 16x16x128 scaled MFMA, accumulator pinned in AGPR (=a,...,0) so the
+    f32x4 acc accumulates in place and the compiler does not shuffle it
+    between AGPR slots.
+
+    a/b are i32x4 -- 16 bytes = 32 fp4 per lane = the K=128 operand. The operand
+    format field cbsz/blgp (0 = fp8 e4m3, 4 = fp4 e2m1) is what selects the
+    element width; the opcode is the same either way.
+
+    sa/sb are broadcast-i32 E8M0 scales (one e8m0 replicated to 4 bytes), so
+    op_sel is a don't-care and is left at its default -- which is why this kernel
+    needs neither preshuffled scales nor op_sel bookkeeping."""
+    asm = "v_mfma_scale_f32_16x16x128_f8f6f4 $0, $1, $2, $0, $3, $4 cbsz:4 blgp:4"
+    return _llvm.inline_asm(
+        Vec.make_type(4, fx.Float32),
+        [
+            arith._to_raw(a),
+            arith._to_raw(b),
+            arith._to_raw(sa),
+            arith._to_raw(sb),
+            arith._to_raw(acc),
+        ],
+        asm,
+        "=a,v,v,v,v,0",
+        has_side_effects=True,
+    )
+
+
+def _compile(R: int, C: int, E: int, sc_pair: bool, order: str):
+    """Build the launch fn. Compile-time: (R, C, E, sc_pair, order) ONLY.
+
+    Deliberately absent from the key: the row stride, the group sizes, the
+    contraction length and the number of K iterations -- all runtime. Under
+    real routing every one of those varies per step, and anything shape-keyed
+    here becomes a JIT compile plus a retained GPU module per step per layer.
+
+    `order` picks the block->group mapping (see slot_to_group). Like
+    `sc_pair` it is a key, not a runtime branch, because it decides which code
+    exists at all. Only the default is ever compiled in production; the other
+    two exist to be timed against it in the same pass.
+    """
+    assert order in ORDER_MODES, f"unknown order {order!r}"
+    ORDER = order
+    N_TILES_A = BLOCK_R // 4 // 16
+    N_TILES_B = BLOCK_C // 4 // 16
+    N_ACCUMS = N_TILES_A * N_TILES_B
+    N_LDS_ROUNDS = max(N_TILES_A, N_TILES_B)
+
+    # The cooperative dwordx2 scale load needs its element index even. The
+    # index is (half_base + lane)*SCALE_I32_ROW + m_start_i32 + k, with k
+    # always even (chunks start on the unrolled body's first K-step), and
+    # m_start_i32 even because the window base is WINDOW_ALIGN(=256)-aligned.
+    # `lane` varies, so evenness reduces to SCALE_I32_ROW = M_ROW/128 being
+    # even, i.e. M_ROW % 256 == 0.
+    #
+    # When it is odd the pair load would be misaligned for odd lanes, so fall
+    # back to TWO dword loads -- same bytes and same cache lines, one extra
+    # instruction per half. Requiring 256 instead would be an integration
+    # trap: the MoE token dispatcher pads per-expert counts to 32, so M_ROW
+    # is a multiple of 32 and only 1 in 8 such values is a multiple of 256.
+    # 128 is the alignment the sibling even-groups body already contracts for.
+    #
+    # `sc_pair` is a compile-key bit rather than a runtime branch: it changes
+    # the vmcnt barrier constants below, which must be compile-time. It adds
+    # at most ONE extra variant, so the compile set stays bounded -- the
+    # property that keeping M_ROW out of the key exists to protect.
+    SC_PAIR = sc_pair
+    N_SC_OPS = 4 if SC_PAIR else 8  # scale vm ops per unrolled body
+    N_CHUNK = 8  # raw i32 carried per chunk (4 halves x 2 K-steps)
+
+    # ── vmcnt accounting, unchanged from the equal-groups body ──
+    # An unrolled body is 2 K-steps and issues, between barriers:
+    #   R1a = N_SC_OPS scale loads (next chunk) + (NA+NB) g2s copies
+    #   R2a = (NA+NB) g2s copies
+    #   R1b = (NA+NB) g2s copies      R2b = (NA+NB) g2s copies
+    # Barrier 1 of a K-step must retire that step's minus-2 R2; barrier 2 the
+    # minus-1 R1. SAFE UNDER REORDERING within a region: the only region
+    # holding more than one thing is R1a, and if the scheduler sinks the scale
+    # loads below the g2s copies there, the barrier retires more than
+    # required, never less. A count that is too LARGE under-waits and reads
+    # unfilled LDS -- and that failure is silent.
+    # fp4 re-derivation: an fp4 K-step needs a whole chunk (its two scale
+    # i32 are ksub 0 and 1), so BOTH half-bodies now issue one, where the
+    # MXFP8 body's single chunk covered both of its steps. R1b gains
+    # N_SC_OPS, which lifts W1A and W2B by the same amount and leaves W2A
+    # and W1B -- already counting a chunk -- unchanged. All four coincide.
+    W1A = 2 * (N_TILES_A + N_TILES_B) + N_SC_OPS
+    W2A = 2 * (N_TILES_A + N_TILES_B) + N_SC_OPS
+    W1B = 2 * (N_TILES_A + N_TILES_B) + N_SC_OPS
+    W2B = 2 * (N_TILES_A + N_TILES_B) + N_SC_OPS
+
+    LDS_BLOCK_R = BLOCK_R // 2  # 128: each wave-dim half owns 128 rows
+    LDS_BLOCK_C = BLOCK_C // 2
+
+    def _interleave_plan(n_mfma, n_g2s, n_tiles):
+        """Where to slot each load into the cluster's MFMA stream.
+
+        Plain Python, run before tracing: FlyDSL's AST rewriter turns an
+        `if` inside a nested kernel-body function into a separate `__then_N`
+        that cannot see the enclosing closure, so schedule logic cannot live
+        in the body. The body then walks the plan with no branches at all.
+        """
+        acts = []
+        for r in range(max(n_g2s, n_tiles)):
+            if r < n_g2s:
+                acts.append(("g", r))
+            if r < n_tiles:
+                acts.append(("s0", r))
+                acts.append(("s1", r))
+        g_at = [[] for _ in range(n_mfma)]
+        s0_at = [[] for _ in range(n_mfma)]
+        s1_at = [[] for _ in range(n_mfma)]
+        for n_, act in enumerate(acts):
+            pos = int(round((n_ + 1) * n_mfma / (len(acts) + 1)))
+            {"g": g_at, "s0": s0_at, "s1": s1_at}[act[0]][pos].append(act[1])
+        return g_at, s0_at, s1_at
+
+    # (tile_i, tile_j, ksub); ksub outermost so an accumulator's two MFMAs
+    # are not back-to-back on the same AGPR.
+    MFMA_SEQ = [
+        (i, j, ks)
+        for ks in range(KSUBS)
+        for i in range(N_TILES_A)
+        for j in range(N_TILES_B)
+    ]
+    PLANS = {
+        (N_TILES_A, N_TILES_B): _interleave_plan(len(MFMA_SEQ), N_TILES_A, N_TILES_B),
+        (N_TILES_B, N_TILES_A): _interleave_plan(len(MFMA_SEQ), N_TILES_B, N_TILES_A),
+    }
+
+    a_lds_size = LDS_BLOCK_R * BLOCK_K_BYTES
+    b_lds_size = LDS_BLOCK_C * BLOCK_K_BYTES
+
+    def slot_to_group(offs_rsrc, slot):
+        """Dispatch slot -> (group, m_start, m_end), read on device.
+
+        Defined OUTSIDE the kernel body on purpose: FlyDSL's AST rewriter
+        rewrites the kernel function only, and it turns a Python `if` into an
+        scf.if region (assignments inside do not escape) and a Python `range`
+        into a dynamic scf.for (the induction variable stops being an int and
+        cannot index a Python list). Out here both are ordinary Python again,
+        so `LPT` is a real compile-time branch and the loops are unrolled by
+        construction.
+
+        ── LPT (longest processing time first) ──
+        With the identity mapping `g = slot`, the group order IS the dispatch
+        order, because the hardware issues workgroups in increasing block id.
+        A large group sitting at a high `g` therefore starts in the last wave
+        and sets the makespan by itself. Here slot d takes the d-th LONGEST
+        group instead.
+
+        MEASURED (E=8, N=1408, K=2048, 24576 tok/expert, 4 draws), sizes
+        sorted descending vs ascending -- same multiset, so identical sum AND
+        max K_eff, i.e. pure schedule: largest-first wins by 3.0-21.8%.
+
+        Every block recomputes the whole permutation from the E offsets it
+        already reads: E scalar loads and E*E uniform compares, tens of SALU
+        ops against a 200+ iteration K-walk. No host sort, no second launch,
+        no device scratch, and `offs` stays the tensor the caller passed.
+
+        The sort key is `end - floor(start/256)*256`, the window the block
+        will actually walk (header note 2), not the group size -- the
+        round-down means two equal-sized groups can differ by a K-step, and
+        the walk is what costs. Ties break on index, so the ranks are a
+        permutation of 0..E-1 for any input, empty groups included.
+
+        ── Two effects, not one ──
+        `lpt` gains ~5% even on EQUAL groups, where its ranking provably
+        returns the identity permutation, so part of the win is not the
+        schedule at all. Mode `idsel` isolates it: identity mapping, but the
+        offsets read the way `lpt` reads them. See ORDER_MODES.
+        """
+        if ORDER == "id":
+            # The original mapping. Both loads are at a COMPUTED index, and
+            # the g-1 one has to wait on a select, so a block cannot know its
+            # window until a dependent scalar load returns. Bounded, not
+            # max_size: the g==0 read is clamped to index 0 and then discarded
+            # by the select, so it must not touch memory beyond OFFS.
+            g = slot
+            g_prev = arith.select(g > fx.Int32(0), g - fx.Int32(1), fx.Int32(0))
+            prev_raw = buffer_ops.buffer_load(
+                offs_rsrc, g_prev, vec_width=1, dtype=T.i32, is_scalar=True
+            )
+            end_raw = buffer_ops.buffer_load(
+                offs_rsrc, g, vec_width=1, dtype=T.i32, is_scalar=True
+            )
+            m_start = arith.select(g > fx.Int32(0), ArithValue(prev_raw), fx.Int32(0))
+            return g, ArithValue(m_start), ArithValue(end_raw)
+
+        # All E offsets at CONSTANT indices: no address depends on anything,
+        # so they issue together at block entry instead of serialising behind
+        # a computed index. E=8 int32 is one 32-byte line either way.
+        ends = [
+            ArithValue(
+                buffer_ops.buffer_load(
+                    offs_rsrc, fx.Int32(i), vec_width=1, dtype=T.i32, is_scalar=True
+                )
+            )
+            for i in range(E)
+        ]
+        starts = [ArithValue(fx.Int32(0))] + ends[:-1]
+
+        if ORDER == "idsel":
+            # Identity mapping, `lpt`'s load pattern: the control for how much
+            # of `lpt`'s gain is scheduling and how much is just this.
+            g = slot
+            m_start = ArithValue(fx.Int32(0))
+            m_end = ends[0]
+            for i in range(E):
+                mine = g == fx.Int32(i)
+                m_start = arith.select(mine, starts[i], m_start)
+                m_end = arith.select(mine, ends[i], m_end)
+            return g, ArithValue(m_start), ArithValue(m_end)
+
+        cost = [
+            ends[i] - (starts[i] // fx.Int32(WINDOW_ALIGN)) * fx.Int32(WINDOW_ALIGN)
+            for i in range(E)
+        ]
+
+        g = ArithValue(fx.Int32(0))
+        m_start = ArithValue(fx.Int32(0))
+        m_end = ends[0]
+        for i in range(E):
+            rank = ArithValue(fx.Int32(0))
+            for j in range(E):
+                # j < i wins ties, so the order is strict and total; j == i
+                # takes the `>` branch and contributes 0.
+                ahead = (cost[j] >= cost[i]) if j < i else (cost[j] > cost[i])
+                rank = rank + arith.select(ahead, fx.Int32(1), fx.Int32(0))
+            mine = rank == slot
+            g = arith.select(mine, fx.Int32(i), g)
+            m_start = arith.select(mine, starts[i], m_start)
+            m_end = arith.select(mine, ends[i], m_end)
+        return ArithValue(g), ArithValue(m_start), ArithValue(m_end)
+
+    @fx.struct
+    class SharedStorage:
+        A_lds_cur_0: fx.Array[fx.Int8, a_lds_size, 16]
+        A_lds_cur_1: fx.Array[fx.Int8, a_lds_size, 16]
+        A_lds_next_0: fx.Array[fx.Int8, a_lds_size, 16]
+        A_lds_next_1: fx.Array[fx.Int8, a_lds_size, 16]
+        B_lds_cur_0: fx.Array[fx.Int8, b_lds_size, 16]
+        B_lds_cur_1: fx.Array[fx.Int8, b_lds_size, 16]
+        B_lds_next_0: fx.Array[fx.Int8, b_lds_size, 16]
+        B_lds_next_1: fx.Array[fx.Int8, b_lds_size, 16]
+
+    @flyc.kernel(known_block_size=[256, 1, 1])
+    def kernel_wgrad(
+        A: fx.Tensor,
+        B: fx.Tensor,
+        OUT: fx.Tensor,
+        A_scale: fx.Tensor,
+        B_scale: fx.Tensor,
+        OFFS: fx.Tensor,
+        n_r_tiles: fx.Int32,
+        n_c_tiles: fx.Int32,
+        out_r: fx.Int32,
+        out_c: fx.Int32,
+        m_row: fx.Int32,
+    ):
+        I8_IR_t = fx.Int8.ir_type
+
+        # Runtime row stride. One e8m0 per 32 contracting elements, 4 packed
+        # per i32, so a row is m_row/128 i32 and m_row/32 bytes.
+        sc_i32_row = ArithValue(m_row) // fx.Int32(BLOCK_M)
+        sc_e8_row = ArithValue(m_row) // fx.Int32(SCALE_BLOCK)
+
+        # ── Block -> (group, output tile). One block per (g, tile). ──
+        bid = fx.block_idx.x
+        tiles_per_g = n_r_tiles * n_c_tiles
+        slot = ArithValue(bid) // tiles_per_g
+        ttile = ArithValue(bid) % tiles_per_g
+        r_base = (ttile // n_c_tiles) * fx.Int32(BLOCK_R)
+        c_base = (ttile % n_c_tiles) * fx.Int32(BLOCK_C)
+
+        # ── Group bounds, read ON DEVICE (uniform s.buffer.load, no sync) ──
+        offs_rsrc = buffer_ops.create_buffer_resource(
+            OFFS, max_size=False, num_records_bytes=E * 4
+        )
+
+        g, m_start, m_end = slot_to_group(offs_rsrc, slot)
+
+        # ── The window: base rounded DOWN to 256, length rounded UP to an
+        # even number of K-steps >= 4. See notes 1-3 in the file header. ──
+        lo0 = (m_start // fx.Int32(WINDOW_ALIGN)) * fx.Int32(WINDOW_ALIGN)
+        head = m_start - lo0  # 0..224, multiple of 32
+        span = m_end - lo0  # real elements from the window base
+        k_need = (span + fx.Int32(BLOCK_K_ELEMS - 1)) // fx.Int32(BLOCK_K_ELEMS)
+        k_even = ((k_need + fx.Int32(1)) // fx.Int32(2)) * fx.Int32(2)
+        K_eff = arith.select(k_even < fx.Int32(4), fx.Int32(4), k_even)
+        N_ROLLED = K_eff - fx.Int32(2)  # even, >= 2: no constexpr peel needed
+        # Scale-i32 index of the window base. Still lo0/128 -- an i32 is 4
+        # e8m0 = 128 elements whatever the element format -- and still even,
+        # because lo0 is 256-aligned. Our K-step spans i32 (2s, 2s+1).
+        m_start_i32 = lo0 // fx.Int32(BLOCK_M)
+
+        lds = fx.SharedAllocator().allocate(SharedStorage).peek()
+        a_cur0, a_cur1 = lds.A_lds_cur_0, lds.A_lds_cur_1
+        a_next0, a_next1 = lds.A_lds_next_0, lds.A_lds_next_1
+        b_cur0, b_cur1 = lds.B_lds_cur_0, lds.B_lds_cur_1
+        b_next0, b_next1 = lds.B_lds_next_0, lds.B_lds_next_1
+
+        lane_id = fx.thread_idx.x % 64
+        wave_id = fx.thread_idx.x // 64
+        wave_i = wave_id // 2
+        wave_j = wave_id % 2
+
+        m_lane = lane_id % fx.Int32(16)
+        k_grp = lane_id // fx.Int32(16)
+        kshift = k_grp * fx.Int32(8)
+        kgrp32 = k_grp * fx.Int32(SCALE_BLOCK)  # this lane's sub-block offset
+        mask_ff = fx.Int32(0xFF)
+        bcast = fx.Int32(0x01010101)
+        zero_i32 = fx.Int32(0)
+
+        # Contraction (K-walk) global offsets, in BYTES: an fp4 operand row
+        # is m_row/2 bytes and the window base lo0 sits at lo0/2. lo0 is
+        # 256-aligned so lo0/2 is a whole 128-byte LDS row.
+        m_row_bytes = ArithValue(m_row) // fx.Int32(FP4_PER_BYTE)
+        lo0_bytes = lo0 // fx.Int32(FP4_PER_BYTE)
+        A0_gl = r_base * m_row_bytes + lo0_bytes
+        A1_gl = (r_base + fx.Int32(LDS_BLOCK_R)) * m_row_bytes + lo0_bytes
+        B0_gl = c_base * m_row_bytes + lo0_bytes
+        B1_gl = (c_base + fx.Int32(LDS_BLOCK_C)) * m_row_bytes + lo0_bytes
+
+        gA = make_fp8_buffer_tensor(A, I8_IR_t)
+        gB = make_fp8_buffer_tensor(B, I8_IR_t)
+        a_div = fx.logical_divide(gA, fx.make_layout(1, 1))
+        b_div = fx.logical_divide(gB, fx.make_layout(1, 1))
+
+        # BOUNDED scale descriptors. Two independent reasons, both real:
+        #   * the cooperative load has lane L take row (half_base + L), so the
+        #     last row tile of an operand whose R (or C) is not a multiple of
+        #     256 addresses rows that do not exist -- at R=1408 = 5.5 tiles,
+        #     128 of the last tile's 256 rows;
+        #   * this kernel's window runs PAST the group and past the operand's
+        #     last row on the final K-steps by construction.
+        # Both must read 0, not memory: an 0xFF byte is e8m0 NaN and the A-side
+        # mask does not neutralise it (0 * NaN = NaN). `max_size=False` alone
+        # does NOT do this on a dynamic memref -- it silently yields
+        # 0xFFFFFFFF. (The data descriptors get a real bound because
+        # make_fp8_buffer_tensor emits a runtime fly.cosize instead.)
+        sa_bytes = arith.index_cast(
+            T.i64, arith.index_cast(T.index, fx.Int32(R) * sc_e8_row)
+        )
+        sb_bytes = arith.index_cast(
+            T.i64, arith.index_cast(T.index, fx.Int32(C) * sc_e8_row)
+        )
+        sa_rsrc = buffer_ops.create_buffer_resource(
+            A_scale, max_size=False, num_records_bytes=sa_bytes
+        )
+        sb_rsrc = buffer_ops.create_buffer_resource(
+            B_scale, max_size=False, num_records_bytes=sb_bytes
+        )
+
+        # BYTE row stride -- the swizzle walks bytes.
+        gl_off_a = compute_global_swizzle(
+            lane_id, wave_id, m_row_bytes, N_LDS_ROUNDS, preshuffled=False
+        )
+        gl_off_b = compute_global_swizzle(
+            lane_id, wave_id, m_row_bytes, N_LDS_ROUNDS, preshuffled=False
+        )
+
+        a_g2s = G2SLoader(a_div, gl_off_a, N_TILES_A, I8_IR_t, wave_id)
+        b_g2s = G2SLoader(b_div, gl_off_b, N_TILES_B, I8_IR_t, wave_id)
+        a_s2r = S2RLoader(wave_i, N_TILES_A)
+        b_s2r = S2RLoader(wave_j, N_TILES_B)
+
+        # ── MXFP8 scales: the equal-groups body's cooperative wide load, unchanged ──
+        # ONE dwordx2 per operand-half per unrolled body: lane L takes row
+        # (half_base + L), so 64 lanes cover the half's 64 rows with no
+        # duplicate address, and the pair spans the body's TWO K-steps
+        # (adjacent i32 in the same row). 16 dword loads/K-step become 2 -- an
+        # 8x cut in L1 requests, which is what actually set the pace: 16 loads
+        # x 16 distinct cache lines per K-step equalled ALL of the step's data
+        # traffic, so the address path, not the matrix core, was the limit.
+        # The tile each lane needs is recovered with ds_bpermute (lane L pulls
+        # tile t from lane t*16 + L%16) -- LDS crossbar, not HBM.
+        assert (
+            N_TILES_A == 4 and N_TILES_B == 4
+        ), "cooperative scale load assumes 4x16=64 rows/half"
+
+        sa0_base = r_base + wave_i * fx.Int32(N_TILES_A * 16)
+        sa1_base = r_base + fx.Int32(LDS_BLOCK_R) + wave_i * fx.Int32(N_TILES_A * 16)
+        sb0_base = c_base + wave_j * fx.Int32(N_TILES_B * 16)
+        sb1_base = c_base + fx.Int32(LDS_BLOCK_C) + wave_j * fx.Int32(N_TILES_B * 16)
+
+        # Only the row term is per-lane; the half base and the K index are
+        # wave-uniform, so they ride the buffer instruction's SGPR soffset and
+        # the address costs no per-step VALU and exactly one VGPR. (On gfx950
+        # soffset IS included in the num_records bounds check, so the bound
+        # above really does clamp these.)
+        sc_voff = lane_id * sc_i32_row
+        sc_sbase = [
+            (_rs, (_base * sc_i32_row + m_start_i32) * fx.Int32(4))
+            for _rs, _base in (
+                (sa_rsrc, sa0_base),
+                (sa_rsrc, sa1_base),
+                (sb_rsrc, sb0_base),
+                (sb_rsrc, sb1_base),
+            )
+        ]
+        sc_perm = [
+            fx.Int32(t_ * 64) + m_lane * fx.Int32(4)
+            for t_ in range_constexpr(N_TILES_A)
+        ]
+
+        def issue_chunk(k_i32):
+            """Cooperative scale loads for K-steps (k_i32, k_i32+1).
+
+            Returns 2 raw i32 per operand-half, flat: [a0_lo, a0_hi, a1_lo, ...].
+            """
+            out = []
+            for _rs, _sb in sc_sbase:
+                soff = _sb + k_i32 * fx.Int32(4)
+                # const_expr, not a bare `if`: 0.3.0's AST rewriter
+                # routes an `if` in a kernel body through scf_if_dispatch.
+                # For a Python-constant condition that still calls only the
+                # taken branch -- so this is about intent, not correctness:
+                # const_expr says "compile-time" at the call site instead of
+                # leaving a reader to check _is_dynamic.
+                if const_expr(SC_PAIR):
+                    v = fx.Vector(
+                        buffer_ops.buffer_load(
+                            _rs, sc_voff, vec_width=2, dtype=T.i32, soffset_bytes=soff
+                        )
+                    )
+                    out.append(v[0])
+                    out.append(v[1])
+                else:
+                    # Two dwords: a dword needs only 4-byte alignment, so this
+                    # is valid for any SCALE_I32_ROW parity.
+                    out.append(
+                        buffer_ops.buffer_load(
+                            _rs, sc_voff, vec_width=1, dtype=T.i32, soffset_bytes=soff
+                        )
+                    )
+                    out.append(
+                        buffer_ops.buffer_load(
+                            _rs,
+                            sc_voff,
+                            vec_width=1,
+                            dtype=T.i32,
+                            soffset_bytes=soff + fx.Int32(4),
+                        )
+                    )
+            return out
+
+        def window_ok(sub_idx):
+            """Is this lane's 32-element sub-block inside the real group?
+
+            ``sub_idx`` is the MFMA K-sub-block index -- equivalently the
+            scale-i32 index -- so ``e = sub_idx*128 + k_grp*32`` relative to
+            the window base. IDENTICAL to the MXFP8 formula: there it was the
+            K-step index because a step was one sub-block; here a step is two,
+            and the caller passes 2*step + ksub. Covers, with one predicate:
+            the leading round-down to 256, the trailing partial K-step, the
+            even/>=4 extension, and empty groups.
+            """
+            e = sub_idx * fx.Int32(BLOCK_M) + kgrp32
+            return (e >= head) & (e < span)
+
+        def use_chunk(chunk, p, k_idx):
+            """Redistribute + consume the chunk's K-step `p` -> (sa0,sa1,sb0,sb1),
+            masked to e8m0 0x00 outside the group.
+
+            BOTH operands are masked, not just A. Masking A alone is the
+            cheaper argument -- a == 0 kills the product -- but it is only
+            valid while b is finite, and an e8m0 byte of 0xFF is NaN, for
+            which 0 * NaN = NaN. Out-of-*allocation* reads are already
+            clamped to 0 by the bounded descriptors above, but the pad
+            columns this window deliberately reads are INSIDE the
+            allocation, so nothing but this select covers them. 8 extra
+            per-lane selects per K-step against 64 MFMAs.
+            """
+            ok = window_ok(k_idx)
+            groups = []
+            for h_ in range_constexpr(4):
+                src = chunk[2 * h_ + p]
+                grp = []
+                for t_ in range_constexpr(N_TILES_A):
+                    v = rocdl.ds_bpermute(res=T.i32, index=sc_perm[t_], src=src)
+                    sc = ((ArithValue(v) >> kshift) & mask_ff) * bcast
+                    grp.append(arith.select(ok, sc, zero_i32))
+                groups.append(grp)
+            return groups
+
+        def use_step(chunk, k_step):
+            """Both sub-blocks of K-step ``k_step``: sa[ksub][tile] etc."""
+            sa0, sa1, sb0, sb1 = [], [], [], []
+            for ks in range_constexpr(KSUBS):
+                g0, g1, g2, g3 = use_chunk(
+                    chunk, ks, k_step * fx.Int32(KSUBS) + fx.Int32(ks)
+                )
+                sa0.append(g0)
+                sa1.append(g1)
+                sb0.append(g2)
+                sb1.append(g3)
+            return sa0, sa1, sb0, sb1
+
+        def mma(a, b, c, sa, sb):
+            for ks in range_constexpr(KSUBS):
+                for i in range_constexpr(N_TILES_A):
+                    for j in range_constexpr(N_TILES_B):
+                        idx = i * N_TILES_B + j
+                        c[idx] = _mfma_scale_agpr(
+                            a[i][ks], b[j][ks], sa[ks][i], sb[ks][j], c[idx]
+                        )
+            return c
+
+        zero = Vec.filled(4, 0.0, fx.Float32)
+        c00 = [zero] * N_ACCUMS
+        c01 = [zero] * N_ACCUMS
+        c10 = [zero] * N_ACCUMS
+        c11 = [zero] * N_ACCUMS
+
+        def _lds_swizzle(s2r):
+            """Byte offsets of a tile's two K=128 sub-blocks in the staged
+            128-byte row. Same formula as the MXFP8 body's -- the LDS
+            geometry is in bytes -- but these are now two OPERANDS, not two
+            halves of one."""
+            out = []
+            for row_off in range_constexpr(s2r.n_tiles):
+                row = (
+                    s2r.wave_idx * fx.Int32(s2r.n_tiles * 16)
+                    + fx.Int32(row_off * 16)
+                    + (lane_id % fx.Int32(16))
+                )
+                swz = []
+                for ii in range_constexpr(KSUBS):
+                    col = (lane_id // fx.Int32(16)) * fx.Int32(16) + fx.Int32(ii * 64)
+                    r_, c_ = swizzle_128(row, col)
+                    swz.append(r_ * fx.Int32(BLOCK_K_BYTES) + c_)
+                out.append(swz)
+            return out
+
+        def s2r_load_fp4(s2r, lds_src):
+            """Per tile: ``[i32x4_ksub0, i32x4_ksub1]``, NOT packed -- an fp4
+            K=128 operand is 16 bytes, so each half already IS an operand."""
+            swz = _lds_swizzle(s2r)
+            return [
+                [s2r.load_one(lds_src, swz[t_][ks]) for ks in range_constexpr(KSUBS)]
+                for t_ in range_constexpr(s2r.n_tiles)
+            ]
+
+        # ── Prologue: 8-buffer LDS pipeline pre-fill ──
+        # Chunk 0 is issued FIRST, ahead of every data copy, so it is the
+        # oldest thing in flight: the two prologue barriers keep their counts
+        # (an older op never changes how many ops trail a newer one), they
+        # retire the chunk for free, and the wave enters the loop in exactly
+        # the steady state W1A assumes. K_eff >= 4 guarantees steps 0 and 1
+        # exist, so this needs no guard.
+        # TWO chunks: an fp4 K-step consumes a whole chunk (its two i32 are
+        # ksub 0 and 1), and the unrolled body is two K-steps. Both are issued
+        # ahead of every data copy so they stay the oldest ops in flight and
+        # the prologue barrier counts below are unchanged -- an older op never
+        # changes how many ops trail a newer one.
+        chunk0 = issue_chunk(fx.Int32(0))
+        chunk1 = issue_chunk(fx.Int32(KSUBS))
+        a_g2s.load(a_cur0, A0_gl + 0 * BLOCK_K_BYTES)
+        b_g2s.load(b_cur0, B0_gl + 0 * BLOCK_K_BYTES)
+        b_g2s.load(b_cur1, B1_gl + 0 * BLOCK_K_BYTES)
+        a_g2s.load(a_cur1, A1_gl + 0 * BLOCK_K_BYTES)
+
+        a_g2s.load(a_next0, A0_gl + 1 * BLOCK_K_BYTES)
+        b_g2s.load(b_next0, B0_gl + 1 * BLOCK_K_BYTES)
+        b_g2s.load(b_next1, B1_gl + 1 * BLOCK_K_BYTES)
+        a_g2s.load(a_next1, A1_gl + 1 * BLOCK_K_BYTES)
+
+        wait_barrier((3 * N_TILES_A) + (4 * N_TILES_B))
+        a0 = s2r_load_fp4(a_s2r, a_cur0)
+        wait_barrier((3 * N_TILES_A) + (3 * N_TILES_B))
+        b0 = s2r_load_fp4(b_s2r, b_cur0)
+
+        def _cluster_plain(lds_dst, g2s, k_off, s2r, lds_src, a, b, c, sa, sb):
+            g2s.load(lds_dst, k_off)
+            rt = s2r_load_fp4(s2r, lds_src)
+            c = mma(a, b, c, sa, sb)
+            return c, rt
+
+        def _cluster_il(lds_dst, g2s, k_off, s2r, lds_src, a, b, c, sa, sb):
+            # Interleave this quadrant's 32 scaled MFMAs (4x4 tiles x 2 ksub)
+            # with the g2s (4 steps) and s2r (4 tiles x 2 sub-blocks) loads of
+            # the NEXT fragment, so the loads co-issue in the MFMA execute
+            # shadow.
+            #
+            # The MXFP8 body spelled this schedule out by hand for its 16
+            # MFMAs. At 32 it is generated instead, by the same rule the
+            # forward body uses: spread the 12 loads evenly across the MFMA
+            # stream. fp4 doubles the MFMAs per cluster without changing the
+            # load count, so every load lands in a wider shadow than before.
+            swz = _lds_swizzle(s2r)
+            rt = [[None, None] for _ in range(s2r.n_tiles)]
+            g_at, s0_at, s1_at = PLANS[(g2s.n_load_steps, s2r.n_tiles)]
+
+            for idx in range_constexpr(len(MFMA_SEQ)):
+                for gi in range_constexpr(len(g_at[idx])):
+                    g2s.load_one(lds_dst, k_off, g_at[idx][gi])
+                for si in range_constexpr(len(s0_at[idx])):
+                    t_ = s0_at[idx][si]
+                    rt[t_][0] = s2r.load_one(lds_src, swz[t_][0])
+                for si in range_constexpr(len(s1_at[idx])):
+                    t_ = s1_at[idx][si]
+                    rt[t_][1] = s2r.load_one(lds_src, swz[t_][1])
+                i_, j_, ks_ = MFMA_SEQ[idx]
+                c[i_ * N_TILES_B + j_] = _mfma_scale_agpr(
+                    a[i_][ks_],
+                    b[j_][ks_],
+                    sa[ks_][i_],
+                    sb[ks_][j_],
+                    c[i_ * N_TILES_B + j_],
+                )
+            return c, rt
+
+        _cluster = _cluster_il if _INTERLEAVE else _cluster_plain
+
+        # ── Main K-loop (scf.for, unroll-2, RUNTIME trip count) ──
+        # One body = 2 K-steps: the ping-pong pointer swap is period-2 so LDS
+        # pointers are not loop-carried; carried state is the 4 accumulator
+        # groups PLUS the a0/b0 fragments (this schedule prefetches the next
+        # fragment during compute) PLUS the prefetched scale chunk.
+        # N_ROLLED = K_eff - 2 is even by construction, so the constexpr
+        # odd-remainder peel is not needed here at all.
+        _R = arith._to_raw
+        NA, NB = N_TILES_A, N_TILES_B
+
+        def _one_step(kk_i, a0, b0, accs, bufs, chunk, p, issue_k):
+            """One fp4 K-step (256 tokens = two K=128 MFMA sub-blocks).
+
+            `p` is the step's slot in the unrolled body (0 or 1). BOTH slots
+            issue a chunk now -- each fp4 K-step needs its own pair of scale
+            i32 -- where the MXFP8 body issued one per body. `issue_k` is the
+            scale-i32 index of the step being prefetched.
+            """
+            c00, c01, c10, c11 = accs
+            ac0, ac1, an0, an1, bc0, bc1, bn0, bn1 = bufs
+            k2 = (kk_i + fx.Int32(2)) * fx.Int32(BLOCK_K_BYTES)
+            wait_barrier(W1A if p == 0 else W1B)
+            # The scales this step consumes came off HBM a whole body ago and
+            # the barrier above already retired them; the only HBM touch here
+            # is the prefetch for the body two K-steps out -- the same horizon
+            # the data ping-pong runs at.
+            ch_new = issue_chunk(issue_k)
+            sa0, sa1, sb0, sb1 = use_step(chunk, kk_i)
+            c00, b1 = _cluster(
+                ac0, a_g2s, A0_gl + k2, b_s2r, bc1, a0, b0, c00, sa0, sb0
+            )
+            c01, a1 = _cluster(
+                bc0, b_g2s, B0_gl + k2, a_s2r, ac1, a0, b1, c01, sa0, sb1
+            )
+            wait_barrier(W2A if p == 0 else W2B)
+            c10, a0n = _cluster(
+                bc1, b_g2s, B1_gl + k2, a_s2r, an0, a1, b0, c10, sa1, sb0
+            )
+            c11, b0n = _cluster(
+                ac1, a_g2s, A1_gl + k2, b_s2r, bn0, a1, b1, c11, sa1, sb1
+            )
+            new_bufs = (an0, an1, ac0, ac1, bn0, bn1, bc0, bc1)
+            return a0n, b0n, (c00, c01, c10, c11), new_bufs, ch_new
+
+        bufs0 = (a_cur0, a_cur1, a_next0, a_next1, b_cur0, b_cur1, b_next0, b_next1)
+
+        # a0/b0 are now [tile][ksub] nests; flatten for the scf.for state.
+        def _flat_frag(frag):
+            out = []
+            for t_ in frag:
+                out.append(_R(t_[0]))
+                out.append(_R(t_[1]))
+            return out
+
+        def _unflat_frag(flat, n_tiles):
+            return [
+                [flat[KSUBS * i + ks] for ks in range(KSUBS)] for i in range(n_tiles)
+            ]
+
+        # Two chunks carried, not one: each fp4 K-step of the body owns a
+        # pair of scale i32, so the body prefetches two. 8 more live i32 than
+        # the MXFP8 body -- paid back by the fragments, which stay the same
+        # width (4 tiles x 2 x i32x4 == 4 tiles x i32x8).
+        NA_F = KSUBS * NA
+        NB_F = KSUBS * NB
+
+        def _pack(a0, b0, accs, ch0, ch1):
+            c00, c01, c10, c11 = accs
+            return (
+                _flat_frag(a0)
+                + _flat_frag(b0)
+                + [_R(x) for x in c00]
+                + [_R(x) for x in c01]
+                + [_R(x) for x in c10]
+                + [_R(x) for x in c11]
+                + [_R(x) for x in ch0]
+                + [_R(x) for x in ch1]
+            )
+
+        def _unpack(state):
+            o = 0
+            a0 = _unflat_frag(state[o : o + NA_F], NA)
+            o += NA_F
+            b0 = _unflat_frag(state[o : o + NB_F], NB)
+            o += NB_F
+            c00 = list(state[o : o + N_ACCUMS])
+            o += N_ACCUMS
+            c01 = list(state[o : o + N_ACCUMS])
+            o += N_ACCUMS
+            c10 = list(state[o : o + N_ACCUMS])
+            o += N_ACCUMS
+            c11 = list(state[o : o + N_ACCUMS])
+            o += N_ACCUMS
+            ch0 = list(state[o : o + N_CHUNK])
+            o += N_CHUNK
+            ch1 = list(state[o : o + N_CHUNK])
+            o += N_CHUNK
+            return a0, b0, (c00, c01, c10, c11), ch0, ch1
+
+        init_state = _pack(a0, b0, (c00, c01, c10, c11), chunk0, chunk1)
+        state = init_state
+        for kk, state in range(0, N_ROLLED, 2, init=init_state):
+            a0, b0, accs, ch0, ch1 = _unpack(state)
+            kk_i = fx.Int32(kk)
+            # Step kk consumes ch0 and prefetches step kk+2's pair; step kk+1
+            # consumes ch1 and prefetches step kk+3's. Scale-i32 index of
+            # step s is 2s.
+            a0, b0, accs, bufs, ch0n = _one_step(
+                kk_i,
+                a0,
+                b0,
+                accs,
+                bufs0,
+                ch0,
+                0,
+                (kk_i + fx.Int32(2)) * fx.Int32(KSUBS),
+            )
+            a0, b0, accs, bufs, ch1n = _one_step(
+                kk_i + fx.Int32(1),
+                a0,
+                b0,
+                accs,
+                bufs,
+                ch1,
+                1,
+                (kk_i + fx.Int32(3)) * fx.Int32(KSUBS),
+            )
+            state = yield _pack(a0, b0, accs, ch0n, ch1n)
+
+        a0, b0, accs, chunk0, chunk1 = _unpack(state)
+        c00, c01, c10, c11 = accs
+        a_cur0, a_cur1, a_next0, a_next1, b_cur0, b_cur1, b_next0, b_next1 = bufs0
+
+        # ── Tail steps K_eff-2 and K_eff-1 ──
+        # Neither touches HBM for scales: the last loop body prefetched the
+        # chunk covering exactly these two steps. The barrier counts stay at
+        # the steady-state values -- the tails issue no scale loads, and a count that is
+        # too SMALL only retires more than needed, never less.
+        t0 = K_eff - fx.Int32(2)
+        t1 = K_eff - fx.Int32(1)
+
+        wait_barrier((2 * N_TILES_A) + (2 * N_TILES_B))
+        sa0, sa1, sb0, sb1 = use_step(chunk0, t0)
+        b1 = s2r_load_fp4(b_s2r, b_cur1)
+        c00 = mma(a0, b0, c00, sa0, sb0)
+        a1 = s2r_load_fp4(a_s2r, a_cur1)
+        c01 = mma(a0, b1, c01, sa0, sb1)
+        wait_barrier((1 * N_TILES_A) + (1 * N_TILES_B))
+        a0 = s2r_load_fp4(a_s2r, a_next0)
+        c10 = mma(a1, b0, c10, sa1, sb0)
+        b0 = s2r_load_fp4(b_s2r, b_next0)
+        c11 = mma(a1, b1, c11, sa1, sb1)
+
+        a_cur0, a_next0 = a_next0, a_cur0
+        a_cur1, a_next1 = a_next1, a_cur1
+        b_cur0, b_next0 = b_next0, b_cur0
+        b_cur1, b_next1 = b_next1, b_cur1
+
+        wait_barrier(0)
+        sa0, sa1, sb0, sb1 = use_step(chunk1, t1)
+        b1 = s2r_load_fp4(b_s2r, b_cur1)
+        a1 = s2r_load_fp4(a_s2r, a_cur1)
+        c00 = mma(a0, b0, c00, sa0, sb0)
+        c01 = mma(a0, b1, c01, sa0, sb1)
+        c10 = mma(a1, b0, c10, sa1, sb0)
+        c11 = mma(a1, b1, c11, sa1, sb1)
+
+        # ── Epilogue: DIRECT f32 store into out[g] (no atomics) ──
+        # Exactly one block owns each (group, output tile), so every valid
+        # (row, col) is written once and the output needs no zero-init.
+        #
+        # EMPTY GROUPS need one explicit correction. The A-scale mask forces
+        # e8m0 to 0x00, which is 2**-127 and NOT zero, so a fully-masked block
+        # accumulates a*2**-127*b ~ 1e-36 per step rather than exactly 0. In a
+        # non-empty group that is 38 orders of magnitude under the real
+        # entries and irrelevant, but an expert that received no tokens must
+        # get an exactly-zero gradient plane: 1e-36 is a normal bf16, and an
+        # Adam-style optimiser divides by sqrt(v), so a consistently tiny
+        # gradient is not automatically a tiny update. A chunked body gets this by
+        # giving empty groups no block at all; here every (g, tile) has one,
+        # so it is a select on the stored value.
+        nonempty = m_end > m_start
+        f32_zero = fx.Float32(0.0)
+        out_r_i = arith.index_cast(T.index, out_r)
+        out_c_i = arith.index_cast(T.index, out_c)
+        n_experts = fx.Int32(E)
+        nbytes = arith.index_cast(
+            T.i64,
+            out_r_i * out_c_i * arith.index_cast(T.index, n_experts) * fx.Index(4),
+        )
+        o_rsrc = buffer_ops.create_buffer_resource(
+            OUT, max_size=False, num_records_bytes=nbytes
+        )
+        base_row = r_base + wave_i * fx.Int32(N_TILES_A * 16)
+        base_col = c_base + wave_j * fx.Int32(N_TILES_B * 16)
+        g_off = g * out_r * out_c
+        oob = out_r * out_c * n_experts
+
+        def store_group(frag, br, bc):
+            for ti in range_constexpr(N_TILES_A):
+                row = br + fx.Int32(ti * 16) + k_grp * fx.Int32(4)
+                for tj in range_constexpr(N_TILES_B):
+                    col = bc + fx.Int32(tj * 16) + m_lane
+                    col_ok = col < out_c
+                    vec = frag[ti * N_TILES_B + tj]
+                    for e in range_constexpr(4):
+                        r_ = row + fx.Int32(e)
+                        ok = (r_ < out_r) & col_ok
+                        off = arith.select(ok, g_off + r_ * out_c + col, oob)
+                        val = fx.Vector(vec)[e]
+                        val = arith.select(nonempty, val, f32_zero)
+                        buffer_ops.buffer_store(val, o_rsrc, off)
+
+        store_group(c00, base_row, base_col)
+        store_group(c01, base_row, base_col + fx.Int32(LDS_BLOCK_C))
+        store_group(c10, base_row + fx.Int32(LDS_BLOCK_R), base_col)
+        store_group(
+            c11, base_row + fx.Int32(LDS_BLOCK_R), base_col + fx.Int32(LDS_BLOCK_C)
+        )
+
+    @flyc.jit
+    def launch_wgrad(
+        A,
+        B,
+        OUT,
+        A_scale,
+        B_scale,
+        OFFS,
+        n_blocks: fx.Int32,
+        n_r_tiles: fx.Int32,
+        n_c_tiles: fx.Int32,
+        out_r: fx.Int32,
+        out_c: fx.Int32,
+        m_row: fx.Int32,
+        stream: fx.Stream,
+    ):
+        kernel_wgrad(
+            A,
+            B,
+            OUT,
+            A_scale,
+            B_scale,
+            OFFS,
+            n_r_tiles,
+            n_c_tiles,
+            out_r,
+            out_c,
+            m_row,
+            value_attrs={
+                "rocdl.waves_per_eu": 1,
+                "rocdl.flat_work_group_size": "256,256",
+            },
+        ).launch(grid=(n_blocks, 1, 1), block=(256, 1, 1), stream=stream)
+
+    return launch_wgrad
+
+
+@functools.lru_cache(maxsize=None)
+def cached_launch(R: int, C: int, E: int, sc_pair: bool, order: str):
+    return _compile(R, C, E, sc_pair, order)

--- a/op_tests/test_flydsl_grouped_gemm_mxfp4_ragged.py
+++ b/op_tests/test_flydsl_grouped_gemm_mxfp4_ragged.py
@@ -1,0 +1,325 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+"""Ragged MXFP4 (a4w4) grouped GEMM and wgrad on gfx950.
+
+Group sizes are UNEQUAL and live on the device: each block reads its own bounds
+from ``group_end_offsets`` and the host never syncs to learn them. The two
+directions differ in which axis the groups cut:
+
+    flydsl_grouped_gemm_a4w4_ragged   out[group_g] = X[group_g] @ W[g]^T
+                                      groups partition the OUTPUT ROWS
+    flydsl_grouped_wgrad_a4w4_ragged  grad_W[g]    = go[group_g]^T @ ia[group_g]
+                                      groups partition the CONTRACTION
+
+Operands are built with aiter's own per-1x32 quant at ``shuffle=False``: these
+kernels take the plain cast output, with no preshuffled weight and no shuffled
+scale plane.
+
+``--groups`` is the ragged axis of the sweep, and its non-``even`` modes are not
+padding -- they are the shapes under which a ragged MXFP4 kernel silently drops
+work or emits NaN, and each needs its own geometry to reproduce at all:
+
+    even     equal groups; the perf shape
+    skewed   unequal groups, one much hotter than the rest
+    empty    a zero-length group next to a hot one
+    slack    M runs past offs[-1]; those rows belong to no group and must stay
+             exactly zero and finite
+
+The reference is a per-group f32 matmul over the SAME dequantized fp4 bits, so
+what it measures is the kernel's arithmetic, not the cast's rounding.
+"""
+
+import argparse
+import itertools
+
+import pandas as pd
+import torch
+
+import aiter
+from aiter import dtypes
+from aiter.jit.utils.chip_info import get_gfx
+from aiter.ops.flydsl import (
+    flydsl_grouped_gemm_a4w4_ragged,
+    flydsl_grouped_wgrad_a4w4_ragged,
+)
+from aiter.test_common import benchmark, checkAllclose, run_perftest
+from aiter.utility import fp4_utils
+
+torch.set_default_device("cuda")
+
+SUPPORTED_GFX = ["gfx950"]
+SCALE_GROUP_SIZE = 32
+SEED = 0
+# The wgrad reads its scale plane as whole i32 (4 e8m0 each), so a token row must
+# be a whole number of dwords.
+WGRAD_ROW_ALIGN = 128
+GROUP_MODES = ["even", "skewed", "empty", "slack"]
+
+
+def group_sizes(mode, e, m):
+    """(sizes, slack) for one ragged mode. ``sum(sizes) + slack == m``.
+
+    Every mode keeps each group a multiple of WGRAD_ROW_ALIGN so the same shapes
+    drive both kernels.
+    """
+    unit = WGRAD_ROW_ALIGN
+    assert m % (e * unit) == 0, f"m={m} must be a multiple of e*{unit}"
+    n_units = m // unit
+    if mode == "even":
+        return [m // e] * e, 0
+    if mode == "skewed":
+        # One group takes half the tokens, the rest split what is left.
+        hot = (n_units // 2) * unit
+        rest = m - hot
+        per = (rest // (e - 1) // unit) * unit if e > 1 else 0
+        sizes = [hot] + [per] * (e - 1)
+        return sizes, m - sum(sizes)
+    if mode == "empty":
+        # A zero-length group immediately before the hottest one.
+        sizes, _ = group_sizes("skewed", e, m)
+        sizes = [0] + sizes[:-1] if e > 1 else sizes
+        return sizes, m - sum(sizes)
+    if mode == "slack":
+        # Capacity padding: M runs past the last group's end.
+        sizes, _ = group_sizes("even", e, m)
+        sizes[-1] -= unit
+        return sizes, m - sum(sizes)
+    raise ValueError(f"unknown group mode {mode!r}")
+
+
+def quant_mxfp4(x):
+    """Per-1x32 MXFP4 cast along the last axis, no shuffle, as uint8 views."""
+    quant = aiter.get_triton_quant(aiter.QuantType.per_1x32)
+    packed, scale = quant(x.contiguous(), shuffle=False)
+    return packed.view(torch.uint8), scale.view(torch.uint8)
+
+
+def dequant_mxfp4(packed, scale):
+    """Undo the cast to f32. Mirrors op_tests/test_gemm_a4w4.py's reference."""
+    x = fp4_utils.mxfp4_to_f32(packed)
+    s = fp4_utils.e8m0_to_f32(scale).repeat_interleave(SCALE_GROUP_SIZE, dim=1)
+    return x * s[:, : x.shape[1]]
+
+
+def run_torch_grouped_gemm(x_q, x_s, w_q, w_s, offs, e, n, k, dtype):
+    """Reference only: per-group f32 matmul over the same dequantized bits.
+
+    Rows covered by no group stay zero, which is what the kernel must produce for
+    the ``slack`` mode's trailing capacity padding.
+    """
+    x_d = dequant_mxfp4(x_q, x_s)
+    w_d = dequant_mxfp4(
+        w_q.reshape(e * n, k // 2), w_s.reshape(e * n, k // SCALE_GROUP_SIZE)
+    ).reshape(e, n, k)
+    out = torch.zeros(x_q.shape[0], n, dtype=dtypes.fp32)
+    start = 0
+    for g in range(e):
+        end = int(offs[g])
+        if end > start:
+            out[start:end] = x_d[start:end] @ w_d[g].T
+        start = end
+    return out.to(dtype)
+
+
+def run_torch_wgrad(go_t, go_s, ia_t, ia_s, offs, e, n, k, dtype):
+    """Reference only. An empty group contributes nothing, so its plane is zero."""
+    go_d, ia_d = dequant_mxfp4(go_t, go_s), dequant_mxfp4(ia_t, ia_s)
+    out = torch.zeros(e, n, k, dtype=dtypes.fp32)
+    start = 0
+    for g in range(e):
+        end = int(offs[g])
+        if end > start:
+            out[g] = go_d[:, start:end] @ ia_d[:, start:end].T
+        start = end
+    return out.to(dtype)
+
+
+@benchmark()
+def test_grouped_gemm(e, m, n, k, dtype, groups):
+    sizes, slack = group_sizes(groups, e, m)
+    offs = torch.tensor([sum(sizes[: i + 1]) for i in range(e)], dtype=dtypes.i32)
+    torch.manual_seed(SEED)
+    x = torch.randn(m, k, dtype=dtype)
+    w = torch.randn(e, n, k, dtype=dtype)
+    x_q, x_s = quant_mxfp4(x)
+    w_q, w_s = quant_mxfp4(w.reshape(e * n, k))
+    w_q = w_q.reshape(e, n, k // 2)
+    w_s = w_s.reshape(e, n, k // SCALE_GROUP_SIZE)
+    # The MoE caller owns the destination, so pass one rather than letting the
+    # kernel allocate and zero-fill its own.
+    out = torch.zeros(m, n, dtype=dtype)
+
+    ref = run_torch_grouped_gemm(x_q, x_s, w_q, w_s, offs, e, n, k, dtype)
+
+    candidates = {
+        "flydsl": lambda: flydsl_grouped_gemm_a4w4_ragged(
+            x_q, w_q, x_s, w_s, offs, out=out
+        ),
+    }
+
+    tokens = sum(sizes)  # slack rows are not work
+    flops = 2 * tokens * n * k
+    nbytes = (
+        m * k // 2  # x, 2 fp4 per byte
+        + e * n * k // 2  # w
+        + (m * k + e * n * k) // SCALE_GROUP_SIZE  # e8m0 scale planes
+        + m * n * out.element_size()  # out
+    )
+
+    ret = {"gfx": get_gfx()}
+    for name, fn in candidates.items():
+        got, us = run_perftest(fn)
+        err = checkAllclose(
+            ref.to(dtypes.fp32),
+            got.to(dtypes.fp32),
+            rtol=1e-2,
+            atol=1e-2,
+            msg=f"{name}: ragged mxfp4 grouped gemm [{groups}]",
+        )
+        if slack:
+            # Rows past offs[-1] belong to no group. Uninitialised memory here is
+            # the failure this mode exists to catch, so it is an exact check.
+            tail = got[int(offs[-1]) :]
+            assert torch.equal(
+                tail, torch.zeros_like(tail)
+            ), f"{name}: {tail.shape[0]} slack rows must stay exactly zero"
+            assert torch.isfinite(tail).all(), f"{name}: non-finite slack rows"
+        ret[f"{name} us"] = us
+        ret[f"{name} TFLOPS"] = flops / us / 1e6
+        ret[f"{name} TB/s"] = nbytes / us / 1e6
+        ret[f"{name} err"] = err
+    return ret
+
+
+@benchmark()
+def test_grouped_wgrad(e, m, n, k, dtype, groups):
+    sizes, slack = group_sizes(groups, e, m)
+    offs = torch.tensor([sum(sizes[: i + 1]) for i in range(e)], dtype=dtypes.i32)
+    torch.manual_seed(SEED)
+    # Both operands are contracted over tokens, so both are cast along the token
+    # axis -- i.e. the plain per-1x32 cast applied to the transpose, which is how
+    # the backward pass produces them.
+    go = torch.randn(m, n, dtype=dtype)
+    ia = torch.randn(m, k, dtype=dtype)
+    go_t, go_s = quant_mxfp4(go.transpose(0, 1))
+    ia_t, ia_s = quant_mxfp4(ia.transpose(0, 1))
+
+    ref = run_torch_wgrad(go_t, go_s, ia_t, ia_s, offs, e, n, k, dtype)
+
+    candidates = {
+        "flydsl": lambda: flydsl_grouped_wgrad_a4w4_ragged(
+            go_t, go_s, ia_t, ia_s, offs
+        ),
+    }
+
+    tokens = sum(sizes)
+    flops = 2 * tokens * n * k
+    nbytes = (
+        m * n // 2  # go_t
+        + m * k // 2  # ia_t
+        + (m * n + m * k) // SCALE_GROUP_SIZE  # scale planes
+        + e * n * k * torch.finfo(dtype).bits // 8  # grad_W
+    )
+
+    ret = {"gfx": get_gfx()}
+    for name, fn in candidates.items():
+        got, us = run_perftest(fn)
+        err = checkAllclose(
+            ref.to(dtypes.fp32),
+            got.to(dtypes.fp32),
+            rtol=1e-2,
+            atol=1e-2,
+            msg=f"{name}: ragged mxfp4 wgrad [{groups}]",
+        )
+        for g, size in enumerate(sizes):
+            if size == 0:
+                # An expert that routed no token has no gradient. Anything other
+                # than exact zero here is uninitialised memory reaching the
+                # optimizer, which no tolerance would catch.
+                assert torch.equal(
+                    got[g], torch.zeros_like(got[g])
+                ), f"{name}: empty group g{g} must produce an exactly-zero plane"
+        assert torch.isfinite(got).all(), f"{name}: non-finite wgrad output"
+        ret[f"{name} us"] = us
+        ret[f"{name} TFLOPS"] = flops / us / 1e6
+        ret[f"{name} TB/s"] = nbytes / us / 1e6
+        ret[f"{name} err"] = err
+    return ret
+
+
+def main():
+    if get_gfx() not in SUPPORTED_GFX:
+        aiter.logger.warning(
+            "ragged mxfp4 grouped gemm/wgrad needs %s (CDNA4 scaled MFMA); "
+            "unsupported on %s; skipping",
+            SUPPORTED_GFX,
+            get_gfx(),
+        )
+        return
+
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.RawTextHelpFormatter,
+        description="config input of test",
+    )
+    parser.add_argument(
+        "-d",
+        "--dtype",
+        type=dtypes.str2Dtype,
+        nargs="*",
+        default=[dtypes.d_dtypes["bf16"]],
+        choices=[dtypes.d_dtypes["bf16"]],
+        metavar="{bf16}",
+        help="output data type.",
+    )
+    parser.add_argument(
+        "-e",
+        "--experts",
+        type=int,
+        nargs="*",
+        default=[8],
+        help="number of groups (experts).",
+    )
+    parser.add_argument(
+        "-s",
+        "--mnk",
+        type=dtypes.str2tuple,
+        nargs="*",
+        default=[(32768, 2048, 1408), (32768, 1408, 2048)],
+        help="m,n,k -- m is total tokens across all groups.",
+    )
+    parser.add_argument(
+        "-g",
+        "--groups",
+        type=str,
+        nargs="*",
+        default=GROUP_MODES,
+        choices=GROUP_MODES,
+        help="ragged group-size distribution.",
+    )
+    args = parser.parse_args()
+
+    for dtype in args.dtype:
+        rows = []
+        for groups, e, (m, n, k) in itertools.product(
+            args.groups, args.experts, args.mnk
+        ):
+            rows.append(test_grouped_gemm(e, m, n, k, dtype, groups))
+        aiter.logger.info(
+            "ragged mxfp4 grouped gemm (fwd/dgrad) summary:\n%s",
+            pd.DataFrame(rows).to_markdown(index=False),
+        )
+
+        rows = []
+        for groups, e, (m, n, k) in itertools.product(
+            args.groups, args.experts, args.mnk
+        ):
+            rows.append(test_grouped_wgrad(e, m, n, k, dtype, groups))
+        aiter.logger.info(
+            "ragged mxfp4 grouped wgrad summary:\n%s",
+            pd.DataFrame(rows).to_markdown(index=False),
+        )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Adds the two a4w4 grouped GEMMs for gfx950 whose groups are **unequal and device-resident**: each block reads its own bounds from `group_end_offsets`, and the host never syncs to learn them.

| op | computes | groups partition |
|---|---|---|
| `flydsl_grouped_gemm_a4w4_ragged` | `out[group_g] = X[group_g] @ W[g]^T` | the **output rows** |
| `flydsl_grouped_wgrad_a4w4_ragged` | `grad_W[g] = go[group_g]^T @ ia[group_g]` | the **contraction** |

## Why this isn't covered by an existing path

I checked every MXFP4 GEMM in the tree before writing this:

| existing | why it can't serve this |
|---|---|
| `flydsl_grouped_gemm_a8w4_masked` | gfx1250 TDM, a8w4, contiguous-M via `m_tile_map` |
| `flydsl_mxfp4_gemm1` / `gemm2` | fused MoE — needs `moe_sorting` output and fuses an activation |
| `flydsl_batched_gemm_mxfp4` | strided-batched: equal M per batch, cannot express unequal groups |
| CK `gemm_a4w4_blockscale`, ASM `f4gemm` | dense single GEMM |

No existing path takes ragged, device-resident group sizes on gfx950, and there is no weight-gradient GEMM in the tree at all.

## No preshuffle required

Both kernels take the plain per-1x32 cast output — **no preshuffled weight, no shuffled scale plane**. One e8m0 is broadcast to 4 bytes so the MFMA `op_sel` is a don't-care, which is what removes the preshuffle the dense fp4 paths carry. That is the point for the backward pass, where the operand is produced fresh every step and a preshuffle would sit on the critical path rather than being amortized over a static weight.

## Reuse rather than a third copy

The six FlyDSL fp8-GEMM helpers (`G2SLoader`, `S2RLoader`, `compute_global_swizzle`, `make_fp8_buffer_tensor`, `swizzle_128`, `wait_barrier`) are imported from `gemm_a8w8_8wave`, and `buffer_ops` from `kernels/`. I diffed both against the copies these kernels were developed against — identical apart from black's line wrapping — so no third copy enters the tree. They address **bytes**, not elements, which is why an fp4 kernel reuses an fp8 helper set unchanged.

## Performance

MI350X VF (gfx950), flydsl 0.3.2, real DSV3-16B EP=8 rank0 group sizes (E=8, M=375936), arms interleaved, median of 3 `do_bench` medians:

| op | N, K | ms | TF/s | vs bf16 `_grouped_mm` |
|---|---|---:|---:|---|
| fwd/dgrad | 2048, 1408 | 1.276 | 1699 | 1.98x |
| fwd/dgrad | 1408, 2048 | 1.119 | 1937 | 2.56x |
| wgrad | 2048, 1408 | 1.168 | 1856 | — |
| wgrad | 1408, 2048 | 1.121 | 1934 | — |

For an honest baseline I also timed a per-expert loop of aiter's dense `gemm_a4w4` at the same total work — which gets preshuffled weights and shuffled scales *off* the timed path and pays no ragged mapping. **The GEMMs are at parity there (1.11x and 1.00x.)** The win this PR delivers is the ragged dispatch and the absent preshuffle, not a faster inner loop. Noting that explicitly so the numbers above aren't read as an inner-loop claim.

## Test plan

`op_tests/test_flydsl_grouped_gemm_mxfp4_ragged.py`, self-contained in aiter — operands from `aiter.get_triton_quant(QuantType.per_1x32)` at `shuffle=False`, reference from `fp4_utils`.

The ragged distribution is a **swept axis** (`-g even/skewed/empty/slack`) rather than a set of ad-hoc asserts, so each edge is a table row with its own `err`. Those modes are not padding — they are the shapes under which a ragged MXFP4 kernel silently drops work or emits NaN:

- trailing slack rows past `offs[-1]` belong to no group: must stay exactly zero and finite;
- an empty group adjacent to a much hotter one;
- an empty expert's gradient plane must be exactly zero (uninitialised memory here reaches the optimizer, and no tolerance would catch it).

All 16 rows pass at `err = 0`; the run takes 7.6 s, under the 15 s `split_tests` default.

```
|   e |     m |    n |    k | groups   | gfx    |   flydsl us |   flydsl TFLOPS |   flydsl err |
|   8 | 32768 | 2048 | 1408 | even     | gfx950 |     130.331 |         1449.99 |            0 |
|   8 | 32768 | 1408 | 2048 | even     | gfx950 |     123.202 |         1533.89 |            0 |
|   8 | 32768 | 2048 | 1408 | skewed   | gfx950 |     128.055 |         1464.24 |            0 |
|   8 | 32768 | 1408 | 2048 | skewed   | gfx950 |     119.138 |         1573.82 |            0 |
```

The wgrad table shows the straggler its group axis implies: under `skewed`/`empty` it drops from ~1470 to ~1050-1120 TF/s while the GEMM stays flat, because only the wgrad's groups cut the contraction.

## Validation

`validate-kernel-pr` on a locked idle gfx950, base `0ebd9f0e8` vs head, patch applied in an isolated worktree — **verdict PASS**:

- `merge_sim`, `gpu_claim`, `runtime_compat`, `test_policy`, `baseline_control`, `correctness_repo_tests`, `correctness_s1_grid`, `execution_receipt` — all `pass`
- independent grid `adds-coverage`: all 3 cells outside the target's own `-s` defaults, including `K % 256 == 128` (the half-K-step tail) and a 2x-M long-context cell; the invalid-grid control run correctly fails, proving the channel is consumed
- `execution_receipt`: route observed, all 3 required shapes executed, 1248 route calls; `arch_coverage: {gfx950: runtime}`
- `perf`: `skip` — the PR adds the target, so a base timing would need transplanting it into a tree where these kernels don't exist

`index_width_scan` flagged 7 index x stride candidates. I reviewed each: five are bounded by tile/wave constants, and the wgrad's `r_ * out_c` is bounded by `E*R*C` (weight dims, ~2.3e7). The seventh — the GEMM epilogue's `r_ * out_n + col` — was genuinely unguarded and scales as `M*N`, reaching int32 at M = 1,048,576 tokens on one rank. An overflow there does not fault: the bounded buffer descriptor clamps out-of-range, but a *wrapped* index lands back inside the allocation and silently corrupts a row. **The scan caught a real gap and this PR fixes it**, mirroring the guard the wgrad already carried (`torch._check` under compile, since M is an unbacked SymInt; `NotImplementedError` eager so a caller can fall back).

## Notes for review

- gfx950 only, gated in the launcher via `get_gfx()`; the op test skips cleanly elsewhere.
- Group offsets stay on device by design. The calling convention is `torch._grouped_mm`'s, not `moe_sorting`'s — that is what makes the no-host-sync dispatch possible, and it is the convention a training framework already produces.
