### PR TITLE
[HIP] Optional sigmoid on gated_rmsnorm_fp8_per_token_quant

### DIFF
--- a/aiter/ops/gated_rmsnorm_fp8_per_token_quant.py
+++ b/aiter/ops/gated_rmsnorm_fp8_per_token_quant.py
@@ -5,8 +5,10 @@
 Fused Gated RMSNorm + FP8 Per-Token Quantization
 
 Operations:
-1. Per-head Gated RMSNorm: norm(x) * silu(z) where:
+1. Per-head Gated RMSNorm: norm(x) * gate(z) where:
    - norm(x) = x * weight / sqrt(variance + eps) (standard RMSNorm over head_dim)
+   - gate(z) = sigmoid(z) if use_sigmoid, else silu(z)
+   - sigmoid(z) = 1 / (1 + exp(-z))
    - silu(z) = z / (1 + exp(-z))
 2. Flatten: [num_tokens, num_heads, head_dim] -> [num_tokens, num_heads*head_dim]
 3. FP8 per-token quantization: ONE scale per token across the full flattened row.
@@ -32,6 +34,7 @@ def gated_rmsnorm_fp8_per_token_quant(
     z: Tensor,
     weight: Tensor,
     epsilon: float,
+    use_sigmoid: bool = False,
 ) -> None:
     """
     HIP kernel for fused Gated RMSNorm + FP8 per-token quantization.
@@ -43,6 +46,7 @@ def gated_rmsnorm_fp8_per_token_quant(
         z: [num_tokens, num_heads, head_dim] gating tensor (bf16/fp16)
         weight: [head_dim] RMSNorm weight (bf16/fp16)
         epsilon: numerical stability epsilon
+        use_sigmoid: If true, use sigmoid(z) instead of silu(z)
 
     This is a JIT-compiled binding that will be replaced with the actual kernel.
     """

--- a/csrc/include/gated_rmsnorm_quant.h
+++ b/csrc/include/gated_rmsnorm_quant.h
@@ -59,6 +59,7 @@ void gated_rmsnorm_fp8_group_quant(
  *   z: Gating tensor [num_tokens, num_heads, head_dim] (bf16/fp16)
  *   weight: RMSNorm weight [head_dim] (bf16/fp16)
  *   epsilon: Small value for numerical stability
+ *   use_sigmoid: If true, use sigmoid(z) instead of silu(z)
  */
 void gated_rmsnorm_fp8_per_token_quant(
     aiter_tensor_t& out,           // [num_tokens, num_heads * head_dim]
@@ -66,7 +67,8 @@ void gated_rmsnorm_fp8_per_token_quant(
     const aiter_tensor_t& x,        // [num_tokens, num_heads, head_dim] - input to normalize
     const aiter_tensor_t& z,        // [num_tokens, num_heads, head_dim] - gating tensor
     const aiter_tensor_t& weight,   // [head_dim] - RMSNorm weight
-    double epsilon);
+    double epsilon,
+    bool use_sigmoid = false);
 
 
 } // namespace aiter

--- a/csrc/include/rocm_ops.hpp
+++ b/csrc/include/rocm_ops.hpp
@@ -2486,6 +2486,7 @@ namespace py = pybind11;
           py::arg("z"),                                    \
           py::arg("weight"),                               \
           py::arg("epsilon"),                              \
+          py::arg("use_sigmoid") = false,                  \
           "Fused Gated RMSNorm + FP8 Per-Token Quantization");
 
 #define MHC_PYBIND                                \

