### PR TITLE
[Triton/Gluon] [gfx950] Tuned configs for ff_a16w16_fused_gated at small batch

### DIFF
--- a/aiter/ops/triton/configs/gfx950/triton/gemm/ff_a16w16_fused/FF-A16W16-fused-N=11264-K=2048.json
+++ b/aiter/ops/triton/configs/gfx950/triton/gemm/ff_a16w16_fused/FF-A16W16-fused-N=11264-K=2048.json
@@ -1,0 +1,46 @@
+{
+    "M_LEQ_4": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 8,
+        "num_stages": 2,
+        "waves_per_eu": 2,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg"
+    },
+    "M_LEQ_8": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 8,
+        "num_stages": 2,
+        "waves_per_eu": 2,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg"
+    },
+    "M_LEQ_64": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 8,
+        "num_stages": 2,
+        "waves_per_eu": 2,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg"
+    },
+    "any": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 8,
+        "num_stages": 1,
+        "waves_per_eu": 2,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": null
+    }
+}

--- a/aiter/ops/triton/configs/gfx950/triton/gemm/ff_a16w16_fused/FF-A16W16-fused-N=16384-K=1280.json
+++ b/aiter/ops/triton/configs/gfx950/triton/gemm/ff_a16w16_fused/FF-A16W16-fused-N=16384-K=1280.json
@@ -1,0 +1,46 @@
+{
+    "M_LEQ_4": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 8,
+        "num_stages": 2,
+        "waves_per_eu": 2,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg"
+    },
+    "M_LEQ_8": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 8,
+        "num_stages": 2,
+        "waves_per_eu": 2,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg"
+    },
+    "M_LEQ_64": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 8,
+        "num_stages": 2,
+        "waves_per_eu": 2,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg"
+    },
+    "any": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 8,
+        "num_stages": 1,
+        "waves_per_eu": 2,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": null
+    }
+}

--- a/aiter/ops/triton/configs/gfx950/triton/gemm/ff_a16w16_fused/FF-A16W16-fused-N=16384-K=2048.json
+++ b/aiter/ops/triton/configs/gfx950/triton/gemm/ff_a16w16_fused/FF-A16W16-fused-N=16384-K=2048.json
@@ -1,0 +1,46 @@
+{
+    "M_LEQ_4": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 8,
+        "num_stages": 2,
+        "waves_per_eu": 2,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg"
+    },
+    "M_LEQ_8": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 8,
+        "num_stages": 2,
+        "waves_per_eu": 2,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg"
+    },
+    "M_LEQ_64": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 8,
+        "num_stages": 2,
+        "waves_per_eu": 2,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg"
+    },
+    "any": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 8,
+        "num_stages": 1,
+        "waves_per_eu": 2,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": null
+    }
+}

--- a/aiter/ops/triton/configs/gfx950/triton/gemm/ff_a16w16_fused/FF-A16W16-fused-N=16384-K=8192.json
+++ b/aiter/ops/triton/configs/gfx950/triton/gemm/ff_a16w16_fused/FF-A16W16-fused-N=16384-K=8192.json
@@ -1,0 +1,46 @@
+{
+    "M_LEQ_4": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 8,
+        "num_stages": 2,
+        "waves_per_eu": 2,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg"
+    },
+    "M_LEQ_8": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 8,
+        "num_stages": 2,
+        "waves_per_eu": 2,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg"
+    },
+    "M_LEQ_64": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 8,
+        "num_stages": 2,
+        "waves_per_eu": 2,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg"
+    },
+    "any": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 8,
+        "num_stages": 1,
+        "waves_per_eu": 2,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": null
+    }
+}

--- a/aiter/ops/triton/configs/gfx950/triton/gemm/ff_a16w16_fused/FF-A16W16-fused-N=22016-K=4096.json
+++ b/aiter/ops/triton/configs/gfx950/triton/gemm/ff_a16w16_fused/FF-A16W16-fused-N=22016-K=4096.json
@@ -1,0 +1,46 @@
+{
+    "M_LEQ_4": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 8,
+        "num_stages": 2,
+        "waves_per_eu": 2,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg"
+    },
+    "M_LEQ_8": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 8,
+        "num_stages": 2,
+        "waves_per_eu": 2,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg"
+    },
+    "M_LEQ_64": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 8,
+        "num_stages": 3,
+        "waves_per_eu": 2,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg"
+    },
+    "any": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 8,
+        "num_stages": 1,
+        "waves_per_eu": 2,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": null
+    }
+}

