### PR TITLE
[Triton/Gluon] [gfx950] Fix ff_a16w16_fused M<=8 launch failure, add tuned configs

### DIFF
--- a/aiter/ops/triton/configs/gemm/gfx950-FF-A16W16-fused-N=11264-K=2048.json
+++ b/aiter/ops/triton/configs/gemm/gfx950-FF-A16W16-fused-N=11264-K=2048.json
@@ -1,12 +1,12 @@
 {
     "M_LEQ_4": {
-        "BLOCK_SIZE_M": 4,
-        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 128,
         "BLOCK_SIZE_K": 256,
         "GROUP_SIZE_M": 1,
         "num_warps": 8,
-        "num_stages": 1,
-        "waves_per_eu": 3,
+        "num_stages": 2,
+        "waves_per_eu": 2,
         "matrix_instr_nonkdim": 16,
         "cache_modifier": ".cg"
     },
@@ -22,12 +22,12 @@
         "cache_modifier": ".cg"
     },
     "M_LEQ_64": {
-        "BLOCK_SIZE_M": 64,
-        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 128,
         "BLOCK_SIZE_K": 256,
         "GROUP_SIZE_M": 1,
         "num_warps": 8,
-        "num_stages": 1,
+        "num_stages": 2,
         "waves_per_eu": 2,
         "matrix_instr_nonkdim": 16,
         "cache_modifier": ".cg"

--- a/aiter/ops/triton/configs/gemm/gfx950-FF-A16W16-fused-N=16384-K=1280.json
+++ b/aiter/ops/triton/configs/gemm/gfx950-FF-A16W16-fused-N=16384-K=1280.json
@@ -1,12 +1,12 @@
 {
     "M_LEQ_4": {
-        "BLOCK_SIZE_M": 4,
-        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 128,
         "BLOCK_SIZE_K": 256,
         "GROUP_SIZE_M": 1,
         "num_warps": 8,
-        "num_stages": 1,
-        "waves_per_eu": 3,
+        "num_stages": 2,
+        "waves_per_eu": 2,
         "matrix_instr_nonkdim": 16,
         "cache_modifier": ".cg"
     },
@@ -22,12 +22,12 @@
         "cache_modifier": ".cg"
     },
     "M_LEQ_64": {
-        "BLOCK_SIZE_M": 64,
-        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 128,
         "BLOCK_SIZE_K": 256,
         "GROUP_SIZE_M": 1,
         "num_warps": 8,
-        "num_stages": 1,
+        "num_stages": 2,
         "waves_per_eu": 2,
         "matrix_instr_nonkdim": 16,
         "cache_modifier": ".cg"

--- a/aiter/ops/triton/configs/gemm/gfx950-FF-A16W16-fused-N=16384-K=2048.json
+++ b/aiter/ops/triton/configs/gemm/gfx950-FF-A16W16-fused-N=16384-K=2048.json
@@ -1,12 +1,12 @@
 {
     "M_LEQ_4": {
-        "BLOCK_SIZE_M": 4,
-        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 128,
         "BLOCK_SIZE_K": 256,
         "GROUP_SIZE_M": 1,
         "num_warps": 8,
-        "num_stages": 1,
-        "waves_per_eu": 3,
+        "num_stages": 2,
+        "waves_per_eu": 2,
         "matrix_instr_nonkdim": 16,
         "cache_modifier": ".cg"
     },
@@ -22,12 +22,12 @@
         "cache_modifier": ".cg"
     },
     "M_LEQ_64": {
-        "BLOCK_SIZE_M": 64,
-        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 128,
         "BLOCK_SIZE_K": 256,
         "GROUP_SIZE_M": 1,
         "num_warps": 8,
-        "num_stages": 1,
+        "num_stages": 2,
         "waves_per_eu": 2,
         "matrix_instr_nonkdim": 16,
         "cache_modifier": ".cg"

--- a/aiter/ops/triton/configs/gemm/gfx950-FF-A16W16-fused-N=16384-K=8192.json
+++ b/aiter/ops/triton/configs/gemm/gfx950-FF-A16W16-fused-N=16384-K=8192.json
@@ -1,12 +1,12 @@
 {
     "M_LEQ_4": {
-        "BLOCK_SIZE_M": 4,
-        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 128,
         "BLOCK_SIZE_K": 256,
         "GROUP_SIZE_M": 1,
         "num_warps": 8,
-        "num_stages": 1,
-        "waves_per_eu": 3,
+        "num_stages": 2,
+        "waves_per_eu": 2,
         "matrix_instr_nonkdim": 16,
         "cache_modifier": ".cg"
     },
@@ -22,12 +22,12 @@
         "cache_modifier": ".cg"
     },
     "M_LEQ_64": {
-        "BLOCK_SIZE_M": 64,
-        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 128,
         "BLOCK_SIZE_K": 256,
         "GROUP_SIZE_M": 1,
         "num_warps": 8,
-        "num_stages": 1,
+        "num_stages": 2,
         "waves_per_eu": 2,
         "matrix_instr_nonkdim": 16,
         "cache_modifier": ".cg"

--- a/aiter/ops/triton/configs/gemm/gfx950-FF-A16W16-fused-N=22016-K=4096.json
+++ b/aiter/ops/triton/configs/gemm/gfx950-FF-A16W16-fused-N=22016-K=4096.json
@@ -1,12 +1,12 @@
 {
     "M_LEQ_4": {
-        "BLOCK_SIZE_M": 4,
-        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 128,
         "BLOCK_SIZE_K": 256,
         "GROUP_SIZE_M": 1,
         "num_warps": 8,
-        "num_stages": 1,
-        "waves_per_eu": 3,
+        "num_stages": 2,
+        "waves_per_eu": 2,
         "matrix_instr_nonkdim": 16,
         "cache_modifier": ".cg"
     },
@@ -24,10 +24,10 @@
     "M_LEQ_64": {
         "BLOCK_SIZE_M": 64,
         "BLOCK_SIZE_N": 256,
-        "BLOCK_SIZE_K": 256,
+        "BLOCK_SIZE_K": 64,
         "GROUP_SIZE_M": 1,
         "num_warps": 8,
-        "num_stages": 1,
+        "num_stages": 3,
         "waves_per_eu": 2,
         "matrix_instr_nonkdim": 16,
         "cache_modifier": ".cg"

--- a/aiter/ops/triton/configs/gemm/gfx950-FF-A16W16-fused-N=27648-K=5120.json
+++ b/aiter/ops/triton/configs/gemm/gfx950-FF-A16W16-fused-N=27648-K=5120.json
@@ -1,12 +1,12 @@
 {
     "M_LEQ_4": {
-        "BLOCK_SIZE_M": 4,
-        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 128,
         "BLOCK_SIZE_K": 256,
         "GROUP_SIZE_M": 1,
         "num_warps": 8,
-        "num_stages": 1,
-        "waves_per_eu": 3,
+        "num_stages": 2,
+        "waves_per_eu": 2,
         "matrix_instr_nonkdim": 16,
         "cache_modifier": ".cg"
     },
@@ -24,10 +24,10 @@
     "M_LEQ_64": {
         "BLOCK_SIZE_M": 64,
         "BLOCK_SIZE_N": 256,
-        "BLOCK_SIZE_K": 256,
+        "BLOCK_SIZE_K": 64,
         "GROUP_SIZE_M": 1,
         "num_warps": 8,
-        "num_stages": 1,
+        "num_stages": 3,
         "waves_per_eu": 2,
         "matrix_instr_nonkdim": 16,
         "cache_modifier": ".cg"

--- a/aiter/ops/triton/configs/gemm/gfx950-FF-A16W16-fused-N=28672-K=4096.json
+++ b/aiter/ops/triton/configs/gemm/gfx950-FF-A16W16-fused-N=28672-K=4096.json
@@ -1,12 +1,12 @@
 {
     "M_LEQ_4": {
-        "BLOCK_SIZE_M": 4,
-        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 128,
         "BLOCK_SIZE_K": 256,
         "GROUP_SIZE_M": 1,
         "num_warps": 8,
-        "num_stages": 1,
-        "waves_per_eu": 3,
+        "num_stages": 2,
+        "waves_per_eu": 2,
         "matrix_instr_nonkdim": 16,
         "cache_modifier": ".cg"
     },
@@ -24,10 +24,10 @@
     "M_LEQ_64": {
         "BLOCK_SIZE_M": 64,
         "BLOCK_SIZE_N": 256,
-        "BLOCK_SIZE_K": 256,
+        "BLOCK_SIZE_K": 64,
         "GROUP_SIZE_M": 1,
         "num_warps": 8,
-        "num_stages": 1,
+        "num_stages": 3,
         "waves_per_eu": 2,
         "matrix_instr_nonkdim": 16,
         "cache_modifier": ".cg"

--- a/aiter/ops/triton/utils/_triton/tunning/ut_ff_a16w16_fused_gated.py
+++ b/aiter/ops/triton/utils/_triton/tunning/ut_ff_a16w16_fused_gated.py
@@ -1,0 +1,55 @@
+import sys
+
+############################################################
+# <import>
+import torch
+import triton  # noqa: F401
+from _utils import (
+    get_input_shape_and_config_list,
+    run_profile,
+)
+
+from aiter.ops.triton.gemm.feed_forward.ff_a16w16_fused_gated import (
+    ff_a16w16_fused_gated,
+)
+from op_tests.triton_tests.gemm.feed_forward.ff_test_utils import (
+    generate_ff_inputs,
+)
+
+############################################################
+
+input_shape, config_list = get_input_shape_and_config_list(sys.argv, shape_size=3)
+
+############################################################
+# <generate input>
+# screen.py passes the KERNEL dims: input_shape = (M, N, K) with N = 2*intermediate,
+# K = hidden. generate_ff_inputs wants (batch, hidden, intermediate).
+M, N, K = input_shape
+dtype = torch.bfloat16
+x, w1, w2, _, _, y = generate_ff_inputs(
+    M,
+    K,
+    N // 2,
+    dtype,
+    layout="TN",
+    gating=True,
+    output=True,
+)
+############################################################
+
+for config in config_list:
+    if config is not None:
+        config = config.copy()
+        # The fused FF kernel takes no NUM_KSPLIT parameter: its down-projection is
+        # already split over pid_n and recombined with atomic_add, so the split count
+        # is not selectable. Drop the harness's key so it is not forwarded.
+        config.pop("NUM_KSPLIT", None)
+
+    def fn(config=config):
+        ############################################################
+        # <run API>
+        y.zero_()
+        ff_a16w16_fused_gated(x, w1, w2, dtype, y=y, config=config)
+        ############################################################
+
+    run_profile(fn)


### PR DESCRIPTION
## Motivation

Two problems with the gfx950 configs for `ff_a16w16_fused_gated` / `ff_a16w16_fused_ungated`.

**A launch failure at 4 < M <= 8.** `M_LEQ_8` is the only bucket in `gfx950-FF-A16W16-fused.json` with `num_stages=2`, and `BLOCK_SIZE_N=256` with `BLOCK_SIZE_K=256` double-buffered does not fit in LDS on gfx950. Every call in that range raises at launch, on any shape, tuned or not.

**Small batch is served by a large-M tile.** The remaining buckets use `BLOCK_SIZE_M=64` with `num_stages=1`, so at M=8-32 the kernel runs a 64-row tile over a handful of real rows with no software pipeline. This kernel exists to be the fast path at small batch (#778: "only outperforms the two-kernel implementation when M < 128"), so that is the regime that matters for it.

## Technical Details

**1. `M_LEQ_8` bucket.**

```
triton.runtime.errors.OutOfResources: out of resource: shared memory,
Required: 278464, Hardware limit: 163840
```

Reproduce on current `main`, gfx950 — any shape, M=8:

```python
from aiter.ops.triton.gemm.feed_forward.ff_a16w16_fused_gated import ff_a16w16_fused_gated
# M=8, hidden=3072, intermediate=8192  ->  OutOfResources at launch
```

Changed to `BLOCK_SIZE_M=32, BN=128, BK=256, num_stages=2`. It fits, and it is faster than simply dropping to `num_stages=1`, measured at M=8 on shapes with no specialized config (ms, lower is better):

| untuned shape | `BN256 BK256 ns2` (current) | `ns1` | `BN128 BK256 ns2` (this PR) |
|---|---|---|---|
| H=3072, I=8192 | crash | 0.0968 | **0.0753** |
| H=1024, I=4096 | crash | 0.0366 | **0.0269** |

**2. Seven per-`(N,K)` specialized configs.** Re-tuned with `num_stages` 2/3 re-enabled. `num_stages=1` dates from #2940, which worked around the LLVM `87717bf9` SIInsertWaitcnts crash of Apr 2026; that is fixed in the current LLVM pin (`b010a18d`), verified by re-running the shapes that used to crash with `num_stages=2/3`.

An LDS constraint shapes the search: `BK=256` with `num_stages>=2` needs ~328 KB at `BM>=32` and will not compile, so `BK<=128` is required whenever `ns>=2` at those block sizes.

Note on dimensions: the kernel's `(M, N, K)` are not the FF dimensions. Batch is `M`, `K = hidden`, and `N = 2 x intermediate` (gate and up halves stored concatenated). Filenames use the kernel `N, K`.

Also adds `utils/_triton/tunning/ut_ff_a16w16_fused_gated.py`. It pops `NUM_KSPLIT`: this kernel takes no such parameter, because its down-projection is already split over `pid_n` and recombined with `tl.atomic_add`, so the split count is not selectable.

## Test Plan

1. **M=8 regression.** Called through the default path (`config=None`) at M=8 on both tuned and untuned shapes, confirming the launch failure is gone and untuned shapes pick up the fixed default bucket.
2. **Correctness.** Every config checked against an fp32 reference, `((x @ w1[:I].T) * (x @ w1[I:].T)).bf16().f32() @ w2`, gate rel <= 6e-2. The tolerance is not slack: the kernel accumulates with `tl.atomic_add(..., sem="relaxed")`, so summation order varies per run and bf16 addition is not associative. Results are correct but not bit-reproducible by construction.
3. **Performance.** Three-way sweep on `main` — current shipped config vs this PR vs the unfused `ff_a16w16_gated` path — over 3 shapes x M in {4, 8, 16, 32, 64}, `triton.testing.do_bench`.
4. **Resolution check.** Verified `get_gemm_config` picks up the specialized files and that shapes without one fall back to the default with `is_tuned=False`.

## Test Result

M=8, default path, previously crashing:

| shape | specialized config? | result |
|---|---|---|
| H=3072, I=8192 | no | OK (was OutOfResources) |
| H=1280, I=8192 | yes | OK (was OutOfResources) |
| H=8192, I=28672 | no | OK (was OutOfResources) |

Speedup over the currently shipped config (M=8 omitted: the baseline cannot run):

| shape (H x I) | M=4 | M=16 | M=32 | M=64 |
|---|---|---|---|---|
| 1280 x 8192 | 1.58x | 1.81x | 1.79x | 1.49x |
| 4096 x 14336 | 1.39x | 1.39x | 1.37x | 1.35x |

All within the correctness gate; shapes without a specialized config are unaffected apart from the `M_LEQ_8` fix.

**Scope of the claim.** These numbers compare the fused kernel against its own shipped config. They are not a claim that the fused kernel is the right choice at every one of these points — for `4096 x 14336` the unfused two-GEMM path is still faster at M=4-32 (fused/unfused 0.68-0.83x), and only wins at M=64 (1.26x). Choosing between the two kernels is an API-level routing question, not something a config can express. This PR makes the fused kernel faster whenever it is the one being called.

**Not included:** a config for `8192 x 28672`. Re-tuning it measured 0.96-1.06x versus the shipped config, i.e. neutral, so it does not earn a specialized file. It still benefits from the `M_LEQ_8` fix through the default bucket.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/TheRock/blob/main/GOVERNANCE.md#pull-requests.