--- a/csrc/kernels/gated_rmsnorm_quant_kernels.cu
+++ b/csrc/kernels/gated_rmsnorm_quant_kernels.cu
@@ -340,7 +340,7 @@ void gated_rmsnorm_fp8_group_quant(
  * - ONLY supports head_dim=128 (RMSNorm group) and num_heads <= 128.
  * - AMD GPU: warp_size=64.
  */
-template <typename DTYPE_I, typename DTYPE_O, int GROUP_SIZE = 128, int THREAD_DATA_SIZE = 16>
+template <typename DTYPE_I, typename DTYPE_O, int GROUP_SIZE = 128, int THREAD_DATA_SIZE = 16, bool USE_SIGMOID = false>
 __global__ void gated_rmsnorm_fp8_per_token_quant_kernel(
     DTYPE_O* __restrict__ out,           // [num_tokens, num_heads * head_dim]
     float* __restrict__ scale,           // [num_tokens]
@@ -425,13 +425,18 @@ __global__ void gated_rmsnorm_fp8_per_token_quant_kernel(
         float variance = sum_sq * inv_head_dim;
         float inv_std = rsqrtf(variance + static_cast<float>(epsilon));
 
-        // norm(x) * silu(z), and track this thread's local amax.
+        // norm(x) * gate(z), and track this thread's local amax.
+        // gate = sigmoid(z) if USE_SIGMOID, else silu(z).
         #pragma unroll
         for (int i = 0; i < THREAD_DATA_SIZE; i++) {
             float normed = x_vals[i] * weight_vals[i] * inv_std;
             float sigmoid_z = 1.0f / (1.0f + expf(-z_vals[i]));
-            float silu_z = z_vals[i] * sigmoid_z;
-            gated_vals[i] = normed * silu_z;
+            if constexpr (USE_SIGMOID) {
+                gated_vals[i] = normed * sigmoid_z;
+            } else {
+                float silu_z = z_vals[i] * sigmoid_z;
+                gated_vals[i] = normed * silu_z;
+            }
             local_max = fmaxf(local_max, fabsf(gated_vals[i]));
         }
     }
@@ -487,7 +492,7 @@ __global__ void gated_rmsnorm_fp8_per_token_quant_kernel(
     }
 }
 
-template <typename DTYPE_I, typename DTYPE_O, int THREAD_DATA_SIZE>
+template <typename DTYPE_I, typename DTYPE_O, int THREAD_DATA_SIZE, bool USE_SIGMOID>
 void gated_rmsnorm_fp8_per_token_quant_launcher_impl(
     aiter_tensor_t& out,
     aiter_tensor_t& scale,
@@ -519,7 +524,7 @@ void gated_rmsnorm_fp8_per_token_quant_launcher_impl(
     const int64_t z_token_stride = z.stride(0);
     const int64_t z_head_stride  = z.stride(1);
 
-    gated_rmsnorm_fp8_per_token_quant_kernel<DTYPE_I, DTYPE_O, GROUP_SIZE, THREAD_DATA_SIZE>
+    gated_rmsnorm_fp8_per_token_quant_kernel<DTYPE_I, DTYPE_O, GROUP_SIZE, THREAD_DATA_SIZE, USE_SIGMOID>
         <<<grid, block, 0, stream>>>(
             reinterpret_cast<DTYPE_O*>(out.data_ptr()),
             reinterpret_cast<float*>(scale.data_ptr()),
@@ -544,7 +549,8 @@ void gated_rmsnorm_fp8_per_token_quant_launcher(
     const aiter_tensor_t& x,        // [num_tokens, num_heads, head_dim]
     const aiter_tensor_t& z,        // [num_tokens, num_heads, head_dim]
     const aiter_tensor_t& weight,   // [head_dim]
-    double epsilon)
+    double epsilon,
+    bool use_sigmoid)
 {
     AITER_CHECK(x.dim() == 3, "Input x must be 3D: [num_tokens, num_heads, head_dim]");
     AITER_CHECK(z.dim() == 3, "Input z must be 3D: [num_tokens, num_heads, head_dim]");
@@ -577,8 +583,13 @@ void gated_rmsnorm_fp8_per_token_quant_launcher(
     AITER_CHECK(static_cast<int64_t>(scale.numel()) == num_tokens, "scale must have num_tokens elements, got ", scale.numel());
 
     constexpr int thread_data_size = 16;
-    gated_rmsnorm_fp8_per_token_quant_launcher_impl<DTYPE_I, DTYPE_O, thread_data_size>(
-        out, scale, x, z, weight, epsilon, num_tokens, num_heads, head_dim);
+    if (use_sigmoid) {
+        gated_rmsnorm_fp8_per_token_quant_launcher_impl<DTYPE_I, DTYPE_O, thread_data_size, true>(
+            out, scale, x, z, weight, epsilon, num_tokens, num_heads, head_dim);
+    } else {
+        gated_rmsnorm_fp8_per_token_quant_launcher_impl<DTYPE_I, DTYPE_O, thread_data_size, false>(
+            out, scale, x, z, weight, epsilon, num_tokens, num_heads, head_dim);
+    }
 }
 
 /**
@@ -590,7 +601,8 @@ void gated_rmsnorm_fp8_per_token_quant(
     const aiter_tensor_t& x,        // [num_tokens, num_heads, head_dim]
     const aiter_tensor_t& z,        // [num_tokens, num_heads, head_dim]
     const aiter_tensor_t& weight,   // [head_dim]
-    double epsilon)
+    double epsilon,
+    bool use_sigmoid)
 {
     AITER_CHECK(x.is_gpu(), "Input x must be on CUDA device");
     AITER_CHECK(z.is_gpu(), "Input z must be on CUDA device");
@@ -611,10 +623,10 @@ void gated_rmsnorm_fp8_per_token_quant(
 
     if (x.dtype() == AITER_DTYPE_bf16) {
         gated_rmsnorm_fp8_per_token_quant_launcher<opus::bf16_t, opus::fp8_t>(
-            out, scale, x, z, weight, epsilon);
+            out, scale, x, z, weight, epsilon, use_sigmoid);
     } else if (x.dtype() == AITER_DTYPE_fp16) {
         gated_rmsnorm_fp8_per_token_quant_launcher<opus::fp16_t, opus::fp8_t>(
-            out, scale, x, z, weight, epsilon);
+            out, scale, x, z, weight, epsilon, use_sigmoid);
     } else {
         AITER_CHECK(false, "Unsupported dtype combination. Input: ", AiterDtype_to_str(x.dtype()),
                     ", Output: ", AiterDtype_to_str(out.dtype()));

--- a/op_tests/test_gated_rmsnorm_fp8_quant.py
+++ b/op_tests/test_gated_rmsnorm_fp8_quant.py
@@ -346,6 +346,7 @@ def gated_rmsnorm_fp8_per_token_quant_reference_impl(
     weight: torch.Tensor,
     eps: float,
     quant_dtype,
+    use_sigmoid: bool = False,
 ):
     """Reference that matches the fused HIP kernel math and per-token quant path."""
     if quant_dtype == torch.float8_e4m3fnuz:
@@ -362,7 +363,10 @@ def gated_rmsnorm_fp8_per_token_quant_reference_impl(
     normed = x.float() * inv_std
     normed = normed * weight.float().view(1, 1, -1)
 
-    gated = normed * silu(z.float())  # [num_tokens, num_heads, head_dim]
+    if use_sigmoid:
+        gated = normed * torch.sigmoid(z.float())
+    else:
+        gated = normed * silu(z.float())  # [num_tokens, num_heads, head_dim]
     flat = gated.reshape(num_tokens, -1)  # [num_tokens, num_heads*head_dim]
 
     # One scale per token across the whole row.
@@ -376,14 +380,14 @@ def gated_rmsnorm_fp8_per_token_quant_reference_impl(
 
 
 @perftest()
-def run_reference(x, z, weight, eps, quant_dtype):
+def run_reference(x, z, weight, eps, quant_dtype, use_sigmoid: bool = False):
     return gated_rmsnorm_fp8_per_token_quant_reference_impl(
-        x, z, weight, eps, quant_dtype
+        x, z, weight, eps, quant_dtype, use_sigmoid
     )
 
 
 @perftest()
-def run_hip(x, z, weight, eps, quant_dtype):
+def run_hip(x, z, weight, eps, quant_dtype, use_sigmoid: bool = False):
     from aiter.ops.gated_rmsnorm_fp8_per_token_quant import (
         gated_rmsnorm_fp8_per_token_quant,
     )
@@ -394,7 +398,7 @@ def run_hip(x, z, weight, eps, quant_dtype):
     )
     scales = torch.empty((num_tokens,), dtype=torch.float32, device=x.device)
 
-    gated_rmsnorm_fp8_per_token_quant(out_quant, scales, x, z, weight, eps)
+    gated_rmsnorm_fp8_per_token_quant(out_quant, scales, x, z, weight, eps, use_sigmoid)
     return out_quant, scales
 
 
@@ -415,6 +419,7 @@ def test_gated_rmsnorm_fp8_per_token_quant(
     dtype: torch.dtype,
     eps: float = 1e-6,
     quant_dtype=dtypes.fp8,
+    use_sigmoid: bool = False,
 ):
     torch.manual_seed(42)
     device = "cuda"
@@ -430,13 +435,14 @@ def test_gated_rmsnorm_fp8_per_token_quant(
     print("Test Configuration:")
     print(f"  Shape: [{num_tokens}, {num_heads}, {head_dim}]")
     print(f"  dtype: {dtype}, quant_dtype: {quant_dtype}, eps: {eps}")
+    print(f"  use_sigmoid: {use_sigmoid}")
     print(f"{'='*80}")
 
     (ref_quant, ref_scales), ref_time = run_reference(
-        x.clone(), z.clone(), weight, eps, quant_dtype
+        x.clone(), z.clone(), weight, eps, quant_dtype, use_sigmoid
     )
     (hip_quant, hip_scales), hip_time = run_hip(
-        x.clone(), z.clone(), weight, eps, quant_dtype
+        x.clone(), z.clone(), weight, eps, quant_dtype, use_sigmoid
     )
 
     ref_bw = calculate_bandwidth_per_token(num_tokens, num_heads, head_dim, ref_time)
@@ -528,15 +534,18 @@ if __name__ == "__main__":
     results = []
     for quant_dtype in quant_dtypes:
         for num_tokens, num_heads, head_dim in test_configs:
-            r = test_gated_rmsnorm_fp8_per_token_quant(
-                num_tokens=num_tokens,
-                num_heads=num_heads,
-                head_dim=head_dim,
-                dtype=dtype,
-                quant_dtype=quant_dtype,
-            )
-            r["quant_dtype"] = str(quant_dtype)
-            results.append(r)
+            for use_sigmoid in [False, True]:
+                r = test_gated_rmsnorm_fp8_per_token_quant(
+                    num_tokens=num_tokens,
+                    num_heads=num_heads,
+                    head_dim=head_dim,
+                    dtype=dtype,
+                    quant_dtype=quant_dtype,
+                    use_sigmoid=use_sigmoid,
+                )
+                r["quant_dtype"] = str(quant_dtype)
+                r["use_sigmoid"] = use_sigmoid
+                results.append(r)
 
     df = pd.DataFrame(results)
     aiter.logger.info(


### PR DESCRIPTION
## Summary

`gated_rmsnorm_fp8_per_token_quant` is SiLU-only today (`norm(x) * silu(z)`), from #3844. Qwen GDN / SGLang #28655 need that default. Kimi-K3 `o_norm` is `FusedRMSNormGated(activation="sigmoid")`: `norm(x) * sigmoid(z)`.

This PR adds `use_sigmoid=False` on the existing API (last arg, default false). Host `if` instantiates `USE_SIGMOID` on the kernel, same pattern as `TRANSPOSE_SCALE` on the group kernel in this file. RMSNorm, token-wide amax, FP8 store, and the `0x80` flush are unchanged.

`gated_rmsnorm_fp8_group_quant` is not touched.

## Testing

`op_tests/test_gated_rmsnorm_fp8_quant.py` checks the HIP kernel against a PyTorch reference (dequantized values + per-token scales) for both gates:

- default SiLU (`use_sigmoid=False`) vs a SiLU ref
- `use_sigmoid=True` vs a sigmoid ref
- bf16 and fp16 (`--dtype bf16` / `--dtype fp16`)

```bash
python3 op_tests/test_gated_rmsnorm_fp8_quant.py --dtype bf16
python3 op_tests/test_gated_rmsnorm_fp8_quant.py --dtype fp16
```

gfx950 MI355X, image `rocm/pytorch:rocm7.2.4_ubuntu24.04_py3.12_pytorch_release_2.10.0`.
Dequant `checkAllclose atol=rtol=0.01` (fail if mismatch fraction `> 5%`); scales `atol=rtol=0.001`.
This run: 112/112 `Test PASSED`, 0 `failed!`. 65 dequant `warning!` (34 bf16, 31 fp16) are FP8 tails at `0.0%` mismatch; they also show up on the unchanged group kernel.

### Latency

Same launch and shapes. Sigmoid is the same kernel minus the extra `z` multiply. HIP times stay in the same band across gates and across bf16/fp16.

HIP times (us):
| num_tokens | num_heads | bf16 SiLU | bf16 sigmoid | fp16 SiLU | fp16 sigmoid |
| --: | --: | --: | --: | --: | --: |
| 1 | 32 | 3.37 | 3.19 | 3.37 | 3.21 |
| 3 | 32 | 3.91 | 3.91 | 3.90 | 3.83 |
| 128 | 32 | 5.11 | 5.22 | 5.16 | 5.18 |
| 256 | 32 | 5.86 | 5.89 | 5.74 | 5.79 |
| 512 | 32 | 7.67 | 7.56 | 7.58 | 7.62 |
| 1024 | 1 | 5.33 | 5.32 | 5.32 | 5.31 |
| 1024 | 12 | 6.65 | 6.72 | 6.70 | 6.64 |
| 1024 | 16 | 7.48 | 7.43 | 7.50 | 7.46 |
| 1024 | 32 | 10.81 | 10.61 | 10.79 | 10.87 |
| 1024 | 40 | 12.98 | 12.92 | 12.98 | 12.90 |
| 1024 | 64 | 17.14 | 17.06 | 17.44 | 17.05 |
| 2048 | 16 | 10.51 | 10.37 | 10.51 | 10.51 |
| 2048 | 32 | 17.18 | 17.42 | 17.38 | 17.51 |
| 2048 | 64 | 31.71 | 30.38 | 30.97 | 30.57 |
| 2048 | 128 | 59.41 | 58.50 | 58.73 | 59.45 |
| 4096 | 32 | 29.97 | 30.37 | 30.12 | 30.29 |
| 8192 | 32 | 55.15 | 56.02 | 55.30 | 56.46 |