--- a/aiter/ops/triton/configs/gfx950/triton/gemm/ff_a16w16_fused/FF-A16W16-fused-N=27648-K=5120.json
+++ b/aiter/ops/triton/configs/gfx950/triton/gemm/ff_a16w16_fused/FF-A16W16-fused-N=27648-K=5120.json
@@ -1,0 +1,46 @@
+{
+    "M_LEQ_4": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 8,
+        "num_stages": 2,
+        "waves_per_eu": 2,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg"
+    },
+    "M_LEQ_8": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 8,
+        "num_stages": 2,
+        "waves_per_eu": 2,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg"
+    },
+    "M_LEQ_64": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 8,
+        "num_stages": 3,
+        "waves_per_eu": 2,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg"
+    },
+    "any": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 8,
+        "num_stages": 1,
+        "waves_per_eu": 2,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": null
+    }
+}

--- a/aiter/ops/triton/configs/gfx950/triton/gemm/ff_a16w16_fused/FF-A16W16-fused-N=28672-K=4096.json
+++ b/aiter/ops/triton/configs/gfx950/triton/gemm/ff_a16w16_fused/FF-A16W16-fused-N=28672-K=4096.json
@@ -1,0 +1,46 @@
+{
+    "M_LEQ_4": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 8,
+        "num_stages": 2,
+        "waves_per_eu": 2,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg"
+    },
+    "M_LEQ_8": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 8,
+        "num_stages": 2,
+        "waves_per_eu": 2,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg"
+    },
+    "M_LEQ_64": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 8,
+        "num_stages": 3,
+        "waves_per_eu": 2,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg"
+    },
+    "any": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 8,
+        "num_stages": 1,
+        "waves_per_eu": 2,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": null
+    }
+}

--- a/aiter/ops/triton/configs/gfx950/triton/gemm/ff_a16w16_fused/FF-A16W16-fused-N=57344-K=8192.json
+++ b/aiter/ops/triton/configs/gfx950/triton/gemm/ff_a16w16_fused/FF-A16W16-fused-N=57344-K=8192.json
@@ -1,0 +1,46 @@
+{
+    "M_LEQ_4": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 8,
+        "num_stages": 2,
+        "waves_per_eu": 2,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg"
+    },
+    "M_LEQ_8": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 8,
+        "num_stages": 2,
+        "waves_per_eu": 2,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg"
+    },
+    "M_LEQ_64": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 8,
+        "num_stages": 3,
+        "waves_per_eu": 2,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": ".cg"
+    },
+    "any": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 8,
+        "num_stages": 1,
+        "waves_per_eu": 2,
+        "matrix_instr_nonkdim": 16,
+        "cache_modifier": null
+    }
+}

