### PR TITLE
[Triton/Gluon] fix(gluon): mask invalid V cache padding before PA accumulation

### DIFF
--- a/aiter/ops/triton/gluon/pa_decode_gluon.py
+++ b/aiter/ops/triton/gluon/pa_decode_gluon.py
@@ -846,6 +846,17 @@ def paged_attention_decode_v2_gluon_large_block_dot_kernel(
             value_block = gl.load(value_cache_ptr + value_block_offsets)
             # Transpose to [KV_COMPUTE_BLOCK_SIZE, HEAD_SIZE_POW2]
             value_block = gl.permute(value_block, [1, 0])
+        # Unused cache lanes may contain NaN/Inf. Masking their attention
+        # probability is insufficient: MFMA would still evaluate 0 * NaN.
+        if kv_sub_sequence_start_index + KV_COMPUTE_BLOCK_SIZE > context_length:
+            value_token_offsets = kv_sub_sequence_start_index + gl.arange(
+                0,
+                KV_COMPUTE_BLOCK_SIZE,
+                layout=gl.SliceLayout(1, value_block.type.layout),
+            )
+            value_block = gl.where(
+                value_token_offsets[:, None] < context_length, value_block, 0
+            )
         # Perform matrix multiplication
         qk_matrix = gl.amd.cdna3.mfma(query_converted, key_converted, qk_accumulator)
         qk_matrix = gl.reshape(
@@ -1814,6 +1825,17 @@ def paged_attention_decode_sliding_window_head_1(
         value_tensor = gl.reshape(
             value_tensor, [CONTEXT_PARTITION_SIZE, HEAD_SIZE_POW2]
         )
+        # Mask physical padding before PV MFMA, including ONE_SHOT dispatch.
+        value_token_start = kv_block_start_idx * KV_COMPUTE_BLOCK_SIZE
+        if value_token_start + CONTEXT_PARTITION_SIZE > context_length:
+            value_token_offsets = value_token_start + gl.arange(
+                0,
+                CONTEXT_PARTITION_SIZE,
+                layout=gl.SliceLayout(1, value_tensor.type.layout),
+            )
+            value_tensor = gl.where(
+                value_token_offsets[:, None] < context_length, value_tensor, 0
+            )
         # Compute QK attention scores using MFMA (overlaps with value load)
         attention_scores = gl.amd.cdna3.mfma(
             query_converted, key_converted, qk_accumulator
@@ -2925,6 +2947,18 @@ def paged_attention_decode_sliding_window(
         value_tensor = gl.reshape(
             value_tensor, [CONTEXT_PARTITION_SIZE, HEAD_SIZE_POW2]
         )
+        # ONE_SHOT dispatch also uses this kernel. Physical V padding must
+        # not enter MFMA even when its softmax probability is zero.
+        value_token_start = kv_block_start_idx * KV_COMPUTE_BLOCK_SIZE
+        if value_token_start + CONTEXT_PARTITION_SIZE > context_length:
+            value_token_offsets = value_token_start + gl.arange(
+                0,
+                CONTEXT_PARTITION_SIZE,
+                layout=gl.SliceLayout(1, value_tensor.type.layout),
+            )
+            value_tensor = gl.where(
+                value_token_offsets[:, None] < context_length, value_tensor, 0
+            )
 
         attention_scores = gl.reshape(
             attention_scores, [QUERY_GROUP_SIZE_POW2, CONTEXT_PARTITION_SIZE]
@@ -3793,6 +3827,19 @@ def paged_attention_decode_v2_gluon_dot_kernel(
             value_tensor = gl.permute(value_tensor, [0, 2, 1])
             value_tensor = gl.reshape(
                 value_tensor, [KV_COMPUTE_BLOCK_SIZE, HEAD_SIZE_POW2]
+            )
+
+        # Zero unused V-cache register lanes before PV MFMA: masking the
+        # probability alone cannot suppress 0 * NaN/Inf from cache padding.
+        # Full compute blocks retain the unmasked fast path.
+        if kv_subsequence_start_idx + KV_COMPUTE_BLOCK_SIZE > context_length:
+            value_token_offsets = kv_subsequence_start_idx + gl.arange(
+                0,
+                KV_COMPUTE_BLOCK_SIZE,
+                layout=gl.SliceLayout(1, value_tensor.type.layout),
+            )
+            value_tensor = gl.where(
+                value_token_offsets[:, None] < context_length, value_tensor, 0
             )
 
         # Apply quantization scaling to attention scores

--- a/op_tests/triton_tests/test_pa_decode_gluon.py
+++ b/op_tests/triton_tests/test_pa_decode_gluon.py
@@ -3,6 +3,7 @@
 
 import argparse
 import hashlib
+import math
 import random
 import sys
 
@@ -2205,6 +2206,125 @@ def test_multi_case_set(case_set_name):
         sliding_window_accuracy_test()
     elif case_set_name == "sliding_window_performance":
         sliding_window_performance_test()
+
+
+@pytest.mark.skipif(
+    torch.version.hip is None or not torch.cuda.is_available(),
+    reason="requires an AMD GPU",
+)
+@pytest.mark.parametrize(
+    "page,lengths,dim,query_length,kv_heads",
+    [
+        (16, [2049, 513, 17], 256, 1, 4),
+        (16, [16, 17], 128, 1, 4),
+        (16, [17, 257], 128, 2, 4),
+        (1024, [1025, 17], 256, 1, 4),
+        (16, [16, 17], 128, 1, 1),
+    ],
+)
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("transposed", [False, True])
+def test_unused_v_cache_padding(
+    page, lengths, dim, query_length, kv_heads, dtype, transposed
+):
+    """NaN/Inf in unused V slots must not affect eager or Graph output."""
+    torch.manual_seed(20260909)
+    batch, heads = len(lengths), kv_heads * 4
+    cols = math.ceil(max(lengths) / page)
+    nblocks = batch * cols
+    q = torch.randn(batch * query_length, heads, dim, device="cuda", dtype=dtype)
+    k = torch.randn(nblocks, kv_heads, dim // 8, page, 8, device="cuda", dtype=dtype)
+    clean_v = torch.randn(nblocks, kv_heads, page, dim, device="cuda", dtype=dtype)
+    table = torch.arange(nblocks, device="cuda", dtype=torch.int32).view(batch, cols)
+    lens = torch.tensor(lengths, device="cuda", dtype=torch.int32)
+    out = torch.empty_like(q)
+    parts = math.ceil(max(lengths) / 256)
+    workspace_shape = (batch, kv_heads, parts, query_length * heads // kv_heads)
+    workspace = {
+        "exp_sums": torch.full(workspace_shape, float("nan"), device="cuda"),
+        "max_logits": torch.full(workspace_shape, float("nan"), device="cuda"),
+        "temporary_output": torch.full(
+            (*workspace_shape, dim), float("nan"), device="cuda", dtype=dtype
+        ),
+    }
+
+    def pack(v):
+        if transposed:
+            return (
+                v.view(nblocks, kv_heads, page // 8, 8, dim)
+                .permute(0, 1, 2, 4, 3)
+                .contiguous()
+            )
+        return v.transpose(2, 3).contiguous()
+
+    def launch(v):
+        pa_decode_gluon(
+            out,
+            q,
+            k,
+            v,
+            lens,
+            table,
+            dim**-0.5,
+            query_length,
+            parts,
+            256,
+            dtype,
+            ps=False,
+            **workspace,
+        )
+
+    launch(pack(clean_v))
+    expected = out.clone()
+    assert torch.isfinite(expected).all().item()
+    # Independent reference reads only live tokens, never physical padding.
+    references = []
+    for b, length in enumerate(lengths):
+        rows = table[b].long()
+        keys = (
+            k[rows]
+            .permute(0, 3, 1, 2, 4)
+            .reshape(-1, kv_heads, dim)[:length]
+            .repeat_interleave(4, dim=1)
+            .float()
+        )
+        values = (
+            clean_v[rows]
+            .permute(0, 2, 1, 3)
+            .reshape(-1, kv_heads, dim)[:length]
+            .repeat_interleave(4, dim=1)
+            .float()
+        )
+        for token in range(query_length):
+            live = length - query_length + token + 1
+            query = q[b * query_length + token].float()
+            p = torch.softmax(
+                torch.einsum("hd,thd->ht", query, keys[:live]) * dim**-0.5, dim=-1
+            )
+            references.append(torch.einsum("ht,thd->hd", p, values[:live]))
+    torch.testing.assert_close(
+        expected.float(), torch.stack(references), rtol=2e-2, atol=2e-2
+    )
+
+    for poison in (float("nan"), float("inf")):
+        poisoned = clean_v.clone()
+        for b, length in enumerate(lengths):
+            for block in range(cols):
+                valid = max(0, min(page, length - block * page))
+                poisoned[b * cols + block, :, valid:] = poison
+        value = pack(poisoned)
+        launch(value)
+        torch.testing.assert_close(out, expected, rtol=0, atol=0)
+        # Replay the same poisoned cache; no host/cache cleanup is allowed.
+        for _ in range(3):
+            launch(value)
+        torch.cuda.synchronize()
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph):
+            launch(value)
+        for _ in range(2):
+            graph.replay()
+            torch.testing.assert_close(out, expected, rtol=0, atol=0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Motivation

Gluon paged attention can produce non-finite output when physically allocated
but logically unused V-cache slots contain NaN or Inf. This can occur with
reused GPU allocations even when Q and all valid K/V tokens are finite.

Masking the corresponding attention probabilities to zero is insufficient:
the PV matrix multiplication can still evaluate `0 * NaN` or `0 * Inf`.
Unused cache slots must not affect attention over valid tokens.

This bug was discovered during **RTP-LLM end-to-end inference testing** after
upgrading its AITER dependency. In RTP-LLM's Qwen3.5-4B model service, it was
reproduced after an 8K request followed by 2K requests at concurrency 3.
The failure occurred with both original Triton GDN and FlyDSL GDN. Capturing
the failing paged-attention inputs from RTP-LLM and replaying them in isolation
localized the root cause to AITER's Gluon paged-attention kernel, not GDN.

## Technical Details

Mask invalid V **register lanes** to zero before PV MFMA in four kernels:

- `paged_attention_decode_v2_gluon_dot_kernel`
- `paged_attention_decode_v2_gluon_large_block_dot_kernel`
- `paged_attention_decode_sliding_window`
- `paged_attention_decode_sliding_window_head_1`

The latter two also serve one-shot dispatches. The mask uses the absolute
token offset and `context_length`, and is applied when the loaded compute
block extends beyond the logical sequence end.

This change does not modify the KV cache in memory, clear the whole cache,
change valid V values, or add a GPU kernel launch. Full compute blocks bypass
the V selection. Public interfaces and GDN kernels are unchanged.

No zero-overhead or speedup claim is made: the added condition/masking may
affect generated code, and dedicated PA performance benchmarking is still
needed. GDN benchmark gains are not evidence of this PA fix's performance.

## Test Plan

Add `op_tests/test_pa_decode_gluon_nan_padding.py`, containing one unittest
method with **20 parameter combinations**:

- FP16 and BF16 inputs/cache.
- Linear and transposed V-cache layouts.
- Page sizes 16 and 1024; head dimensions 128 and 256.
- One or four KV heads, with four query heads per KV head.
- Query lengths 1 and 2.
- Ragged batches, including page-aligned and partial-page sequence lengths.

For each combination:

1. Compare clean-cache output against an independent FP32 PyTorch reference
   that reads only live tokens (`rtol=2e-2`, `atol=2e-2`).
2. Replace only unused V-cache slots with NaN, then separately with Inf.
3. Require poisoned-cache output to equal clean-cache output exactly
   (`rtol=0`, `atol=0`).
4. Repeat that exact comparison over two HIP Graph replays for each poison.

Run against the intended AITER installation:

```bash
python op_tests/test_pa_decode_gluon_nan_padding.py -v
ruff check aiter/ops/triton/gluon/pa_decode_gluon.py op_tests/test_pa_decode_gluon_nan_padding.py
black --check aiter/ops/triton/gluon/pa_decode_gluon.py op_tests/test_pa_decode_gluon_nan_padding.py
```

Confirm the imported AITER module belongs to the build being tested; an
unrelated installed wheel must not silently substitute for the changed source.

## Test Result

Validated on AMD MI308X with AMD Triton 3.8 and FlyDSL 0.3.2 using a repaired
AITER `0.1.22.dev59+gc6677e075` wheel. Its `pa_decode_gluon.py` was verified
byte-for-byte identical to this commit's file. All 20 combinations passed,
including the eager and repeated HIP Graph checks. Ruff and Black passed.

Captured failing service input: BF16 Q `[2,16,256]`, four KV heads, context
lengths `[2049,2049]`, page size 16, and partition size 256.

| Replay of the same captured input | Non-finite output elements |
|---|---:|
| Original kernel | 252 |
| Original kernel, only unused K padding zeroed | 252 |
| Original kernel, only unused V padding zeroed | 0 |
| Fixed kernel, original cache contents retained | 0 |

The fixed output matched the independent FP32 attention reference with maximum
absolute error approximately **0.00598**. The previously failing service
sequence completed without the degenerate output in the tested Graph-on/off
configurations.

### Validation boundaries

- Testing covers the non-quantized, `ps=False` configurations above. It does
  not establish coverage of every sliding-window setting, quantization mode,
  architecture, or shape supported by the module.
- A fresh source-tree rerun was blocked during import of a separate
  `gfx1250` MXFP4 Gluon kernel with `ValueError: No function definition found
  for kernel`, before the PA test executed. The byte-identical repaired-wheel
  run is the successful validation environment; full source-tree CI remains
  necessary.
- Fixing this PA NaN failure is not a claim of bit-identical full-model
  generation between different GDN implementations. Separate finite 8K
  generation differences remain outside this fix's demonstrated result.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
- [x] Add targeted regression coverage and an independent numerical reference.
- [x] Validate eager execution and HIP Graph replay on MI308X.
- [x] Run Ruff and Black checks.
- [ ] Complete source-tree CI in a compatible dependency environment.