--- a/aiter/ops/triton/utils/_triton/tunning/ut_ff_a16w16_fused_gated.py
+++ b/aiter/ops/triton/utils/_triton/tunning/ut_ff_a16w16_fused_gated.py
@@ -1,0 +1,55 @@
+import sys
+
+############################################################
+# <import>
+import torch
+import triton  # noqa: F401
+from _utils import (
+    get_input_shape_and_config_list,
+    run_profile,
+)
+
+from aiter.ops.triton.gemm.feed_forward.ff_a16w16_fused_gated import (
+    ff_a16w16_fused_gated,
+)
+from op_tests.triton_tests.gemm.feed_forward.ff_test_utils import (
+    generate_ff_inputs,
+)
+
+############################################################
+
+input_shape, config_list = get_input_shape_and_config_list(sys.argv, shape_size=3)
+
+############################################################
+# <generate input>
+# screen.py passes the KERNEL dims: input_shape = (M, N, K) with N = 2*intermediate,
+# K = hidden. generate_ff_inputs wants (batch, hidden, intermediate).
+M, N, K = input_shape
+dtype = torch.bfloat16
+x, w1, w2, _, _, y = generate_ff_inputs(
+    M,
+    K,
+    N // 2,
+    dtype,
+    layout="TN",
+    gating=True,
+    output=True,
+)
+############################################################
+
+for config in config_list:
+    if config is not None:
+        config = config.copy()
+        # The fused FF kernel takes no NUM_KSPLIT parameter: its down-projection is
+        # already split over pid_n and recombined with atomic_add, so the split count
+        # is not selectable. Drop the harness's key so it is not forwarded.
+        config.pop("NUM_KSPLIT", None)
+
+    def fn(config=config):
+        ############################################################
+        # <run API>
+        y.zero_()
+        ff_a16w16_fused_gated(x, w1, w2, dtype, y=y, config=config)
+        ############################################################
+
+    run_profile(fn)


### PR DESCRIPTION
## Motivation

`ff_a16w16_fused_gated` exists to beat the unfused two-GEMM path at small batch — that is its stated reason for existing (#778: "only outperforms the two-kernel implementation when M < 128"). On gfx950 it had regressed to **losing to the unfused path at every M**, including the small-batch regime it targets. The kernel still emits its runtime warning about being slower above M=64, but it was no longer faster below it either, so there was no shape where selecting it was correct.

This PR restores the small-batch advantage with tuned configs only. No kernel or Python logic changes.

## Technical Details

Two independent, config-level causes:

**1. The per-M configs were flattened into one large-M bucket.** `configs/gfx950/triton/gemm/ff_a16w16_fused/DEFAULT.json` serves both `M_LEQ_64` and `any` with `BLOCK_SIZE_M=64, BN=256, BK=256`. That is a large-M-shaped tile: at M=16 a 64-row tile wastes three quarters of its rows on padding in the up-projection MFMA. #778 shipped per-M configs; the config-standardization work (e.g. #1587) collapsed them, so small-M shapes silently lost their tuning.

**2. The software pipeline was disabled for an LLVM crash that is now fixed.**

```
d295caf6  2026-04-29  "fix num_stages in ff_a16w16_fused to account for irregular shapes (#2940)"
-  "num_stages": 2
+  "num_stages": 1
```

#2940 landed three weeks after the LLVM `87717bf9` SIInsertWaitcnts crash and worked around it by disabling the pipeline. **That crash is fixed in the current LLVM pin (`b010a18d`)** — verified by reproducing the exact crashing shapes (`num_stages=2/3` on 4096×4096×4096 and 4096×106496×16384) with no crash. So `num_stages=1` is a stale workaround, and `num_stages>=2` is central to the recovery here.

**The fix.** Eight per-`(N,K)` specialized config files covering representative FF shapes, emitted only where the fused kernel actually beats the unfused baseline. `DEFAULT.json` is untouched, so untuned shapes resolve exactly as before (`is_tuned=False`).

| file (kernel N, K) | model (H × I) | small-M config | `M_LEQ_64` config |
|---|---|---|---|
| N=16384-K=1280 | 1280 × 8192 | BM32 BN128 BK256 ns2 | BM32 BN128 BK256 ns2 |
| N=11264-K=2048 | 2048 × 5632 | BM32 BN128 BK256 ns2 | BM32 BN128 BK256 ns2 |
| N=16384-K=2048 | 2048 × 8192 | BM32 BN128 BK256 ns2 | BM32 BN128 BK256 ns2 |
| N=16384-K=8192 | 8192 × 8192 | BM32 BN128 BK256 ns2 | BM32 BN128 BK256 ns2 |
| N=22016-K=4096 | 4096 × 11008 | BM32 BN128 BK256 ns2 | BM64 BN256 BK64 ns3 |
| N=28672-K=4096 | 4096 × 14336 | BM32 BN128 BK256 ns2 | BM64 BN256 BK64 ns3 |
| N=27648-K=5120 | 5120 × 13824 | BM32 BN128 BK256 ns2 | BM64 BN256 BK64 ns3 |
| N=57344-K=8192 | 8192 × 28672 | BM32 BN256 BK128 ns2 | BM64 BN256 BK64 ns3 |

Note on dimensions: the kernel's `(M, N, K)` are not the FF dimensions. Batch is `M`, `K = hidden`, and `N = 2 × intermediate` (the gate and up halves are stored concatenated). Specialized filenames use the **kernel** N and K.

An LDS constraint shapes the search: `BK=256` with `num_stages>=2` needs roughly 328 KB of LDS at `BM>=32` and will not compile, so `BK<=128` is required whenever `ns>=2` at those block sizes. The emitted configs respect this.

Also adds `utils/_triton/tunning/ut_ff_a16w16_fused_gated.py`, the tuning entry point. It pops `NUM_KSPLIT` from each config: this kernel takes no such parameter, because its down-projection is already split over `pid_n` and recombined with `tl.atomic_add`, so the split count is not selectable.

## Test Plan

1. **Tuning sweep.** 8 shapes × M ∈ {4, 8, 16, 32, 64} over a config search that re-enables `num_stages ∈ {1,2,3}` (LDS-safe), measured with `triton.testing.do_bench`. A specialized file was emitted only for shapes where the best fused config beat the unfused baseline at some M.

2. **Correctness gate.** Every emitted config checked against an fp32 reference, `((x @ w1[:I].T) * (x @ w1[I:].T)).bf16().f32() @ w2`, tolerance rel ≤ 6e-2. The tolerance is not slack: the kernel accumulates through `tl.atomic_add(..., sem="relaxed")`, so partials arrive in a different order each run and bf16 rounding is not associative. Results are correct but not bit-reproducible by construction.

3. **End-to-end via the default path.** Re-measured with `config=None` so the specialized JSON is resolved through `get_gemm_config` exactly as in production, rather than by passing configs in directly. `load_config_json` caches negative lookups, so this required a fresh process after adding files.

4. **Regression check on untuned shapes**, confirming they still resolve to `DEFAULT.json` with `is_tuned=False`.

5. **Pipeline safety.** `num_stages=2/3` confirmed to compile and run on both the LLVM currently pinned by aiter's Triton (`f6a045ff`) and `b010a18d`.

## Test Result

Fused vs unfused, default path (`config=None`), gfx950:

| shape (hidden × intermediate) | M=8 | M=32 | M=64 |
|---|---|---|---|
| 1280 × 8192 | 2.98× | 3.72× | 1.30× |
| 4096 × 14336 | 1.62× | 1.92× | 1.31× |
| 8192 × 28672 | 1.79× | 1.96× | 2.01× |

All fused wins; all within the correctness gate. Untuned shapes unchanged.

**Why it wins**, from `rocprofv3` PMC counters at M=32, H=1280, I=8192 — this is an occupancy effect, not a bandwidth one:

| | time | waves | traffic |
|---|---|---|---|
| fused (1 kernel) | **27.2 µs** | 1024 | 42.3 MB |
| unfused GEMM 1 | 17.9 µs | 1024 | 22.0 MB |
| unfused GEMM 2 | 16.5 µs | **320** | 12.7 MB |
| unfused total | 34.4 µs | — | 34.7 MB |

The fused kernel is faster while moving *more* memory traffic, so the win is not a memory effect. The standalone down-projection raises only 320 wavefronts across 40 workgroups on a 256-CU part: its output `(M=32 × H=1280)` is too small to tile, and even the smallest MFMA-viable tiling (16×16) yields just 160 workgroups. The fused kernel's split over `pid_n` — the same split that forces the atomics — supplies 128 workgroups and 1024 waves. This is why the effect is confined to small batch: at 4096³ the output already has thousands of tiles, the extra parallelism is worthless, and the fused kernel loses (measured time ratio 2.99× against a traffic ratio of 3.00×).

Durations above are under PMC serialization, so only within-run ratios are meaningful; the wall-clock wins in the first table are separate `do_bench` measurements.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/TheRock/blob/main/GOVERNANCE.md#pull-requests.
