### PR TITLE
[HIP] [JIT] feat: add packed BF16 mHC computation and gfx1250 tuning

### DIFF
--- a/aiter/jit/core.py
+++ b/aiter/jit/core.py
@@ -1106,6 +1106,14 @@ def build_module(
         if not AITER_DISABLE_KERNARG_PRELOAD:
             flags_hip += ["-mllvm --amdgpu-kernarg-preload-count=32"]
 
+        # AITER_DEBUG_INFO=1 emits device-side DWARF so rocprofv3 ATT can map instructions
+        # back to source lines (the Source column is empty without it). Verified not to
+        # change codegen -- same VGPR count and occupancy with and without -- but it
+        # inflates compile time (~30% on module_mhc) and object size (4.5 MB -> 16 MB),
+        # so it is opt-in rather than always on.
+        if int(os.environ.get("AITER_DEBUG_INFO", "0")) != 0:
+            flags_hip += ["-g"]
+
         # Imitate https://github.com/ROCm/composable_kernel/blob/c8b6b64240e840a7decf76dfaa13c37da5294c4a/CMakeLists.txt#L190-L214
         hip_version = parse(get_hip_version().split()[-1].rstrip("-").replace("-", "+"))
         if hip_version <= Version("6.3.42132"):

--- a/aiter/ops/mhc.py
+++ b/aiter/ops/mhc.py
@@ -21,8 +21,25 @@ def mhc_pre_gemm_sqrsum(
     x: Tensor,
     fn: Tensor,
     tile_k: int = 128,  # 64 or 128
-    is_fn_pack_bf16: int = 0,
+    is_fn_pack_bf16: int = 0,  # 1: fn is pre-packed int32 (hi<<16|lo) from mhc_pre_convert_fn
 ) -> None: ...
+
+
+@compile_ops("module_mhc", develop=True)
+def mhc_pre_convert_fn(
+    fn_packed: Tensor,  # (hc_mult3, hc_hidden_size) int32 out
+    fn: Tensor,  # (hc_mult3, hc_hidden_size) fp32 in
+) -> None: ...
+
+
+def mhc_pre_convert_fn_ref(fn: torch.Tensor) -> torch.Tensor:
+    """Torch equivalent of the HIP ``mhc_pre_convert_fn`` kernel: pack fp32 fn into
+    int32 dwords (hi = bf16(fn) in [31:16], lo = bf16(fn - fp32(hi)) in [15:0])."""
+    hi = fn.to(torch.bfloat16)
+    lo = (fn - hi.to(torch.float32)).to(torch.bfloat16)
+    hi_bits = hi.view(torch.int16).to(torch.int32) & 0xFFFF
+    lo_bits = lo.view(torch.int16).to(torch.int32) & 0xFFFF
+    return ((hi_bits << 16) | lo_bits).to(torch.int32).contiguous()
 
 
 @compile_ops("module_mhc", develop=True)
@@ -323,7 +340,7 @@ def mhc_pre(
     norm_weight: torch.Tensor | None = None,
     norm_eps: float = 1e-6,
     large_m_splitk: bool = False,
-    is_fn_pack_bf16: int = 0,
+    is_fn_pack_bf16: int = 0,  # 1: fn is pre-packed int32 (hi<<16|lo) from mhc_pre_convert_fn
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     m = residual.size(0)
     hc_mult = residual.size(1)
@@ -343,6 +360,7 @@ def mhc_pre(
     )
     out = out_pad[:, :, :hc_mult3]
     sqrsum = torch.empty(selected_splitk, m, dtype=dtypes.fp32, device=device)
+    # is_fn_pack_bf16=1: fn is the pre-packed int32 tensor (bf16 hi/lo MFMA path).
     mhc_pre_gemm_sqrsum(out, sqrsum, residual, fn, selected_tile_k, is_fn_pack_bf16)
     # out = out.sum(0)
     # sqrsum = sqrsum.sum(0)

--- a/aiter/ops/mhc.py
+++ b/aiter/ops/mhc.py
@@ -231,44 +231,51 @@ def _mhc_fused_config_gfx942_80(m, hidden_size, num_cu):
 
 
 def _mhc_fused_config_gfx1250_256(m, hidden_size, num_cu):
+    """Tuned on the pair (this gemm + the mhc_pre_big_fuse reduction that always
+    follows it), not on the gemm alone. The reduction reads (split_k, m, hc_mult3)
+    and (split_k, m), so its cost grows with split_k: tuning the gemm in isolation
+    picks split_k up to 4x too deep and loses ~1.06x end-to-end at m<=512.
+
+    Thresholds below were measured at num_cu=256 only; they are written relative to
+    num_cu because they are occupancy-driven, not because the scaling was verified.
+    """
     tile_k = 32 if hidden_size % 32 == 0 else 64
-    valid = _mhc_fused_valid_splitk(hidden_size, tile_k, num_cu)
+    # k_loop >= 1 is enough: the LDS/fn ring guards every prefetch against k_loop
+    # (verified bit-exact against split_k=1), and small m wants a deep split.
+    valid = _mhc_fused_valid_splitk(hidden_size, tile_k, num_cu, prefetch_stages=1)
     if not valid:
         return 1, 16, 32, tile_k
 
-    tile_n = 32
-    # Re-tuned on gfx1250/256 (TDM residual load): fn-reuse (tile_m=32) wins from
-    # m=512 up; m<=256 is launch-bound and stays on tile_m=16.
-    tile_m = 16 if m <= 256 else 32
+    tile_n = 32  # re-measured over tile_n in {16, 32}: 16 never wins
 
-    # (m upper bound, target split_k) measured per (m, hidden) then merged; the
-    # target is snapped to a legal divisor below so it stays valid for any hidden.
-    # Mid/large m follows blocks_m*split_k ~= 4*cu (~128*cu/m); small m is
-    # launch-bound (high split_k, config barely matters); very large m goes deeper.
-    if hidden_size >= 7168:
-        table = [
-            (128, 32),
-            (256, 32),
-            (512, 32),
-            (1024, 32),
-            (2048, 16),
-            (4096, 8),
-            (8192, 14),
-            (1 << 30, 7),
-        ]
+    # split_k, snapped DOWN to a legal divisor -- never to the geometrically nearest
+    # one, which on a coarse lattice overshoots badly (hidden=5120, m=512: split_k=80
+    # is 1.48x slower than 40).
+    if m <= num_cu:
+        # launch-bound: the optimum holds split_k*m ~= 32*num_cu. Deeper stops paying
+        # (the reduction grows with split_k), shallower starves the gemm grid.
+        target = max(1, 32 * num_cu // m)
+    elif m <= 2 * num_cu:
+        target = num_cu // 8  # short plateau between the two regimes
     else:
-        table = [
-            (128, 64),
-            (256, 32),
-            (512, 32),
-            (1024, 32),
-            (2048, 16),
-            (4096, 8),
-            (8192, 8),
-            (1 << 30, 8),
-        ]
-    target = next(t for ub, t in table if m <= ub)
-    splitk = min(valid, key=lambda s: (abs(math.log(s) - math.log(target)), -s))
+        # the optimum tracks the largest power of two <= 128*num_cu/m; flooring to a
+        # power of two matters (a plain geometric snap overshoots at every m that is
+        # not one, e.g. m=3072 wants 8, not 14)
+        ideal = int(max(1.0, 128.0 * num_cu / m))
+        target = 1 << (ideal.bit_length() - 1)
+    below = [sk for sk in valid if sk <= target]
+    splitk = max(below) if below else min(valid)
+
+    # tile_m. Small m keeps 16: with the pair's shallower split_k the fn-reuse grid no
+    # longer fills the device (this is the opposite of what tuning the gemm alone says).
+    # tile_m=64 pays off (up to 1.07x at m=8192/16384) only where its grid tiles whole
+    # waves exactly; at m=6144 or 12288, where it does not, it loses up to 1.09x.
+    if m <= 1.5 * num_cu:
+        tile_m = 16
+    elif m >= 16 * num_cu and m % 64 == 0 and ((m // 64) * splitk) % num_cu == 0:
+        tile_m = 64
+    else:
+        tile_m = 32
     return splitk, tile_m, tile_n, tile_k
 
 

--- a/aiter/ops/mhc.py
+++ b/aiter/ops/mhc.py
@@ -21,7 +21,7 @@ def mhc_pre_gemm_sqrsum(
     x: Tensor,
     fn: Tensor,
     tile_k: int = 128,  # 64 or 128
-    is_fn_pack_bf16: int = 0,  # 1: fn is pre-packed int32 (hi<<16|lo) from mhc_pre_convert_fn
+    is_res_w_preshuffle_bf16: int = 0,  # 1: fn is pre-packed int32 (hi<<16|lo) from mhc_pre_convert_fn
 ) -> None: ...
 
 
@@ -30,46 +30,6 @@ def mhc_pre_convert_fn(
     fn_packed: Tensor,  # (hc_mult3, hc_hidden_size) int32 out
     fn: Tensor,  # (hc_mult3, hc_hidden_size) fp32 in
 ) -> None: ...
-
-
-@compile_ops("module_mhc", develop=True)
-def mhc_pre_shuffle_fn(
-    fn_shuffled: Tensor,  # (hc_hidden_size // 32, n_pad, 32) out
-    fn: Tensor,  # (hc_mult3, hc_hidden_size) fp32 in
-    is_fn_pack_bf16: int = 0,
-) -> None: ...
-
-
-def mhc_fn_shuffle_n_pad(hc_mult3: int) -> int:
-    """Rows stored per K block by the preshuffled fn layout -- hc_mult3, unpadded.
-
-    Padding up to the tile_n the kernel reads would be real extra read traffic (fn is
-    re-read by every m-block), so the kernel steers the surplus lanes out of bounds
-    instead, which reads 0 exactly as the unshuffled path does.
-    """
-    return hc_mult3
-
-
-def mhc_pre_shuffle_fn_alloc(fn: torch.Tensor, is_fn_pack_bf16: int = 0) -> torch.Tensor:
-    """Allocate + fill the preshuffled fn for the FUSED post_pre gemm.
-
-    ``fn[n][K] -> fnS[K // 32][n][K % 32]``, N zero-padded to a multiple of 32. Pass the
-    result as ``fn`` together with ``fn_n_pad`` to ``mhc_fused_post_pre``. The layout is
-    independent of (tile_m, tile_n, tile_k, warp_size), so one copy serves every config;
-    it does NOT match the unfused ``mhc_pre`` path, which stages fn through LDS.
-    """
-    hc_mult3, hc_hidden_size = fn.shape
-    assert hc_hidden_size % 32 == 0, f"{hc_hidden_size=} must be divisible by 32"
-    n_rows = mhc_fn_shuffle_n_pad(hc_mult3)
-    out = torch.empty(
-        hc_hidden_size // 32,
-        n_rows,
-        32,
-        dtype=dtypes.i32 if is_fn_pack_bf16 else dtypes.fp32,
-        device=fn.device,
-    )
-    mhc_pre_shuffle_fn(out, fn, is_fn_pack_bf16)
-    return out
 
 
 def mhc_pre_convert_fn_ref(fn: torch.Tensor) -> torch.Tensor:
@@ -97,6 +57,7 @@ def mhc_pre_big_fuse(
     hc_sinkhorn_eps: float = 1e-6,
     hc_post_mult_value: float = 1.0,
     sinkhorn_repeat: int = 20,
+    res_preshuffle: int = 0,
 ) -> None: ...
 
 
@@ -117,7 +78,45 @@ def mhc_pre_big_fuse_rmsnorm(
     norm_eps: float = 1e-6,
     hc_post_mult_value: float = 1.0,
     sinkhorn_repeat: int = 20,
+    res_preshuffle: int = 0,
 ) -> None: ...
+
+
+# Pre-shuffled residual layout used by the fused post+pre path when
+# is_res_w_preshuffle_bf16 is set (kernel-side constant: mhc_res_ks).
+#   resS[k // KS][head][row][k % KS]  <-  res[row][head][k]
+# The tensor keeps its (m, hc_mult, hidden_size) shape and element count; only the
+# order of the elements inside the buffer changes. Both the gemm's residual read and
+# its next_residual write use this layout, so it stays internal to a stack of layers:
+# only the first residual in and the last one out need converting.
+MHC_RES_KS = 32
+# ABLATION KNOB: 0 keeps the plain residual layout while leaving the bf16 fn gemm on.
+# Must be kept in lockstep with mhc_res_shuffle in csrc/kernels/mhc_kernels.cu.
+MHC_RES_SHUFFLE = 1
+
+
+def mhc_res_shuffle(residual: torch.Tensor) -> torch.Tensor:
+    """res[row][head][k] -> resS[k//KS][head][row][k%KS], same shape."""
+    m, hc_mult, hidden_size = residual.shape
+    assert hidden_size % MHC_RES_KS == 0
+    return (
+        residual.view(m, hc_mult, hidden_size // MHC_RES_KS, MHC_RES_KS)
+        .permute(2, 1, 0, 3)
+        .contiguous()
+        .view(m, hc_mult, hidden_size)
+    )
+
+
+def mhc_res_unshuffle(shuffled: torch.Tensor) -> torch.Tensor:
+    """Inverse of :func:`mhc_res_shuffle`."""
+    m, hc_mult, hidden_size = shuffled.shape
+    assert hidden_size % MHC_RES_KS == 0
+    return (
+        shuffled.view(hidden_size // MHC_RES_KS, hc_mult, m, MHC_RES_KS)
+        .permute(2, 1, 0, 3)
+        .contiguous()
+        .view(m, hc_mult, hidden_size)
+    )
 
 
 @functools.lru_cache(maxsize=1024)
@@ -355,7 +354,7 @@ def mhc_pre_fake(
     norm_weight: torch.Tensor | None = None,
     norm_eps: float = 1e-6,
     large_m_splitk: bool = False,
-    is_fn_pack_bf16: int = 0,
+    is_res_w_preshuffle_bf16: int = 0,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     m = residual.size(0)
     hc_mult = residual.size(1)
@@ -381,7 +380,7 @@ def mhc_pre(
     norm_weight: torch.Tensor | None = None,
     norm_eps: float = 1e-6,
     large_m_splitk: bool = False,
-    is_fn_pack_bf16: int = 0,  # 1: fn is pre-packed int32 (hi<<16|lo) from mhc_pre_convert_fn
+    is_res_w_preshuffle_bf16: int = 0,  # 1: fn is pre-packed int32 (hi<<16|lo) from mhc_pre_convert_fn
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     m = residual.size(0)
     hc_mult = residual.size(1)
@@ -401,8 +400,8 @@ def mhc_pre(
     )
     out = out_pad[:, :, :hc_mult3]
     sqrsum = torch.empty(selected_splitk, m, dtype=dtypes.fp32, device=device)
-    # is_fn_pack_bf16=1: fn is the pre-packed int32 tensor (bf16 hi/lo MFMA path).
-    mhc_pre_gemm_sqrsum(out, sqrsum, residual, fn, selected_tile_k, is_fn_pack_bf16)
+    # is_res_w_preshuffle_bf16=1: fn is the pre-packed int32 tensor (bf16 hi/lo MFMA path).
+    mhc_pre_gemm_sqrsum(out, sqrsum, residual, fn, selected_tile_k, is_res_w_preshuffle_bf16)
     # out = out.sum(0)
     # sqrsum = sqrsum.sum(0)
 
@@ -478,8 +477,7 @@ def mhc_fused_post_pre_gemm_sqrsum(
     tile_m: int = 16,  # 16, 32 or 64
     tile_n: int = 32,  # 16 or 32
     tile_k: int = 32,  # 32 or 64
-    is_fn_pack_bf16: int = 0,
-    fn_n_pad: int = 0,  # >0: fn is preshuffled (mhc_pre_shuffle_fn_alloc)
+    is_res_w_preshuffle_bf16: int = 0,
 ) -> None: ...
 
 
@@ -499,8 +497,7 @@ def mhc_fused_post_pre_fake(
     norm_weight: torch.Tensor | None = None,
     norm_eps: float = 1e-6,
     force_fused: bool = False,
-    is_fn_pack_bf16: int = 0,
-    fn_n_pad: int = 0,
+    is_res_w_preshuffle_bf16: int = 0,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
     m = layer_input.size(0)
     hc_mult = residual_in.size(1)
@@ -529,7 +526,7 @@ def mhc_fused_post_pre_large_m(
     sinkhorn_repeat: int = 20,
     norm_weight: torch.Tensor | None = None,
     norm_eps: float = 1e-6,
-    is_fn_pack_bf16: int = 0,
+    is_res_w_preshuffle_bf16: int = 0,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
     """gfx950 large-M post+pre (M > 1024): upstream ``mhc_post`` + ``mhc_pre``."""
     m = residual_in.size(0)
@@ -570,7 +567,7 @@ def mhc_fused_post_pre_large_m(
         norm_weight,
         norm_eps,
         large_m_splitk=True,
-        is_fn_pack_bf16=is_fn_pack_bf16,
+        is_res_w_preshuffle_bf16=is_res_w_preshuffle_bf16,
     )
     return post_mix, comb_mix, layer_input_out, next_residual
 
@@ -592,8 +589,7 @@ def mhc_fused_post_pre(
     norm_weight: torch.Tensor | None = None,
     norm_eps: float = 1e-6,
     force_fused: bool = False,
-    is_fn_pack_bf16: int = 0,
-    fn_n_pad: int = 0,
+    is_res_w_preshuffle_bf16: int = 0,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
     """Fused mhc_post + next mhc_pre (HIP), mirroring ``mhc_pre`` with post-step inputs.
 
@@ -619,6 +615,14 @@ def mhc_fused_post_pre(
         "gfx1250": 1024,
     }.get(arch, 1024)
 
+    # The pre-shuffled residual layout is produced and consumed only by
+    # mhc_fused_post_pre_gemm_sqrsum + mhc_pre_big_fuse{,_rmsnorm}. The fallbacks below
+    # go through mhc_post / the large_m kernel, which read res[row][head][k]; feeding
+    # them a shuffled tensor would silently compute garbage, so refuse instead.
+    assert not (is_res_w_preshuffle_bf16 and not force_fused and m >= fused_m_upper_bound), (
+        "is_res_w_preshuffle_bf16 requires the fused path (pass force_fused=True); "
+        f"m={m} >= fused_m_upper_bound={fused_m_upper_bound} would fall back to mhc_post + mhc_pre"
+    )
     if not force_fused and m >= fused_m_upper_bound:
         next_residual = torch.empty_like(residual_in)
         mhc_post(
@@ -640,10 +644,13 @@ def mhc_fused_post_pre(
             sinkhorn_repeat,
             norm_weight,
             norm_eps,
-            is_fn_pack_bf16=is_fn_pack_bf16,
+            is_res_w_preshuffle_bf16=is_res_w_preshuffle_bf16,
         )
         return post_mix, comb_mix, layer_input_out, next_residual
 
+    assert not (
+        is_res_w_preshuffle_bf16 and force_fused and arch == "gfx950" and m > fused_m_upper_bound
+    ), "mhc_fused_post_pre_large_m does not implement the pre-shuffled residual layout"
     if force_fused and arch == "gfx950" and m > fused_m_upper_bound:
         return mhc_fused_post_pre_large_m(
             layer_input,
@@ -660,7 +667,7 @@ def mhc_fused_post_pre(
             sinkhorn_repeat,
             norm_weight,
             norm_eps,
-            is_fn_pack_bf16=is_fn_pack_bf16,
+            is_res_w_preshuffle_bf16=is_res_w_preshuffle_bf16,
         )
 
     assert layer_input.shape == (
@@ -672,26 +679,11 @@ def mhc_fused_post_pre(
         f"got {tuple(residual_in.shape)}"
     )
     hc_hidden_size = hc_mult * hidden_size
-    if fn_n_pad:
-        # Preshuffled fn: (hc_hidden_size // 32, fn_n_pad, 32); hc_mult3 is no longer a
-        # dimension of it, so derive it from hc_mult (the plain-layout branch derives it
-        # from fn.size(0) and asserts the same identity).
-        hc_mult3 = hc_mult * 2 + hc_mult * hc_mult
-        assert fn.shape == (
-            hc_hidden_size // 32,
-            fn_n_pad,
-            32,
-        ), (
-            f"preshuffled fn shape mismatch: expected ({hc_hidden_size // 32}, "
-            f"{fn_n_pad}, 32), got {tuple(fn.shape)}"
-        )
-        assert fn_n_pad == hc_mult3
-    else:
-        hc_mult3 = fn.size(0)
-        assert hc_mult3 == hc_mult * 2 + hc_mult * hc_mult or (
-            hc_mult3 == hc_mult and sinkhorn_repeat == 0
-        )
-        assert fn.size(1) == hc_hidden_size
+    hc_mult3 = fn.size(0)
+    assert hc_mult3 == hc_mult * 2 + hc_mult * hc_mult or (
+        hc_mult3 == hc_mult and sinkhorn_repeat == 0
+    )
+    assert fn.size(1) == hc_hidden_size
 
     if post_layer_mix.ndim == 3:
         post_layer_mix = post_layer_mix.squeeze(-1)
@@ -729,8 +721,7 @@ def mhc_fused_post_pre(
         selected_tile_m,
         selected_tile_n,
         selected_tile_k,
-        is_fn_pack_bf16,
-        fn_n_pad,
+        is_res_w_preshuffle_bf16,
     )
 
     post_mix = torch.empty(m, hc_mult, 1, dtype=dtypes.fp32, device=device)
@@ -753,6 +744,7 @@ def mhc_fused_post_pre(
             norm_eps,
             hc_post_mult_value,
             sinkhorn_repeat,
+            res_preshuffle=is_res_w_preshuffle_bf16 and MHC_RES_SHUFFLE,
         )
     else:
         mhc_pre_big_fuse(
@@ -769,6 +761,7 @@ def mhc_fused_post_pre(
             hc_sinkhorn_eps,
             hc_post_mult_value,
             sinkhorn_repeat,
+            res_preshuffle=is_res_w_preshuffle_bf16 and MHC_RES_SHUFFLE,
         )
 
     return post_mix, comb_mix, layer_input_out, next_residual

--- a/aiter/ops/mhc.py
+++ b/aiter/ops/mhc.py
@@ -314,6 +314,7 @@ def mhc_pre_fake(
     sinkhorn_repeat: int = 20,  # if 0, only do pre for hc_head
     norm_weight: torch.Tensor | None = None,
     norm_eps: float = 1e-6,
+    large_m_splitk: bool = False,
     is_fn_pack_bf16: int = 0,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     m = residual.size(0)

--- a/aiter/ops/mhc.py
+++ b/aiter/ops/mhc.py
@@ -32,6 +32,46 @@ def mhc_pre_convert_fn(
 ) -> None: ...
 
 
+@compile_ops("module_mhc", develop=True)
+def mhc_pre_shuffle_fn(
+    fn_shuffled: Tensor,  # (hc_hidden_size // 32, n_pad, 32) out
+    fn: Tensor,  # (hc_mult3, hc_hidden_size) fp32 in
+    is_fn_pack_bf16: int = 0,
+) -> None: ...
+
+
+def mhc_fn_shuffle_n_pad(hc_mult3: int) -> int:
+    """Rows stored per K block by the preshuffled fn layout -- hc_mult3, unpadded.
+
+    Padding up to the tile_n the kernel reads would be real extra read traffic (fn is
+    re-read by every m-block), so the kernel steers the surplus lanes out of bounds
+    instead, which reads 0 exactly as the unshuffled path does.
+    """
+    return hc_mult3
+
+
+def mhc_pre_shuffle_fn_alloc(fn: torch.Tensor, is_fn_pack_bf16: int = 0) -> torch.Tensor:
+    """Allocate + fill the preshuffled fn for the FUSED post_pre gemm.
+
+    ``fn[n][K] -> fnS[K // 32][n][K % 32]``, N zero-padded to a multiple of 32. Pass the
+    result as ``fn`` together with ``fn_n_pad`` to ``mhc_fused_post_pre``. The layout is
+    independent of (tile_m, tile_n, tile_k, warp_size), so one copy serves every config;
+    it does NOT match the unfused ``mhc_pre`` path, which stages fn through LDS.
+    """
+    hc_mult3, hc_hidden_size = fn.shape
+    assert hc_hidden_size % 32 == 0, f"{hc_hidden_size=} must be divisible by 32"
+    n_rows = mhc_fn_shuffle_n_pad(hc_mult3)
+    out = torch.empty(
+        hc_hidden_size // 32,
+        n_rows,
+        32,
+        dtype=dtypes.i32 if is_fn_pack_bf16 else dtypes.fp32,
+        device=fn.device,
+    )
+    mhc_pre_shuffle_fn(out, fn, is_fn_pack_bf16)
+    return out
+
+
 def mhc_pre_convert_fn_ref(fn: torch.Tensor) -> torch.Tensor:
     """Torch equivalent of the HIP ``mhc_pre_convert_fn`` kernel: pack fp32 fn into
     int32 dwords (hi = bf16(fn) in [31:16], lo = bf16(fn - fp32(hi)) in [15:0])."""
@@ -439,6 +479,7 @@ def mhc_fused_post_pre_gemm_sqrsum(
     tile_n: int = 32,  # 16 or 32
     tile_k: int = 32,  # 32 or 64
     is_fn_pack_bf16: int = 0,
+    fn_n_pad: int = 0,  # >0: fn is preshuffled (mhc_pre_shuffle_fn_alloc)
 ) -> None: ...
 
 
@@ -459,6 +500,7 @@ def mhc_fused_post_pre_fake(
     norm_eps: float = 1e-6,
     force_fused: bool = False,
     is_fn_pack_bf16: int = 0,
+    fn_n_pad: int = 0,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
     m = layer_input.size(0)
     hc_mult = residual_in.size(1)
@@ -551,6 +593,7 @@ def mhc_fused_post_pre(
     norm_eps: float = 1e-6,
     force_fused: bool = False,
     is_fn_pack_bf16: int = 0,
+    fn_n_pad: int = 0,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
     """Fused mhc_post + next mhc_pre (HIP), mirroring ``mhc_pre`` with post-step inputs.
 
@@ -628,12 +671,27 @@ def mhc_fused_post_pre(
         f"residual_in shape mismatch: expected ({m}, {hc_mult}, {hidden_size}), "
         f"got {tuple(residual_in.shape)}"
     )
-    hc_mult3 = fn.size(0)
-    assert hc_mult3 == hc_mult * 2 + hc_mult * hc_mult or (
-        hc_mult3 == hc_mult and sinkhorn_repeat == 0
-    )
     hc_hidden_size = hc_mult * hidden_size
-    assert fn.size(1) == hc_hidden_size
+    if fn_n_pad:
+        # Preshuffled fn: (hc_hidden_size // 32, fn_n_pad, 32); hc_mult3 is no longer a
+        # dimension of it, so derive it from hc_mult (the plain-layout branch derives it
+        # from fn.size(0) and asserts the same identity).
+        hc_mult3 = hc_mult * 2 + hc_mult * hc_mult
+        assert fn.shape == (
+            hc_hidden_size // 32,
+            fn_n_pad,
+            32,
+        ), (
+            f"preshuffled fn shape mismatch: expected ({hc_hidden_size // 32}, "
+            f"{fn_n_pad}, 32), got {tuple(fn.shape)}"
+        )
+        assert fn_n_pad == hc_mult3
+    else:
+        hc_mult3 = fn.size(0)
+        assert hc_mult3 == hc_mult * 2 + hc_mult * hc_mult or (
+            hc_mult3 == hc_mult and sinkhorn_repeat == 0
+        )
+        assert fn.size(1) == hc_hidden_size
 
     if post_layer_mix.ndim == 3:
         post_layer_mix = post_layer_mix.squeeze(-1)
@@ -672,6 +730,7 @@ def mhc_fused_post_pre(
         selected_tile_n,
         selected_tile_k,
         is_fn_pack_bf16,
+        fn_n_pad,
     )
 
     post_mix = torch.empty(m, hc_mult, 1, dtype=dtypes.fp32, device=device)

--- a/aiter/ops/mhc.py
+++ b/aiter/ops/mhc.py
@@ -120,11 +120,24 @@ def mhc_res_unshuffle(shuffled: torch.Tensor) -> torch.Tensor:
 
 
 @functools.lru_cache(maxsize=1024)
-def get_mhc_pre_splitk(m: int, hc_hidden_size: int) -> tuple[int, int]:
+def get_mhc_pre_splitk(
+    m: int, hc_hidden_size: int, is_w_preshuffle_bf16: bool = False
+) -> tuple[int, int]:
     prefetch_stages = 2
     tile_m = 16 * 4
     num_cu = get_cu_num()
     arch = get_gfx_runtime()
+    # Vector LDS weight reads shorten the gfx1250 BF16 loop. More split-K
+    # workgroups improve latency hiding for large M without changing FP32 tuning.
+    prefill_tg_factor = (
+        8
+        if is_w_preshuffle_bf16
+        and arch == "gfx1250"
+        and num_cu == 256
+        and m >= 2048
+        and hc_hidden_size in (4 * 4096, 4 * 7168)
+        else 4
+    )
     tile_k_tg_dict = (
         {
             128: 2 * num_cu,
@@ -132,7 +145,7 @@ def get_mhc_pre_splitk(m: int, hc_hidden_size: int) -> tuple[int, int]:
         }
         if arch.startswith("gfx9")
         else {
-            64: 4 * num_cu,
+            64: prefill_tg_factor * num_cu,
         }
     )
     selected_splitk = 1
@@ -412,10 +425,16 @@ def mhc_pre(
         hc_mult3 == hc_mult and sinkhorn_repeat == 0
     )
     hc_hidden_size = hc_mult * hidden_size
+    # The tuned packed-weight policy targets the standard four-stream pre GEMM.
+    packed_config = bool(is_w_preshuffle_bf16) and hc_mult == 4 and hc_mult3 == 24
     if large_m_splitk:
-        selected_splitk, selected_tile_k = get_mhc_pre_splitk_large_m(m, hc_hidden_size)
+        selected_splitk, selected_tile_k = get_mhc_pre_splitk_large_m(
+            m, hc_hidden_size, is_w_preshuffle_bf16=packed_config
+        )
     else:
-        selected_splitk, selected_tile_k = get_mhc_pre_splitk(m, hc_hidden_size)
+        selected_splitk, selected_tile_k = get_mhc_pre_splitk(
+            m, hc_hidden_size, is_w_preshuffle_bf16=packed_config
+        )
     device = residual.device
     out_pad = torch.empty(
         selected_splitk, m, (hc_mult3 + 31) // 32 * 32, dtype=dtypes.fp32, device=device
@@ -486,11 +505,15 @@ def mhc_post(
 ) -> None: ...
 
 
-def get_mhc_pre_splitk_large_m(m: int, hc_hidden_size: int) -> tuple[int, int]:
+def get_mhc_pre_splitk_large_m(
+    m: int, hc_hidden_size: int, is_w_preshuffle_bf16: bool = False
+) -> tuple[int, int]:
     """Split-K policy for gfx950 large-M post_pre kernel (M > 1024)."""
     if get_gfx_runtime() == "gfx950" and m >= 8192 and hc_hidden_size % (8 * 64) == 0:
         return 8, 64
-    return get_mhc_pre_splitk(m, hc_hidden_size)
+    return get_mhc_pre_splitk(
+        m, hc_hidden_size, is_w_preshuffle_bf16=is_w_preshuffle_bf16
+    )
 
 
 @compile_ops("module_mhc", develop=True)

--- a/aiter/ops/mhc.py
+++ b/aiter/ops/mhc.py
@@ -21,7 +21,7 @@ def mhc_pre_gemm_sqrsum(
     x: Tensor,
     fn: Tensor,
     tile_k: int = 128,  # 64 or 128
-    is_res_w_preshuffle_bf16: int = 0,  # 1: fn is pre-packed int32 (hi<<16|lo) from mhc_pre_convert_fn
+    is_w_preshuffle_bf16: int = 0,  # 1: fn is pre-packed BF16 hi/lo from mhc_pre_convert_fn
 ) -> None: ...
 
 
@@ -332,12 +332,13 @@ _MHC_FUSED_POST_PRE_CONFIG = {
 
 @functools.lru_cache(maxsize=1024)
 def get_mhc_fused_post_pre_config(
-    m: int, hidden_size: int
+    m: int, hidden_size: int, is_res_w_preshuffle_bf16: bool = False
 ) -> tuple[int, int, int, int]:
     """Select (split_k, tile_m, tile_n, tile_k) for the fused post+pre GEMM.
 
     Looks up a per-chip tuned policy keyed by (gfx_arch, cu_num); falls back to a
-    conservative default for untuned chips. K = hidden_size per stream.
+    conservative default for untuned chips. Packed BF16 decode uses a separate
+    adjustment for the direct-store pipeline. K = hidden_size per stream.
     """
     num_cu = get_cu_num()
     try:
@@ -345,7 +346,21 @@ def get_mhc_fused_post_pre_config(
     except Exception:  # noqa: BLE001
         arch = "unknown"
     policy = _MHC_FUSED_POST_PRE_CONFIG.get((arch, num_cu), _mhc_fused_config_default)
-    return policy(m, hidden_size, num_cu)
+    split_k, tile_m, tile_n, tile_k = policy(m, hidden_size, num_cu)
+    if (
+        is_res_w_preshuffle_bf16
+        and MHC_RES_SHUFFLE
+        and arch == "gfx1250"
+        and num_cu == 256
+        and 1 <= m <= 1024
+    ):
+        # Direct residual stores change the best GEMM + reduction configuration.
+        # Keep the packed decode policy separate from FP32 and prefill tuning.
+        if hidden_size == 7168 and 512 < m <= 768:
+            tile_m = 16
+        elif hidden_size == 4096 and 960 < m:
+            split_k = 16
+    return split_k, tile_m, tile_n, tile_k
 
 
 def mhc_pre_fake(
@@ -361,7 +376,7 @@ def mhc_pre_fake(
     norm_weight: torch.Tensor | None = None,
     norm_eps: float = 1e-6,
     large_m_splitk: bool = False,
-    is_res_w_preshuffle_bf16: int = 0,
+    is_w_preshuffle_bf16: int = 0,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     m = residual.size(0)
     hc_mult = residual.size(1)
@@ -387,7 +402,7 @@ def mhc_pre(
     norm_weight: torch.Tensor | None = None,
     norm_eps: float = 1e-6,
     large_m_splitk: bool = False,
-    is_res_w_preshuffle_bf16: int = 0,  # 1: fn is pre-packed int32 (hi<<16|lo) from mhc_pre_convert_fn
+    is_w_preshuffle_bf16: int = 0,  # 1: fn is pre-packed BF16 hi/lo from mhc_pre_convert_fn
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     m = residual.size(0)
     hc_mult = residual.size(1)
@@ -407,8 +422,15 @@ def mhc_pre(
     )
     out = out_pad[:, :, :hc_mult3]
     sqrsum = torch.empty(selected_splitk, m, dtype=dtypes.fp32, device=device)
-    # is_res_w_preshuffle_bf16=1: fn is the pre-packed int32 tensor (bf16 hi/lo MFMA path).
-    mhc_pre_gemm_sqrsum(out, sqrsum, residual, fn, selected_tile_k, is_res_w_preshuffle_bf16)
+    # The flag selects packed weights and BF16 compute; residual keeps its plain layout.
+    mhc_pre_gemm_sqrsum(
+        out,
+        sqrsum,
+        residual,
+        fn,
+        selected_tile_k,
+        is_w_preshuffle_bf16=is_w_preshuffle_bf16,
+    )
     # out = out.sum(0)
     # sqrsum = sqrsum.sum(0)
 
@@ -574,7 +596,7 @@ def mhc_fused_post_pre_large_m(
         norm_weight,
         norm_eps,
         large_m_splitk=True,
-        is_res_w_preshuffle_bf16=is_res_w_preshuffle_bf16,
+        is_w_preshuffle_bf16=is_res_w_preshuffle_bf16,
     )
     return post_mix, comb_mix, layer_input_out, next_residual
 
@@ -651,7 +673,7 @@ def mhc_fused_post_pre(
             sinkhorn_repeat,
             norm_weight,
             norm_eps,
-            is_res_w_preshuffle_bf16=is_res_w_preshuffle_bf16,
+            is_w_preshuffle_bf16=is_res_w_preshuffle_bf16,
         )
         return post_mix, comb_mix, layer_input_out, next_residual
 
@@ -704,7 +726,9 @@ def mhc_fused_post_pre(
     )
 
     selected_splitk, selected_tile_m, selected_tile_n, selected_tile_k = (
-        get_mhc_fused_post_pre_config(m, hidden_size)
+        get_mhc_fused_post_pre_config(
+            m, hidden_size, is_res_w_preshuffle_bf16=bool(is_res_w_preshuffle_bf16)
+        )
     )
     n_splits = selected_splitk
     device = layer_input.device

--- a/aiter/ops/mhc.py
+++ b/aiter/ops/mhc.py
@@ -484,7 +484,7 @@ def mhc_pre_fake(
     return post_mix, comb_mix, layer_input
 
 
-@torch_compile_guard(gen_fake=mhc_pre_fake)
+@torch_compile_guard(mutates_args=[], gen_fake=mhc_pre_fake)
 def mhc_pre(
     residual: torch.Tensor,
     fn: torch.Tensor,
@@ -647,7 +647,7 @@ def mhc_fused_post_pre_fake(
     return post_mix, comb_mix, layer_input_out, next_residual
 
 
-@torch_compile_guard(gen_fake=mhc_fused_post_pre_fake)
+@torch_compile_guard(mutates_args=[], gen_fake=mhc_fused_post_pre_fake)
 def mhc_fused_post_pre_large_m(
     layer_input: torch.Tensor,
     residual_in: torch.Tensor,
@@ -715,7 +715,7 @@ def mhc_fused_post_pre_large_m(
     return post_mix, comb_mix, layer_input_out, next_residual
 
 
-@torch_compile_guard(gen_fake=mhc_fused_post_pre_fake)
+@torch_compile_guard(mutates_args=[], gen_fake=mhc_fused_post_pre_fake)
 def mhc_fused_post_pre(
     layer_input: torch.Tensor,
     residual_in: torch.Tensor,

--- a/aiter/ops/mhc.py
+++ b/aiter/ops/mhc.py
@@ -32,14 +32,56 @@ def mhc_pre_convert_fn(
 ) -> None: ...
 
 
-def mhc_pre_convert_fn_ref(fn: torch.Tensor) -> torch.Tensor:
-    """Torch equivalent of the HIP ``mhc_pre_convert_fn`` kernel: pack fp32 fn into
-    int32 dwords (hi = bf16(fn) in [31:16], lo = bf16(fn - fp32(hi)) in [15:0])."""
+def mhc_fn_kb(arch: str | None = None) -> int:
+    """k elements per hi/lo interleave block in the packed BF16 ``fn`` layout.
+
+    A lane's fn fragment must cover a whole block, i.e.
+    ``vec_tile = tile_k / (warp_size / 16) >= kb``. wave32 reaches 16 at tile_k=32
+    and its WMMA path consumes a whole 16-float block as two verbatim fragments;
+    wave64 only reaches 8 there, so it uses 8-element blocks and keeps tile_k=32.
+
+    MUST stay in lockstep with ``mhc_fn_kb`` in csrc/kernels/mhc_kernels.cu.
+    """
+    if arch is None:
+        arch = get_gfx_runtime()
+    return 16 if arch == "gfx1250" else 8
+
+
+def mhc_shuffle_fn(fn: torch.Tensor, arch: str | None = None) -> torch.Tensor:
+    """Pack FP32 ``fn`` into the layout the ``w_preshuffle_bf16`` GEMM reads.
+
+    Each FP32 weight is split into ``hi = bf16(fn)`` and ``lo = bf16(fn - fp32(hi))``;
+    bf16 shares fp32's 8-bit exponent, so ``lo`` keeps its magnitude and
+    ``hi*x + lo*x`` reconstructs the FP32 product at BF16 MFMA rate.
+
+    The pair is stored block-interleaved. Viewing the (hc_mult3, hc_hidden_size) int32
+    output as uint16, for ``kb = mhc_fn_kb()``::
+
+        hi(k) at  row * 2 * hc_hidden_size + (k // kb) * 2 * kb + (k % kb)
+        lo(k) at  the same index + kb
+
+    so one block of ``kb`` consecutive k occupies ``kb`` floats -- hi in the first
+    half, lo in the second. Element count and row stride are unchanged.
+
+    ``arch`` defaults to the runtime GPU. Pass it explicitly only to build a layout
+    for a different target than the one this process is running on.
+    """
+    assert fn.dtype == torch.float32, f"fn must be fp32, got {fn.dtype}"
+    kb = mhc_fn_kb(arch)
+    n_row, k = fn.shape
+    assert k % kb == 0, f"hc_hidden_size {k} must be divisible by mhc_fn_kb {kb}"
+    fn = fn.contiguous()
     hi = fn.to(torch.bfloat16)
     lo = (fn - hi.to(torch.float32)).to(torch.bfloat16)
-    hi_bits = hi.view(torch.int16).to(torch.int32) & 0xFFFF
-    lo_bits = lo.view(torch.int16).to(torch.int32) & 0xFFFF
-    return ((hi_bits << 16) | lo_bits).to(torch.int32).contiguous()
+    out16 = torch.empty(n_row, 2 * k, dtype=torch.int16, device=fn.device)
+    blocks = out16.view(n_row, k // kb, 2, kb)
+    blocks[:, :, 0, :] = hi.view(torch.int16).view(n_row, k // kb, kb)
+    blocks[:, :, 1, :] = lo.view(torch.int16).view(n_row, k // kb, kb)
+    return out16.view(torch.int32)
+
+
+# Back-compat name; the HIP kernel and this must produce identical bytes.
+mhc_pre_convert_fn_ref = mhc_shuffle_fn
 
 
 @compile_ops("module_mhc", develop=True)

--- a/aiter/ops/mhc.py
+++ b/aiter/ops/mhc.py
@@ -21,7 +21,7 @@ def mhc_pre_gemm_sqrsum(
     x: Tensor,
     fn: Tensor,
     tile_k: int = 128,  # 64 or 128
-    is_w_preshuffle_bf16: int = 0,  # 1: fn is pre-packed BF16 hi/lo from mhc_pre_convert_fn
+    w_preshuffle_bf16: int = 0,  # 1: fn is pre-packed BF16 hi/lo from mhc_pre_convert_fn
 ) -> None: ...
 
 
@@ -82,17 +82,22 @@ def mhc_pre_big_fuse_rmsnorm(
 ) -> None: ...
 
 
-# Pre-shuffled residual layout used by the fused post+pre path when
-# is_res_w_preshuffle_bf16 is set (kernel-side constant: mhc_res_ks).
+# Pre-shuffled residual layout selected independently with res_preshuffle=1
+# (kernel-side tile width: mhc_res_ks).
 #   resS[k // KS][head][row][k % KS]  <-  res[row][head][k]
 # The tensor keeps its (m, hc_mult, hidden_size) shape and element count; only the
 # order of the elements inside the buffer changes. Both the gemm's residual read and
 # its next_residual write use this layout, so it stays internal to a stack of layers:
 # only the first residual in and the last one out need converting.
 MHC_RES_KS = 32
-# ABLATION KNOB: 0 keeps the plain residual layout while leaving the bf16 fn gemm on.
-# Must be kept in lockstep with mhc_res_shuffle in csrc/kernels/mhc_kernels.cu.
-MHC_RES_SHUFFLE = 1
+
+
+def _check_mhc_res_preshuffle_arch(shuffled: bool, arch: str) -> None:
+    if shuffled and arch != "gfx1250":
+        raise ValueError(
+            f"res_preshuffle=1 is only supported on gfx1250, got {arch}; "
+            "use res_preshuffle=0 (BF16 compute is controlled independently)"
+        )
 
 
 def mhc_res_shuffle(residual: torch.Tensor) -> torch.Tensor:
@@ -121,7 +126,7 @@ def mhc_res_unshuffle(shuffled: torch.Tensor) -> torch.Tensor:
 
 @functools.lru_cache(maxsize=1024)
 def get_mhc_pre_splitk(
-    m: int, hc_hidden_size: int, is_w_preshuffle_bf16: bool = False
+    m: int, hc_hidden_size: int, w_preshuffle_bf16: bool = False
 ) -> tuple[int, int]:
     prefetch_stages = 2
     tile_m = 16 * 4
@@ -131,7 +136,7 @@ def get_mhc_pre_splitk(
     # workgroups improve latency hiding for large M without changing FP32 tuning.
     prefill_tg_factor = (
         8
-        if is_w_preshuffle_bf16
+        if w_preshuffle_bf16
         and arch == "gfx1250"
         and num_cu == 256
         and m >= 2048
@@ -292,6 +297,34 @@ def _mhc_fused_config_gfx1250_256(m, hidden_size, num_cu):
     return splitk, tile_m, tile_n, tile_k
 
 
+def _mhc_fused_bf16_shuffled_config_gfx1250_256(m, hidden_size, config):
+    """GEMM + RMSNorm reduction tuning for packed weights and shuffled residuals.
+
+    Measured on gfx1250/256 CU for N=4096/7168. Keep the prior policy for
+    unaligned/tail shapes; the tuned ranges cover M=32..16384 in steps of 32.
+    Plain residuals and FP32 GEMM retain their independent existing policy.
+    """
+    if hidden_size not in (4096, 7168) or not 32 <= m <= 16384 or m % 32:
+        return config
+    split_k, tile_m, tile_n, tile_k = config
+    if hidden_size == 7168:
+        if m <= 96:
+            split_k, tile_m = 112, 16
+        elif m <= 256:
+            split_k, tile_m = 112, 32
+        elif m <= 384 or 512 < m <= 640:
+            split_k, tile_m = 56, 32
+        elif 640 < m <= 1024:
+            # The direct-store pipeline favors tile_m=32 in this range.
+            split_k, tile_m = 32, 32
+    elif 128 < m <= 384 or 512 < m <= 640:
+        split_k, tile_m = 64, 32
+    # Extend tile_m=64 to M>=2048 only when the grid fills whole CU waves.
+    if m >= 2048 and m % 64 == 0 and ((m // 64) * split_k) % 256 == 0:
+        tile_m = 64
+    return split_k, tile_m, tile_n, tile_k
+
+
 def _mhc_fused_config_default(m, hidden_size, num_cu):
     """Generic fallback for untuned chips: pick (split_k, tile_k) by the occupancy
     scoring search (how many thread-groups fit vs. how many the device can run at
@@ -345,24 +378,28 @@ _MHC_FUSED_POST_PRE_CONFIG = {
 
 @functools.lru_cache(maxsize=1024)
 def get_mhc_fused_post_pre_config(
-    m: int, hidden_size: int, is_res_w_preshuffle_bf16: bool = False
+    m: int,
+    hidden_size: int,
+    w_preshuffle_bf16: bool = False,
+    res_preshuffle: bool = False,
 ) -> tuple[int, int, int, int]:
     """Select (split_k, tile_m, tile_n, tile_k) for the fused post+pre GEMM.
 
     Looks up a per-chip tuned policy keyed by (gfx_arch, cu_num); falls back to a
-    conservative default for untuned chips. Packed BF16 decode uses a separate
-    adjustment for the direct-store pipeline. K = hidden_size per stream.
+    conservative default for untuned chips. Packed BF16 with shuffled residuals
+    has separate GEMM + reduction tuning. K = hidden_size per stream.
     """
     num_cu = get_cu_num()
     try:
         arch = get_gfx_runtime()
     except Exception:  # noqa: BLE001
         arch = "unknown"
+    _check_mhc_res_preshuffle_arch(res_preshuffle, arch)
     policy = _MHC_FUSED_POST_PRE_CONFIG.get((arch, num_cu), _mhc_fused_config_default)
     split_k, tile_m, tile_n, tile_k = policy(m, hidden_size, num_cu)
     if (
-        is_res_w_preshuffle_bf16
-        and MHC_RES_SHUFFLE
+        w_preshuffle_bf16
+        and res_preshuffle
         and arch == "gfx1250"
         and num_cu == 256
         and 1 <= m <= 1024
@@ -373,6 +410,10 @@ def get_mhc_fused_post_pre_config(
             tile_m = 16
         elif hidden_size == 4096 and 960 < m:
             split_k = 16
+    if w_preshuffle_bf16 and res_preshuffle and arch == "gfx1250" and num_cu == 256:
+        return _mhc_fused_bf16_shuffled_config_gfx1250_256(
+            m, hidden_size, (split_k, tile_m, tile_n, tile_k)
+        )
     return split_k, tile_m, tile_n, tile_k
 
 
@@ -389,7 +430,7 @@ def mhc_pre_fake(
     norm_weight: torch.Tensor | None = None,
     norm_eps: float = 1e-6,
     large_m_splitk: bool = False,
-    is_w_preshuffle_bf16: int = 0,
+    w_preshuffle_bf16: int = 0,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     m = residual.size(0)
     hc_mult = residual.size(1)
@@ -415,7 +456,7 @@ def mhc_pre(
     norm_weight: torch.Tensor | None = None,
     norm_eps: float = 1e-6,
     large_m_splitk: bool = False,
-    is_w_preshuffle_bf16: int = 0,  # 1: fn is pre-packed BF16 hi/lo from mhc_pre_convert_fn
+    w_preshuffle_bf16: int = 0,  # 1: fn is pre-packed BF16 hi/lo from mhc_pre_convert_fn
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     m = residual.size(0)
     hc_mult = residual.size(1)
@@ -426,14 +467,14 @@ def mhc_pre(
     )
     hc_hidden_size = hc_mult * hidden_size
     # The tuned packed-weight policy targets the standard four-stream pre GEMM.
-    packed_config = bool(is_w_preshuffle_bf16) and hc_mult == 4 and hc_mult3 == 24
+    packed_config = bool(w_preshuffle_bf16) and hc_mult == 4 and hc_mult3 == 24
     if large_m_splitk:
         selected_splitk, selected_tile_k = get_mhc_pre_splitk_large_m(
-            m, hc_hidden_size, is_w_preshuffle_bf16=packed_config
+            m, hc_hidden_size, w_preshuffle_bf16=packed_config
         )
     else:
         selected_splitk, selected_tile_k = get_mhc_pre_splitk(
-            m, hc_hidden_size, is_w_preshuffle_bf16=packed_config
+            m, hc_hidden_size, w_preshuffle_bf16=packed_config
         )
     device = residual.device
     out_pad = torch.empty(
@@ -448,7 +489,7 @@ def mhc_pre(
         residual,
         fn,
         selected_tile_k,
-        is_w_preshuffle_bf16=is_w_preshuffle_bf16,
+        w_preshuffle_bf16=w_preshuffle_bf16,
     )
     # out = out.sum(0)
     # sqrsum = sqrsum.sum(0)
@@ -506,13 +547,13 @@ def mhc_post(
 
 
 def get_mhc_pre_splitk_large_m(
-    m: int, hc_hidden_size: int, is_w_preshuffle_bf16: bool = False
+    m: int, hc_hidden_size: int, w_preshuffle_bf16: bool = False
 ) -> tuple[int, int]:
     """Split-K policy for gfx950 large-M post_pre kernel (M > 1024)."""
     if get_gfx_runtime() == "gfx950" and m >= 8192 and hc_hidden_size % (8 * 64) == 0:
         return 8, 64
     return get_mhc_pre_splitk(
-        m, hc_hidden_size, is_w_preshuffle_bf16=is_w_preshuffle_bf16
+        m, hc_hidden_size, w_preshuffle_bf16=w_preshuffle_bf16
     )
 
 
@@ -529,7 +570,8 @@ def mhc_fused_post_pre_gemm_sqrsum(
     tile_m: int = 16,  # 16, 32 or 64
     tile_n: int = 32,  # 16 or 32
     tile_k: int = 32,  # 32 or 64
-    is_res_w_preshuffle_bf16: int = 0,
+    w_preshuffle_bf16: int = 0,  # 0: FP32; 1: packed BF16 hi/lo
+    res_preshuffle: int = 0,  # 0: plain; 1: shuffled residual (gfx1250 only)
 ) -> None: ...
 
 
@@ -549,7 +591,8 @@ def mhc_fused_post_pre_fake(
     norm_weight: torch.Tensor | None = None,
     norm_eps: float = 1e-6,
     force_fused: bool = False,
-    is_res_w_preshuffle_bf16: int = 0,
+    w_preshuffle_bf16: bool = False,  # True: packed BF16 hi/lo
+    res_preshuffle: bool = False,  # True: shuffled residual (gfx1250 only)
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
     m = layer_input.size(0)
     hc_mult = residual_in.size(1)
@@ -578,9 +621,15 @@ def mhc_fused_post_pre_large_m(
     sinkhorn_repeat: int = 20,
     norm_weight: torch.Tensor | None = None,
     norm_eps: float = 1e-6,
-    is_res_w_preshuffle_bf16: int = 0,
+    w_preshuffle_bf16: bool = False,  # True: packed BF16 hi/lo
+    res_preshuffle: bool = False,  # plain residuals only for this entry point
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
     """gfx950 large-M post+pre (M > 1024): upstream ``mhc_post`` + ``mhc_pre``."""
+    if res_preshuffle:
+        raise ValueError(
+            "mhc_fused_post_pre_large_m requires res_preshuffle=0; "
+            "shuffled residuals require mhc_fused_post_pre on gfx1250"
+        )
     m = residual_in.size(0)
 
     if post_layer_mix.ndim == 3 or not post_layer_mix.is_contiguous():
@@ -619,7 +668,7 @@ def mhc_fused_post_pre_large_m(
         norm_weight,
         norm_eps,
         large_m_splitk=True,
-        is_w_preshuffle_bf16=is_res_w_preshuffle_bf16,
+        w_preshuffle_bf16=int(w_preshuffle_bf16),
     )
     return post_mix, comb_mix, layer_input_out, next_residual
 
@@ -641,7 +690,8 @@ def mhc_fused_post_pre(
     norm_weight: torch.Tensor | None = None,
     norm_eps: float = 1e-6,
     force_fused: bool = False,
-    is_res_w_preshuffle_bf16: int = 0,
+    w_preshuffle_bf16: bool = False,  # True: packed BF16 hi/lo
+    res_preshuffle: bool = False,  # True: shuffled residual (gfx1250 only)
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
     """Fused mhc_post + next mhc_pre (HIP), mirroring ``mhc_pre`` with post-step inputs.
 
@@ -653,29 +703,34 @@ def mhc_fused_post_pre(
     Returns ``(post_mix, comb_mix, layer_input_out, next_residual)`` -- next pre mixes,
     folded layer input, and the new residual stream for the following layer's post.
 
-    ``force_fused``: when True, always use the fused HIP kernel. When False (default),
-    use the fused path only for smaller ``m`` (threshold depends on the detected GPU arch);
-    larger ``m`` falls back to the unfused ``mhc_post`` + ``mhc_pre`` path.
+    ``force_fused``: when True, select the fused HIP path, except for the existing
+    gfx950 large-M post+pre specialization with plain residuals. When False
+    (default), larger ``m`` with plain residuals falls back to ``mhc_post`` +
+    ``mhc_pre`` (threshold depends on the detected GPU arch).
+    Shuffled residuals always use the fused kernel, which understands that layout.
+
+    ``w_preshuffle_bf16=True`` selects BF16 hi/lo compute and requires ``fn`` from
+    ``mhc_pre_convert_fn``. ``res_preshuffle=True`` independently declares that
+    ``residual_in`` is shuffled (gfx1250 only); ``next_residual`` uses the same
+    layout. Neither flag converts inputs. For BF16 with plain residuals, pass
+    ``w_preshuffle_bf16=True, res_preshuffle=False``.
+
+    Both flags are boolean, default to False, and are controlled independently.
     """
     m = layer_input.size(0)
     hc_mult = residual_in.size(1)
     hidden_size = residual_in.size(2)
     arch = get_gfx_runtime()
+    _check_mhc_res_preshuffle_arch(res_preshuffle, arch)
     fused_m_upper_bound = {
         "gfx950": 1024,
         "gfx942": 128,
         "gfx1250": 1024,
     }.get(arch, 1024)
 
-    # The pre-shuffled residual layout is produced and consumed only by
-    # mhc_fused_post_pre_gemm_sqrsum + mhc_pre_big_fuse{,_rmsnorm}. The fallbacks below
-    # go through mhc_post / the large_m kernel, which read res[row][head][k]; feeding
-    # them a shuffled tensor would silently compute garbage, so refuse instead.
-    assert not (is_res_w_preshuffle_bf16 and not force_fused and m >= fused_m_upper_bound), (
-        "is_res_w_preshuffle_bf16 requires the fused path (pass force_fused=True); "
-        f"m={m} >= fused_m_upper_bound={fused_m_upper_bound} would fall back to mhc_post + mhc_pre"
-    )
-    if not force_fused and m >= fused_m_upper_bound:
+    # Plain post/pre fallbacks cannot consume shuffled buffers. BF16 arithmetic
+    # itself is supported by both paths and must not prevent the fallback.
+    if not force_fused and not res_preshuffle and m >= fused_m_upper_bound:
         next_residual = torch.empty_like(residual_in)
         mhc_post(
             next_residual,
@@ -696,14 +751,11 @@ def mhc_fused_post_pre(
             sinkhorn_repeat,
             norm_weight,
             norm_eps,
-            is_w_preshuffle_bf16=is_res_w_preshuffle_bf16,
+            w_preshuffle_bf16=int(w_preshuffle_bf16),
         )
         return post_mix, comb_mix, layer_input_out, next_residual
 
-    assert not (
-        is_res_w_preshuffle_bf16 and force_fused and arch == "gfx950" and m > fused_m_upper_bound
-    ), "mhc_fused_post_pre_large_m does not implement the pre-shuffled residual layout"
-    if force_fused and arch == "gfx950" and m > fused_m_upper_bound:
+    if force_fused and not res_preshuffle and arch == "gfx950" and m > fused_m_upper_bound:
         return mhc_fused_post_pre_large_m(
             layer_input,
             residual_in,
@@ -719,7 +771,8 @@ def mhc_fused_post_pre(
             sinkhorn_repeat,
             norm_weight,
             norm_eps,
-            is_res_w_preshuffle_bf16=is_res_w_preshuffle_bf16,
+            w_preshuffle_bf16=w_preshuffle_bf16,
+            res_preshuffle=False,
         )
 
     assert layer_input.shape == (
@@ -750,7 +803,10 @@ def mhc_fused_post_pre(
 
     selected_splitk, selected_tile_m, selected_tile_n, selected_tile_k = (
         get_mhc_fused_post_pre_config(
-            m, hidden_size, is_res_w_preshuffle_bf16=bool(is_res_w_preshuffle_bf16)
+            m,
+            hidden_size,
+            w_preshuffle_bf16=w_preshuffle_bf16,
+            res_preshuffle=res_preshuffle,
         )
     )
     n_splits = selected_splitk
@@ -775,7 +831,8 @@ def mhc_fused_post_pre(
         selected_tile_m,
         selected_tile_n,
         selected_tile_k,
-        is_res_w_preshuffle_bf16,
+        w_preshuffle_bf16=int(w_preshuffle_bf16),
+        res_preshuffle=int(res_preshuffle),
     )
 
     post_mix = torch.empty(m, hc_mult, 1, dtype=dtypes.fp32, device=device)
@@ -798,7 +855,7 @@ def mhc_fused_post_pre(
             norm_eps,
             hc_post_mult_value,
             sinkhorn_repeat,
-            res_preshuffle=is_res_w_preshuffle_bf16 and MHC_RES_SHUFFLE,
+            res_preshuffle=int(res_preshuffle),
         )
     else:
         mhc_pre_big_fuse(
@@ -815,7 +872,7 @@ def mhc_fused_post_pre(
             hc_sinkhorn_eps,
             hc_post_mult_value,
             sinkhorn_repeat,
-            res_preshuffle=is_res_w_preshuffle_bf16 and MHC_RES_SHUFFLE,
+            res_preshuffle=int(res_preshuffle),
         )
 
     return post_mix, comb_mix, layer_input_out, next_residual

--- a/aiter/ops/mhc.py
+++ b/aiter/ops/mhc.py
@@ -594,9 +594,7 @@ def get_mhc_pre_splitk_large_m(
     """Split-K policy for gfx950 large-M post_pre kernel (M > 1024)."""
     if get_gfx_runtime() == "gfx950" and m >= 8192 and hc_hidden_size % (8 * 64) == 0:
         return 8, 64
-    return get_mhc_pre_splitk(
-        m, hc_hidden_size, w_preshuffle_bf16=w_preshuffle_bf16
-    )
+    return get_mhc_pre_splitk(m, hc_hidden_size, w_preshuffle_bf16=w_preshuffle_bf16)
 
 
 @compile_ops("module_mhc", develop=True)
@@ -797,7 +795,12 @@ def mhc_fused_post_pre(
         )
         return post_mix, comb_mix, layer_input_out, next_residual
 
-    if force_fused and not res_preshuffle and arch == "gfx950" and m > fused_m_upper_bound:
+    if (
+        force_fused
+        and not res_preshuffle
+        and arch == "gfx950"
+        and m > fused_m_upper_bound
+    ):
         return mhc_fused_post_pre_large_m(
             layer_input,
             residual_in,

--- a/csrc/include/aiter_opus_plus.h
+++ b/csrc/include/aiter_opus_plus.h
@@ -651,14 +651,6 @@ OPUS_D decltype(auto) scaled_cast(const S& s, float inverted_scale)
     return scaled_cast<D>(fp32_vec, inverted_scale);
 }
 
-// Optional state for a vector prefetch whose address must survive until a later
-// wait_vector_loads(). Use a separate token for each outstanding load call.
-// The byte offset is the actual VMEM operand, not the source element index.
-struct vector_load_token
-{
-    int byte_offset;
-};
-
 // Load a large vector (vec_size elements of type T) from gmem buffer in chunks.
 // Each chunk issues one buffer_load instruction of chunk_bytes bytes (4/8/16 ->
 // dword/dwordx2/dwordx4). Total loads = vec_size * sizeof(T) / chunk_bytes.
@@ -711,21 +703,6 @@ __device__ opus::vector_t<T, vec_size> load_vector_nbytes(opus::gmem<T>& buffer,
     });
 
     return result;
-}
-
-// Capture the same byte address used by load() without changing ordinary callers.
-template <typename T,
-          int vec_size,
-          int chunk_bytes,
-          int aux = 0,
-          bool interleave = false,
-          int interleave_thread_size = WARP_SIZE>
-__device__ opus::vector_t<T, vec_size> load_vector_nbytes(
-    opus::gmem<T>& buffer, int row_offset, vector_load_token& token)
-{
-    token.byte_offset = static_cast<unsigned>(row_offset) * sizeof(T);
-    return load_vector_nbytes<T, vec_size, chunk_bytes, aux, interleave, interleave_thread_size>(
-        buffer, row_offset);
 }
 
 // Store a vector (vec_size elements of DTYPE_I) to gmem buffer in chunks, with optional type
@@ -876,124 +853,6 @@ __device__ void store_vector(opus::gmem<T>& buffer,
     }
 }
 
-namespace detail {
-#if defined(__gfx1250__)
-    // MI400 guide 6.9.7.2: barrier signal/wait drains XCNT before completing.
-    // Every replay input stays in its assigned register throughout this packet.
-    // Call only where the algorithm already needs a workgroup barrier.
-    template<bool wait_tensor, int policy, typename V, int count>
-    __device__ __forceinline__ void store_vectors_barrier(
-        const __amdgpu_buffer_rsrc_t& resource, V (&data)[count], int (&bytes)[count])
-    {
-        static_assert(policy == 0 || policy == 3, "unsupported store cache policy");
-        static_assert(sizeof(V) == 16 && (count == 2 || count == 4));
-        if constexpr (count == 4) {
-            asm volatile(
-                ".if %c9\n"
-                "buffer_store_b128 %0, %4, %8, null offen th:TH_STORE_WB\n"
-                "buffer_store_b128 %1, %5, %8, null offen th:TH_STORE_WB\n"
-                "buffer_store_b128 %2, %6, %8, null offen th:TH_STORE_WB\n"
-                "buffer_store_b128 %3, %7, %8, null offen th:TH_STORE_WB\n"
-                ".else\n"
-                "buffer_store_b128 %0, %4, %8, null offen\n"
-                "buffer_store_b128 %1, %5, %8, null offen\n"
-                "buffer_store_b128 %2, %6, %8, null offen\n"
-                "buffer_store_b128 %3, %7, %8, null offen\n"
-                ".endif\n"
-                ".if %c10\ns_wait_tensorcnt 0\n.endif\n"
-                "s_barrier_signal -1\ns_barrier_wait 0xffff\n"
-                :: "v"(data[0]), "v"(data[1]), "v"(data[2]), "v"(data[3]),
-                   "v"(bytes[0]), "v"(bytes[1]), "v"(bytes[2]), "v"(bytes[3]),
-                   "s"(resource), "n"(policy), "n"(wait_tensor) : "memory");
-        } else {
-            asm volatile(
-                ".if %c5\n"
-                "buffer_store_b128 %0, %2, %4, null offen th:TH_STORE_WB\n"
-                "buffer_store_b128 %1, %3, %4, null offen th:TH_STORE_WB\n"
-                ".else\n"
-                "buffer_store_b128 %0, %2, %4, null offen\n"
-                "buffer_store_b128 %1, %3, %4, null offen\n"
-                ".endif\n"
-                ".if %c6\ns_wait_tensorcnt 0\n.endif\n"
-                "s_barrier_signal -1\ns_barrier_wait 0xffff\n"
-                :: "v"(data[0]), "v"(data[1]), "v"(bytes[0]), "v"(bytes[1]),
-                   "s"(resource), "n"(policy), "n"(wait_tensor) : "memory");
-        }
-    }
-#endif
-} // namespace detail
-
-// Deferred 16-byte stores for an algorithm that already needs a workgroup
-// barrier. set() uses element offsets; finish<true>() combines the stores with
-// that existing barrier on gfx1250 so replay inputs cannot be recycled early.
-// All workgroup threads must reach finish<true>(); it does not wait for the
-// stores to become globally visible. finish<false>() issues the tail stores.
-// Assign every slot before finish(). The gfx1250 barrier packet supports 2 or 4
-// vectors and cache policies 0/3; set_if() requires a bounded buffer resource.
-// Other architectures issue stores in set() and retain the explicit barrier.
-template <typename T, int vec_size, int count, int aux = 0>
-struct vector_store_batch
-{
-    static_assert(count > 0);
-    static_assert(opus::is_any_of_v<T, float, opus::fp16_t, opus::bf16_t>,
-                  "vector_store_batch supports fp32, fp16, and bf16 storage");
-    using vector_type = opus::vector_t<T, vec_size>;
-    opus::gmem<T>& buffer;
-#if defined(__gfx1250__)
-    vector_type data[count];
-    int bytes[count];
-#endif
-
-    template <typename V>
-    OPUS_D void set(int index, const V& value, int row_offset)
-    {
-        static_assert(opus::vector_traits<V>::size() == vec_size);
-#if defined(__gfx1250__)
-        for(int e = 0; e < vec_size; ++e) data[index][e] = static_cast<T>(value[e]);
-        bytes[index] = static_cast<unsigned>(row_offset) * sizeof(T);
-#else
-        using S = typename opus::vector_traits<V>::dtype;
-        store_vector<T, S, vec_size, aux>(buffer, value, row_offset);
-#endif
-    }
-
-    template <typename V>
-    OPUS_D void set_if(int index, const V& value,
-                      int row_offset, bool valid)
-    {
-#if defined(__gfx1250__)
-        // Keep the masked offset in the bounds-checked VGPR, including the
-        // uniform address terms; a negative offset discards an invalid lane.
-        asm volatile("" : "+v"(row_offset));
-        set(index, value, valid ? row_offset : -1);
-#else
-        if(valid) set(index, value, row_offset);
-#endif
-    }
-
-    template <bool barrier = true, bool wait_tensor = false>
-    OPUS_D void finish()
-    {
-        static_assert(barrier || !wait_tensor, "tensor wait requires the barrier packet");
-#if defined(__gfx1250__)
-        if constexpr(barrier)
-            detail::store_vectors_barrier<wait_tensor, aux>(buffer.cached_rsrc, data, bytes);
-        else
-        {
-            #pragma unroll
-            for(int i = 0; i < count; ++i)
-                buffer.template _store<vec_size>(data[i], bytes[i], 0, opus::number<aux>{});
-            #pragma unroll
-            for(int i = 0; i < count; ++i)
-                asm volatile("" :: "v"(data[i]), "v"(bytes[i]),
-                             "s"(buffer.cached_rsrc) : "memory");
-        }
-#else
-        if constexpr(barrier) __builtin_amdgcn_s_barrier();
-#endif
-    }
-};
-
 // Wait until both the regular load queue and the async-load queue have at most
 // the given number of outstanding entries. A negative count means "don't wait"
 // on that queue: on split-counter archs the corresponding instruction is not
@@ -1011,24 +870,6 @@ OPUS_D void s_wait_all_loadcnt(number<load_cnt> = {}, number<async_load_cnt> = {
 #else
     constexpr index_t vmcnt = (load_cnt < 0 ? 0 : load_cnt) + (async_load_cnt < 0 ? 0 : async_load_cnt);
     s_waitcnt_vmcnt(number<vmcnt>{});
-#endif
-}
-
-// Complete regular vector prefetches and retain their replay inputs until the
-// native load wait. pending=false is useful on the final pipeline iteration.
-template <typename T, int count>
-OPUS_D void wait_vector_loads(opus::gmem<T>& buffer,
-                             const vector_load_token (&tokens)[count], bool pending = true)
-{
-    s_wait_all_loadcnt(number<0>{}, number<-1>{});
-#if defined(__gfx1250__)
-    if(pending)
-    {
-        #pragma unroll
-        for(int i = 0; i < count; ++i)
-            asm volatile("" :: "v"(tokens[i].byte_offset));
-    }
-    asm volatile("" :: "s"(buffer.cached_rsrc));
 #endif
 }
 

--- a/csrc/include/aiter_opus_plus.h
+++ b/csrc/include/aiter_opus_plus.h
@@ -651,6 +651,14 @@ OPUS_D decltype(auto) scaled_cast(const S& s, float inverted_scale)
     return scaled_cast<D>(fp32_vec, inverted_scale);
 }
 
+// Optional state for a vector prefetch whose address must survive until a later
+// wait_vector_loads(). Use a separate token for each outstanding load call.
+// The byte offset is the actual VMEM operand, not the source element index.
+struct vector_load_token
+{
+    int byte_offset;
+};
+
 // Load a large vector (vec_size elements of type T) from gmem buffer in chunks.
 // Each chunk issues one buffer_load instruction of chunk_bytes bytes (4/8/16 ->
 // dword/dwordx2/dwordx4). Total loads = vec_size * sizeof(T) / chunk_bytes.
@@ -703,6 +711,21 @@ __device__ opus::vector_t<T, vec_size> load_vector_nbytes(opus::gmem<T>& buffer,
     });
 
     return result;
+}
+
+// Capture the same byte address used by load() without changing ordinary callers.
+template <typename T,
+          int vec_size,
+          int chunk_bytes,
+          int aux = 0,
+          bool interleave = false,
+          int interleave_thread_size = WARP_SIZE>
+__device__ opus::vector_t<T, vec_size> load_vector_nbytes(
+    opus::gmem<T>& buffer, int row_offset, vector_load_token& token)
+{
+    token.byte_offset = static_cast<unsigned>(row_offset) * sizeof(T);
+    return load_vector_nbytes<T, vec_size, chunk_bytes, aux, interleave, interleave_thread_size>(
+        buffer, row_offset);
 }
 
 // Store a vector (vec_size elements of DTYPE_I) to gmem buffer in chunks, with optional type
@@ -853,6 +876,124 @@ __device__ void store_vector(opus::gmem<T>& buffer,
     }
 }
 
+namespace detail {
+#if defined(__gfx1250__)
+    // MI400 guide 6.9.7.2: barrier signal/wait drains XCNT before completing.
+    // Every replay input stays in its assigned register throughout this packet.
+    // Call only where the algorithm already needs a workgroup barrier.
+    template<bool wait_tensor, int policy, typename V, int count>
+    __device__ __forceinline__ void store_vectors_barrier(
+        const __amdgpu_buffer_rsrc_t& resource, V (&data)[count], int (&bytes)[count])
+    {
+        static_assert(policy == 0 || policy == 3, "unsupported store cache policy");
+        static_assert(sizeof(V) == 16 && (count == 2 || count == 4));
+        if constexpr (count == 4) {
+            asm volatile(
+                ".if %c9\n"
+                "buffer_store_b128 %0, %4, %8, null offen th:TH_STORE_WB\n"
+                "buffer_store_b128 %1, %5, %8, null offen th:TH_STORE_WB\n"
+                "buffer_store_b128 %2, %6, %8, null offen th:TH_STORE_WB\n"
+                "buffer_store_b128 %3, %7, %8, null offen th:TH_STORE_WB\n"
+                ".else\n"
+                "buffer_store_b128 %0, %4, %8, null offen\n"
+                "buffer_store_b128 %1, %5, %8, null offen\n"
+                "buffer_store_b128 %2, %6, %8, null offen\n"
+                "buffer_store_b128 %3, %7, %8, null offen\n"
+                ".endif\n"
+                ".if %c10\ns_wait_tensorcnt 0\n.endif\n"
+                "s_barrier_signal -1\ns_barrier_wait 0xffff\n"
+                :: "v"(data[0]), "v"(data[1]), "v"(data[2]), "v"(data[3]),
+                   "v"(bytes[0]), "v"(bytes[1]), "v"(bytes[2]), "v"(bytes[3]),
+                   "s"(resource), "n"(policy), "n"(wait_tensor) : "memory");
+        } else {
+            asm volatile(
+                ".if %c5\n"
+                "buffer_store_b128 %0, %2, %4, null offen th:TH_STORE_WB\n"
+                "buffer_store_b128 %1, %3, %4, null offen th:TH_STORE_WB\n"
+                ".else\n"
+                "buffer_store_b128 %0, %2, %4, null offen\n"
+                "buffer_store_b128 %1, %3, %4, null offen\n"
+                ".endif\n"
+                ".if %c6\ns_wait_tensorcnt 0\n.endif\n"
+                "s_barrier_signal -1\ns_barrier_wait 0xffff\n"
+                :: "v"(data[0]), "v"(data[1]), "v"(bytes[0]), "v"(bytes[1]),
+                   "s"(resource), "n"(policy), "n"(wait_tensor) : "memory");
+        }
+    }
+#endif
+} // namespace detail
+
+// Deferred 16-byte stores for an algorithm that already needs a workgroup
+// barrier. set() uses element offsets; finish<true>() combines the stores with
+// that existing barrier on gfx1250 so replay inputs cannot be recycled early.
+// All workgroup threads must reach finish<true>(); it does not wait for the
+// stores to become globally visible. finish<false>() issues the tail stores.
+// Assign every slot before finish(). The gfx1250 barrier packet supports 2 or 4
+// vectors and cache policies 0/3; set_if() requires a bounded buffer resource.
+// Other architectures issue stores in set() and retain the explicit barrier.
+template <typename T, int vec_size, int count, int aux = 0>
+struct vector_store_batch
+{
+    static_assert(count > 0);
+    static_assert(opus::is_any_of_v<T, float, opus::fp16_t, opus::bf16_t>,
+                  "vector_store_batch supports fp32, fp16, and bf16 storage");
+    using vector_type = opus::vector_t<T, vec_size>;
+    opus::gmem<T>& buffer;
+#if defined(__gfx1250__)
+    vector_type data[count];
+    int bytes[count];
+#endif
+
+    template <typename V>
+    OPUS_D void set(int index, const V& value, int row_offset)
+    {
+        static_assert(opus::vector_traits<V>::size() == vec_size);
+#if defined(__gfx1250__)
+        for(int e = 0; e < vec_size; ++e) data[index][e] = static_cast<T>(value[e]);
+        bytes[index] = static_cast<unsigned>(row_offset) * sizeof(T);
+#else
+        using S = typename opus::vector_traits<V>::dtype;
+        store_vector<T, S, vec_size, aux>(buffer, value, row_offset);
+#endif
+    }
+
+    template <typename V>
+    OPUS_D void set_if(int index, const V& value,
+                      int row_offset, bool valid)
+    {
+#if defined(__gfx1250__)
+        // Keep the masked offset in the bounds-checked VGPR, including the
+        // uniform address terms; a negative offset discards an invalid lane.
+        asm volatile("" : "+v"(row_offset));
+        set(index, value, valid ? row_offset : -1);
+#else
+        if(valid) set(index, value, row_offset);
+#endif
+    }
+
+    template <bool barrier = true, bool wait_tensor = false>
+    OPUS_D void finish()
+    {
+        static_assert(barrier || !wait_tensor, "tensor wait requires the barrier packet");
+#if defined(__gfx1250__)
+        if constexpr(barrier)
+            detail::store_vectors_barrier<wait_tensor, aux>(buffer.cached_rsrc, data, bytes);
+        else
+        {
+            #pragma unroll
+            for(int i = 0; i < count; ++i)
+                buffer.template _store<vec_size>(data[i], bytes[i], 0, opus::number<aux>{});
+            #pragma unroll
+            for(int i = 0; i < count; ++i)
+                asm volatile("" :: "v"(data[i]), "v"(bytes[i]),
+                             "s"(buffer.cached_rsrc) : "memory");
+        }
+#else
+        if constexpr(barrier) __builtin_amdgcn_s_barrier();
+#endif
+    }
+};
+
 // Wait until both the regular load queue and the async-load queue have at most
 // the given number of outstanding entries. A negative count means "don't wait"
 // on that queue: on split-counter archs the corresponding instruction is not
@@ -870,6 +1011,24 @@ OPUS_D void s_wait_all_loadcnt(number<load_cnt> = {}, number<async_load_cnt> = {
 #else
     constexpr index_t vmcnt = (load_cnt < 0 ? 0 : load_cnt) + (async_load_cnt < 0 ? 0 : async_load_cnt);
     s_waitcnt_vmcnt(number<vmcnt>{});
+#endif
+}
+
+// Complete regular vector prefetches and retain their replay inputs until the
+// native load wait. pending=false is useful on the final pipeline iteration.
+template <typename T, int count>
+OPUS_D void wait_vector_loads(opus::gmem<T>& buffer,
+                             const vector_load_token (&tokens)[count], bool pending = true)
+{
+    s_wait_all_loadcnt(number<0>{}, number<-1>{});
+#if defined(__gfx1250__)
+    if(pending)
+    {
+        #pragma unroll
+        for(int i = 0; i < count; ++i)
+            asm volatile("" :: "v"(tokens[i].byte_offset));
+    }
+    asm volatile("" :: "s"(buffer.cached_rsrc));
 #endif
 }
 

--- a/csrc/include/mhc.h
+++ b/csrc/include/mhc.h
@@ -10,9 +10,12 @@ namespace aiter {
 void mhc_pre_gemm_sqrsum(aiter_tensor_t& out,    // (split_k, m, hc_mult3) / (m, hc_mult3)
                          aiter_tensor_t& sqrsum, // (split_k, m) / (m)
                          aiter_tensor_t& x,      // (m, hc_hidden_size)
-                         aiter_tensor_t& fn,     // (hc_mult3, hc_hidden_size)
+                         aiter_tensor_t& fn,     // (hc_mult3, hc_hidden_size) fp32; packed int32 when is_fn_pack_bf16
                          int tile_k = 128,
                          int is_fn_pack_bf16 = 0);
+// Pre-convert fn (fp32) -> packed int32 (hi<<16 | lo) for the bf16 (is_fn_pack_bf16) gemm path.
+void mhc_pre_convert_fn(aiter_tensor_t& fn_packed, // (hc_mult3, hc_hidden_size) int32 out
+                        aiter_tensor_t& fn);       // (hc_mult3, hc_hidden_size) fp32 in
 void mhc_pre_big_fuse(aiter_tensor_t& post_mix,        // (m, hc_mult)
                       aiter_tensor_t& comb_mix,        // (m, hc_mult * hc_mult)
                       aiter_tensor_t& layer_input,     // (m, hidden_size)

--- a/csrc/include/mhc.h
+++ b/csrc/include/mhc.h
@@ -16,6 +16,11 @@ void mhc_pre_gemm_sqrsum(aiter_tensor_t& out,    // (split_k, m, hc_mult3) / (m,
 // Pre-convert fn (fp32) -> packed int32 (hi<<16 | lo) for the bf16 (is_fn_pack_bf16) gemm path.
 void mhc_pre_convert_fn(aiter_tensor_t& fn_packed, // (hc_mult3, hc_hidden_size) int32 out
                         aiter_tensor_t& fn);       // (hc_mult3, hc_hidden_size) fp32 in
+// Preshuffle fn for the FUSED post_pre gemm: fn[n][K] -> fnS[K/32][n][K%32], n zero-padded
+// to n_pad (a multiple of 32). Optionally packs hi<<16|lo in the same pass.
+void mhc_pre_shuffle_fn(aiter_tensor_t& fn_shuffled, // (hc_hidden_size/32, n_pad, 32) out
+                        aiter_tensor_t& fn,          // (hc_mult3, hc_hidden_size) fp32 in
+                        int is_fn_pack_bf16 = 0);
 void mhc_pre_big_fuse(aiter_tensor_t& post_mix,        // (m, hc_mult)
                       aiter_tensor_t& comb_mix,        // (m, hc_mult * hc_mult)
                       aiter_tensor_t& layer_input,     // (m, hidden_size)
@@ -71,9 +76,10 @@ void mhc_fused_post_pre_gemm_sqrsum(
     aiter_tensor_t& residual_in,     // (m, hc_mult, hidden_size)
     aiter_tensor_t& post_layer_mix,  // (m, hc_mult)
     aiter_tensor_t& comb_res_mix,    // (m, hc_mult, hc_mult)
-    aiter_tensor_t& fn,              // (hc_mult3, hc_mult * hidden_size)
+    aiter_tensor_t& fn,              // (hc_mult3, hc_mult * hidden_size); preshuffled when fn_n_pad
     int tile_m                       = 16,
     int tile_n                       = 32,
     int tile_k                       = 32,
-    int is_fn_pack_bf16              = 0);
+    int is_fn_pack_bf16              = 0,
+    int fn_n_pad                     = 0);
 } // namespace aiter

--- a/csrc/include/mhc.h
+++ b/csrc/include/mhc.h
@@ -10,17 +10,12 @@ namespace aiter {
 void mhc_pre_gemm_sqrsum(aiter_tensor_t& out,    // (split_k, m, hc_mult3) / (m, hc_mult3)
                          aiter_tensor_t& sqrsum, // (split_k, m) / (m)
                          aiter_tensor_t& x,      // (m, hc_hidden_size)
-                         aiter_tensor_t& fn,     // (hc_mult3, hc_hidden_size) fp32; packed int32 when is_fn_pack_bf16
+                         aiter_tensor_t& fn,     // (hc_mult3, hc_hidden_size) fp32; packed int32 when is_res_w_preshuffle_bf16
                          int tile_k = 128,
-                         int is_fn_pack_bf16 = 0);
-// Pre-convert fn (fp32) -> packed int32 (hi<<16 | lo) for the bf16 (is_fn_pack_bf16) gemm path.
+                         int is_res_w_preshuffle_bf16 = 0);
+// Pre-convert fn (fp32) -> packed int32 (hi<<16 | lo) for the bf16 (is_res_w_preshuffle_bf16) gemm path.
 void mhc_pre_convert_fn(aiter_tensor_t& fn_packed, // (hc_mult3, hc_hidden_size) int32 out
                         aiter_tensor_t& fn);       // (hc_mult3, hc_hidden_size) fp32 in
-// Preshuffle fn for the FUSED post_pre gemm: fn[n][K] -> fnS[K/32][n][K%32], n zero-padded
-// to n_pad (a multiple of 32). Optionally packs hi<<16|lo in the same pass.
-void mhc_pre_shuffle_fn(aiter_tensor_t& fn_shuffled, // (hc_hidden_size/32, n_pad, 32) out
-                        aiter_tensor_t& fn,          // (hc_mult3, hc_hidden_size) fp32 in
-                        int is_fn_pack_bf16 = 0);
 void mhc_pre_big_fuse(aiter_tensor_t& post_mix,        // (m, hc_mult)
                       aiter_tensor_t& comb_mix,        // (m, hc_mult * hc_mult)
                       aiter_tensor_t& layer_input,     // (m, hidden_size)
@@ -33,7 +28,10 @@ void mhc_pre_big_fuse(aiter_tensor_t& post_mix,        // (m, hc_mult)
                       float hc_pre_eps         = 1e-6,
                       float hc_sinkhorn_eps    = 1e-6,
                       float hc_post_mult_value = 1.0,
-                      int sinkhorn_repeat      = 20);
+                      int sinkhorn_repeat      = 20,
+                      // 1: residual is in the pre-shuffled resS[k/KS][head][row][k%KS]
+                      // layout written by mhc_fused_post_pre_gemm_sqrsum.
+                      int res_preshuffle       = 0);
 void mhc_pre_big_fuse_rmsnorm(aiter_tensor_t& post_mix,        // (m, hc_mult)
                               aiter_tensor_t& comb_mix,        // (m, hc_mult * hc_mult)
                               aiter_tensor_t& out,             // (m, hidden_size)
@@ -48,7 +46,10 @@ void mhc_pre_big_fuse_rmsnorm(aiter_tensor_t& post_mix,        // (m, hc_mult)
                               float hc_sinkhorn_eps    = 1e-6,
                               float norm_eps           = 1e-6,
                               float hc_post_mult_value = 1.0,
-                              int sinkhorn_repeat      = 20);
+                              int sinkhorn_repeat      = 20,
+                              // 1: residual is in the pre-shuffled
+                              // resS[k/KS][head][row][k%KS] layout.
+                              int res_preshuffle       = 0);
 void mhc_post(aiter_tensor_t& out,            // (m, hc_mult, hidden_size)
               aiter_tensor_t& x,              // (m, hidden_size)
               aiter_tensor_t& residual,       // (m, hc_mult, hidden_size)
@@ -76,10 +77,12 @@ void mhc_fused_post_pre_gemm_sqrsum(
     aiter_tensor_t& residual_in,     // (m, hc_mult, hidden_size)
     aiter_tensor_t& post_layer_mix,  // (m, hc_mult)
     aiter_tensor_t& comb_res_mix,    // (m, hc_mult, hc_mult)
-    aiter_tensor_t& fn,              // (hc_mult3, hc_mult * hidden_size); preshuffled when fn_n_pad
+    aiter_tensor_t& fn,              // (hc_mult3, hc_mult * hidden_size) fp32; packed int32
+                                     // when is_res_w_preshuffle_bf16
     int tile_m                       = 16,
     int tile_n                       = 32,
     int tile_k                       = 32,
-    int is_fn_pack_bf16              = 0,
-    int fn_n_pad                     = 0);
+    // 1: bf16 hi/lo fn gemm, and residual_in / next_residual are in the
+    // pre-shuffled resS[k/KS][head][row][k%KS] layout.
+    int is_res_w_preshuffle_bf16     = 0);
 } // namespace aiter

--- a/csrc/include/mhc.h
+++ b/csrc/include/mhc.h
@@ -10,10 +10,10 @@ namespace aiter {
 void mhc_pre_gemm_sqrsum(aiter_tensor_t& out,    // (split_k, m, hc_mult3) / (m, hc_mult3)
                          aiter_tensor_t& sqrsum, // (split_k, m) / (m)
                          aiter_tensor_t& x,      // (m, hc_hidden_size)
-                         aiter_tensor_t& fn,     // (hc_mult3, hc_hidden_size) fp32; packed int32 when is_res_w_preshuffle_bf16
+                         aiter_tensor_t& fn,     // (hc_mult3, hc_hidden_size) fp32; packed int32 when is_w_preshuffle_bf16
                          int tile_k = 128,
-                         int is_res_w_preshuffle_bf16 = 0);
-// Pre-convert fn (fp32) -> packed int32 (hi<<16 | lo) for the bf16 (is_res_w_preshuffle_bf16) gemm path.
+                         int is_w_preshuffle_bf16 = 0);
+// Pre-convert fn (fp32) into packed int32 BF16 hi/lo weights for the gemm paths.
 void mhc_pre_convert_fn(aiter_tensor_t& fn_packed, // (hc_mult3, hc_hidden_size) int32 out
                         aiter_tensor_t& fn);       // (hc_mult3, hc_hidden_size) fp32 in
 void mhc_pre_big_fuse(aiter_tensor_t& post_mix,        // (m, hc_mult)

--- a/csrc/include/mhc.h
+++ b/csrc/include/mhc.h
@@ -10,9 +10,9 @@ namespace aiter {
 void mhc_pre_gemm_sqrsum(aiter_tensor_t& out,    // (split_k, m, hc_mult3) / (m, hc_mult3)
                          aiter_tensor_t& sqrsum, // (split_k, m) / (m)
                          aiter_tensor_t& x,      // (m, hc_hidden_size)
-                         aiter_tensor_t& fn,     // (hc_mult3, hc_hidden_size) fp32; packed int32 when is_w_preshuffle_bf16
+                         aiter_tensor_t& fn,     // (hc_mult3, hc_hidden_size) fp32; packed int32 when w_preshuffle_bf16
                          int tile_k = 128,
-                         int is_w_preshuffle_bf16 = 0);
+                         int w_preshuffle_bf16 = 0);
 // Pre-convert fn (fp32) into packed int32 BF16 hi/lo weights for the gemm paths.
 void mhc_pre_convert_fn(aiter_tensor_t& fn_packed, // (hc_mult3, hc_hidden_size) int32 out
                         aiter_tensor_t& fn);       // (hc_mult3, hc_hidden_size) fp32 in
@@ -78,11 +78,11 @@ void mhc_fused_post_pre_gemm_sqrsum(
     aiter_tensor_t& post_layer_mix,  // (m, hc_mult)
     aiter_tensor_t& comb_res_mix,    // (m, hc_mult, hc_mult)
     aiter_tensor_t& fn,              // (hc_mult3, hc_mult * hidden_size) fp32; packed int32
-                                     // when is_res_w_preshuffle_bf16
+                                     // when w_preshuffle_bf16
     int tile_m                       = 16,
     int tile_n                       = 32,
     int tile_k                       = 32,
-    // 1: bf16 hi/lo fn gemm, and residual_in / next_residual are in the
-    // pre-shuffled resS[k/KS][head][row][k%KS] layout.
-    int is_res_w_preshuffle_bf16     = 0);
+    // Independent compute and residual-layout controls.
+    int w_preshuffle_bf16           = 0,
+    int res_preshuffle              = 0); // shuffled residuals require gfx1250
 } // namespace aiter

--- a/csrc/include/rocm_ops.hpp
+++ b/csrc/include/rocm_ops.hpp
@@ -2498,7 +2498,7 @@ namespace py = pybind11;
           py::arg("x"),                           \
           py::arg("fn"),                          \
           py::arg("tile_k")          = 128,       \
-          py::arg("is_w_preshuffle_bf16") = 0);  \
+          py::arg("w_preshuffle_bf16") = 0);  \
     m.def("mhc_pre_convert_fn",                   \
           &aiter::mhc_pre_convert_fn,             \
           "mhc_pre_convert_fn",                   \
@@ -2563,7 +2563,8 @@ namespace py = pybind11;
           py::arg("tile_m")          = 16,        \
           py::arg("tile_n")          = 32,        \
           py::arg("tile_k")          = 32,        \
-          py::arg("is_res_w_preshuffle_bf16") = 0);
+          py::arg("w_preshuffle_bf16") = 0,    \
+          py::arg("res_preshuffle") = 0);
 #define CAUSAL_CONV1D_UPDATE_PYBIND                                            \
     m.def("causal_conv1d_update",                                              \
           &aiter::causal_conv1d_update,                                        \

--- a/csrc/include/rocm_ops.hpp
+++ b/csrc/include/rocm_ops.hpp
@@ -2499,6 +2499,11 @@ namespace py = pybind11;
           py::arg("fn"),                          \
           py::arg("tile_k")          = 128,       \
           py::arg("is_fn_pack_bf16") = 0);        \
+    m.def("mhc_pre_convert_fn",                   \
+          &aiter::mhc_pre_convert_fn,             \
+          "mhc_pre_convert_fn",                   \
+          py::arg("fn_packed"),                   \
+          py::arg("fn"));                         \
     m.def("mhc_pre_big_fuse",                     \
           &aiter::mhc_pre_big_fuse,               \
           "mhc_pre_big_fuse",                     \

--- a/csrc/include/rocm_ops.hpp
+++ b/csrc/include/rocm_ops.hpp
@@ -2498,7 +2498,7 @@ namespace py = pybind11;
           py::arg("x"),                           \
           py::arg("fn"),                          \
           py::arg("tile_k")          = 128,       \
-          py::arg("is_res_w_preshuffle_bf16") = 0);  \
+          py::arg("is_w_preshuffle_bf16") = 0);  \
     m.def("mhc_pre_convert_fn",                   \
           &aiter::mhc_pre_convert_fn,             \
           "mhc_pre_convert_fn",                   \

--- a/csrc/include/rocm_ops.hpp
+++ b/csrc/include/rocm_ops.hpp
@@ -2498,18 +2498,12 @@ namespace py = pybind11;
           py::arg("x"),                           \
           py::arg("fn"),                          \
           py::arg("tile_k")          = 128,       \
-          py::arg("is_fn_pack_bf16") = 0);        \
+          py::arg("is_res_w_preshuffle_bf16") = 0);  \
     m.def("mhc_pre_convert_fn",                   \
           &aiter::mhc_pre_convert_fn,             \
           "mhc_pre_convert_fn",                   \
           py::arg("fn_packed"),                   \
           py::arg("fn"));                         \
-    m.def("mhc_pre_shuffle_fn",                   \
-          &aiter::mhc_pre_shuffle_fn,             \
-          "mhc_pre_shuffle_fn",                   \
-          py::arg("fn_shuffled"),                 \
-          py::arg("fn"),                          \
-          py::arg("is_fn_pack_bf16") = 0);        \
     m.def("mhc_pre_big_fuse",                     \
           &aiter::mhc_pre_big_fuse,               \
           "mhc_pre_big_fuse",                     \
@@ -2525,7 +2519,8 @@ namespace py = pybind11;
           py::arg("hc_pre_eps")         = 1e-6,   \
           py::arg("hc_sinkhorn_eps")    = 1e-6,   \
           py::arg("hc_post_mult_value") = 1.0,    \
-          py::arg("sinkhorn_repeat")    = 20);       \
+          py::arg("sinkhorn_repeat")    = 20,      \
+          py::arg("res_preshuffle")     = 0);     \
     m.def("mhc_pre_big_fuse_rmsnorm",             \
           &aiter::mhc_pre_big_fuse_rmsnorm,       \
           "mhc_pre_big_fuse_rmsnorm",             \
@@ -2543,7 +2538,8 @@ namespace py = pybind11;
           py::arg("hc_sinkhorn_eps")    = 1e-6,   \
           py::arg("norm_eps")           = 1e-6,   \
           py::arg("hc_post_mult_value") = 1.0,    \
-          py::arg("sinkhorn_repeat")    = 20);       \
+          py::arg("sinkhorn_repeat")    = 20,      \
+          py::arg("res_preshuffle")     = 0);     \
     m.def("mhc_post",                             \
           &aiter::mhc_post,                       \
           "mhc_post",                             \
@@ -2567,8 +2563,7 @@ namespace py = pybind11;
           py::arg("tile_m")          = 16,        \
           py::arg("tile_n")          = 32,        \
           py::arg("tile_k")          = 32,        \
-          py::arg("is_fn_pack_bf16") = 0,   \
-          py::arg("fn_n_pad")        = 0);
+          py::arg("is_res_w_preshuffle_bf16") = 0);
 #define CAUSAL_CONV1D_UPDATE_PYBIND                                            \
     m.def("causal_conv1d_update",                                              \
           &aiter::causal_conv1d_update,                                        \

--- a/csrc/include/rocm_ops.hpp
+++ b/csrc/include/rocm_ops.hpp
@@ -2504,6 +2504,12 @@ namespace py = pybind11;
           "mhc_pre_convert_fn",                   \
           py::arg("fn_packed"),                   \
           py::arg("fn"));                         \
+    m.def("mhc_pre_shuffle_fn",                   \
+          &aiter::mhc_pre_shuffle_fn,             \
+          "mhc_pre_shuffle_fn",                   \
+          py::arg("fn_shuffled"),                 \
+          py::arg("fn"),                          \
+          py::arg("is_fn_pack_bf16") = 0);        \
     m.def("mhc_pre_big_fuse",                     \
           &aiter::mhc_pre_big_fuse,               \
           "mhc_pre_big_fuse",                     \
@@ -2561,7 +2567,8 @@ namespace py = pybind11;
           py::arg("tile_m")          = 16,        \
           py::arg("tile_n")          = 32,        \
           py::arg("tile_k")          = 32,        \
-          py::arg("is_fn_pack_bf16") = 0);
+          py::arg("is_fn_pack_bf16") = 0,   \
+          py::arg("fn_n_pad")        = 0);
 #define CAUSAL_CONV1D_UPDATE_PYBIND                                            \
     m.def("causal_conv1d_update",                                              \
           &aiter::causal_conv1d_update,                                        \

--- a/csrc/kernels/mhc_kernels.cu
+++ b/csrc/kernels/mhc_kernels.cu
@@ -949,6 +949,9 @@ namespace aiter {
             }
         }
 
+        const float hc_scale0 = hc_scale[0];
+        const float hc_base_v = hc_base[lane_id % hc_mult];
+
         if (threadIdx.x < num_rows * hc_mult3) {
             int row_idx = threadIdx.x / hc_mult3;
             int hc_idx = threadIdx.x % hc_mult3;
@@ -971,7 +974,7 @@ namespace aiter {
             float pre_mix_shared_v;
             if (lane_id < num_rows * hc_mult) {
                 pre_mix_shared_v = s_hc_mult3[lane_id / hc_mult * hc_mult3 + lane_id % hc_mult];
-                pre_mix_shared_v = sigmoid(pre_mix_shared_v * hc_scale[0] + hc_base[lane_id % hc_mult]);
+                pre_mix_shared_v = sigmoid(pre_mix_shared_v * hc_scale0 + hc_base_v);
                 pre_mix_shared_v += hc_pre_eps;
             }
             static_assert(warp_size % (num_rows * hc_mult) == 0, "warp_size must be divisible by num_rows * hc_mult");
@@ -1770,6 +1773,10 @@ namespace aiter {
             }
         }
 
+        const int pre_res_hc_id = (threadIdx.x % (pre_thread_num / num_rows)) % hc_mult;
+        const float hc_scale0 = hc_scale[0];
+        const float hc_base_v = hc_base[pre_res_hc_id];
+
         if (threadIdx.x < num_rows * hc_mult3) {
             int row_idx = threadIdx.x / hc_mult3;
             int hc_idx = threadIdx.x % hc_mult3;
@@ -1809,7 +1816,7 @@ namespace aiter {
             float pre_mix_shared_v = 0.0f;
             if (res_row_id < m_oob) {
                 pre_mix_shared_v = s_hc_mult3[res_row_id * hc_mult3 + res_hc_id];
-                pre_mix_shared_v = sigmoid(pre_mix_shared_v * hc_scale[0] + hc_base[res_hc_id]);
+                pre_mix_shared_v = sigmoid(pre_mix_shared_v * hc_scale0 + hc_base_v);
                 pre_mix_shared_v += hc_pre_eps;
             }
             

--- a/csrc/kernels/mhc_kernels.cu
+++ b/csrc/kernels/mhc_kernels.cu
@@ -21,7 +21,7 @@ namespace aiter {
     static constexpr bool mhc_async_load_oob_guard = false;
 #endif
 
-    // is_fn_pack_bf16 selects the bf16 (fn hi/lo split) matrix compute over the fp32
+    // is_res_w_preshuffle_bf16 selects the bf16 (fn hi/lo split) matrix compute over the fp32
     // one. Wave64 CDNA (gfx942/gfx950/gfx9_4_generic) use opus::mfma<bf16,..,16,16,32>
     // (8 bf16/lane) -- native K=32 on gfx950, chained K=16 (mfma_..16x16x16bf16_1k) on
     // gfx942; gfx1250 uses the wave32 wmma_f32_16x16x32_bf16 (16 bf16/lane, UNVERIFIED
@@ -54,6 +54,39 @@ namespace aiter {
 #define MHC_TDM_DRAIN() ((void)0)
 #endif
 
+
+    // Float index of the 4-float run holding hi(K0 .. K0+7); the matching lo run is +8.
+    // Valid for any K0 that is a multiple of 8 -- every consumer's fragment start is.
+    __host__ __device__ constexpr inline int mhc_fn_hi_float(int K0) {
+        return (K0 / 16) * 16 + (K0 % 16) / 2;
+    }
+
+    // ---- pre-shuffled residual layout (is_res_w_preshuffle_bf16) ----
+    //   resS[k / KS][head][row][k % KS],  KS = mhc_res_ks
+    //   strides: kb -> hc_mult*m*KS,  head -> m*KS,  row -> KS,  kk -> 1
+    // KS is a fixed constant, deliberately NOT derived from tile_m/tile_k: the
+    // layout is a caller-visible tensor contract and must not change when the gemm
+    // config does. It must divide tile_k, the per-lane k-run of every consumer
+    // (ds_read_vec, res_vec_size), and hidden_size/split_k.
+    // (row, kk) is one contiguous tile_m*KS run (2 KB at tile_m=32/KS=32/bf16, vs
+    // the 128 B runs of the [row][head][k] layout), so every *read* of the residual
+    // gets longer bursts as KS grows. The gemm's next_residual *write* does not:
+    // its lanes sit 2*KS bytes apart and carry 16 B each, so above KS=8 each
+    // cacheline is only half written (69 / 143 / 205 us of store time at
+    // KS = 8 / 16 / 32). mhc_nres_tdm_store is what removes that, and is what
+    // makes KS=32 the tuned value.
+    static constexpr int mhc_res_ks = 32;
+    // ABLATION KNOB: 0 keeps the plain residual layout while leaving the bf16 fn gemm on,
+    // so the shuffle's own contribution can be measured. Must be kept in lockstep with
+    // MHC_RES_SHUFFLE in aiter/ops/mhc.py.
+    static constexpr bool mhc_res_shuffle = true;
+    // gfx1250 + shuffled residual only: stage next_residual through LDS and write it
+    // out with one 4D TDM store mirroring the residual load, instead of a scattered
+    // buffer_store_b128 per lane. Buys 460 -> 325 us on the gemm at KS=32; costs
+    // n_stages*hc_mult*tile_m*tile_k elements of LDS. Only profitable for KS >= 16 --
+    // at KS=8 the per-lane store is already fully coalesced and this loses ~85 us.
+    static constexpr bool mhc_nres_tdm_store = true;
+
     constexpr int ceil_pow2(int n) {
         if(n <= 1) return 1;
         int p = 1;
@@ -79,12 +112,13 @@ namespace aiter {
 
     // Pre-convert fn (fp32) into a packed dword: hi = bf16(fn) in [31:16], lo = bf16(fn -
     // fp32(hi)) in [15:0]. Same 4-byte width as fp32 so the gemm's load / LDS / swizzle are
-    // unchanged; the bf16 gemm (is_fn_pack_bf16) then bit-extracts hi/lo instead of
+    // unchanged; the bf16 gemm (is_res_w_preshuffle_bf16) then bit-extracts hi/lo instead of
     // recomputing the fp32->bf16 split per (m_block, k) -- the split was redundant work
     // repeated m_blocks times. fn are model weights (constant across forward passes), so
     // this runs once and the packed int32 tensor is reused every forward.
     template <typename DTYPE_I>
-    __global__ void mhc_pre_convert_fn_kernel(uint32_t* fn_packed, const float* fn, int64_t numel)
+    __global__ void mhc_pre_convert_fn_kernel(uint32_t* fn_packed, const float* fn, int64_t numel,
+                                             [[maybe_unused]] int hc_hidden_size)
     {
         int64_t i = (int64_t)blockIdx.x * blockDim.x + threadIdx.x;
         if (i >= numel) return;
@@ -93,91 +127,15 @@ namespace aiter {
         DTYPE_I lo = static_cast<DTYPE_I>(f - static_cast<float>(hi));
         uint32_t hi_bits = __builtin_bit_cast(uint16_t, hi);
         uint32_t lo_bits = __builtin_bit_cast(uint16_t, lo);
-        fn_packed[i] = (hi_bits << 16) | lo_bits;
-    }
-
-    // ---- fn preshuffle for the FUSED post_pre gemm (mhc_pre_shuffle_fn) ----
-    //
-    // Unshuffled, one wave's fn tile is 16 N-rows of tile_k floats each, and
-    // consecutive N are fn_stride = hc_mult*hidden_size floats apart (114 KB at
-    // hidden=7168, hc_mult=4). So a single k-step touches 16 (x hc_mult heads)
-    // separate 128 B segments scattered across the whole weight -- 16 distinct
-    // memory streams for what is logically one tile.
-    //
-    // Reblock so the N dimension sits INSIDE a K block of 32:
-    //     fn[n][Kflat]  ->  fnS[Kflat/32][n][Kflat%32]
-    // A wave's tile then lands in one (or, for tile_k=64, two adjacent)
-    // 16*32*4 = 2 KB contiguous run.
-    //
-    // The block is fixed at 32, not tile_k, on purpose: every K offset the kernel
-    // forms (warp_id*hidden_size, k_split_offset, k*tile_k) is a multiple of 32,
-    // and each lane's vec_tile run lies inside ONE 32-block for both tile_k=32
-    // (vec_tile=16, lane halves at kr 0/16) and tile_k=64 (vec_tile=32, lane
-    // halves in adjacent blocks). So one layout serves every (tile_m, tile_n,
-    // tile_k, warp_size) combo -- no per-config weight copy.
-    //
-    // n is NOT padded: a K block holds exactly hc_mult3 rows. Padding up to the
-    // tile_n=32 the kernel reads would grow fn by 33% (24 -> 32 rows) and that extra
-    // is real read traffic -- fn is re-read by every m-block, so at m=65536 it is
-    // ~5.6 GB, the same order as the residual stream. The kernel instead keeps the
-    // old "OOB N reads 0" behaviour by steering those lanes past the buffer bound.
-    //
-    // pack_bf16 folds in the same hi<<16|lo packing as mhc_pre_convert_fn: the
-    // shuffle is a permutation of elements and the packing a per-element value
-    // transform, so they compose in a single pass over the (constant) weights.
-    template <typename DTYPE_I, bool pack_bf16>
-    __global__ void mhc_pre_shuffle_fn_kernel(
-        uint32_t* out, const float* fn, int hc_mult3, int hc_hidden_size)
-    {
-        int64_t i = (int64_t)blockIdx.x * blockDim.x + threadIdx.x;
-        int64_t total = (int64_t)(hc_hidden_size / 32) * hc_mult3 * 32;
-        if (i >= total) return;
-        const int kr = (int)(i % 32);
-        const int n  = (int)((i / 32) % hc_mult3);
-        const int64_t kb = i / (32 * (int64_t)hc_mult3);
-        uint32_t v = 0;
-        {
-            float f = fn[(int64_t)n * hc_hidden_size + kb * 32 + kr];
-            if constexpr (pack_bf16) {
-                DTYPE_I hi = static_cast<DTYPE_I>(f);
-                DTYPE_I lo = static_cast<DTYPE_I>(f - static_cast<float>(hi));
-                v = ((uint32_t)__builtin_bit_cast(uint16_t, hi) << 16)
-                  |  (uint32_t)__builtin_bit_cast(uint16_t, lo);
-            } else {
-                v = __builtin_bit_cast(uint32_t, f);
-            }
-        }
-        out[i] = v;
-    }
-
-    void mhc_pre_shuffle_fn(
-        aiter_tensor_t& fn_shuffled, // (hc_hidden_size/32, hc_mult3, 32) int32/fp32 out
-        aiter_tensor_t& fn,          // (hc_mult3, hc_hidden_size) fp32 in
-        int is_fn_pack_bf16
-    )
-    {
-        AITER_CHECK(fn.dtype() == AITER_DTYPE_fp32, "fn must be fp32");
-        AITER_CHECK(fn.dim() == 2, "fn must be 2D (hc_mult3, hc_hidden_size)");
-        const int hc_mult3 = (int)fn.size(0);
-        const int hc_hidden_size = (int)fn.size(1);
-        AITER_CHECK(hc_hidden_size % 32 == 0, "hc_hidden_size must be divisible by 32");
-        const int64_t total = (int64_t)(hc_hidden_size / 32) * hc_mult3 * 32;
-        AITER_CHECK((int64_t)fn_shuffled.numel() == total,
-                    "fn_shuffled numel must be (hc_hidden_size/32) * hc_mult3 * 32");
-        const int block_size = 256;
-        int64_t grid = (total + block_size - 1) / block_size;
-        const HipDeviceGuard device_guard(fn.device_id);
-        const hipStream_t stream = aiter::getCurrentHIPStream();
-        using DTYPE_I = typename hip2opus<hip_bfloat16>::type;
-        auto* o = reinterpret_cast<uint32_t*>(fn_shuffled.data_ptr());
-        auto* f = reinterpret_cast<const float*>(fn.data_ptr());
-        if (is_fn_pack_bf16) {
-            mhc_pre_shuffle_fn_kernel<DTYPE_I, true><<<grid, block_size, 0, stream>>>(
-                o, f, hc_mult3, hc_hidden_size);
-        } else {
-            mhc_pre_shuffle_fn_kernel<DTYPE_I, false><<<grid, block_size, 0, stream>>>(
-                o, f, hc_mult3, hc_hidden_size);
-        }
+        // Same tensor (int32, (hc_mult3, hc_hidden)) viewed as uint16; hi and lo of one
+        // 16-element k block land as [16 hi][16 lo], i.e. 32 B apart. Total size and row
+        // stride in bytes are unchanged.
+        uint16_t* out16 = reinterpret_cast<uint16_t*>(fn_packed);
+        const int64_t n_row = i / hc_hidden_size;
+        const int64_t k = i % hc_hidden_size;
+        const int64_t base = n_row * (2 * (int64_t)hc_hidden_size) + (k / 16) * 32 + (k % 16);
+        out16[base]      = (uint16_t)hi_bits;
+        out16[base + 16] = (uint16_t)lo_bits;
     }
 
     // The packed hi/lo are encoded as bf16 -- the activation/MFMA element type the gemm
@@ -198,7 +156,7 @@ namespace aiter {
         mhc_pre_convert_fn_kernel<DTYPE_I><<<grid, block_size, 0, stream>>>(
             reinterpret_cast<uint32_t*>(fn_packed.data_ptr()),
             reinterpret_cast<const float*>(fn.data_ptr()),
-            numel);
+            numel, (int)fn.size(1));
     }
 
 // Branch must match mma_pack_size (= warp_size == 64 ? 1 : 2): the MFMA path
@@ -255,7 +213,7 @@ namespace aiter {
     mma_f32_16x16x4_fma((a), (b), (c))
 #endif
 
-    template <typename DTYPE_I, int num_warps, int tile_m, int tile_n, int tile_k, bool is_fn_pack_bf16 = false>
+    template <typename DTYPE_I, int num_warps, int tile_m, int tile_n, int tile_k, bool is_res_w_preshuffle_bf16 = false>
     __global__ __launch_bounds__(num_warps *  opus::get_warp_size(), 2)
     void mhc_pre_gemm_sqrsum_kernel(
         float* out,
@@ -489,32 +447,35 @@ namespace aiter {
         static_assert(!mhc_bf16_mma_avail || vec_tile % 8 == 0,
                       "bf16 path needs vec_tile a multiple of 8");
 #if MHC_BF16_MFMA   // wave64 CDNA bf16 MFMA (gfx942 chained-K16 / gfx950 native K32)
-        auto lds_read_fn_chunk_bf16 = [&](float* s_fn_rd_ptr, float (&raw)[repeat_n][8], int c) {
+        // Block-interleaved fn: this chunk's 8 logical K are consecutive from
+        // K0 = 8*(c*mfma_k + lane/mfma_n), so hi(K0..K0+7) occupies the 4 consecutive
+        // floats at mhc_fn_hi_float(K0) and lo the same run + 8. Each run IS one MFMA
+        // fragment (8 bf16), so no per-element extraction is needed downstream.
+        //
+        // UNVALIDATED: wave64 only. This machine is gfx1250 (wave32), which takes the
+        // WMMA path below, so this arm has been compile-checked but not run. Needs a
+        // gfx942/gfx950 correctness run before it is trusted.
+        auto lds_read_fn_chunk_bf16 = [&](float* s_fn_rd_ptr,
+                                          float (&hi_raw)[repeat_n][4],
+                                          float (&lo_raw)[repeat_n][4], int c) {
             #pragma unroll
             for (int n = 0; n < repeat_n; n++) {
                 int fn_row = n * mfma_n + lane_id % mfma_n;
+                int hi_f = mhc_fn_hi_float((c * mfma_k + lane_id / mfma_n) * 8);
+                int mask = (fn_row & 0xF) << fn_xor_shift;
                 if constexpr (fn_vec_size == 1) {
                     #pragma unroll
-                    for (int e = 0; e < 8; e++) {
-                        int kk = c * 8 + e;
-                        int K_wanted = (kk / 8 * mfma_k + lane_id / mfma_n) * 8 + kk % 8;
-                        raw[n][e] = *(s_fn_rd_ptr + fn_row * tile_k +
-                                      (K_wanted ^ ((fn_row & 0xF) << fn_xor_shift)));
+                    for (int t = 0; t < 4; t++) {
+                        hi_raw[n][t] = *(s_fn_rd_ptr + fn_row * tile_k + ((hi_f + t) ^ mask));
+                        lo_raw[n][t] = *(s_fn_rd_ptr + fn_row * tile_k + ((hi_f + 8 + t) ^ mask));
                     }
                 } else {
-                    #pragma unroll
-                    for (int v = 0; v < 8 / fn_vec_size; v++) {
-                        int kk_base = c * 8 + v * fn_vec_size;
-                        int K_wanted_base = (kk_base / 8 * mfma_k + lane_id / mfma_n) * 8 +
-                                            kk_base % 8;
-                        int K_lds_base = K_wanted_base ^ ((fn_row & 0xF) << fn_xor_shift);
-                        fp32x4_t bf_vec = *(reinterpret_cast<fp32x4_t*>(
-                            s_fn_rd_ptr + fn_row * tile_k + K_lds_base));
-                        #pragma unroll
-                        for (int i = 0; i < fn_vec_size; i++) {
-                            raw[n][v * fn_vec_size + i] = bf_vec[i];
-                        }
-                    }
+                    // fn_vec_size == 4 pairs with fn_xor_shift == 2, so the mask's low two
+                    // bits are zero and a 4-float run stays contiguous under the swizzle.
+                    *reinterpret_cast<fp32x4_t*>(hi_raw[n]) = *(reinterpret_cast<fp32x4_t*>(
+                        s_fn_rd_ptr + fn_row * tile_k + (hi_f ^ mask)));
+                    *reinterpret_cast<fp32x4_t*>(lo_raw[n]) = *(reinterpret_cast<fp32x4_t*>(
+                        s_fn_rd_ptr + fn_row * tile_k + ((hi_f + 8) ^ mask)));
                 }
             }
         };
@@ -545,20 +506,18 @@ namespace aiter {
             float* s_fn_rd_ptr = s_fn + (LDS_SLOT) * tile_n * tile_k;                             \
             _Pragma("unroll")                                                                     \
             for (int c = 0; c < n_chunks_bf16; c++) {                                             \
-                float raw[repeat_n][8];                                                           \
-                lds_read_fn_chunk_bf16(s_fn_rd_ptr, raw, c);                                      \
+                float hi_raw[repeat_n][4], lo_raw[repeat_n][4];                                   \
+                lds_read_fn_chunk_bf16(s_fn_rd_ptr, hi_raw, lo_raw, c);                           \
                 s_wait_all_dscnt(0_I);                                                            \
                 _Pragma("unroll")                                                                 \
                 for (int n = 0; n < repeat_n; n++) {                                              \
-                    opus::vector_t<opus::bf16_t, 8> fn_hi, fn_lo;                                 \
-                    /* fn is pre-packed (hi<<16|lo, from mhc_pre_convert_fn); bit-extract both */  \
-                    /* bf16, no fp32->bf16 split -- the redundant per-(m_block,k) work removed. */ \
-                    _Pragma("unroll")                                                             \
-                    for (int e = 0; e < 8; e++) {                                                 \
-                        uint32_t bits = __builtin_bit_cast(uint32_t, raw[n][e]);                  \
-                        fn_hi[e] = __builtin_bit_cast(opus::bf16_t, (uint16_t)(bits >> 16));      \
-                        fn_lo[e] = __builtin_bit_cast(opus::bf16_t, (uint16_t)(bits & 0xFFFFu));  \
-                    }                                                                             \
+                    /* Block-interleaved fn: the two fragments ARE the float runs. */             \
+                    using f32x4_ = opus::vector_t<float, 4>;                                      \
+                    using bf16x8_ = opus::vector_t<opus::bf16_t, 8>;                              \
+                    bf16x8_ fn_hi = __builtin_bit_cast(bf16x8_,                                   \
+                        *reinterpret_cast<f32x4_*>(hi_raw[n]));                                   \
+                    bf16x8_ fn_lo = __builtin_bit_cast(bf16x8_,                                   \
+                        *reinterpret_cast<f32x4_*>(lo_raw[n]));                                   \
                     v_cf[n] = opus::mfma_f32_16x16x32_bf16{}(fn_hi, x_bf[c], v_cf[n]);            \
                     v_cf[n] = opus::mfma_f32_16x16x32_bf16{}(fn_lo, x_bf[c], v_cf[n]);            \
                     __builtin_amdgcn_sched_barrier(0);                                            \
@@ -578,19 +537,31 @@ namespace aiter {
         static constexpr int n_chunks_bf16_w32 = vec_tile / 16;
         static_assert(!mhc_bf16_mma_avail || vec_tile % 16 == 0,
                       "wave32 bf16 needs vec_tile a multiple of 16");
-        auto lds_read_fn_chunk_bf16_w32 = [&](float* s_fn_rd_ptr, float (&raw)[repeat_n][16], int c) {
+        // Block-interleaved fn. The 16 logical K of one wave32 fragment are TWO runs of 8:
+        //   run r (r=0,1):  K0 = k_group*8 + 32*c + 16*r
+        // (x_vec_size=8, interleave_size=2). Each run's hi is 4 consecutive floats at
+        // mhc_fn_hi_float(K0) and its lo the same run + 8, and the runs land in fragment
+        // order, so hi_raw/lo_raw are the two fragments verbatim.
+        auto lds_read_fn_chunk_bf16_w32 = [&](float* s_fn_rd_ptr,
+                                              float (&hi_raw)[repeat_n][8],
+                                              float (&lo_raw)[repeat_n][8], int c) {
             #pragma unroll
             for (int n = 0; n < repeat_n; n++) {
                 int fn_row = n * mfma_n + lane_id % mfma_n;
                 int k_group = lane_id / mfma_m;
+                int mask = (fn_row & 0xF) << fn_xor_shift;
                 #pragma unroll
-                for (int i = 0; i < 16; i++) {
-                    int kk = c * 16 + i;
-                    int K_wanted = k_group * x_vec_size +
-                                   (kk / x_vec_size) * interleave_size * x_vec_size +
-                                   kk % x_vec_size;
-                    raw[n][i] = *(s_fn_rd_ptr + fn_row * tile_k +
-                                  (K_wanted ^ ((fn_row & 0xF) << fn_xor_shift)));
+                for (int r = 0; r < 2; r++) {
+                    int hi_f = mhc_fn_hi_float(k_group * x_vec_size +
+                                               c * 2 * interleave_size * x_vec_size +
+                                               r * interleave_size * x_vec_size);
+                    #pragma unroll
+                    for (int t = 0; t < 4; t++) {
+                        hi_raw[n][r * 4 + t] =
+                            *(s_fn_rd_ptr + fn_row * tile_k + ((hi_f + t) ^ mask));
+                        lo_raw[n][r * 4 + t] =
+                            *(s_fn_rd_ptr + fn_row * tile_k + ((hi_f + 8 + t) ^ mask));
+                    }
                 }
             }
         };
@@ -619,19 +590,18 @@ namespace aiter {
             float* s_fn_rd_ptr = s_fn + (LDS_SLOT) * tile_n * tile_k;                             \
             _Pragma("unroll")                                                                     \
             for (int c = 0; c < n_chunks_bf16_w32; c++) {                                         \
-                float raw[repeat_n][16];                                                          \
-                lds_read_fn_chunk_bf16_w32(s_fn_rd_ptr, raw, c);                                  \
+                float hi_raw[repeat_n][8], lo_raw[repeat_n][8];                                   \
+                lds_read_fn_chunk_bf16_w32(s_fn_rd_ptr, hi_raw, lo_raw, c);                       \
                 s_wait_all_dscnt(0_I);                                                            \
                 _Pragma("unroll")                                                                 \
                 for (int n = 0; n < repeat_n; n++) {                                              \
-                    opus::vector_t<opus::bf16_t, 16> fn_hi, fn_lo;                                \
-                    /* fn is pre-packed (hi<<16|lo); bit-extract both bf16 -- no fp split. */      \
-                    _Pragma("unroll")                                                             \
-                    for (int i = 0; i < 16; i++) {                                                \
-                        uint32_t bits = __builtin_bit_cast(uint32_t, raw[n][i]);                  \
-                        fn_hi[i] = __builtin_bit_cast(opus::bf16_t, (uint16_t)(bits >> 16));      \
-                        fn_lo[i] = __builtin_bit_cast(opus::bf16_t, (uint16_t)(bits & 0xFFFFu));  \
-                    }                                                                             \
+                    /* Block-interleaved fn: the two fragments ARE the float runs. */             \
+                    using f32x8_ = opus::vector_t<float, 8>;                                      \
+                    using bf16x16_ = opus::vector_t<opus::bf16_t, 16>;                            \
+                    bf16x16_ fn_hi = __builtin_bit_cast(bf16x16_,                                 \
+                        *reinterpret_cast<f32x8_*>(hi_raw[n]));                                   \
+                    bf16x16_ fn_lo = __builtin_bit_cast(bf16x16_,                                 \
+                        *reinterpret_cast<f32x8_*>(lo_raw[n]));                                   \
                     v_cf[n] = opus::wmma_f32_16x16x32_bf16{}(fn_hi, x_bf[c], v_cf[n]);            \
                     v_cf[n] = opus::wmma_f32_16x16x32_bf16{}(fn_lo, x_bf[c], v_cf[n]);            \
                     __builtin_amdgcn_sched_barrier(0);                                            \
@@ -725,20 +695,20 @@ namespace aiter {
                 }                                                                                  \
             }                                                                                      \
         } while (0)
-        // is_fn_pack_bf16: bf16 hi/lo MFMA; otherwise fp32 MFMA. The bf16 body (and the
+        // is_res_w_preshuffle_bf16: bf16 hi/lo MFMA; otherwise fp32 MFMA. The bf16 body (and the
         // gfx950-only mfma_f32_16x16x32_bf16 builtin) exists only in the gfx950 device
         // pass; every other arch compiles the fp32 path unconditionally, so the flag is
         // a no-op there (falls back to fp32).
 #if MHC_BF16_MFMA
 #define MHC_PRE_GEMM_STEP(BUF, LDS_SLOT, k, DO_PREFETCH)                    \
-        if constexpr (is_fn_pack_bf16) {                                   \
+        if constexpr (is_res_w_preshuffle_bf16) {                                   \
             GEMM_LOOP_BODY_BF16(BUF, LDS_SLOT, k, DO_PREFETCH);           \
         } else {                                                          \
             GEMM_LOOP_BODY(BUF, LDS_SLOT, k, DO_PREFETCH);               \
         }
 #elif defined(__gfx1250__)
 #define MHC_PRE_GEMM_STEP(BUF, LDS_SLOT, k, DO_PREFETCH)                    \
-        if constexpr (is_fn_pack_bf16) {                                   \
+        if constexpr (is_res_w_preshuffle_bf16) {                                   \
             GEMM_LOOP_BODY_BF16_W32(BUF, LDS_SLOT, k, DO_PREFETCH);       \
         } else {                                                          \
             GEMM_LOOP_BODY(BUF, LDS_SLOT, k, DO_PREFETCH);               \
@@ -822,9 +792,9 @@ namespace aiter {
         aiter_tensor_t& out, // (split_k, m, hc_mult3) / (m, hc_mult3)
         aiter_tensor_t& sqrsum, // (split_k, m) / (m)
         aiter_tensor_t& x, // (m, hc_hidden_size)
-        aiter_tensor_t& fn, // (hc_mult3, hc_hidden_size) fp32; packed int32 (hi<<16|lo) when is_fn_pack_bf16
+        aiter_tensor_t& fn, // (hc_mult3, hc_hidden_size) fp32; packed int32 (hi<<16|lo) when is_res_w_preshuffle_bf16
         int tile_k = 128,
-        int is_fn_pack_bf16 = 0
+        int is_res_w_preshuffle_bf16 = 0
     )
     {
         AITER_CHECK(out.size(0) == sqrsum.size(0), "out and sqrsum must have the same number of split_k or m");
@@ -843,7 +813,7 @@ namespace aiter {
         const HipDeviceGuard device_guard(x.device_id);
         const hipStream_t stream = aiter::getCurrentHIPStream();
 
-        if (is_fn_pack_bf16) {
+        if (is_res_w_preshuffle_bf16) {
 #define MHC_PRE_BF16 true
             MHC_PRE_GEMM_SQRSUM_KERNEL_DISPATCH(tile_k);
 #undef MHC_PRE_BF16
@@ -899,7 +869,8 @@ namespace aiter {
         float hc_post_mult_value,
         int sinkhorn_repeat,
         int n_splits,
-        int sub_hidden_size
+        int sub_hidden_size,
+        int res_preshuffle
     )
     {
         static constexpr int cache_policy = use_nt ? GROUP_NT : RT;
@@ -1092,13 +1063,52 @@ namespace aiter {
             const int res_row_id = res_rowhc_id / hc_mult;
             const int res_hc_id = res_rowhc_id % hc_mult;
             const int K_swizzled = row_hc_iter * res_vec_size;
+            // Pre-shuffled residual (see mhc_res_ks): resS[k/KS][head][row][k%KS].
+            // Both layouts read res_vec_size/KS runs of KS elements at base + p*stride;
+            // for the plain layout stride == KS, i.e. one contiguous res_vec_size run --
+            // which is exactly the 16-byte chunk sequence load_vector_nbytes already
+            // emitted, so the plain path's codegen is unchanged and no second kernel
+            // instantiation is needed.
+            static constexpr int res_ks = mhc_res_ks;
+            // A thread's res_vec_size elements are read as runs of res_run: KS when the
+            // vector spans whole KS blocks, the whole vector when it fits inside one.
+            static constexpr int res_run = res_vec_size < res_ks ? res_vec_size : res_ks;
+            static_assert(res_vec_size % res_run == 0 && res_ks % res_run == 0,
+                "res_vec_size and mhc_res_ks must be multiples of each other");
+            static constexpr int res_pieces = res_vec_size / res_run;
+            static constexpr int res_piece_bytes = res_run * sizeof(DTYPE_I) % 16 == 0
+                ? 16 : (res_run * sizeof(DTYPE_I) % 8 == 0 ? 8 : 4);
+            using res_piece_t = opus::vector_t<DTYPE_I, res_run>;
+            const int64_t res_head_stride = (int64_t)m * res_ks;
+            const int64_t res_kb_stride = (int64_t)hc_mult * res_head_stride;
+            auto buffer_res_shuf = opus::make_gmem<DTYPE_I>(
+                residual, (unsigned int)((int64_t)hc_mult * m * hidden_size * sizeof(DTYPE_I)));
             auto load_res_loop = [&](int i) {
                 res_vec_t v_res;
                 if (i < out_loop) {
-                    v_res = load_vector_nbytes<DTYPE_I, res_vec_size, res_load_bytes, cache_policy, false>(
-                        buffer_res,
-                        res_row_id * residual_stride + res_hc_id * residual_hc_stride +
-                        i * residual_block + K_swizzled);
+                    const int k0 = k_offset + i * residual_block + K_swizzled;
+                    int base, piece_stride;
+                    if (res_preshuffle) {
+                        // see the rmsnorm kernel: row is interior to the shuffled layout, so
+                        // rows >= m_oob need an explicit OOB offset rather than num_records.
+                        base = res_row_id < m_oob
+                             ? (int)((int64_t)(k0 / res_ks) * res_kb_stride
+                                     + (int64_t)res_hc_id * res_head_stride)
+                               + (m_idx + res_row_id) * res_ks + k0 % res_ks
+                             : -1;
+                        piece_stride = res_row_id < m_oob ? (int)res_kb_stride : 0;
+                    } else {
+                        base = res_row_id * residual_stride + res_hc_id * residual_hc_stride
+                             + i * residual_block + K_swizzled;
+                        piece_stride = res_run;
+                    }
+                    auto& buf = res_preshuffle ? buffer_res_shuf : buffer_res;
+                    res_piece_t* dst = reinterpret_cast<res_piece_t*>(&v_res);
+                    #pragma unroll
+                    for (int p = 0; p < res_pieces; p++) {
+                        dst[p] = load_vector_nbytes<DTYPE_I, res_run, res_piece_bytes, cache_policy, false>(
+                            buf, base + p * piece_stride);
+                    }
                 }
                 return v_res;
             };
@@ -1213,7 +1223,8 @@ namespace aiter {
             hc_post_mult_value, \
             sinkhorn_repeat, \
             n_splits, \
-            sub_hidden_size \
+            sub_hidden_size, \
+            res_preshuffle \
         ); \
     });
 
@@ -1244,7 +1255,8 @@ namespace aiter {
         float hc_pre_eps = 1e-6,
         float hc_sinkhorn_eps = 1e-6,
         float hc_post_mult_value = 1.0,
-        int sinkhorn_repeat = 20
+        int sinkhorn_repeat = 20,
+        int res_preshuffle = 0
     )
     {
         int m = residual.size(0);
@@ -1254,6 +1266,8 @@ namespace aiter {
         int hc_mult = residual.size(1);
         int n_splits = gemm_out_mul.dim() > 2 ? gemm_out_mul.size(0) : 1;
         AITER_CHECK(hc_mult == 4, "hc_mult only supports 4");
+        AITER_CHECK(!res_preshuffle || hidden_size % mhc_res_ks == 0,
+                    "pre-shuffled residual needs hidden_size divisible by mhc_res_ks");
 
         const HipDeviceGuard device_guard(layer_input.device_id);
         const hipStream_t stream = aiter::getCurrentHIPStream();
@@ -1719,7 +1733,8 @@ namespace aiter {
         float hc_sinkhorn_eps,
         float norm_eps,
         float hc_post_mult_value,
-        int sinkhorn_repeat
+        int sinkhorn_repeat,
+        int res_preshuffle
     )
     {
         static constexpr int cache_policy = use_nt ? GROUP_NT : RT;
@@ -1923,13 +1938,52 @@ namespace aiter {
             const int out_loop = hidden_size / residual_block;
             const int K_swizzled = row_hc_iter * res_vec_size;
             float sumsq_per_td = 0.0f;
+            // Pre-shuffled residual (see mhc_res_ks), same base + p*stride formulation as
+            // mhc_pre_big_fuse_kernel. Note the cost: this kernel is row-blocked (num_rows
+            // is 1 or 2), so it can never span the shuffled layout's row-contiguous run and
+            // its per-lane run shrinks from res_vec_size to KS elements. The shuffle is a
+            // win for the gemm, which reads tile_m rows at once; here it is a tax.
+            static constexpr int res_ks = mhc_res_ks;
+            // A thread's res_vec_size elements are read as runs of res_run: KS when the
+            // vector spans whole KS blocks, the whole vector when it fits inside one.
+            static constexpr int res_run = res_vec_size < res_ks ? res_vec_size : res_ks;
+            static_assert(res_vec_size % res_run == 0 && res_ks % res_run == 0,
+                "res_vec_size and mhc_res_ks must be multiples of each other");
+            static constexpr int res_pieces = res_vec_size / res_run;
+            static constexpr int res_piece_bytes = res_run * sizeof(DTYPE_I) % 16 == 0
+                ? 16 : (res_run * sizeof(DTYPE_I) % 8 == 0 ? 8 : 4);
+            using res_piece_t = opus::vector_t<DTYPE_I, res_run>;
+            const int64_t res_head_stride = (int64_t)m * res_ks;
+            const int64_t res_kb_stride = (int64_t)hc_mult * res_head_stride;
+            auto buffer_res_shuf = opus::make_gmem<DTYPE_I>(
+                residual, (unsigned int)((int64_t)hc_mult * m * hidden_size * sizeof(DTYPE_I)));
             auto load_res_loop = [&](int i) {
                 res_vec_t v_res;
-                if (i < out_loop && res_row_id < m_oob) {
-                    v_res = load_vector_nbytes<DTYPE_I, res_vec_size, res_load_bytes, 0, false>(
-                        buffer_res,
-                        res_row_id * residual_stride + res_hc_id * residual_hc_stride +
-                        i * residual_block + K_swizzled);
+                if (i < out_loop) {
+                    const int k0 = i * residual_block + K_swizzled;
+                    int base, piece_stride;
+                    if (res_preshuffle) {
+                        // row is interior to the shuffled layout, so num_records can no
+                        // longer clip rows >= m_oob (they alias the next head). Point every
+                        // piece at a negative offset instead -- buffer loads return 0, which
+                        // is what the plain path gets from its num_records bound.
+                        base = res_row_id < m_oob
+                             ? (int)((int64_t)(k0 / res_ks) * res_kb_stride
+                                     + (int64_t)res_hc_id * res_head_stride)
+                               + (m_idx + res_row_id) * res_ks + k0 % res_ks
+                             : -1;
+                        piece_stride = res_row_id < m_oob ? (int)res_kb_stride : 0;
+                    } else {
+                        base = res_row_id * residual_stride + res_hc_id * residual_hc_stride + k0;
+                        piece_stride = res_run;
+                    }
+                    auto& buf = res_preshuffle ? buffer_res_shuf : buffer_res;
+                    res_piece_t* dst = reinterpret_cast<res_piece_t*>(&v_res);
+                    #pragma unroll
+                    for (int p = 0; p < res_pieces; p++) {
+                        dst[p] = load_vector_nbytes<DTYPE_I, res_run, res_piece_bytes, 0, false>(
+                            buf, base + p * piece_stride);
+                    }
                 }
                 return v_res;
             };
@@ -2153,7 +2207,8 @@ namespace aiter {
             hc_sinkhorn_eps, \
             norm_eps, \
             hc_post_mult_value, \
-            sinkhorn_repeat \
+            sinkhorn_repeat, \
+            res_preshuffle \
         ); \
     });
 
@@ -2217,7 +2272,8 @@ namespace aiter {
         float hc_sinkhorn_eps = 1e-6,
         float norm_eps = 1e-6,
         float hc_post_mult_value = 1.0,
-        int sinkhorn_repeat = 20
+        int sinkhorn_repeat = 20,
+        int res_preshuffle = 0
     )
     {
         int m = residual.size(0);
@@ -2227,6 +2283,8 @@ namespace aiter {
         int hc_mult = residual.size(1);
         int n_splits = gemm_out_mul.dim() > 2 ? gemm_out_mul.size(0) : 1;
         AITER_CHECK(hc_mult == 4, "hc_mult only supports 4");
+        AITER_CHECK(!res_preshuffle || hidden_size % mhc_res_ks == 0,
+                    "pre-shuffled residual needs hidden_size divisible by mhc_res_ks");
 
         const HipDeviceGuard device_guard(out.device_id);
         const hipStream_t stream = aiter::getCurrentHIPStream();
@@ -2235,7 +2293,7 @@ namespace aiter {
         MHC_PRE_BIG_FUSE_RM_KERNEL_DISPATCH(m);
     }
 
-    template <typename DTYPE_I, int num_warps, int hc_mult, int tile_m, int tile_n, int tile_k, bool store_nt, bool is_fn_pack_bf16 = false>
+    template <typename DTYPE_I, int num_warps, int hc_mult, int tile_m, int tile_n, int tile_k, bool store_nt, bool is_res_w_preshuffle_bf16 = false>
     __global__ __launch_bounds__(num_warps * opus::get_warp_size(), 1)
     void mhc_fused_post_pre_gemm_sqrsum_kernel(
         float* out,
@@ -2250,9 +2308,7 @@ namespace aiter {
         int hidden_size,
         int x_stride,
         int out_stride,
-        int split_k = 1,
-        int fn_n_pad = 0   // 0: fn is the plain (hc_mult3, hc_hidden_size) layout;
-                           // >0: fn is preshuffled to (hc_hidden_size/32, fn_n_pad, 32)
+        int split_k = 1
     )
     {
         static constexpr int store_policy = store_nt ? GROUP_NT : RT;
@@ -2271,6 +2327,17 @@ namespace aiter {
         static constexpr int n_stages = 2;
         __shared__ DTYPE_I s_x[n_stages * tile_m * tile_k];
         __shared__ DTYPE_I s_residual[n_stages * tile_m * hc_mult * tile_k];
+#if defined(__gfx1250__)
+        // num_warps > 2: the store must be issued by a warp that owns no TDM load
+        // (warps 0/1 issue residual/x), or that warp would carry n_stages loads +
+        // n_stages stores = 4 tensor ops in flight, over the per-wave limit of 3.
+        static constexpr bool nres_tdm = mhc_nres_tdm_store && is_res_w_preshuffle_bf16
+                                         && mhc_res_shuffle && (num_warps > 2);
+#else
+        static constexpr bool nres_tdm = false;
+#endif
+        // Staging tile for the next_residual TDM store; same layout as s_residual.
+        __shared__ DTYPE_I s_nres[nres_tdm ? n_stages * tile_m * hc_mult * tile_k : 1];
 
         int64_t idx = blockIdx.x * tile_m;
         int n_idx = blockIdx.y * tile_n;
@@ -2295,23 +2362,45 @@ namespace aiter {
         using fp32xmma_t = opus::vector_t<float, mma_pack_size>;
 
         DTYPE_I* x_ptr = x + idx * x_stride;
-        // Preshuffled fn is addressed from its base (n_idx folds into the element
-        // offset below) and needs no N bound: the padded rows are zero-filled.
-        float* fn_ptr  = fn_n_pad ? fn : (fn + n_idx * hc_hidden_size);
+        float* fn_ptr  = fn + n_idx * hc_hidden_size;
         float* out_ptr = out + (static_cast<int64_t>(k_split_idx * m + idx)) * out_stride + n_idx;
         int residual_stride = hc_hidden_size;
         int fn_stride = hc_hidden_size;
-        DTYPE_I* residual_ptr = residual + idx * residual_stride;
-        DTYPE_I* next_residual_ptr = next_residual + idx * residual_stride;
+        // Pre-shuffled residual (see mhc_res_ks): resS[k/KS][head][row][k%KS].
+        static constexpr bool res_shuf = is_res_w_preshuffle_bf16 && mhc_res_shuffle;
+        static constexpr int res_ks = mhc_res_ks;
+        static_assert(tile_k % res_ks == 0, "tile_k must be divisible by mhc_res_ks");
+        static constexpr int res_nkb = tile_k / res_ks;              // kb blocks per k-step
+        static constexpr int res_h_stride_lds = tile_m * res_ks;     // LDS head stride
+        static constexpr int res_kb_stride_lds = hc_mult * tile_m * res_ks;
+        const int64_t res_head_stride = (int64_t)m * res_ks;
+        const int64_t res_kb_stride = (int64_t)hc_mult * res_head_stride;
+        // k_split_offset is a multiple of tile_k, hence of KS.
+        const int64_t res_shuf_off =
+            (int64_t)(k_split_offset / res_ks) * res_kb_stride + idx * res_ks;
+        DTYPE_I* residual_ptr = res_shuf
+            ? residual + res_shuf_off : residual + idx * residual_stride;
+        DTYPE_I* next_residual_ptr = res_shuf
+            ? next_residual + res_shuf_off : next_residual + idx * residual_stride;
         const int m_oob = m < idx + tile_m ? (m - idx) : tile_m;
         const int n_oob = hc_mult3 < (n_idx + tile_n) ? (hc_mult3 - n_idx) : tile_n;
         auto g_x = opus::make_gmem<DTYPE_I>(x_ptr, x_stride * sizeof(DTYPE_I) * m_oob);
-        auto g_fn = opus::make_gmem<float>(
-            fn_ptr, fn_n_pad ? (hc_hidden_size * fn_n_pad * (int)sizeof(float))
-                             : (hc_hidden_size * (int)sizeof(float) * n_oob));
-        // fn_n_pad is the row count actually stored per K block (== hc_mult3, unpadded).
-        auto g_res = opus::make_gmem<DTYPE_I>(residual_ptr, residual_stride * sizeof(DTYPE_I) * m_oob);
-        auto g_nres = opus::make_gmem<DTYPE_I>(next_residual_ptr, residual_stride * sizeof(DTYPE_I) * m_oob);
+        auto g_fn = opus::make_gmem<float>(fn_ptr, hc_hidden_size * (int)sizeof(float) * n_oob);
+        // Shuffled bound: this block touches hidden_size/(split_k*KS) kb blocks, NOT
+        // k_loop of them -- one k-step spans res_nkb blocks. (Using k_loop here clamped
+        // 3/4 of the stores out of bounds and made the kernel look 42% faster at m=16384.)
+        // The row dimension is interior to the layout, so the bound cannot express the
+        // m_oob cut the [row][head][k] layout got for free; rows >= m_oob are dropped by
+        // an explicit predicate on the store and zero-filled by the loader instead.
+        const unsigned int res_shuf_bytes = res_shuf
+            ? (unsigned int)(res_kb_stride * (hidden_size / (split_k * res_ks)) * sizeof(DTYPE_I))
+            : 0u;
+        auto g_res = res_shuf
+            ? opus::make_gmem<DTYPE_I>(residual_ptr, res_shuf_bytes)
+            : opus::make_gmem<DTYPE_I>(residual_ptr, residual_stride * sizeof(DTYPE_I) * m_oob);
+        auto g_nres = res_shuf
+            ? opus::make_gmem<DTYPE_I>(next_residual_ptr, res_shuf_bytes)
+            : opus::make_gmem<DTYPE_I>(next_residual_ptr, residual_stride * sizeof(DTYPE_I) * m_oob);
         auto g_o = opus::make_gmem<float>(out_ptr, out_stride * sizeof(float) * m_oob);
 
         static constexpr int tile_mk = tile_m * tile_k;
@@ -2400,15 +2489,32 @@ namespace aiter {
             // in wait_load_cnt(). make() is 2D-only, so the 3D shape/pitch/origin
             // go in through make_from_layout(), already in D# order (dim0 fastest).
             if (warp_id == 0) {
-                using win_t = opus::tdm<DTYPE_I, opus::seq<tile_k, tile_m, hc_mult>>;
-                uint32_t lds = static_cast<uint32_t>(reinterpret_cast<__UINTPTR_TYPE__>(s_residual));
-                DTYPE_I* g = residual_ptr + k_split_offset + k * tile_k;
-                const opus::u32_t shape[3] = {tile_k, (opus::u32_t)m_oob, hc_mult};
-                const opus::u64_t pitch[2] = {(opus::u64_t)residual_stride, (opus::u64_t)hidden_size};
-                const opus::u32_t coord[3] = {0, 0, 0};
-                win_t win;
-                win.make_from_layout(lds, g, shape, pitch, coord);
-                win.async_load(static_cast<uint32_t>(slot * (hc_mult * tile_mk)));
+                if constexpr (res_shuf) {
+                    // Shuffled: 4D tile kk x row x head x kb. The row pitch is KS, so
+                    // (row, kk) is one contiguous tile_m*KS run; TDM writes
+                    // dim0-fastest, giving LDS [kb][head][row][kk].
+                    using win_t = opus::tdm<DTYPE_I, opus::seq<res_ks, tile_m, hc_mult, res_nkb>>;
+                    uint32_t lds = static_cast<uint32_t>(reinterpret_cast<__UINTPTR_TYPE__>(s_residual));
+                    DTYPE_I* g = residual_ptr + (int64_t)k * res_nkb * res_kb_stride;
+                    const opus::u32_t shape[4] = {res_ks, (opus::u32_t)m_oob, hc_mult, res_nkb};
+                    const opus::u64_t pitch[3] = {(opus::u64_t)res_ks,
+                                                  (opus::u64_t)res_head_stride,
+                                                  (opus::u64_t)res_kb_stride};
+                    const opus::u32_t coord[4] = {0, 0, 0, 0};
+                    win_t win;
+                    win.make_from_layout(lds, g, shape, pitch, coord);
+                    win.async_load(static_cast<uint32_t>(slot * (hc_mult * tile_mk)));
+                } else {
+                    using win_t = opus::tdm<DTYPE_I, opus::seq<tile_k, tile_m, hc_mult>>;
+                    uint32_t lds = static_cast<uint32_t>(reinterpret_cast<__UINTPTR_TYPE__>(s_residual));
+                    DTYPE_I* g = residual_ptr + k_split_offset + k * tile_k;
+                    const opus::u32_t shape[3] = {tile_k, (opus::u32_t)m_oob, hc_mult};
+                    const opus::u64_t pitch[2] = {(opus::u64_t)residual_stride, (opus::u64_t)hidden_size};
+                    const opus::u32_t coord[3] = {0, 0, 0};
+                    win_t win;
+                    win.make_from_layout(lds, g, shape, pitch, coord);
+                    win.async_load(static_cast<uint32_t>(slot * (hc_mult * tile_mk)));
+                }
             }
         };
 #else
@@ -2418,7 +2524,37 @@ namespace aiter {
         static constexpr int r_async_load_vec = 16 / sizeof(DTYPE_I) * warp_size <= tile_mk ? 16 / sizeof(DTYPE_I) : 4 / sizeof(DTYPE_I);
 #endif
         static constexpr int residual_load_waitcnt = tile_mk / (warp_size * r_async_load_vec);
-        auto lds_load_residual_tile = [&](int k, int slot){
+        // Shuffled variant (UNVALIDATED: wave64 only -- this machine is gfx1250, which
+        // takes the TDM path above). Per head the tile is res_nkb contiguous runs of
+        // tile_m*KS elements; walk them linearly so the issue count -- and therefore
+        // residual_load_waitcnt -- is unchanged (res_nkb*tile_m*KS == tile_mk).
+        static_assert(!(res_shuf) || r_async_load_vec <= res_ks,
+                      "shuffled residual load must not cross a KS run");
+        auto lds_load_residual_tile_shuf = [&](int k, int slot){
+            DTYPE_I* s_residual_wr_ptr = s_residual + slot * (hc_mult * tile_mk);
+            const int64_t k_off = (int64_t)k * res_nkb * res_kb_stride;
+            #pragma unroll
+            for(int i = 0; i < residual_load_waitcnt; i++) {
+                const int t = i * (warp_size * r_async_load_vec) + lane_id * r_async_load_vec;
+                const int kb = t / (tile_m * res_ks);
+                const int rem = t % (tile_m * res_ks);
+                const int row = rem / res_ks;
+                const int kk = rem % res_ks;
+                const int s_offset = kb * res_kb_stride_lds + warp_id * res_h_stride_lds
+                                   + row * res_ks + kk;
+                const int g_offset = (int)(k_off + (int64_t)kb * res_kb_stride
+                                     + (int64_t)warp_id * res_head_stride) + row * res_ks + kk;
+                if (row < m_oob) {
+                    async_load<r_async_load_vec>(g_res, s_residual_wr_ptr + s_offset, g_offset, 0, opus::number<0>{}, opus::number<GROUP_NT>{});
+                } else {
+                    #pragma unroll
+                    for (int v = 0; v < r_async_load_vec; v++) {
+                        *(s_residual_wr_ptr + s_offset + v) = static_cast<DTYPE_I>(0);
+                    }
+                }
+            }
+        };
+        auto lds_load_residual_tile_plain = [&](int k, int slot){
             static constexpr int rows_per_load = r_async_load_vec * warp_size / tile_k;
             static constexpr int threads_per_row = tile_k / r_async_load_vec;
             DTYPE_I* s_residual_wr_ptr = s_residual + slot * (hc_mult * tile_mk);
@@ -2443,44 +2579,20 @@ namespace aiter {
                 s_offset += s_offset_i;
             }
         };
+        auto lds_load_residual_tile = [&](int k, int slot){
+            if constexpr (res_shuf) { lds_load_residual_tile_shuf(k, slot); }
+            else { lds_load_residual_tile_plain(k, slot); }
+        };
 #endif
         
         static constexpr int fn_load_vec = 16 / sizeof(float);
         static constexpr int fn_load_waitcnt = tile_n * tile_k / (warp_size * fn_load_vec);
         using fp32xfntile = opus::array<fp32xtile, repeat_n>;
-        // fn_n_pad is a launch-uniform scalar, so this is a scalar branch, not a
-        // per-lane one, and both arms issue the identical vec_tile-wide loads --
-        // only the address arithmetic differs.
-        //
-        // Shuffled (fn_n_pad > 0): fnS[Kflat/32][n][Kflat%32]. Every term of kbase
-        // is a multiple of 32 (see mhc_pre_shuffle_fn), so the block index splits as
-        // kbase/32 + kr0/32 and the in-block offset is just kr0 % 32. Consecutive n
-        // are then mfma_n*32 floats apart (2 KB) instead of mfma_n*fn_stride (1.75 MB).
-        const int fn_kbase = warp_id * hidden_size + k_split_offset;
-        const int fn_kr0   = (lane_id / mfma_n) * vec_tile;
         auto vgpr_load_fn_tile = [&](int k) {
             fp32xfntile v_fn;
-            int offset_base, n_step;
-            if (fn_n_pad) {
-                offset_base = ((fn_kbase + k * tile_k + fn_kr0) / 32) * (fn_n_pad * 32)
-                            + (n_idx + lane_id % mfma_n) * 32 + (fn_kr0 % 32);
-                n_step = mfma_n * 32;
-                // N is not padded, so lanes whose row is >= hc_mult3 must still read 0.
-                // Steer them past the buffer bound (the same mechanism the unshuffled
-                // path gets for free from g_fn's n_oob-derived size) instead of storing
-                // zero rows, which would add 33% to fn's read traffic.
-                const int n_row = n_idx + lane_id % mfma_n;
-                for (int n = 0; n < repeat_n; n++) {
-                    v_fn[n] = (n_row + n * mfma_n) < hc_mult3
-                        ? load_vector_nbytes<float, vec_tile, 16, 0, false>(g_fn, offset_base + n * n_step)
-                        : fp32xtile{};
-                }
-                return v_fn;
-            } else {
-                offset_base = lane_id % mfma_n * fn_stride + fn_kbase + lane_id / mfma_n * vec_tile
-                    + k * tile_k;
-                n_step = mfma_n * fn_stride;
-            }
+            const int offset_base = lane_id % mfma_n * fn_stride + warp_id * hidden_size
+                                  + lane_id / mfma_n * vec_tile + k * tile_k + k_split_offset;
+            const int n_step = mfma_n * fn_stride;
             for(int n = 0; n < repeat_n; n++) {
                 v_fn[n] = load_vector_nbytes<float, vec_tile, 16, 0, false>(g_fn, offset_base + n * n_step);
             }
@@ -2546,8 +2658,23 @@ namespace aiter {
                     using DTYPE_I_vec = opus::vector_t<DTYPE_I, ds_read_vec>;
                     DTYPE_I_vec x_vec = *(reinterpret_cast<DTYPE_I_vec*>(s_x_rd_ptr + s_offset));
                     DTYPE_I_vec residual_vec[hc_mult];
-                    for(int h = 0; h < hc_mult; h++) {
-                        residual_vec[h] = *(reinterpret_cast<DTYPE_I_vec*>(s_residual_rd_ptr + s_offset + h * tile_mk));
+                    // k_local within the k-step; ds_read_vec == KS keeps each read
+                    // inside exactly one kk run, so only the addressing changes.
+                    [[maybe_unused]] const int res_kl = s_offset % tile_k;
+                    [[maybe_unused]] const int res_row = b * mfma_m + lane_id % mfma_m;
+                    if constexpr (res_shuf) {
+                        static_assert(ds_read_vec <= res_ks && res_ks % ds_read_vec == 0,
+                                      "ds_read_vec must divide mhc_res_ks");
+                        const int r_base = (res_kl / res_ks) * res_kb_stride_lds
+                                         + res_row * res_ks + (res_kl % res_ks);
+                        for(int h = 0; h < hc_mult; h++) {
+                            residual_vec[h] = *(reinterpret_cast<DTYPE_I_vec*>(
+                                s_residual_rd_ptr + r_base + h * res_h_stride_lds));
+                        }
+                    } else {
+                        for(int h = 0; h < hc_mult; h++) {
+                            residual_vec[h] = *(reinterpret_cast<DTYPE_I_vec*>(s_residual_rd_ptr + s_offset + h * tile_mk));
+                        }
                     }
                     s_wait_all_dscnt(opus::number<hc_mult>{});
                     for(int k = 0; k < ds_read_vec; k++) {
@@ -2563,11 +2690,37 @@ namespace aiter {
                             sqrsum_part[b] += res[t] * res[t];
                         }
                     }
-                    store_vector<DTYPE_I, float, ds_read_vec, 0, false>(
-                        g_nres, res, (b * mfma_m + lane_id % mfma_m) * residual_stride + warp_id * hidden_size + i * tile_k +
-                        (s_offset % tile_k) + k_split_offset);
+                    if constexpr (nres_tdm) {
+                        // Deposit into this warp's head slice of the same
+                        // [kb][head][row][kk] tile the residual TDM load produces;
+                        // it leaves as one TDM store. Rows past m_oob are written
+                        // here and clipped by tensor_dim1 = m_oob.
+                        DTYPE_I* s_nres_wr = s_nres + slot * (hc_mult * tile_mk);
+                        const int w_off = (res_kl / res_ks) * res_kb_stride_lds
+                                        + warp_id * res_h_stride_lds
+                                        + res_row * res_ks + (res_kl % res_ks);
+                        DTYPE_I_vec nres_v;
+                        for (int e = 0; e < ds_read_vec; e++) {
+                            nres_v[e] = static_cast<DTYPE_I>(res[e]);
+                        }
+                        *(reinterpret_cast<DTYPE_I_vec*>(s_nres_wr + w_off)) = nres_v;
+                    } else if constexpr (res_shuf) {
+                        // Rows past m_oob alias the next head's region (row is interior
+                        // to the layout, so the buffer bound cannot cut them) -- drop
+                        // them with a negative offset, which buffer_store discards.
+                        const int nres_off = res_row < m_oob
+                            ? (int)(((int64_t)i * res_nkb + res_kl / res_ks) * res_kb_stride
+                                    + (int64_t)warp_id * res_head_stride)
+                              + res_row * res_ks + (res_kl % res_ks)
+                            : -1;
+                        store_vector<DTYPE_I, float, ds_read_vec, 0, false>(g_nres, res, nres_off);
+                    } else {
+                        store_vector<DTYPE_I, float, ds_read_vec, 0, false>(
+                            g_nres, res, res_row * residual_stride + warp_id * hidden_size + i * tile_k +
+                            res_kl + k_split_offset);
+                    }
                     s_offset += step;
-                    if constexpr (is_fn_pack_bf16 && mhc_bf16_mma_avail) {
+                    if constexpr (is_res_w_preshuffle_bf16 && mhc_bf16_mma_avail) {
 #if MHC_BF16_MFMA
                         // bf16 MFMA (wave64 CDNA): one mfma_f32_16x16x32_bf16 contracts
                         // ds_read_vec (=8) K-elems/lane x 4 lane-groups = 32 K, replacing
@@ -2583,19 +2736,24 @@ namespace aiter {
                         }
                         for(int n = 0; n < repeat_n; n++) {
                             opus::vector_t<opus::bf16_t, ds_read_vec> fn_hi8, fn_lo8;
-                            // fn is pre-packed (hi<<16|lo, from mhc_pre_convert_fn); bit-extract
-                            // both bf16 -- no fp32->bf16 split recomputed per (m_block, k).
-                            for (int e = 0; e < ds_read_vec; e++) {
-                                float fv = v_fn[n][e + j * ds_read_vec];
-                                uint32_t bits = __builtin_bit_cast(uint32_t, fv);
-                                fn_hi8[e] = __builtin_bit_cast(opus::bf16_t, (uint16_t)(bits >> 16));
-                                fn_lo8[e] = __builtin_bit_cast(opus::bf16_t, (uint16_t)(bits & 0xFFFFu));
+                            {
+                                // Fragment is 8 bf16 = 4 floats; block j/2 is [8 f32 hi][8 f32 lo]
+                                // and the wanted half sits at (j%2)*4 inside each.
+                                using f32x4 = opus::vector_t<float, 4>;
+                                const int off = (j / 2) * 16 + (j % 2) * 4;
+                                f32x4 hi_raw, lo_raw;
+                                for (int e = 0; e < 4; e++) {
+                                    hi_raw[e] = v_fn[n][off + e];
+                                    lo_raw[e] = v_fn[n][off + 8 + e];
+                                }
+                                fn_hi8 = __builtin_bit_cast(opus::vector_t<opus::bf16_t, 8>, hi_raw);
+                                fn_lo8 = __builtin_bit_cast(opus::vector_t<opus::bf16_t, 8>, lo_raw);
                             }
                             v_cf[b][n] = opus::mfma_f32_16x16x32_bf16{}(fn_hi8, res_bf, v_cf[b][n]);
                             v_cf[b][n] = opus::mfma_f32_16x16x32_bf16{}(fn_lo8, res_bf, v_cf[b][n]);
                         }
 #elif defined(__gfx1250__)
-                        // UNVERIFIED (no gfx1250 HW): wave32 WMMA bf16. One
+                        // wave32 WMMA bf16 (validated on gfx1250). One
                         // wmma_f32_16x16x32_bf16 needs 16 K-elems/lane = two band_j steps
                         // combined (2 x ds_read_vec). fn and res are placed at the same
                         // fragment index using the exact (k,j) pairing the fp32 path uses
@@ -2613,16 +2771,25 @@ namespace aiter {
                             }
                             for (int n = 0; n < repeat_n; n++) {
                                 opus::vector_t<opus::bf16_t, 16> fn_hi, fn_lo;
-                                // fn is pre-packed (hi<<16|lo); bit-extract both bf16 -- no fp split.
-                                for (int e = 0; e < ds_read_vec; e++) {
-                                    float fv0 = v_fn[n][e + (j - 1) * ds_read_vec];
-                                    float fv1 = v_fn[n][e + j * ds_read_vec];
-                                    uint32_t b0 = __builtin_bit_cast(uint32_t, fv0);
-                                    uint32_t b1 = __builtin_bit_cast(uint32_t, fv1);
-                                    fn_hi[e]               = __builtin_bit_cast(opus::bf16_t, (uint16_t)(b0 >> 16));
-                                    fn_hi[ds_read_vec + e] = __builtin_bit_cast(opus::bf16_t, (uint16_t)(b1 >> 16));
-                                    fn_lo[e]               = __builtin_bit_cast(opus::bf16_t, (uint16_t)(b0 & 0xFFFFu));
-                                    fn_lo[ds_read_vec + e] = __builtin_bit_cast(opus::bf16_t, (uint16_t)(b1 & 0xFFFFu));
+                                // The 64 B this lane already loaded IS [16 hi][16 lo] for
+                                // this k block, so the two fragments are its halves --
+                                // no shift, no mask, no v_perm. 16 floats per block, hi in
+                                // the first 8, lo in the next 8.
+                                {
+                                    // Move in FLOAT units (whole-VGPR v_mov, foldable by the
+                                    // register allocator) and reinterpret once. Slicing a bf16
+                                    // vector element-wise instead makes the compiler emit
+                                    // sub-register extract/insert -- the very shift+mask this
+                                    // layout exists to remove.
+                                    using f32x8 = opus::vector_t<float, 8>;
+                                    const int off = ((j - 1) * ds_read_vec / 16) * 16;
+                                    f32x8 hi_raw, lo_raw;
+                                    for (int e = 0; e < 8; e++) {
+                                        hi_raw[e] = v_fn[n][off + e];
+                                        lo_raw[e] = v_fn[n][off + 8 + e];
+                                    }
+                                    fn_hi = __builtin_bit_cast(opus::vector_t<opus::bf16_t, 16>, hi_raw);
+                                    fn_lo = __builtin_bit_cast(opus::vector_t<opus::bf16_t, 16>, lo_raw);
                                 }
                                 v_cf[b][n] = opus::wmma_f32_16x16x32_bf16{}(fn_hi, res_bf, v_cf[b][n]);
                                 v_cf[b][n] = opus::wmma_f32_16x16x32_bf16{}(fn_lo, res_bf, v_cf[b][n]);
@@ -2698,13 +2865,44 @@ namespace aiter {
         // proves stage i+s resident ONLY while all n_stages-1 later stages are
         // actually outstanding -- true throughout the steady state, and the reason
         // the tail below falls back to a full drain once the ring stops refilling.
+        // ---- next_residual store via TDM (mirror of lds_load_residual_tile) ----
+        // The same 4D tile kk x row x head x kb, read back out of LDS. Warp 2 owns
+        // no TDM load, so issuing here keeps every wave at n_stages tensor ops. Order
+        // is: deposit (compute_store_tile) -> nres_deposit_fence -> workgroup barrier
+        // -> issue; slot reuse is held behind the store by MHC_TDM_KEEP(n_stages-1)
+        // in wait_load_cnt.
+        auto nres_deposit_fence = [&](){ if constexpr (nres_tdm) { s_wait_all_dscnt(0_I); } };
+#if defined(__gfx1250__)
+        auto tdm_store_nres_tile = [&](int k, int slot){
+            if constexpr (nres_tdm) {
+                if (warp_id == 2) {
+                    using win_t = opus::tdm<DTYPE_I, opus::seq<res_ks, tile_m, hc_mult, res_nkb>>;
+                    uint32_t lds = static_cast<uint32_t>(reinterpret_cast<__UINTPTR_TYPE__>(s_nres));
+                    DTYPE_I* g = next_residual_ptr + (int64_t)k * res_nkb * res_kb_stride;
+                    const opus::u32_t shape[4] = {res_ks, (opus::u32_t)m_oob, hc_mult, res_nkb};
+                    const opus::u64_t pitch[3] = {(opus::u64_t)res_ks,
+                                                  (opus::u64_t)res_head_stride,
+                                                  (opus::u64_t)res_kb_stride};
+                    const opus::u32_t coord[4] = {0, 0, 0, 0};
+                    win_t win;
+                    win.make_from_layout(lds, g, shape, pitch, coord);
+                    win.async_store(static_cast<uint32_t>(slot * (hc_mult * tile_mk)));
+                }
+            }
+        };
+#else
+        auto tdm_store_nres_tile = [](int, int){};
+#endif
+
         int i = 0;
         for(; i + 2 * n_stages - 1 < k_loop; i += n_stages) {
             opus::static_for<n_stages>([&](auto S) {
                 constexpr int s = S.value;
                 wait_load_cnt();
                 compute_store_tile(i + s, s, v_fn[s]);
+                nres_deposit_fence();
                 __builtin_amdgcn_s_barrier();
+                tdm_store_nres_tile(i + s, s);
                 lds_load_x_tile(i + s + n_stages, s);
                 lds_load_residual_tile(i + s + n_stages, s);
                 v_fn[s] = vgpr_load_fn_tile(i + s + n_stages);
@@ -2729,7 +2927,9 @@ namespace aiter {
                 if (k + n_stages < k_loop) {
                     wait_load_cnt();
                     compute_store_tile(k, slot, v_fn[slot]);
+                    nres_deposit_fence();
                     __builtin_amdgcn_s_barrier();
+                    tdm_store_nres_tile(k, slot);
                     lds_load_x_tile(k + n_stages, slot);
                     lds_load_residual_tile(k + n_stages, slot);
                     v_fn[slot] = vgpr_load_fn_tile(k + n_stages);
@@ -2738,9 +2938,16 @@ namespace aiter {
                     MHC_TDM_DRAIN();
                     __builtin_amdgcn_s_barrier();
                     compute_store_tile(k, slot, v_fn[slot]);
+                    if constexpr (nres_tdm) {
+                        nres_deposit_fence();
+                        __builtin_amdgcn_s_barrier();
+                        tdm_store_nres_tile(k, slot);
+                    }
                 }
             }
         });
+        // Every next_residual TDM store must retire before the kernel ends.
+        if constexpr (nres_tdm) { MHC_TDM_DRAIN(); }
 
         // Reduce v_cf (gemm_out_mul) and sqrsum across the hc_mult warps in LDS so
         // only warp 0 writes a single (split_k) partial, instead of each warp
@@ -2829,8 +3036,7 @@ namespace aiter {
                 hidden_size, \
                 x_stride, \
                 out_stride, \
-                split_k, \
-                fn_n_pad); \
+                split_k); \
     });
 
 #define MHC_FUSED_POST_PRE_GEMM_SQRSUM_KERNEL_IMPL(num_warps, tile_m, tile_n, tile_k) \
@@ -2876,25 +3082,18 @@ namespace aiter {
         int tile_m = 16,
         int tile_n = 32,
         int tile_k = 32,
-        int is_fn_pack_bf16 = 0,
-        // 0: fn is the plain (hc_mult3, hc_hidden_size) layout.
-        // >0: fn came from mhc_pre_shuffle_fn -> (hc_hidden_size/32, fn_n_pad, 32).
-        int fn_n_pad = 0)
+        int is_res_w_preshuffle_bf16 = 0)
     {
         int m = layer_input.size(0);
         int hidden_size = layer_input.size(1);
         int hc_mult = residual_in.size(1);
-        // Preshuffled fn is (hc_hidden_size/32, fn_n_pad, 32), so hc_mult3 / hc_hidden_size
-        // are no longer its dim0/dim1 and its stride(0) is not the K pitch. Derive them
-        // from the shapes that do not change, and check the shuffled shape instead.
-        const bool fn_shuffled = fn_n_pad > 0;
-        int hc_mult3 = fn_shuffled ? (hc_mult * hc_mult + 2 * hc_mult) : (int)fn.size(0);
-        int hc_hidden_size = fn_shuffled ? (hc_mult * hidden_size) : (int)fn.size(1);
+        int hc_mult3 = fn.size(0);
+        int hc_hidden_size = fn.size(1);
         int x_stride = layer_input.stride(0);
         int out_stride = gemm_out_mul.stride(1);
         int split_k = gemm_out_sqrsum.size(0);
         const int res_stride = residual_in.stride(0);
-        const int fn_stride = fn_shuffled ? hc_hidden_size : (int)fn.stride(0);
+        const int fn_stride = (int)fn.stride(0);
 
         AITER_CHECK(hc_mult == 4, "hc_mult only supports 4");
         AITER_CHECK(res_stride == hc_hidden_size,
@@ -2902,14 +3101,6 @@ namespace aiter {
                     hc_hidden_size,
                     "), got ",
                     res_stride);
-        if (fn_shuffled) {
-            AITER_CHECK(fn.dim() == 3 && fn.size(0) == hc_hidden_size / 32 &&
-                            fn.size(1) == fn_n_pad && fn.size(2) == 32,
-                        "preshuffled fn must be (hc_hidden_size/32, fn_n_pad, 32)");
-            AITER_CHECK(fn_n_pad == hc_mult3, "fn_n_pad must equal hc_mult3 (rows per K block)");
-            AITER_CHECK(hc_hidden_size % 32 == 0,
-                        "hc_hidden_size must be divisible by 32 for the preshuffled fn");
-        } else {
             AITER_CHECK(fn_stride == hc_hidden_size,
                         "fn stride(0) must equal hc_hidden_size (",
                         hc_hidden_size,
@@ -2917,7 +3108,6 @@ namespace aiter {
                         fn_stride);
             AITER_CHECK(hc_hidden_size == hc_mult * hidden_size,
                         "fn K dim must equal hc_mult * hidden_size");
-        }
         AITER_CHECK(gemm_out_mul.size(0) == split_k,
                     "gemm_out_mul dim0 must be split_k");
         AITER_CHECK(gemm_out_sqrsum.size(0) == split_k,
@@ -2943,7 +3133,7 @@ namespace aiter {
         const hipStream_t stream = aiter::getCurrentHIPStream();
         dim3 block(block_size);
 
-        if (is_fn_pack_bf16) {
+        if (is_res_w_preshuffle_bf16) {
 #define MHC_FUSED_BF16 true
             MHC_FUSED_POST_PRE_GEMM_SQRSUM_KERNEL_DISPATCH(tile_k);
 #undef MHC_FUSED_BF16

--- a/csrc/kernels/mhc_kernels.cu
+++ b/csrc/kernels/mhc_kernels.cu
@@ -86,6 +86,15 @@ namespace aiter {
     // n_stages*hc_mult*tile_m*tile_k elements of LDS. Only profitable for KS >= 16 --
     // at KS=8 the per-lane store is already fully coalesced and this loses ~85 us.
     static constexpr bool mhc_nres_tdm_store = true;
+    // gfx1250: stage mhc_pre_gemm_sqrsum_kernel's x tile through LDS with one 2D TDM
+    // per k-step instead of a per-lane strided buffer_load into VGPRs. Frees the 32 VGPRs
+    // x used to live in (+1 wave/SIMD) at the cost of an LDS round trip, so it wins on
+    // deep k_loop and loses on shallow: 7168x8192 -30%, small m +10..37%.
+    static constexpr bool mhc_pre_x_tdm = true;
+    // One 16 B read vector of pad per row. The consumer reads a column of mfma_m rows at
+    // once, and an unpadded tile_k*sizeof(DTYPE_I) pitch is a power of two, which puts
+    // those rows in the same LDS bank. 0 measures the conflict.
+    static constexpr bool mhc_pre_x_tdm_pad = true;
 
     constexpr int ceil_pow2(int n) {
         if(n <= 1) return 1;
@@ -238,6 +247,26 @@ namespace aiter {
         static constexpr int mfma_k = 4;
         static constexpr int ovec = mfma_m * mfma_n / warp_size;
         __shared__ float s_fn[tile_n * tile_k * 2];
+        // Ring depth of the staged x tile; must match the gemm loop's k+2 prefetch
+        // distance and the MHC_TDM_KEEP that guards slot reuse.
+        static constexpr int x_tdm_stages = 2;
+        static constexpr int x_pad_elems = mhc_pre_x_tdm_pad ? 16 / (int)sizeof(DTYPE_I) : 0;
+        static constexpr int x_lds_pitch = tile_k + x_pad_elems;
+        static constexpr int x_tdm_lds_bytes =
+            (int)sizeof(s_fn) + x_tdm_stages * tile_m * x_lds_pitch * (int)sizeof(DTYPE_I);
+#if defined(__gfx1250__)
+        // bf16-only by measurement, not by any data dependence: the fp32 fallback's live
+        // set (v_af is vec_tile floats against x_bf's bf16 half) pays more for the LDS
+        // round trip than it wins back (332.7 -> 337.1 us at 7168x8192).
+        // The LDS test keeps tile_k=128 -- 67584 B/workgroup, past the 64 KiB limit --
+        // degrading to the per-lane load instead of failing to launch, should gfx1250
+        // ever dispatch it (get_mhc_pre_splitk offers only 64 off gfx9).
+        static constexpr bool x_tdm = mhc_pre_x_tdm && is_res_w_preshuffle_bf16
+                                      && (x_tdm_lds_bytes <= 64 * 1024);
+#else
+        static constexpr bool x_tdm = false;
+#endif
+        __shared__ DTYPE_I s_x[x_tdm ? x_tdm_stages * tile_m * x_lds_pitch : 1];
         static_assert(tile_k % warp_size == 0, "tile_k must be divisible by warp_size");
         static_assert(tile_n % warp_per_block == 0, "tile_n must be divisible by (block_size / warp_size)");
         static_assert(tile_k % (mfma_k * 8) == 0, "tile_k must be divisible by (mfma_k * 8)");
@@ -360,23 +389,123 @@ namespace aiter {
         };
 
         static constexpr int x_vec_size = 8;
-        static constexpr int x_load_waitcnt = vec_tile / x_vec_size;
+        // TDM tracks x on TENSORcnt, not loadcnt; -1 suppresses s_wait_loadcnt (0 would
+        // emit a spurious one).
+        static constexpr int x_load_waitcnt = x_tdm ? 0 : vec_tile / x_vec_size;
+        static constexpr int x_wait_idle = x_tdm ? -1 : 0;
+        static constexpr int x_wait_prefetch = x_tdm ? -1 : 2 * x_load_waitcnt;
+        static constexpr int x_chunks = vec_tile / x_vec_size;
         static constexpr int fn_lds_load_waitcnt =
             ((tile_n / warp_per_block) * (tile_k / fn_vec_size) + warp_size - 1) / warp_size;
+
+        // 2D tile: dim0 = hidden (tile_k, contiguous), dim1 = row (tile_m, stride
+        // x_stride). TDM writes dim0-fastest, so it lands at row * x_lds_pitch + kk.
+        // Both extents are the real tensor's, with this tile's start as the origin, so
+        // tensor_dimN = what remains and a short k tail or m tail clips itself.
+        // Issued by warp 0 alone -- TDM is a wave-level DMA, not per-lane -- which keeps
+        // x_tdm_stages ops in flight, inside the <= 3 per-wave budget. Rebuilt per issue
+        // rather than walked with move(): measured a wash, and move() would tie
+        // correctness to the issue order staying exactly k order.
+        [[maybe_unused]] auto lds_load_x_tile = [&](int k, int slot) {
+#if defined(__gfx1250__)
+            if constexpr (x_tdm) {
+                if (warp_id == 0) {
+                    // padding<T, tile_k, 0> is not "no padding": a nonzero interval reads
+                    // as enabled, and the tag then rejects the zero amount.
+                    using pad_t = std::conditional_t<(x_pad_elems > 0),
+                                      opus::tdm_traits::padding<DTYPE_I, tile_k, x_pad_elems>,
+                                      opus::tdm_traits::padding<>>;
+                    static_assert(x_lds_pitch == (x_pad_elems > 0 ? pad_t::pitch_elements : tile_k),
+                                  "x_lds_pitch must match the D#'s own LDS row pitch");
+                    using win_t = opus::tdm<DTYPE_I, opus::seq<tile_k, tile_m>, pad_t>;
+                    uint32_t lds = static_cast<uint32_t>(reinterpret_cast<__UINTPTR_TYPE__>(s_x));
+                    auto win = opus::make_tdm<win_t>(
+                        lds, x_ptr,
+                        static_cast<opus::u32_t>(hc_hidden_size),
+                        static_cast<opus::u32_t>(m_oob),
+                        static_cast<opus::u64_t>(x_stride),
+                        static_cast<opus::u32_t>(k_split_offset + k * tile_k),
+                        0u);
+                    win.async_load(static_cast<uint32_t>(slot * (tile_m * x_lds_pitch)));
+                }
+            }
+#endif
+        };
+        // Reproduces exactly what load_vector_nbytes<..., interleave> put in v_a: chunk i
+        // is the 8 elements at k = (lane/mfma_m)*x_vec_size + i*interleave_size*x_vec_size.
+        [[maybe_unused]] auto lds_read_x_tile = [&](halfxtile& dst, int slot) {
+            if constexpr (x_tdm) {
+                const DTYPE_I* p = s_x + slot * (tile_m * x_lds_pitch)
+                                 + (warp_id * mfma_m + lane_id % mfma_m) * x_lds_pitch
+                                 + (lane_id / mfma_m) * x_vec_size;
+                #pragma unroll
+                for (int i = 0; i < x_chunks; i++) {
+                    reinterpret_cast<halfx8_t*>(&dst)[i] =
+                        *reinterpret_cast<const halfx8_t*>(p + i * interleave_size * x_vec_size);
+                }
+            }
+        };
+
         halfxtile v_a[2];
-        v_a[0] = load_vector_nbytes<DTYPE_I, vec_tile, 8 * sizeof(DTYPE_I), 0, true, interleave_size>(g_a, ga_offset);
-        __builtin_amdgcn_sched_barrier(0);
-        lds_load_fn_tile(0);
-        v_a[1] = load_vector_nbytes<DTYPE_I, vec_tile, 8 * sizeof(DTYPE_I), 0, true, interleave_size>(g_a, ga_offset + tile_k);
-        lds_load_fn_tile(1);
-        
+        if constexpr (x_tdm) {
+            lds_load_x_tile(0, 0);
+            lds_load_fn_tile(0);
+            lds_load_x_tile(1, 1);
+            lds_load_fn_tile(1);
+        } else {
+            v_a[0] = load_vector_nbytes<DTYPE_I, vec_tile, 8 * sizeof(DTYPE_I), 0, true, interleave_size>(g_a, ga_offset);
+            __builtin_amdgcn_sched_barrier(0);
+            lds_load_fn_tile(0);
+            v_a[1] = load_vector_nbytes<DTYPE_I, vec_tile, 8 * sizeof(DTYPE_I), 0, true, interleave_size>(g_a, ga_offset + tile_k);
+            lds_load_fn_tile(1);
+        }
+
         fp32xovec_t v_cf[repeat_n];
         for (int n = 0; n < repeat_n; n++) {
             opus::clear(v_cf[n]);
         }
-        s_wait_all_loadcnt(opus::number<x_load_waitcnt>{}, opus::number<2 * fn_lds_load_waitcnt>{});
+        s_wait_all_loadcnt(opus::number<x_tdm ? -1 : x_load_waitcnt>{}, opus::number<2 * fn_lds_load_waitcnt>{});
         const int k_loop = hc_hidden_size / (split_k * tile_k);
 
+        // Consumed in two places: the per-lane path already has v_a[BUF] on entry, the
+        // TDM path only after the barrier that publishes the stage. Hoisted so the two
+        // call sites cannot drift apart.
+#define MHC_PRE_X_CONSUME_F32(BUF)                                                                \
+            for (int i = 0; i < vec_tile; i++)                                                    \
+                v_af[i] = static_cast<float>(v_a[BUF][i]);                                        \
+            if (n_idx == 0) {                                                                     \
+                for (int i = 0; i < vec_tile; i++)                                                \
+                    sqrsum_part += v_af[i] * v_af[i];                                             \
+            }                                                                                     
+#define MHC_PRE_X_CONSUME_W32(BUF)                                                                \
+            if (n_idx == 0) {                                                                     \
+                for (int i = 0; i < vec_tile; i++) {                                              \
+                    float xv = static_cast<float>(v_a[BUF][i]);                                   \
+                    sqrsum_part += xv * xv;                                                       \
+                }                                                                                 \
+            }                                                                                     \
+            _Pragma("unroll")                                                                     \
+            for (int c = 0; c < n_chunks_bf16_w32; c++)                                           \
+                for (int i = 0; i < 16; i++)                                                      \
+                    x_bf[c][i] = opus::fp32_to_bf16(static_cast<float>(v_a[BUF][c * 16 + i]));
+
+
+        // TDMs are issued in k order and a body prefetches at its very end, so on entry
+        // to the body reading step k at most ONE later TDM -- TDM(k+1) -- is in flight.
+        // KEEP is right whenever that one was issued; only a step with no successor
+        // drains. In-loop steps always have one; the last step never does; the
+        // second-to-last has one iff k_loop is even (for k_loop == 2 it comes from the
+        // prologue). Deriving this from DO_PREFETCH instead drains both steps whenever
+        // k_loop == 2, which is every small-m shape.
+#define MHC_X_WAIT_KEEP                                                                           \
+            do { if constexpr (x_tdm) { MHC_TDM_KEEP(x_tdm_stages - 1); } } while (0)
+#define MHC_X_WAIT_DRAIN                                                                          \
+            do { if constexpr (x_tdm) { MHC_TDM_DRAIN(); } } while (0)
+#define MHC_X_WAIT_TAIL                                                                           \
+            do { if constexpr (x_tdm) {                                                           \
+                if ((k_loop & 1) == 0) { MHC_TDM_KEEP(x_tdm_stages - 1); }                        \
+                else                   { MHC_TDM_DRAIN(); }                                       \
+            } } while (0)
         static constexpr int gemm_steps = tile_k / mfma_k * repeat_n;
         static constexpr int bf_kk_per_window = 8 / repeat_n;
         static constexpr int bf_vecs_per_n = bf_kk_per_window / fn_vec_size;
@@ -526,6 +655,8 @@ namespace aiter {
             if (DO_PREFETCH) {                                                                    \
                 __syncthreads();                                                                  \
                 lds_load_fn_tile((k) + 2);                                                        \
+                /* Same slot; the __syncthreads above holds the refill behind every read. */      \
+                if constexpr (x_tdm) { lds_load_x_tile((k) + 2, (LDS_SLOT)); }                    \
             }                                                                                     \
         } while (0)
 #endif // MHC_BF16_MFMA (wave64 bf16 path)
@@ -565,28 +696,27 @@ namespace aiter {
                 }
             }
         };
-#define GEMM_LOOP_BODY_BF16_W32(BUF, LDS_SLOT, k, DO_PREFETCH)                                    \
+#define GEMM_LOOP_BODY_BF16_W32(BUF, LDS_SLOT, k, DO_PREFETCH, X_WAIT)                            \
         do {                                                                                      \
-            if (n_idx == 0) {                                                                     \
-                for (int i = 0; i < vec_tile; i++) {                                              \
-                    float xv = static_cast<float>(v_a[BUF][i]);                                   \
-                    sqrsum_part += xv * xv;                                                       \
-                }                                                                                 \
-            }                                                                                     \
             opus::vector_t<opus::bf16_t, 16> x_bf[n_chunks_bf16_w32];                             \
-            _Pragma("unroll")                                                                     \
-            for (int c = 0; c < n_chunks_bf16_w32; c++)                                           \
-                for (int i = 0; i < 16; i++)                                                      \
-                    x_bf[c][i] = opus::fp32_to_bf16(static_cast<float>(v_a[BUF][c * 16 + i]));    \
+            if constexpr (!x_tdm) { MHC_PRE_X_CONSUME_W32(BUF) }                                  \
             if (DO_PREFETCH) {                                                                    \
-                v_a[BUF] = load_vector_nbytes<DTYPE_I, vec_tile, 8 * sizeof(DTYPE_I),             \
-                                                0, true, interleave_size>(                        \
-                    g_a, ga_offset + ((k) + 2) * tile_k);                                         \
-                s_wait_all_loadcnt(opus::number<2 * x_load_waitcnt>{}, opus::number<fn_lds_load_waitcnt>{}); \
+                if constexpr (!x_tdm) {                                                           \
+                    v_a[BUF] = load_vector_nbytes<DTYPE_I, vec_tile, 8 * sizeof(DTYPE_I),         \
+                                                    0, true, interleave_size>(                    \
+                        g_a, ga_offset + ((k) + 2) * tile_k);                                     \
+                }                                                                                 \
+                s_wait_all_loadcnt(opus::number<x_wait_prefetch>{}, opus::number<fn_lds_load_waitcnt>{}); \
             } else {                                                                              \
-                s_wait_all_loadcnt(0_I, 0_I);                                                     \
+                s_wait_all_loadcnt(opus::number<x_wait_idle>{}, 0_I);                             \
             }                                                                                     \
+            X_WAIT;                                                                               \
             __builtin_amdgcn_s_barrier();                                                         \
+            if constexpr (x_tdm) {                                                                \
+                lds_read_x_tile(v_a[BUF], (LDS_SLOT));                                            \
+                s_wait_all_dscnt(0_I);                                                            \
+                MHC_PRE_X_CONSUME_W32(BUF)                                                        \
+            }                                                                                     \
             float* s_fn_rd_ptr = s_fn + (LDS_SLOT) * tile_n * tile_k;                             \
             _Pragma("unroll")                                                                     \
             for (int c = 0; c < n_chunks_bf16_w32; c++) {                                         \
@@ -610,28 +740,33 @@ namespace aiter {
             if (DO_PREFETCH) {                                                                    \
                 __syncthreads();                                                                  \
                 lds_load_fn_tile((k) + 2);                                                        \
+                /* Same slot; the __syncthreads above holds the refill behind every read. */      \
+                if constexpr (x_tdm) { lds_load_x_tile((k) + 2, (LDS_SLOT)); }                    \
             }                                                                                     \
         } while (0)
 #endif // __gfx1250__ (bf16 path)
 
-#define GEMM_LOOP_BODY(BUF, LDS_SLOT, k, DO_PREFETCH)                                             \
+#define GEMM_LOOP_BODY(BUF, LDS_SLOT, k, DO_PREFETCH, X_WAIT)                                     \
         do {                                                                                      \
             fp32xtile v_af;                                                                       \
-            for (int i = 0; i < vec_tile; i++)                                                    \
-                v_af[i] = static_cast<float>(v_a[BUF][i]);                                        \
-            if (n_idx == 0) {                                                                     \
-                for (int i = 0; i < vec_tile; i++)                                                \
-                    sqrsum_part += v_af[i] * v_af[i];                                             \
-            }                                                                                     \
+            if constexpr (!x_tdm) { MHC_PRE_X_CONSUME_F32(BUF) }                                  \
             if (DO_PREFETCH) {                                                                    \
-                v_a[BUF] = load_vector_nbytes<DTYPE_I, vec_tile, 8 * sizeof(DTYPE_I),             \
-                                                0, true, interleave_size>(                        \
-                    g_a, ga_offset + ((k) + 2) * tile_k);                                         \
-                s_wait_all_loadcnt(opus::number<2 * x_load_waitcnt>{}, opus::number<fn_lds_load_waitcnt>{}); \
+                if constexpr (!x_tdm) {                                                           \
+                    v_a[BUF] = load_vector_nbytes<DTYPE_I, vec_tile, 8 * sizeof(DTYPE_I),         \
+                                                    0, true, interleave_size>(                    \
+                        g_a, ga_offset + ((k) + 2) * tile_k);                                     \
+                }                                                                                 \
+                s_wait_all_loadcnt(opus::number<x_wait_prefetch>{}, opus::number<fn_lds_load_waitcnt>{}); \
             } else {                                                                              \
-                s_wait_all_loadcnt(0_I, 0_I);                                                     \
+                s_wait_all_loadcnt(opus::number<x_wait_idle>{}, 0_I);                             \
             }                                                                                     \
+            X_WAIT;                                                                               \
             __builtin_amdgcn_s_barrier();                                                         \
+            if constexpr (x_tdm) {                                                                \
+                lds_read_x_tile(v_a[BUF], (LDS_SLOT));                                            \
+                s_wait_all_dscnt(0_I);                                                            \
+                MHC_PRE_X_CONSUME_F32(BUF)                                                        \
+            }                                                                                      \
             float* s_fn_rd_ptr = s_fn + (LDS_SLOT) * tile_n * tile_k;                             \
             float v_bf[2][8];                                                                      \
             if constexpr (warp_size == 32) {                                                       \
@@ -694,45 +829,55 @@ namespace aiter {
                     v_cf[n_old] = MMA_F32_16X16X4(b_pack, a_pack, v_cf[n_old]);                    \
                 }                                                                                  \
             }                                                                                      \
+            /* At the end of the body, not beside the fn prefetch: the tail MMAs still             \
+               read v_af, which under x_tdm came out of this very slot. */                         \
+            if (DO_PREFETCH) {                                                                     \
+                if constexpr (x_tdm) { lds_load_x_tile((k) + 2, (LDS_SLOT)); }                     \
+            }                                                                                      \
         } while (0)
         // is_res_w_preshuffle_bf16: bf16 hi/lo MFMA; otherwise fp32 MFMA. The bf16 body (and the
         // gfx950-only mfma_f32_16x16x32_bf16 builtin) exists only in the gfx950 device
         // pass; every other arch compiles the fp32 path unconditionally, so the flag is
         // a no-op there (falls back to fp32).
 #if MHC_BF16_MFMA
-#define MHC_PRE_GEMM_STEP(BUF, LDS_SLOT, k, DO_PREFETCH)                    \
+#define MHC_PRE_GEMM_STEP(BUF, LDS_SLOT, k, DO_PREFETCH, X_WAIT)                    \
         if constexpr (is_res_w_preshuffle_bf16) {                                   \
             GEMM_LOOP_BODY_BF16(BUF, LDS_SLOT, k, DO_PREFETCH);           \
         } else {                                                          \
-            GEMM_LOOP_BODY(BUF, LDS_SLOT, k, DO_PREFETCH);               \
+            GEMM_LOOP_BODY(BUF, LDS_SLOT, k, DO_PREFETCH, X_WAIT);               \
         }
 #elif defined(__gfx1250__)
-#define MHC_PRE_GEMM_STEP(BUF, LDS_SLOT, k, DO_PREFETCH)                    \
+#define MHC_PRE_GEMM_STEP(BUF, LDS_SLOT, k, DO_PREFETCH, X_WAIT)                    \
         if constexpr (is_res_w_preshuffle_bf16) {                                   \
-            GEMM_LOOP_BODY_BF16_W32(BUF, LDS_SLOT, k, DO_PREFETCH);       \
+            GEMM_LOOP_BODY_BF16_W32(BUF, LDS_SLOT, k, DO_PREFETCH, X_WAIT);       \
         } else {                                                          \
-            GEMM_LOOP_BODY(BUF, LDS_SLOT, k, DO_PREFETCH);               \
+            GEMM_LOOP_BODY(BUF, LDS_SLOT, k, DO_PREFETCH, X_WAIT);               \
         }
 #else
-#define MHC_PRE_GEMM_STEP(BUF, LDS_SLOT, k, DO_PREFETCH)                    \
-        GEMM_LOOP_BODY(BUF, LDS_SLOT, k, DO_PREFETCH)
+#define MHC_PRE_GEMM_STEP(BUF, LDS_SLOT, k, DO_PREFETCH, X_WAIT)                    \
+        GEMM_LOOP_BODY(BUF, LDS_SLOT, k, DO_PREFETCH, X_WAIT)
 #endif
         for (int k = 0; k < k_loop - 2; k += 2) {
-            MHC_PRE_GEMM_STEP(0, k % 2, k, 1);
+            MHC_PRE_GEMM_STEP(0, k % 2, k, 1, MHC_X_WAIT_KEEP);
             if (k + 3 < k_loop) {
-                MHC_PRE_GEMM_STEP(1, (k + 1) % 2, k + 1, 1);
+                MHC_PRE_GEMM_STEP(1, (k + 1) % 2, k + 1, 1, MHC_X_WAIT_KEEP);
             } else {
-                MHC_PRE_GEMM_STEP(1, (k + 1) % 2, k + 1, 0);
+                MHC_PRE_GEMM_STEP(1, (k + 1) % 2, k + 1, 0, MHC_X_WAIT_KEEP);
             }
         }
-        MHC_PRE_GEMM_STEP(0, 0, 0, 0);
+        MHC_PRE_GEMM_STEP(0, 0, 0, 0, MHC_X_WAIT_TAIL);
         if ((k_loop & 1) == 0) {
-            MHC_PRE_GEMM_STEP(1, 1, 0, 0);
+            MHC_PRE_GEMM_STEP(1, 1, 0, 0, MHC_X_WAIT_DRAIN);
         }
 #undef MHC_PRE_GEMM_STEP
 #undef GEMM_LOOP_BODY
 #undef GEMM_LOOP_BODY_BF16
 #undef GEMM_LOOP_BODY_BF16_W32
+#undef MHC_PRE_X_CONSUME_F32
+#undef MHC_PRE_X_CONSUME_W32
+#undef MHC_X_WAIT_KEEP
+#undef MHC_X_WAIT_DRAIN
+#undef MHC_X_WAIT_TAIL
 
         if (n_idx == 0) {
             float sqrsum_ = cross_row_sum_4(sqrsum_part, lane_id);

--- a/csrc/kernels/mhc_kernels.cu
+++ b/csrc/kernels/mhc_kernels.cu
@@ -1688,17 +1688,67 @@ namespace aiter {
     }
 
 
+
+    // k_blocks must divide nblk exactly (the kernel has no tail loop), so the pick
+    // is over the divisor lattice of nblk.  Splitting K grows the grid to
+    // m * k_blocks and shrinks each work-group's loop to hidden_size / k_blocks:
+    // useful until the machine is full, pure prologue cost after.  So aim for
+    // cu_num * (work-groups per CU), and take the divisor nearest that in ratio.
+    //
+    // Two fixes over the old heuristic, worth geomean 1.055x / max 1.63x with no
+    // regression on gfx1250 (256 CU), over m in [64, 8192] x hidden in
+    // {1280, 2560, 4096, 7168}:
+    //   - occupancy: it hardcoded 32 / (block_size / WARP_SIZE), i.e. "32 waves per
+    //     CU" -- 2048 threads only at 64 threads per wave, half the real figure on
+    //     wave32.  Query the device instead.
+    //   - search: it walked DOWN to the first exact divisor, which collapses to 1 on
+    //     a coarse lattice (hidden 7168, residual_block 1024 => nblk 7 => k in
+    //     {1, 7}, so m = 512 ran 512 work-groups on 256 CUs).
+    // Work-groups a CU can hold: thread-limited here, not LDS-limited (20 KB per
+    // work-group at residual_block 1024, against 320 KB per CU on gfx1250).
+    static inline int mhc_post_wgs_per_cu(int block_size)
+    {
+        static const int threads_per_cu = []() {
+            hipDevice_t dev;
+            hipDeviceProp_t dev_prop;
+            HIP_CALL(hipGetDevice(&dev));
+            HIP_CALL(hipGetDeviceProperties(&dev_prop, dev));
+            return (int)dev_prop.maxThreadsPerMultiProcessor;
+        }();
+        const int wgs = threads_per_cu / block_size;
+        return wgs > 0 ? wgs : 1;
+    }
+
+    static inline int mhc_post_pick_kblocks(
+        int m, int hidden_size, int residual_block, int cu_num, int block_size)
+    {
+        const int nblk        = hidden_size / residual_block;
+        const int grid_target = cu_num * mhc_post_wgs_per_cu(block_size);
+        const int target      = (m > 0 && grid_target / m > 0) ? grid_target / m : 1;
+        int best              = 1;
+        int64_t best_score    = -1;
+        for(int k = 1; k <= nblk; k++)
+        {
+            if(nblk % k)
+                continue;
+            // Ratio, not difference: against a target of 4, k = 7 fits better than
+            // k = 1 though both are 3 away.
+            const int64_t score =
+                (k >= target) ? (int64_t)k * 1024 / target : (int64_t)target * 1024 / k;
+            if(best_score < 0 || score <= best_score) // ties resolve toward more parallelism
+            {
+                best_score = score;
+                best       = k;
+            }
+        }
+        return best;
+    }
+
 #define MHC_POST_KERNEL_IMPL_RAW_(kernel_name, hidden_size, residual_block, store_nt) \
     AITER_CHECK(hidden_size % residual_block == 0, "hidden_size must be divisible by residual_block"); \
     AITER_CHECK(hidden_size >= residual_block * 2, "hidden_size must be >= residual_block * 2 stages prefetch"); \
     int block_size = 4 * WARP_SIZE; \
-    int num_tg_cu = 32 / (block_size / WARP_SIZE); \
-    int max_k_blocks = min(cu_num * num_tg_cu / m, hidden_size / (residual_block)); \
-    if (max_k_blocks < 1) max_k_blocks = 1; \
-    int k_blocks = max_k_blocks; \
-    for(; k_blocks > 1; k_blocks--) { \
-        if (hidden_size % (k_blocks * residual_block) == 0 && hidden_size / k_blocks >= residual_block) break; \
-    } \
+    int k_blocks = mhc_post_pick_kblocks(m, hidden_size, residual_block, cu_num, block_size); \
     int sub_hidden_size = hidden_size / k_blocks; \
     dim3 grid(m, k_blocks); \
     dim3 block(block_size); \
@@ -1722,13 +1772,7 @@ namespace aiter {
     AITER_CHECK(hidden_size % residual_block == 0, "hidden_size must be divisible by residual_block"); \
     AITER_CHECK(hidden_size >= residual_block * 2, "hidden_size must be >= residual_block * 2 stages prefetch"); \
     int block_size = 4 * WARP_SIZE; \
-    int num_tg_cu = 32 / (block_size / WARP_SIZE); \
-    int max_k_blocks = min(cu_num * num_tg_cu / m, hidden_size / (residual_block)); \
-    if (max_k_blocks < 1) max_k_blocks = 1; \
-    int k_blocks = max_k_blocks; \
-    for(; k_blocks > 1; k_blocks--) { \
-        if (hidden_size % (k_blocks * residual_block) == 0 && hidden_size / k_blocks >= residual_block) break; \
-    } \
+    int k_blocks = mhc_post_pick_kblocks(m, hidden_size, residual_block, cu_num, block_size); \
     int sub_hidden_size = hidden_size / k_blocks; \
     dim3 grid(m, k_blocks); \
     dim3 block(block_size); \

--- a/csrc/kernels/mhc_kernels.cu
+++ b/csrc/kernels/mhc_kernels.cu
@@ -44,10 +44,13 @@ namespace aiter {
     // prefetched stage in flight (<=2 inflight, within the <=3 budget); DRAIN
     // waits for all residual TDMs. No-ops off gfx1250 (residual uses async_load).
 #if defined(__gfx1250__)
-#define MHC_TDM_KEEP1() opus::s_wait_tensorcnt(opus::number<1>{})
+// KEEP(N): drain this wave's TDMs down to N still in flight -- N = ring depth - 1,
+// i.e. every stage prefetched AFTER the one about to be consumed may stay
+// outstanding. DRAIN waits for all of them.
+#define MHC_TDM_KEEP(N) opus::s_wait_tensorcnt(opus::number<(N)>{})
 #define MHC_TDM_DRAIN() opus::s_wait_tensorcnt(opus::number<0>{})
 #else
-#define MHC_TDM_KEEP1() ((void)0)
+#define MHC_TDM_KEEP(N) ((void)0)
 #define MHC_TDM_DRAIN() ((void)0)
 #endif
 
@@ -2235,7 +2238,7 @@ namespace aiter {
         // gives free row OOB (out-of-range rows load 0), so no manual zero-fill and
         // no async counter -> x is TENSORcnt-tracked, x_load_waitcnt = 0.
         static constexpr int x_load_waitcnt = 0;
-        auto lds_load_x_tile = [&](int k){
+        auto lds_load_x_tile = [&](int k, int slot){
             if (warp_id == 1) {
                 using win_t = opus::tdm<DTYPE_I, opus::seq<tile_k, tile_m>>;
                 uint32_t lds = static_cast<uint32_t>(reinterpret_cast<__UINTPTR_TYPE__>(s_x));
@@ -2243,7 +2246,7 @@ namespace aiter {
                 // make(lds_base, global_ptr, shape0, shape1, dim0_stride); the
                 // double-buffer half is the per-issue LDS write offset (elements).
                 auto win = opus::make_tdm<win_t>(lds, g, tile_k, m_oob, x_stride);
-                win.async_load(static_cast<uint32_t>((k & 1) * tile_mk));
+                win.async_load(static_cast<uint32_t>(slot * tile_mk));
             }
         };
 #else
@@ -2254,11 +2257,11 @@ namespace aiter {
 #endif
         static constexpr int x_async_load_threads = block_size * x_async_load_vec < tile_mk ? block_size : tile_mk / x_async_load_vec;
         static constexpr int x_load_waitcnt = tile_mk / (x_async_load_threads * x_async_load_vec);
-        auto lds_load_x_tile = [&](int k){
+        auto lds_load_x_tile = [&](int k, int slot){
             static constexpr int rows_per_load = x_async_load_vec * x_async_load_threads / tile_k;
             static constexpr int threads_per_row = tile_k / x_async_load_vec;
             if(threadIdx.x < x_async_load_threads) {
-                DTYPE_I* s_x_wr_ptr = s_x + (k & 1) * tile_mk;
+                DTYPE_I* s_x_wr_ptr = s_x + slot * tile_mk;
                 int offset_base = threadIdx.x / threads_per_row * x_stride + threadIdx.x % threads_per_row * x_async_load_vec + k_split_offset + k * tile_k;
                 static constexpr int s_offset_i = x_async_load_threads * x_async_load_vec;
                 [[maybe_unused]] const int row_base = threadIdx.x / threads_per_row;
@@ -2299,7 +2302,7 @@ namespace aiter {
         // (out-of-range rows load 0). residual is TENSORcnt-tracked, so it no longer
         // contributes to the async counter -> residual_load_waitcnt = 0.
         static constexpr int residual_load_waitcnt = 0;
-        auto lds_load_residual_tile = [&](int k){
+        auto lds_load_residual_tile = [&](int k, int slot){
             // TDM is a wave-level DMA (not per-lane, not EXEC-gated); a single wave
             // issues one op that fills the whole all-head tile. Only warp 0 issues;
             // the others see the data after the tensorcnt wait + workgroup barrier
@@ -2314,7 +2317,7 @@ namespace aiter {
                 const opus::u32_t coord[3] = {0, 0, 0};
                 win_t win;
                 win.make_from_layout(lds, g, shape, pitch, coord);
-                win.async_load(static_cast<uint32_t>((k & 1) * (hc_mult * tile_mk)));
+                win.async_load(static_cast<uint32_t>(slot * (hc_mult * tile_mk)));
             }
         };
 #else
@@ -2324,10 +2327,10 @@ namespace aiter {
         static constexpr int r_async_load_vec = 16 / sizeof(DTYPE_I) * warp_size <= tile_mk ? 16 / sizeof(DTYPE_I) : 4 / sizeof(DTYPE_I);
 #endif
         static constexpr int residual_load_waitcnt = tile_mk / (warp_size * r_async_load_vec);
-        auto lds_load_residual_tile = [&](int k){
+        auto lds_load_residual_tile = [&](int k, int slot){
             static constexpr int rows_per_load = r_async_load_vec * warp_size / tile_k;
             static constexpr int threads_per_row = tile_k / r_async_load_vec;
-            DTYPE_I* s_residual_wr_ptr = s_residual + (k & 1) * (hc_mult * tile_mk);
+            DTYPE_I* s_residual_wr_ptr = s_residual + slot * (hc_mult * tile_mk);
             int offset_base = lane_id / threads_per_row * hc_hidden_size + warp_id * hidden_size
                 + lane_id % threads_per_row * r_async_load_vec + k_split_offset + k * tile_k;
             static constexpr int s_offset_i = warp_size * r_async_load_vec;
@@ -2377,18 +2380,26 @@ namespace aiter {
 
         const int k_loop = hidden_size / (split_k * tile_k);
 
-        fp32xfntile v_fn0;
-        fp32xfntile v_fn1;
+        // n_stages-deep LDS ring + matching fn register ring. The slot is passed
+        // explicitly (never derived from k) so that every ring index below is a
+        // compile-time constant: v_fn[] must stay in registers, and the LDS
+        // pointers must fold into an immediate offset.
+        fp32xfntile v_fn[n_stages];
 
-        lds_load_x_tile(0);
-        lds_load_residual_tile(0);
-        v_fn0 = vgpr_load_fn_tile(0);
+        lds_load_x_tile(0, 0);
+        lds_load_residual_tile(0, 0);
+        v_fn[0] = vgpr_load_fn_tile(0);
         __builtin_amdgcn_sched_barrier(0);
-        if (k_loop > 1) {
-            lds_load_x_tile(1);
-            lds_load_residual_tile(1);
-            v_fn1 = vgpr_load_fn_tile(1);
-        }
+        opus::static_for<n_stages>([&](auto S) {
+            constexpr int s = S.value;
+            if constexpr (s >= 1) {
+                if (s < k_loop) {
+                    lds_load_x_tile(s, s);
+                    lds_load_residual_tile(s, s);
+                    v_fn[s] = vgpr_load_fn_tile(s);
+                }
+            }
+        });
 
         float sqrsum_part[m_repeat];
         fp32xovec_t v_cf[m_repeat][repeat_n];
@@ -2399,9 +2410,9 @@ namespace aiter {
             }
         }
 
-        auto compute_store_tile = [&](int i, fp32xfntile& v_fn) {
-            DTYPE_I* s_x_rd_ptr = s_x + (i & 1) * tile_mk;
-            DTYPE_I* s_residual_rd_ptr = s_residual + (i & 1) * (hc_mult * tile_mk);
+        auto compute_store_tile = [&](int i, int slot, fp32xfntile& v_fn) {
+            DTYPE_I* s_x_rd_ptr = s_x + slot * tile_mk;
+            DTYPE_I* s_residual_rd_ptr = s_residual + slot * (hc_mult * tile_mk);
             static constexpr int ds_read_vec = 16 / sizeof(DTYPE_I);
             static constexpr int step = ds_read_vec;
             static constexpr int band_j = band_mk / (warp_size * ds_read_vec);
@@ -2518,8 +2529,10 @@ namespace aiter {
         // gfx9 only: x and residual share the async counter, so the "leave in flight"
         // count is one stage's worth of async loads. On gfx1250 both x and residual
         // are TDM (TENSORcnt), there are no async loads, and these are unused.
-        [[maybe_unused]] static constexpr int x_async_wait = mhc_async_load_oob_guard ? 0 : x_load_waitcnt + residual_load_waitcnt;
-        [[maybe_unused]] static constexpr int r_async_wait = mhc_async_load_oob_guard ? 0 : residual_load_waitcnt;
+        // Leave (n_stages - 1) stages' worth of async loads in flight, matching
+        // MHC_TDM_KEEP(n_stages - 1) on the TDM side.
+        [[maybe_unused]] static constexpr int x_async_wait = mhc_async_load_oob_guard ? 0 : (n_stages - 1) * (x_load_waitcnt + residual_load_waitcnt);
+        [[maybe_unused]] static constexpr int r_async_wait = mhc_async_load_oob_guard ? 0 : (n_stages - 1) * residual_load_waitcnt;
 #if defined(__gfx1250__)
         auto wait_load_cnt = [&]() {
             // x (warp 1) and residual (warp 0) are both TDM / TENSORcnt-tracked. Each
@@ -2529,7 +2542,7 @@ namespace aiter {
             // loadcnt; there are no async loads left, so the async count is -1
             // (sentinel: suppress s_wait_asynccnt emission; 0 would emit a spurious
             // s_wait_asynccnt 0).
-            MHC_TDM_KEEP1();
+            MHC_TDM_KEEP(n_stages - 1);
             s_wait_all_loadcnt(opus::number<fn_load_waitcnt*2>{}, opus::number<-1>{});
             __builtin_amdgcn_s_barrier();
             s_wait_all_loadcnt(opus::number<fn_load_waitcnt>{}, opus::number<-1>{});
@@ -2538,7 +2551,7 @@ namespace aiter {
         auto wait_load_cnt = [&]() {
             // Ensure the current residual TDM stage is resident before the barrier
             // below publishes it to all warps; leave the next prefetched stage in flight.
-            MHC_TDM_KEEP1();
+            MHC_TDM_KEEP(n_stages - 1);
             if(threadIdx.x < x_async_load_threads) {
                 s_wait_all_loadcnt(opus::number<fn_load_waitcnt*2>{}, opus::number<x_async_wait>{});
             }
@@ -2555,51 +2568,59 @@ namespace aiter {
         };
 #endif
 
+        // Steady state, unrolled by n_stages so `s` (and hence the ring slot) is a
+        // compile-time constant. Invariant on entry to an iteration: stage i+s is
+        // resident-or-in-flight in slot s, for s in [0, n_stages). The bound
+        // i + 2*n_stages - 1 < k_loop guarantees every prefetch i+s+n_stages issued
+        // in the body is a real stage, so the body needs no k_loop test.
+        //
+        // wait_load_cnt() drains only to n_stages-1 TDMs left in flight, which
+        // proves stage i+s resident ONLY while all n_stages-1 later stages are
+        // actually outstanding -- true throughout the steady state, and the reason
+        // the tail below falls back to a full drain once the ring stops refilling.
         int i = 0;
-        for(; i + 3 < k_loop ; i += 2) {
-            wait_load_cnt();
-            compute_store_tile(i, v_fn0);
-            __builtin_amdgcn_s_barrier();
-            lds_load_x_tile(i + 2);
-            lds_load_residual_tile(i + 2);
-            v_fn0 = vgpr_load_fn_tile(i + 2);
-            __builtin_amdgcn_sched_barrier(0);
-            wait_load_cnt();
-            compute_store_tile(i + 1, v_fn1);
-            __builtin_amdgcn_s_barrier();
-            lds_load_x_tile(i + 3);
-            lds_load_residual_tile(i + 3);
-            v_fn1 = vgpr_load_fn_tile(i + 3);
+        for(; i + 2 * n_stages - 1 < k_loop; i += n_stages) {
+            opus::static_for<n_stages>([&](auto S) {
+                constexpr int s = S.value;
+                wait_load_cnt();
+                compute_store_tile(i + s, s, v_fn[s]);
+                __builtin_amdgcn_s_barrier();
+                lds_load_x_tile(i + s + n_stages, s);
+                lds_load_residual_tile(i + s + n_stages, s);
+                v_fn[s] = vgpr_load_fn_tile(i + s + n_stages);
+                __builtin_amdgcn_sched_barrier(0);
+            });
         }
 
-        if (i + 1 < k_loop) {
-            wait_load_cnt();
-            compute_store_tile(i, v_fn0);
-            if (i + 2 < k_loop) {
-                __builtin_amdgcn_s_barrier();
-                lds_load_x_tile(i + 2);
-                lds_load_residual_tile(i + 2);
-                v_fn0 = vgpr_load_fn_tile(i + 2);
-                wait_load_cnt();
+        // Tail: at most 2*n_stages-1 stages left. Unrolled over the same slot
+        // sequence (slot = s % n_stages, compile-time) with two runtime guards:
+        //   k < k_loop            -- this stage exists at all
+        //   k + n_stages < k_loop -- the ring can still be refilled from this step
+        // Once refilling stops the outstanding count falls below n_stages-1, so
+        // wait_load_cnt()'s partial drain would no longer prove residency; those
+        // steps take the full drain instead. Conservative by at most one step (the
+        // k+n_stages == k_loop case still has n_stages-1 outstanding), which is
+        // exactly what the previous hand-rolled 2-stage tail did.
+        opus::static_for<2 * n_stages - 1>([&](auto S) {
+            constexpr int s = S.value;
+            const int k = i + s;
+            if (k < k_loop) {
+                constexpr int slot = s % n_stages;
+                if (k + n_stages < k_loop) {
+                    wait_load_cnt();
+                    compute_store_tile(k, slot, v_fn[slot]);
+                    __builtin_amdgcn_s_barrier();
+                    lds_load_x_tile(k + n_stages, slot);
+                    lds_load_residual_tile(k + n_stages, slot);
+                    v_fn[slot] = vgpr_load_fn_tile(k + n_stages);
+                } else {
+                    s_wait_all_loadcnt(0_I, 0_I);
+                    MHC_TDM_DRAIN();
+                    __builtin_amdgcn_s_barrier();
+                    compute_store_tile(k, slot, v_fn[slot]);
+                }
             }
-            else {
-                s_wait_all_loadcnt(0_I, 0_I);
-                MHC_TDM_DRAIN();
-                __builtin_amdgcn_s_barrier();
-            }
-            compute_store_tile(i + 1, v_fn1);
-            if (i + 2 < k_loop) {
-                s_wait_all_loadcnt(0_I, 0_I);
-                MHC_TDM_DRAIN();
-                __builtin_amdgcn_s_barrier();
-                compute_store_tile(i + 2, v_fn0);
-            }
-        } else if (i < k_loop) {
-            s_wait_all_loadcnt(0_I, 0_I);
-            MHC_TDM_DRAIN();
-            __builtin_amdgcn_s_barrier();
-            compute_store_tile(i, v_fn0);
-        }
+        });
 
         // Reduce v_cf (gemm_out_mul) and sqrsum across the hc_mult warps in LDS so
         // only warp 0 writes a single (split_k) partial, instead of each warp

--- a/csrc/kernels/mhc_kernels.cu
+++ b/csrc/kernels/mhc_kernels.cu
@@ -96,6 +96,90 @@ namespace aiter {
         fn_packed[i] = (hi_bits << 16) | lo_bits;
     }
 
+    // ---- fn preshuffle for the FUSED post_pre gemm (mhc_pre_shuffle_fn) ----
+    //
+    // Unshuffled, one wave's fn tile is 16 N-rows of tile_k floats each, and
+    // consecutive N are fn_stride = hc_mult*hidden_size floats apart (114 KB at
+    // hidden=7168, hc_mult=4). So a single k-step touches 16 (x hc_mult heads)
+    // separate 128 B segments scattered across the whole weight -- 16 distinct
+    // memory streams for what is logically one tile.
+    //
+    // Reblock so the N dimension sits INSIDE a K block of 32:
+    //     fn[n][Kflat]  ->  fnS[Kflat/32][n][Kflat%32]
+    // A wave's tile then lands in one (or, for tile_k=64, two adjacent)
+    // 16*32*4 = 2 KB contiguous run.
+    //
+    // The block is fixed at 32, not tile_k, on purpose: every K offset the kernel
+    // forms (warp_id*hidden_size, k_split_offset, k*tile_k) is a multiple of 32,
+    // and each lane's vec_tile run lies inside ONE 32-block for both tile_k=32
+    // (vec_tile=16, lane halves at kr 0/16) and tile_k=64 (vec_tile=32, lane
+    // halves in adjacent blocks). So one layout serves every (tile_m, tile_n,
+    // tile_k, warp_size) combo -- no per-config weight copy.
+    //
+    // n is NOT padded: a K block holds exactly hc_mult3 rows. Padding up to the
+    // tile_n=32 the kernel reads would grow fn by 33% (24 -> 32 rows) and that extra
+    // is real read traffic -- fn is re-read by every m-block, so at m=65536 it is
+    // ~5.6 GB, the same order as the residual stream. The kernel instead keeps the
+    // old "OOB N reads 0" behaviour by steering those lanes past the buffer bound.
+    //
+    // pack_bf16 folds in the same hi<<16|lo packing as mhc_pre_convert_fn: the
+    // shuffle is a permutation of elements and the packing a per-element value
+    // transform, so they compose in a single pass over the (constant) weights.
+    template <typename DTYPE_I, bool pack_bf16>
+    __global__ void mhc_pre_shuffle_fn_kernel(
+        uint32_t* out, const float* fn, int hc_mult3, int hc_hidden_size)
+    {
+        int64_t i = (int64_t)blockIdx.x * blockDim.x + threadIdx.x;
+        int64_t total = (int64_t)(hc_hidden_size / 32) * hc_mult3 * 32;
+        if (i >= total) return;
+        const int kr = (int)(i % 32);
+        const int n  = (int)((i / 32) % hc_mult3);
+        const int64_t kb = i / (32 * (int64_t)hc_mult3);
+        uint32_t v = 0;
+        {
+            float f = fn[(int64_t)n * hc_hidden_size + kb * 32 + kr];
+            if constexpr (pack_bf16) {
+                DTYPE_I hi = static_cast<DTYPE_I>(f);
+                DTYPE_I lo = static_cast<DTYPE_I>(f - static_cast<float>(hi));
+                v = ((uint32_t)__builtin_bit_cast(uint16_t, hi) << 16)
+                  |  (uint32_t)__builtin_bit_cast(uint16_t, lo);
+            } else {
+                v = __builtin_bit_cast(uint32_t, f);
+            }
+        }
+        out[i] = v;
+    }
+
+    void mhc_pre_shuffle_fn(
+        aiter_tensor_t& fn_shuffled, // (hc_hidden_size/32, hc_mult3, 32) int32/fp32 out
+        aiter_tensor_t& fn,          // (hc_mult3, hc_hidden_size) fp32 in
+        int is_fn_pack_bf16
+    )
+    {
+        AITER_CHECK(fn.dtype() == AITER_DTYPE_fp32, "fn must be fp32");
+        AITER_CHECK(fn.dim() == 2, "fn must be 2D (hc_mult3, hc_hidden_size)");
+        const int hc_mult3 = (int)fn.size(0);
+        const int hc_hidden_size = (int)fn.size(1);
+        AITER_CHECK(hc_hidden_size % 32 == 0, "hc_hidden_size must be divisible by 32");
+        const int64_t total = (int64_t)(hc_hidden_size / 32) * hc_mult3 * 32;
+        AITER_CHECK((int64_t)fn_shuffled.numel() == total,
+                    "fn_shuffled numel must be (hc_hidden_size/32) * hc_mult3 * 32");
+        const int block_size = 256;
+        int64_t grid = (total + block_size - 1) / block_size;
+        const HipDeviceGuard device_guard(fn.device_id);
+        const hipStream_t stream = aiter::getCurrentHIPStream();
+        using DTYPE_I = typename hip2opus<hip_bfloat16>::type;
+        auto* o = reinterpret_cast<uint32_t*>(fn_shuffled.data_ptr());
+        auto* f = reinterpret_cast<const float*>(fn.data_ptr());
+        if (is_fn_pack_bf16) {
+            mhc_pre_shuffle_fn_kernel<DTYPE_I, true><<<grid, block_size, 0, stream>>>(
+                o, f, hc_mult3, hc_hidden_size);
+        } else {
+            mhc_pre_shuffle_fn_kernel<DTYPE_I, false><<<grid, block_size, 0, stream>>>(
+                o, f, hc_mult3, hc_hidden_size);
+        }
+    }
+
     // The packed hi/lo are encoded as bf16 -- the activation/MFMA element type the gemm
     // uses -- so the gemm's bit-extract round-trips.
     void mhc_pre_convert_fn(
@@ -2166,7 +2250,9 @@ namespace aiter {
         int hidden_size,
         int x_stride,
         int out_stride,
-        int split_k = 1
+        int split_k = 1,
+        int fn_n_pad = 0   // 0: fn is the plain (hc_mult3, hc_hidden_size) layout;
+                           // >0: fn is preshuffled to (hc_hidden_size/32, fn_n_pad, 32)
     )
     {
         static constexpr int store_policy = store_nt ? GROUP_NT : RT;
@@ -2209,7 +2295,9 @@ namespace aiter {
         using fp32xmma_t = opus::vector_t<float, mma_pack_size>;
 
         DTYPE_I* x_ptr = x + idx * x_stride;
-        float* fn_ptr  = fn + n_idx * hc_hidden_size;
+        // Preshuffled fn is addressed from its base (n_idx folds into the element
+        // offset below) and needs no N bound: the padded rows are zero-filled.
+        float* fn_ptr  = fn_n_pad ? fn : (fn + n_idx * hc_hidden_size);
         float* out_ptr = out + (static_cast<int64_t>(k_split_idx * m + idx)) * out_stride + n_idx;
         int residual_stride = hc_hidden_size;
         int fn_stride = hc_hidden_size;
@@ -2218,7 +2306,10 @@ namespace aiter {
         const int m_oob = m < idx + tile_m ? (m - idx) : tile_m;
         const int n_oob = hc_mult3 < (n_idx + tile_n) ? (hc_mult3 - n_idx) : tile_n;
         auto g_x = opus::make_gmem<DTYPE_I>(x_ptr, x_stride * sizeof(DTYPE_I) * m_oob);
-        auto g_fn = opus::make_gmem<float>(fn_ptr, hc_hidden_size * sizeof(float) * n_oob);
+        auto g_fn = opus::make_gmem<float>(
+            fn_ptr, fn_n_pad ? (hc_hidden_size * fn_n_pad * (int)sizeof(float))
+                             : (hc_hidden_size * (int)sizeof(float) * n_oob));
+        // fn_n_pad is the row count actually stored per K block (== hc_mult3, unpadded).
         auto g_res = opus::make_gmem<DTYPE_I>(residual_ptr, residual_stride * sizeof(DTYPE_I) * m_oob);
         auto g_nres = opus::make_gmem<DTYPE_I>(next_residual_ptr, residual_stride * sizeof(DTYPE_I) * m_oob);
         auto g_o = opus::make_gmem<float>(out_ptr, out_stride * sizeof(float) * m_oob);
@@ -2357,12 +2448,41 @@ namespace aiter {
         static constexpr int fn_load_vec = 16 / sizeof(float);
         static constexpr int fn_load_waitcnt = tile_n * tile_k / (warp_size * fn_load_vec);
         using fp32xfntile = opus::array<fp32xtile, repeat_n>;
+        // fn_n_pad is a launch-uniform scalar, so this is a scalar branch, not a
+        // per-lane one, and both arms issue the identical vec_tile-wide loads --
+        // only the address arithmetic differs.
+        //
+        // Shuffled (fn_n_pad > 0): fnS[Kflat/32][n][Kflat%32]. Every term of kbase
+        // is a multiple of 32 (see mhc_pre_shuffle_fn), so the block index splits as
+        // kbase/32 + kr0/32 and the in-block offset is just kr0 % 32. Consecutive n
+        // are then mfma_n*32 floats apart (2 KB) instead of mfma_n*fn_stride (1.75 MB).
+        const int fn_kbase = warp_id * hidden_size + k_split_offset;
+        const int fn_kr0   = (lane_id / mfma_n) * vec_tile;
         auto vgpr_load_fn_tile = [&](int k) {
             fp32xfntile v_fn;
-            int offset_base = lane_id % mfma_n * fn_stride + warp_id * hidden_size + lane_id / mfma_n * vec_tile
-                + k * tile_k + k_split_offset;
+            int offset_base, n_step;
+            if (fn_n_pad) {
+                offset_base = ((fn_kbase + k * tile_k + fn_kr0) / 32) * (fn_n_pad * 32)
+                            + (n_idx + lane_id % mfma_n) * 32 + (fn_kr0 % 32);
+                n_step = mfma_n * 32;
+                // N is not padded, so lanes whose row is >= hc_mult3 must still read 0.
+                // Steer them past the buffer bound (the same mechanism the unshuffled
+                // path gets for free from g_fn's n_oob-derived size) instead of storing
+                // zero rows, which would add 33% to fn's read traffic.
+                const int n_row = n_idx + lane_id % mfma_n;
+                for (int n = 0; n < repeat_n; n++) {
+                    v_fn[n] = (n_row + n * mfma_n) < hc_mult3
+                        ? load_vector_nbytes<float, vec_tile, 16, 0, false>(g_fn, offset_base + n * n_step)
+                        : fp32xtile{};
+                }
+                return v_fn;
+            } else {
+                offset_base = lane_id % mfma_n * fn_stride + fn_kbase + lane_id / mfma_n * vec_tile
+                    + k * tile_k;
+                n_step = mfma_n * fn_stride;
+            }
             for(int n = 0; n < repeat_n; n++) {
-                v_fn[n] = load_vector_nbytes<float, vec_tile, 16, 0, false>(g_fn, offset_base + n * mfma_n * fn_stride);
+                v_fn[n] = load_vector_nbytes<float, vec_tile, 16, 0, false>(g_fn, offset_base + n * n_step);
             }
             return v_fn;
         };
@@ -2709,7 +2829,8 @@ namespace aiter {
                 hidden_size, \
                 x_stride, \
                 out_stride, \
-                split_k); \
+                split_k, \
+                fn_n_pad); \
     });
 
 #define MHC_FUSED_POST_PRE_GEMM_SQRSUM_KERNEL_IMPL(num_warps, tile_m, tile_n, tile_k) \
@@ -2755,18 +2876,25 @@ namespace aiter {
         int tile_m = 16,
         int tile_n = 32,
         int tile_k = 32,
-        int is_fn_pack_bf16 = 0)
+        int is_fn_pack_bf16 = 0,
+        // 0: fn is the plain (hc_mult3, hc_hidden_size) layout.
+        // >0: fn came from mhc_pre_shuffle_fn -> (hc_hidden_size/32, fn_n_pad, 32).
+        int fn_n_pad = 0)
     {
         int m = layer_input.size(0);
         int hidden_size = layer_input.size(1);
         int hc_mult = residual_in.size(1);
-        int hc_mult3 = fn.size(0);
-        int hc_hidden_size = fn.size(1);
+        // Preshuffled fn is (hc_hidden_size/32, fn_n_pad, 32), so hc_mult3 / hc_hidden_size
+        // are no longer its dim0/dim1 and its stride(0) is not the K pitch. Derive them
+        // from the shapes that do not change, and check the shuffled shape instead.
+        const bool fn_shuffled = fn_n_pad > 0;
+        int hc_mult3 = fn_shuffled ? (hc_mult * hc_mult + 2 * hc_mult) : (int)fn.size(0);
+        int hc_hidden_size = fn_shuffled ? (hc_mult * hidden_size) : (int)fn.size(1);
         int x_stride = layer_input.stride(0);
         int out_stride = gemm_out_mul.stride(1);
         int split_k = gemm_out_sqrsum.size(0);
         const int res_stride = residual_in.stride(0);
-        const int fn_stride = fn.stride(0);
+        const int fn_stride = fn_shuffled ? hc_hidden_size : (int)fn.stride(0);
 
         AITER_CHECK(hc_mult == 4, "hc_mult only supports 4");
         AITER_CHECK(res_stride == hc_hidden_size,
@@ -2774,13 +2902,22 @@ namespace aiter {
                     hc_hidden_size,
                     "), got ",
                     res_stride);
-        AITER_CHECK(fn_stride == hc_hidden_size,
-                    "fn stride(0) must equal hc_hidden_size (",
-                    hc_hidden_size,
-                    "), got ",
-                    fn_stride);
-        AITER_CHECK(hc_hidden_size == hc_mult * hidden_size,
-                    "fn K dim must equal hc_mult * hidden_size");
+        if (fn_shuffled) {
+            AITER_CHECK(fn.dim() == 3 && fn.size(0) == hc_hidden_size / 32 &&
+                            fn.size(1) == fn_n_pad && fn.size(2) == 32,
+                        "preshuffled fn must be (hc_hidden_size/32, fn_n_pad, 32)");
+            AITER_CHECK(fn_n_pad == hc_mult3, "fn_n_pad must equal hc_mult3 (rows per K block)");
+            AITER_CHECK(hc_hidden_size % 32 == 0,
+                        "hc_hidden_size must be divisible by 32 for the preshuffled fn");
+        } else {
+            AITER_CHECK(fn_stride == hc_hidden_size,
+                        "fn stride(0) must equal hc_hidden_size (",
+                        hc_hidden_size,
+                        "), got ",
+                        fn_stride);
+            AITER_CHECK(hc_hidden_size == hc_mult * hidden_size,
+                        "fn K dim must equal hc_mult * hidden_size");
+        }
         AITER_CHECK(gemm_out_mul.size(0) == split_k,
                     "gemm_out_mul dim0 must be split_k");
         AITER_CHECK(gemm_out_sqrsum.size(0) == split_k,

--- a/csrc/kernels/mhc_kernels.cu
+++ b/csrc/kernels/mhc_kernels.cu
@@ -70,8 +70,48 @@ namespace aiter {
         ival = __builtin_bit_cast(int, val);
         val += __builtin_bit_cast(float,
             __builtin_amdgcn_ds_bpermute((lane_id ^ 16) * 4, ival));
-    
+
         return val;
+    }
+
+    // Pre-convert fn (fp32) into a packed dword: hi = bf16(fn) in [31:16], lo = bf16(fn -
+    // fp32(hi)) in [15:0]. Same 4-byte width as fp32 so the gemm's load / LDS / swizzle are
+    // unchanged; the bf16 gemm (is_fn_pack_bf16) then bit-extracts hi/lo instead of
+    // recomputing the fp32->bf16 split per (m_block, k) -- the split was redundant work
+    // repeated m_blocks times. fn are model weights (constant across forward passes), so
+    // this runs once and the packed int32 tensor is reused every forward.
+    template <typename DTYPE_I>
+    __global__ void mhc_pre_convert_fn_kernel(uint32_t* fn_packed, const float* fn, int64_t numel)
+    {
+        int64_t i = (int64_t)blockIdx.x * blockDim.x + threadIdx.x;
+        if (i >= numel) return;
+        float f = fn[i];
+        DTYPE_I hi = static_cast<DTYPE_I>(f);
+        DTYPE_I lo = static_cast<DTYPE_I>(f - static_cast<float>(hi));
+        uint32_t hi_bits = __builtin_bit_cast(uint16_t, hi);
+        uint32_t lo_bits = __builtin_bit_cast(uint16_t, lo);
+        fn_packed[i] = (hi_bits << 16) | lo_bits;
+    }
+
+    // The packed hi/lo are encoded as bf16 -- the activation/MFMA element type the gemm
+    // uses -- so the gemm's bit-extract round-trips.
+    void mhc_pre_convert_fn(
+        aiter_tensor_t& fn_packed, // (hc_mult3, hc_hidden_size) int32 out
+        aiter_tensor_t& fn         // (hc_mult3, hc_hidden_size) fp32 in
+    )
+    {
+        AITER_CHECK(fn.dtype() == AITER_DTYPE_fp32, "fn must be fp32");
+        AITER_CHECK(fn_packed.numel() == fn.numel(), "fn_packed and fn must have same numel");
+        int64_t numel = static_cast<int64_t>(fn.numel());
+        const int block_size = 256;
+        int64_t grid = (numel + block_size - 1) / block_size;
+        const HipDeviceGuard device_guard(fn.device_id);
+        const hipStream_t stream = aiter::getCurrentHIPStream();
+        using DTYPE_I = typename hip2opus<hip_bfloat16>::type;
+        mhc_pre_convert_fn_kernel<DTYPE_I><<<grid, block_size, 0, stream>>>(
+            reinterpret_cast<uint32_t*>(fn_packed.data_ptr()),
+            reinterpret_cast<const float*>(fn.data_ptr()),
+            numel);
     }
 
 // Branch must match mma_pack_size (= warp_size == 64 ? 1 : 2): the MFMA path
@@ -424,12 +464,15 @@ namespace aiter {
                 _Pragma("unroll")                                                                 \
                 for (int n = 0; n < repeat_n; n++) {                                              \
                     opus::vector_t<opus::bf16_t, 8> fn_hi, fn_lo;                                 \
+                    /* fn is pre-packed (hi<<16|lo, from mhc_pre_convert_fn); bit-extract both */  \
+                    /* bf16, no fp32->bf16 split -- the redundant per-(m_block,k) work removed. */ \
                     _Pragma("unroll")                                                             \
-                    for (int e = 0; e < 8; e++) fn_hi[e] = opus::fp32_to_bf16(raw[n][e]);         \
+                    for (int e = 0; e < 8; e++) {                                                 \
+                        uint32_t bits = __builtin_bit_cast(uint32_t, raw[n][e]);                  \
+                        fn_hi[e] = __builtin_bit_cast(opus::bf16_t, (uint16_t)(bits >> 16));      \
+                        fn_lo[e] = __builtin_bit_cast(opus::bf16_t, (uint16_t)(bits & 0xFFFFu));  \
+                    }                                                                             \
                     v_cf[n] = opus::mfma_f32_16x16x32_bf16{}(fn_hi, x_bf[c], v_cf[n]);            \
-                    _Pragma("unroll")                                                             \
-                    for (int e = 0; e < 8; e++)                                                   \
-                        fn_lo[e] = opus::fp32_to_bf16(raw[n][e] - opus::bf16_to_fp32(fn_hi[e]));  \
                     v_cf[n] = opus::mfma_f32_16x16x32_bf16{}(fn_lo, x_bf[c], v_cf[n]);            \
                     __builtin_amdgcn_sched_barrier(0);                                            \
                 }                                                                                 \
@@ -495,12 +538,14 @@ namespace aiter {
                 _Pragma("unroll")                                                                 \
                 for (int n = 0; n < repeat_n; n++) {                                              \
                     opus::vector_t<opus::bf16_t, 16> fn_hi, fn_lo;                                \
+                    /* fn is pre-packed (hi<<16|lo); bit-extract both bf16 -- no fp split. */      \
                     _Pragma("unroll")                                                             \
-                    for (int i = 0; i < 16; i++) fn_hi[i] = opus::fp32_to_bf16(raw[n][i]);        \
+                    for (int i = 0; i < 16; i++) {                                                \
+                        uint32_t bits = __builtin_bit_cast(uint32_t, raw[n][i]);                  \
+                        fn_hi[i] = __builtin_bit_cast(opus::bf16_t, (uint16_t)(bits >> 16));      \
+                        fn_lo[i] = __builtin_bit_cast(opus::bf16_t, (uint16_t)(bits & 0xFFFFu));  \
+                    }                                                                             \
                     v_cf[n] = opus::wmma_f32_16x16x32_bf16{}(fn_hi, x_bf[c], v_cf[n]);            \
-                    _Pragma("unroll")                                                             \
-                    for (int i = 0; i < 16; i++)                                                  \
-                        fn_lo[i] = opus::fp32_to_bf16(raw[n][i] - opus::bf16_to_fp32(fn_hi[i]));  \
                     v_cf[n] = opus::wmma_f32_16x16x32_bf16{}(fn_lo, x_bf[c], v_cf[n]);            \
                     __builtin_amdgcn_sched_barrier(0);                                            \
                 }                                                                                 \
@@ -690,7 +735,7 @@ namespace aiter {
         aiter_tensor_t& out, // (split_k, m, hc_mult3) / (m, hc_mult3)
         aiter_tensor_t& sqrsum, // (split_k, m) / (m)
         aiter_tensor_t& x, // (m, hc_hidden_size)
-        aiter_tensor_t& fn, // (hc_mult3, hc_hidden_size)
+        aiter_tensor_t& fn, // (hc_mult3, hc_hidden_size) fp32; packed int32 (hi<<16|lo) when is_fn_pack_bf16
         int tile_k = 128,
         int is_fn_pack_bf16 = 0
     )
@@ -2398,14 +2443,15 @@ namespace aiter {
                         }
                         for(int n = 0; n < repeat_n; n++) {
                             opus::vector_t<opus::bf16_t, ds_read_vec> fn_hi8, fn_lo8;
+                            // fn is pre-packed (hi<<16|lo, from mhc_pre_convert_fn); bit-extract
+                            // both bf16 -- no fp32->bf16 split recomputed per (m_block, k).
                             for (int e = 0; e < ds_read_vec; e++) {
-                                fn_hi8[e] = opus::fp32_to_bf16(v_fn[n][e + j * ds_read_vec]);
+                                float fv = v_fn[n][e + j * ds_read_vec];
+                                uint32_t bits = __builtin_bit_cast(uint32_t, fv);
+                                fn_hi8[e] = __builtin_bit_cast(opus::bf16_t, (uint16_t)(bits >> 16));
+                                fn_lo8[e] = __builtin_bit_cast(opus::bf16_t, (uint16_t)(bits & 0xFFFFu));
                             }
                             v_cf[b][n] = opus::mfma_f32_16x16x32_bf16{}(fn_hi8, res_bf, v_cf[b][n]);
-                            for (int e = 0; e < ds_read_vec; e++) {
-                                float f = v_fn[n][e + j * ds_read_vec];
-                                fn_lo8[e] = opus::fp32_to_bf16(f - opus::bf16_to_fp32(fn_hi8[e]));
-                            }
                             v_cf[b][n] = opus::mfma_f32_16x16x32_bf16{}(fn_lo8, res_bf, v_cf[b][n]);
                         }
 #elif defined(__gfx1250__)
@@ -2427,17 +2473,18 @@ namespace aiter {
                             }
                             for (int n = 0; n < repeat_n; n++) {
                                 opus::vector_t<opus::bf16_t, 16> fn_hi, fn_lo;
+                                // fn is pre-packed (hi<<16|lo); bit-extract both bf16 -- no fp split.
                                 for (int e = 0; e < ds_read_vec; e++) {
-                                    fn_hi[e]              = opus::fp32_to_bf16(v_fn[n][e + (j - 1) * ds_read_vec]);
-                                    fn_hi[ds_read_vec + e] = opus::fp32_to_bf16(v_fn[n][e + j * ds_read_vec]);
+                                    float fv0 = v_fn[n][e + (j - 1) * ds_read_vec];
+                                    float fv1 = v_fn[n][e + j * ds_read_vec];
+                                    uint32_t b0 = __builtin_bit_cast(uint32_t, fv0);
+                                    uint32_t b1 = __builtin_bit_cast(uint32_t, fv1);
+                                    fn_hi[e]               = __builtin_bit_cast(opus::bf16_t, (uint16_t)(b0 >> 16));
+                                    fn_hi[ds_read_vec + e] = __builtin_bit_cast(opus::bf16_t, (uint16_t)(b1 >> 16));
+                                    fn_lo[e]               = __builtin_bit_cast(opus::bf16_t, (uint16_t)(b0 & 0xFFFFu));
+                                    fn_lo[ds_read_vec + e] = __builtin_bit_cast(opus::bf16_t, (uint16_t)(b1 & 0xFFFFu));
                                 }
                                 v_cf[b][n] = opus::wmma_f32_16x16x32_bf16{}(fn_hi, res_bf, v_cf[b][n]);
-                                for (int e = 0; e < ds_read_vec; e++) {
-                                    float f0 = v_fn[n][e + (j - 1) * ds_read_vec];
-                                    float f1 = v_fn[n][e + j * ds_read_vec];
-                                    fn_lo[e]              = opus::fp32_to_bf16(f0 - opus::bf16_to_fp32(fn_hi[e]));
-                                    fn_lo[ds_read_vec + e] = opus::fp32_to_bf16(f1 - opus::bf16_to_fp32(fn_hi[ds_read_vec + e]));
-                                }
                                 v_cf[b][n] = opus::wmma_f32_16x16x32_bf16{}(fn_lo, res_bf, v_cf[b][n]);
                             }
                         }

--- a/csrc/kernels/mhc_kernels.cu
+++ b/csrc/kernels/mhc_kernels.cu
@@ -2384,9 +2384,11 @@ namespace aiter {
         lds_load_residual_tile(0);
         v_fn0 = vgpr_load_fn_tile(0);
         __builtin_amdgcn_sched_barrier(0);
-        lds_load_x_tile(1);
-        lds_load_residual_tile(1);
-        v_fn1 = vgpr_load_fn_tile(1);
+        if (k_loop > 1) {
+            lds_load_x_tile(1);
+            lds_load_residual_tile(1);
+            v_fn1 = vgpr_load_fn_tile(1);
+        }
 
         float sqrsum_part[m_repeat];
         fp32xovec_t v_cf[m_repeat][repeat_n];
@@ -2670,8 +2672,8 @@ namespace aiter {
         dim3 grid(mb, n_blocks, split_k); \
         AITER_CHECK(hidden_size % (tile_k * split_k) == 0, \
                     "hidden_size must be divisible by tile_k * split_k"); \
-        AITER_CHECK(hidden_size >= (tile_k * split_k) * 2, \
-                    "hidden_size must be >= tile_k * split_k * 2 for prefetch"); \
+        AITER_CHECK(hidden_size >= (tile_k * split_k), \
+                    "hidden_size must be >= tile_k * split_k (>=1 k-tile per split)"); \
         mhc_fused_post_pre_gemm_sqrsum_kernel<DTYPE_I, num_warps, 4, tile_m, tile_n, tile_k, store_nt, MHC_FUSED_BF16> \
             <<<grid, block, 0, stream>>>( \
                 reinterpret_cast<float*>(gemm_out_mul.data_ptr()), \

--- a/csrc/kernels/mhc_kernels.cu
+++ b/csrc/kernels/mhc_kernels.cu
@@ -2822,6 +2822,32 @@ namespace aiter {
         using float_hc_mult = opus::vector_t<float, hc_mult>;
         float post_mix_v[m_repeat];
         float_hc_mult comb_mix[m_repeat];
+#if defined(__gfx1250__)
+        // Keep coefficient loads in a shared EXEC region instead of waiting
+        // after every scalar read. Full decode tiles can batch all row bands;
+        // the per-band path avoids the prefill regression from that fast path.
+        if (decode_pipeline && m_oob == tile_m) {
+            for(int b = 0; b < m_repeat; b++) {
+                int row = b * mfma_m + lane_id % mfma_m;
+                post_mix_v[b] = post_layer_mix[(row + idx) * hc_mult + warp_id];
+                for(int h = 0; h < hc_mult; h++) {
+                    comb_mix[b][h] = comb_res_mix[(row + idx) * hc_mult2 + h * hc_mult + warp_id];
+                }
+            }
+        } else {
+            for(int b = 0; b < m_repeat; b++) {
+                int row = b * mfma_m + lane_id % mfma_m;
+                post_mix_v[b] = 0.0f;
+                opus::clear(comb_mix[b]);
+                if (row < m_oob) {
+                    post_mix_v[b] = post_layer_mix[(row + idx) * hc_mult + warp_id];
+                    for(int h = 0; h < hc_mult; h++) {
+                        comb_mix[b][h] = comb_res_mix[(row + idx) * hc_mult2 + h * hc_mult + warp_id];
+                    }
+                }
+            }
+        }
+#else
         for(int b = 0; b < m_repeat; b++) {
             int row = b * mfma_m + lane_id % mfma_m;
             post_mix_v[b] = row < m_oob ? post_layer_mix[(row + idx) * hc_mult + warp_id] : 0.0f;
@@ -2829,6 +2855,7 @@ namespace aiter {
                 comb_mix[b][h] = row < m_oob ? comb_res_mix[(row + idx) * hc_mult2 + h * hc_mult + warp_id] : 0.0f;
             }
         }
+#endif
 
         const int k_loop = hidden_size / (split_k * tile_k);
 

--- a/csrc/kernels/mhc_kernels.cu
+++ b/csrc/kernels/mhc_kernels.cu
@@ -2865,43 +2865,51 @@ namespace aiter {
         auto compute_store_tile = [&](int i, int slot, fp32xfntile& v_fn) {
             DTYPE_I* s_x_rd_ptr = s_x + slot * tile_mk;
             DTYPE_I* s_residual_rd_ptr = s_residual + slot * (hc_mult * tile_mk);
+            static constexpr bool batch_lds = decode_pipeline || (mhc_bf16_mma_avail && warp_size == 32 && is_res_w_preshuffle_bf16 && res_shuf && tile_k == 32);
             static constexpr int ds_read_vec = 16 / sizeof(DTYPE_I);
             static constexpr int step = ds_read_vec;
             static constexpr int band_j = band_mk / (warp_size * ds_read_vec);
             // gfx1250 wave32 bf16 needs a 16-K/lane WMMA fragment = two band_j
             // iterations (2 x ds_read_vec) combined; band_j is even for tile_k in {32,64}.
-            for(int b = 0; b < m_repeat; b++) {
-                int s_offset = b * band_mk + lane_id % mfma_m * tile_k + lane_id / mfma_m * vec_tile;
-                [[maybe_unused]] float res_buf[2][ds_read_vec];  // gfx1250 bf16: buffer 2 j's -> 16/lane
-                // Issue both halves of the BF16 fragment before consuming either.
-                // Native LDS loads retain their register dependencies, so the
-                // compiler can wait at use instead of draining to a fixed count.
-                using pref_vec = opus::vector_t<DTYPE_I, ds_read_vec>;
-                pref_vec pref_x[band_j], pref_res[band_j][hc_mult];
-                if constexpr (decode_pipeline) {
+            using pref_vec = opus::vector_t<DTYPE_I, ds_read_vec>;
+            pref_vec pref_x[band_j], pref_res[band_j][hc_mult];
+            auto prefetch_band = [&](int pb) {
+                if constexpr (batch_lds) {
                     for (int pj = 0; pj < band_j; ++pj) {
-                        const int off = s_offset + pj * step;
+                        const int off = pb * band_mk + lane_id % mfma_m * tile_k
+                                      + lane_id / mfma_m * vec_tile + pj * step;
                         pref_x[pj] = *reinterpret_cast<pref_vec*>(s_x_rd_ptr + off);
                         const int kl = off % tile_k;
-                        const int row = b * mfma_m + lane_id % mfma_m;
+                        const int row = pb * mfma_m + lane_id % mfma_m;
                         const int rb = (kl / res_ks) * res_kb_stride_lds + row * res_ks + kl % res_ks;
                         for (int h = 0; h < hc_mult; ++h)
                             pref_res[pj][h] = *reinterpret_cast<pref_vec*>(s_residual_rd_ptr + rb + h * res_h_stride_lds);
                     }
                     __builtin_amdgcn_sched_barrier(0);
                 }
+            };
+            // Decode keeps its per-band load order. In the other BF16 path,
+            // the next band is fetched while the current WMMA is still pending.
+            if constexpr (!decode_pipeline) prefetch_band(0);
+            for(int b = 0; b < m_repeat; b++) {
+                if constexpr (decode_pipeline) prefetch_band(b);
+                int s_offset = b * band_mk + lane_id % mfma_m * tile_k + lane_id / mfma_m * vec_tile;
+                [[maybe_unused]] opus::vector_t<float, 8> res_bf_raw;
+                // Issue both halves of the BF16 fragment before consuming either.
+                // Native LDS loads retain their register dependencies, so the
+                // compiler can wait at use instead of draining to a fixed count.
                 for(int j = 0; j < band_j; j++) {
                     opus::vector_t<float, ds_read_vec> res;
                     using DTYPE_I_vec = opus::vector_t<DTYPE_I, ds_read_vec>;
                     DTYPE_I_vec x_vec;
-                    if constexpr (decode_pipeline) x_vec = pref_x[j];
+                    if constexpr (batch_lds) x_vec = pref_x[j];
                     else x_vec = *(reinterpret_cast<DTYPE_I_vec*>(s_x_rd_ptr + s_offset));
                     DTYPE_I_vec residual_vec[hc_mult];
                     // k_local within the k-step; ds_read_vec == KS keeps each read
                     // inside exactly one kk run, so only the addressing changes.
                     [[maybe_unused]] const int res_kl = s_offset % tile_k;
                     [[maybe_unused]] const int res_row = b * mfma_m + lane_id % mfma_m;
-                    if constexpr (decode_pipeline) {
+                    if constexpr (batch_lds) {
                         for (int h = 0; h < hc_mult; ++h) residual_vec[h] = pref_res[j][h];
                     } else if constexpr (res_shuf) {
                         static_assert(ds_read_vec <= res_ks && res_ks % ds_read_vec == 0,
@@ -2917,7 +2925,7 @@ namespace aiter {
                             residual_vec[h] = *(reinterpret_cast<DTYPE_I_vec*>(s_residual_rd_ptr + s_offset + h * tile_mk));
                         }
                     }
-                    if constexpr (!decode_pipeline) s_wait_all_dscnt(opus::number<hc_mult>{});
+                    if constexpr (!batch_lds) s_wait_all_dscnt(opus::number<hc_mult>{});
                     for(int k = 0; k < ds_read_vec; k++) {
                         res[k] = static_cast<float>(x_vec[k]) * post_mix_v[b];
                     }
@@ -3003,12 +3011,16 @@ namespace aiter {
                         // over matching K. rept0 = the earlier j, rept1 = this j.
                         static_assert(ds_read_vec == 8, "wave32 bf16 expects 8 elems/lane per step");
                         static_assert(band_j % 2 == 0, "gfx1250 bf16 needs band_j even (2-j combine)");
-                        for (int e = 0; e < ds_read_vec; e++) res_buf[j & 1][e] = res[e];
+                        opus::vector_t<opus::bf16_t, 8> res_bf_half;
+                        for (int e = 0; e < ds_read_vec; e++) {
+                            res_bf_half[e] = opus::fp32_to_bf16(res[e]);
+                        }
+                        auto raw_half = __builtin_bit_cast(opus::vector_t<float, 4>, res_bf_half);
+                        for (int e = 0; e < 4; e++) res_bf_raw[(j & 1) * 4 + e] = raw_half[e];
                         if ((j & 1) == 1) {
-                            opus::vector_t<opus::bf16_t, 16> res_bf;
-                            for (int e = 0; e < ds_read_vec; e++) {
-                                res_bf[e]              = opus::fp32_to_bf16(res_buf[0][e]);
-                                res_bf[ds_read_vec + e] = opus::fp32_to_bf16(res_buf[1][e]);
+                            auto res_bf = __builtin_bit_cast(opus::vector_t<opus::bf16_t, 16>, res_bf_raw);
+                            if constexpr (!decode_pipeline) {
+                                if (j + 1 == band_j && b + 1 < m_repeat) prefetch_band(b + 1);
                             }
                             for (int n = 0; n < repeat_n; n++) {
                                 opus::vector_t<opus::bf16_t, 16> fn_hi, fn_lo;
@@ -3231,6 +3243,15 @@ namespace aiter {
         // both. Reuse s_residual as scratch (dead after the k_loop); cast to float.
         float* s_red = reinterpret_cast<float*>(s_residual);
         static constexpr int v_per_lane = m_repeat * repeat_n * ovec;
+        // Interleave aligned four-float groups across lanes for vector LDS access.
+        auto reduction_offset = [&](int head, int c) {
+            if constexpr (mhc_bf16_mma_avail && warp_size == 32 && is_res_w_preshuffle_bf16) {
+                return head * warp_size * v_per_lane + (c / 4) * warp_size * 4
+                     + lane_id * 4 + c % 4;
+            } else {
+                return (head * warp_size + lane_id) * v_per_lane + c;
+            }
+        };
         float* s_sq = s_red + (hc_mult - 1) * warp_size * v_per_lane;  // disjoint
         // sqrsum per-warp partial (computed on all warps; DPP, no barrier needed)
         float sqrsum_w[m_repeat];
@@ -3247,12 +3268,11 @@ namespace aiter {
             __syncthreads();
         }  // (1) finish reads before scratch reuse
         if (warp_id != 0) {
-            int base = (warp_id - 1) * warp_size * v_per_lane + lane_id * v_per_lane;
             int c = 0;
             for (int b = 0; b < m_repeat; b++)
                 for (int n = 0; n < repeat_n; n++)
                     for (int e = 0; e < ovec; e++)
-                        s_red[base + c++] = v_cf[b][n][e];
+                        s_red[reduction_offset(warp_id - 1, c++)] = v_cf[b][n][e];
             if (n_idx == 0 && lane_id < mfma_m)
                 for (int b = 0; b < m_repeat; b++)
                     s_sq[((warp_id - 1) * mfma_m + lane_id) * m_repeat + b] = sqrsum_w[b];
@@ -3265,12 +3285,11 @@ namespace aiter {
         }  // (2) all LDS deposits visible
         if (warp_id == 0) {
             for (int w = 0; w < hc_mult - 1; w++) {
-                int base = w * warp_size * v_per_lane + lane_id * v_per_lane;
                 int c = 0;
                 for (int b = 0; b < m_repeat; b++)
                     for (int n = 0; n < repeat_n; n++)
                         for (int e = 0; e < ovec; e++)
-                            v_cf[b][n][e] += s_red[base + c++];
+                            v_cf[b][n][e] += s_red[reduction_offset(w, c++)];
             }
             for (int b = 0; b < m_repeat; b++) {
                 int gc_offset = (b * mfma_m + lane_id % mfma_m) * out_stride + (lane_id / mfma_m) * ovec;

--- a/csrc/kernels/mhc_kernels.cu
+++ b/csrc/kernels/mhc_kernels.cu
@@ -222,7 +222,7 @@ namespace aiter {
     mma_f32_16x16x4_fma((a), (b), (c))
 #endif
 
-    template <typename DTYPE_I, int num_warps, int tile_m, int tile_n, int tile_k, bool is_w_preshuffle_bf16 = false>
+    template <typename DTYPE_I, int num_warps, int tile_m, int tile_n, int tile_k, bool is_w_preshuffle_bf16 = false, bool vector_fn_load = false>
     __global__ __launch_bounds__(num_warps *  opus::get_warp_size(), 2)
     void mhc_pre_gemm_sqrsum_kernel(
         float* out,
@@ -686,12 +686,25 @@ namespace aiter {
                     int hi_f = mhc_fn_hi_float(k_group * x_vec_size +
                                                c * 2 * interleave_size * x_vec_size +
                                                r * interleave_size * x_vec_size);
-                    #pragma unroll
-                    for (int t = 0; t < 4; t++) {
-                        hi_raw[n][r * 4 + t] =
-                            *(s_fn_rd_ptr + fn_row * tile_k + ((hi_f + t) ^ mask));
-                        lo_raw[n][r * 4 + t] =
-                            *(s_fn_rd_ptr + fn_row * tile_k + ((hi_f + 8 + t) ^ mask));
+                    if constexpr (vector_fn_load) {
+                        // The XOR mask preserves each aligned four-float run.
+                        // Explicit vector loads avoid scalar LDS gathers and
+                        // register repacking of the BF16 WMMA fragments.
+                        using f32x4_ = opus::vector_t<float, 4>;
+                        *reinterpret_cast<f32x4_*>(hi_raw[n] + r * 4) =
+                            *reinterpret_cast<const f32x4_*>(
+                                s_fn_rd_ptr + fn_row * tile_k + (hi_f ^ mask));
+                        *reinterpret_cast<f32x4_*>(lo_raw[n] + r * 4) =
+                            *reinterpret_cast<const f32x4_*>(
+                                s_fn_rd_ptr + fn_row * tile_k + ((hi_f + 8) ^ mask));
+                    } else {
+                        #pragma unroll
+                        for (int t = 0; t < 4; t++) {
+                            hi_raw[n][r * 4 + t] =
+                                *(s_fn_rd_ptr + fn_row * tile_k + ((hi_f + t) ^ mask));
+                            lo_raw[n][r * 4 + t] =
+                                *(s_fn_rd_ptr + fn_row * tile_k + ((hi_f + 8 + t) ^ mask));
+                        }
                     }
                 }
             }
@@ -892,7 +905,7 @@ namespace aiter {
         }
     }
 
-#define MHC_PRE_GEMM_SQRSUM_KERNEL_IMPL(num_warps, tile_n, tile_k) \
+#define MHC_PRE_GEMM_SQRSUM_KERNEL_IMPL(num_warps, tile_n, tile_k, vector_fn_load) \
     AITER_DISPATCH_FLOATING16_TYPES_rmTorch(x.dtype(), "mhc_pre_gemm_sqrsum", [&] { \
         using DTYPE_I = typename hip2opus<scalar_t>::type; \
         const int tile_m = m_per_block; \
@@ -901,7 +914,7 @@ namespace aiter {
         dim3 block(num_warps * WARP_SIZE); \
         AITER_CHECK(hc_hidden_size % (tile_k * split_k) == 0, "hc_hidden_size must be divisible by tile_k * split_k"); \
         AITER_CHECK(hc_hidden_size >= (tile_k * split_k) * 2, "hc_hidden_size must >= tile_k * split_k * 2 stages prefetch"); \
-        mhc_pre_gemm_sqrsum_kernel<DTYPE_I, num_warps, tile_m, tile_n, tile_k, MHC_PRE_BF16><<<grid, block, 0, stream>>>( \
+        mhc_pre_gemm_sqrsum_kernel<DTYPE_I, num_warps, tile_m, tile_n, tile_k, MHC_PRE_BF16, vector_fn_load><<<grid, block, 0, stream>>>( \
             reinterpret_cast<float*>(out.data_ptr()), \
             reinterpret_cast<float*>(sqrsum.data_ptr()), \
             reinterpret_cast<DTYPE_I*>(x.data_ptr()), \
@@ -916,18 +929,31 @@ namespace aiter {
         ); \
     });
 
+// Packed BF16 vector LDS reads benefit both decode and prefill on gfx1250.
+// Query warp size at runtime: WARP_SIZE evaluates to 64 in host constant expressions.
 #define MHC_PRE_GEMM_SQRSUM_KERNEL_DISPATCH(tile_k) \
     if (tile_k == 64) { \
+        const bool vector_fn_load = MHC_PRE_BF16 && get_warp_size_func() == 32 && cu_num == 256 \
+            && hc_mult3 == 24 \
+            && (hc_hidden_size == 4 * 4096 || hc_hidden_size == 4 * 7168); \
         if (cu_num * 2 > m_blocks * split_k || hc_mult3 <= 16) { \
-            MHC_PRE_GEMM_SQRSUM_KERNEL_IMPL(4, 16, 64); \
+            if (vector_fn_load) { \
+                MHC_PRE_GEMM_SQRSUM_KERNEL_IMPL(4, 16, 64, true); \
+            } else { \
+                MHC_PRE_GEMM_SQRSUM_KERNEL_IMPL(4, 16, 64, false); \
+            } \
         } else { \
-            MHC_PRE_GEMM_SQRSUM_KERNEL_IMPL(4, 32, 64); \
+            if (vector_fn_load) { \
+                MHC_PRE_GEMM_SQRSUM_KERNEL_IMPL(4, 32, 64, true); \
+            } else { \
+                MHC_PRE_GEMM_SQRSUM_KERNEL_IMPL(4, 32, 64, false); \
+            } \
         } \
     } else if (tile_k == 128 || hc_mult3 <= 16) { \
         if (cu_num > m_blocks * split_k) { \
-            MHC_PRE_GEMM_SQRSUM_KERNEL_IMPL(4, 16, 128); \
+            MHC_PRE_GEMM_SQRSUM_KERNEL_IMPL(4, 16, 128, false); \
         } else { \
-            MHC_PRE_GEMM_SQRSUM_KERNEL_IMPL(4, 32, 128); \
+            MHC_PRE_GEMM_SQRSUM_KERNEL_IMPL(4, 32, 128, false); \
         } \
     } else { \
         AITER_CHECK(false, "tile_k must be 64 or 128"); \

--- a/csrc/kernels/mhc_kernels.cu
+++ b/csrc/kernels/mhc_kernels.cu
@@ -21,7 +21,7 @@ namespace aiter {
     static constexpr bool mhc_async_load_oob_guard = false;
 #endif
 
-    // is_res_w_preshuffle_bf16 selects the bf16 (fn hi/lo split) matrix compute over the fp32
+    // The packed-weight path selects the bf16 (fn hi/lo split) matrix compute over the fp32
     // one. Wave64 CDNA (gfx942/gfx950/gfx9_4_generic) use opus::mfma<bf16,..,16,16,32>
     // (8 bf16/lane) -- native K=32 on gfx950, chained K=16 (mfma_..16x16x16bf16_1k) on
     // gfx942; gfx1250 uses the wave32 wmma_f32_16x16x32_bf16 (16 bf16/lane, UNVERIFIED
@@ -121,7 +121,7 @@ namespace aiter {
 
     // Pre-convert fn (fp32) into a packed dword: hi = bf16(fn) in [31:16], lo = bf16(fn -
     // fp32(hi)) in [15:0]. Same 4-byte width as fp32 so the gemm's load / LDS / swizzle are
-    // unchanged; the bf16 gemm (is_res_w_preshuffle_bf16) then bit-extracts hi/lo instead of
+    // unchanged; the bf16 gemm then reads the pre-packed hi/lo instead of
     // recomputing the fp32->bf16 split per (m_block, k) -- the split was redundant work
     // repeated m_blocks times. fn are model weights (constant across forward passes), so
     // this runs once and the packed int32 tensor is reused every forward.
@@ -222,7 +222,7 @@ namespace aiter {
     mma_f32_16x16x4_fma((a), (b), (c))
 #endif
 
-    template <typename DTYPE_I, int num_warps, int tile_m, int tile_n, int tile_k, bool is_res_w_preshuffle_bf16 = false>
+    template <typename DTYPE_I, int num_warps, int tile_m, int tile_n, int tile_k, bool is_w_preshuffle_bf16 = false>
     __global__ __launch_bounds__(num_warps *  opus::get_warp_size(), 2)
     void mhc_pre_gemm_sqrsum_kernel(
         float* out,
@@ -261,7 +261,7 @@ namespace aiter {
         // The LDS test keeps tile_k=128 -- 67584 B/workgroup, past the 64 KiB limit --
         // degrading to the per-lane load instead of failing to launch, should gfx1250
         // ever dispatch it (get_mhc_pre_splitk offers only 64 off gfx9).
-        static constexpr bool x_tdm = mhc_pre_x_tdm && is_res_w_preshuffle_bf16
+        static constexpr bool x_tdm = mhc_pre_x_tdm && is_w_preshuffle_bf16
                                       && (x_tdm_lds_bytes <= 64 * 1024);
 #else
         static constexpr bool x_tdm = false;
@@ -835,20 +835,20 @@ namespace aiter {
                 if constexpr (x_tdm) { lds_load_x_tile((k) + 2, (LDS_SLOT)); }                     \
             }                                                                                      \
         } while (0)
-        // is_res_w_preshuffle_bf16: bf16 hi/lo MFMA; otherwise fp32 MFMA. The bf16 body (and the
+        // is_w_preshuffle_bf16: bf16 hi/lo MFMA; otherwise fp32 MFMA. The bf16 body (and the
         // gfx950-only mfma_f32_16x16x32_bf16 builtin) exists only in the gfx950 device
         // pass; every other arch compiles the fp32 path unconditionally, so the flag is
         // a no-op there (falls back to fp32).
 #if MHC_BF16_MFMA
 #define MHC_PRE_GEMM_STEP(BUF, LDS_SLOT, k, DO_PREFETCH, X_WAIT)                    \
-        if constexpr (is_res_w_preshuffle_bf16) {                                   \
+        if constexpr (is_w_preshuffle_bf16) {                                   \
             GEMM_LOOP_BODY_BF16(BUF, LDS_SLOT, k, DO_PREFETCH);           \
         } else {                                                          \
             GEMM_LOOP_BODY(BUF, LDS_SLOT, k, DO_PREFETCH, X_WAIT);               \
         }
 #elif defined(__gfx1250__)
 #define MHC_PRE_GEMM_STEP(BUF, LDS_SLOT, k, DO_PREFETCH, X_WAIT)                    \
-        if constexpr (is_res_w_preshuffle_bf16) {                                   \
+        if constexpr (is_w_preshuffle_bf16) {                                   \
             GEMM_LOOP_BODY_BF16_W32(BUF, LDS_SLOT, k, DO_PREFETCH, X_WAIT);       \
         } else {                                                          \
             GEMM_LOOP_BODY(BUF, LDS_SLOT, k, DO_PREFETCH, X_WAIT);               \
@@ -937,9 +937,9 @@ namespace aiter {
         aiter_tensor_t& out, // (split_k, m, hc_mult3) / (m, hc_mult3)
         aiter_tensor_t& sqrsum, // (split_k, m) / (m)
         aiter_tensor_t& x, // (m, hc_hidden_size)
-        aiter_tensor_t& fn, // (hc_mult3, hc_hidden_size) fp32; packed int32 (hi<<16|lo) when is_res_w_preshuffle_bf16
+        aiter_tensor_t& fn, // (hc_mult3, hc_hidden_size) fp32; packed int32 BF16 hi/lo when is_w_preshuffle_bf16
         int tile_k = 128,
-        int is_res_w_preshuffle_bf16 = 0
+        int is_w_preshuffle_bf16 = 0
     )
     {
         AITER_CHECK(out.size(0) == sqrsum.size(0), "out and sqrsum must have the same number of split_k or m");
@@ -958,7 +958,7 @@ namespace aiter {
         const HipDeviceGuard device_guard(x.device_id);
         const hipStream_t stream = aiter::getCurrentHIPStream();
 
-        if (is_res_w_preshuffle_bf16) {
+        if (is_w_preshuffle_bf16) {
 #define MHC_PRE_BF16 true
             MHC_PRE_GEMM_SQRSUM_KERNEL_DISPATCH(tile_k);
 #undef MHC_PRE_BF16
@@ -2482,7 +2482,7 @@ namespace aiter {
         MHC_PRE_BIG_FUSE_RM_KERNEL_DISPATCH(m);
     }
 
-    template <typename DTYPE_I, int num_warps, int hc_mult, int tile_m, int tile_n, int tile_k, bool store_nt, bool is_res_w_preshuffle_bf16 = false>
+    template <typename DTYPE_I, int num_warps, int hc_mult, int tile_m, int tile_n, int tile_k, bool store_nt, bool is_res_w_preshuffle_bf16 = false, bool decode_direct_store = false>
     __global__ __launch_bounds__(num_warps * opus::get_warp_size(), 1)
     void mhc_fused_post_pre_gemm_sqrsum_kernel(
         float* out,
@@ -2521,9 +2521,14 @@ namespace aiter {
         // (warps 0/1 issue residual/x), or that warp would carry n_stages loads +
         // n_stages stores = 4 tensor ops in flight, over the per-wave limit of 3.
         static constexpr bool nres_tdm = mhc_nres_tdm_store && is_res_w_preshuffle_bf16
-                                         && mhc_res_shuffle && (num_warps > 2);
+                                         && mhc_res_shuffle && (num_warps > 2) && !decode_direct_store;
 #else
         static constexpr bool nres_tdm = false;
+#endif
+#if defined(__gfx1250__)
+        static constexpr bool decode_pipeline = decode_direct_store && is_res_w_preshuffle_bf16 && mhc_res_shuffle;
+#else
+        static constexpr bool decode_pipeline = false;
 #endif
         // Staging tile for the next_residual TDM store; same layout as s_residual.
         __shared__ DTYPE_I s_nres[nres_tdm ? n_stages * tile_m * hc_mult * tile_k : 1];
@@ -2813,7 +2818,7 @@ namespace aiter {
         __builtin_amdgcn_sched_barrier(0);
         opus::static_for<n_stages>([&](auto S) {
             constexpr int s = S.value;
-            if constexpr (s >= 1) {
+            if constexpr (s >= 1 && !decode_pipeline) {
                 if (s < k_loop) {
                     lds_load_x_tile(s, s);
                     lds_load_residual_tile(s, s);
@@ -2842,16 +2847,37 @@ namespace aiter {
             for(int b = 0; b < m_repeat; b++) {
                 int s_offset = b * band_mk + lane_id % mfma_m * tile_k + lane_id / mfma_m * vec_tile;
                 [[maybe_unused]] float res_buf[2][ds_read_vec];  // gfx1250 bf16: buffer 2 j's -> 16/lane
+                // Issue both halves of the BF16 fragment before consuming either.
+                // Native LDS loads retain their register dependencies, so the
+                // compiler can wait at use instead of draining to a fixed count.
+                using pref_vec = opus::vector_t<DTYPE_I, ds_read_vec>;
+                pref_vec pref_x[band_j], pref_res[band_j][hc_mult];
+                if constexpr (decode_pipeline) {
+                    for (int pj = 0; pj < band_j; ++pj) {
+                        const int off = s_offset + pj * step;
+                        pref_x[pj] = *reinterpret_cast<pref_vec*>(s_x_rd_ptr + off);
+                        const int kl = off % tile_k;
+                        const int row = b * mfma_m + lane_id % mfma_m;
+                        const int rb = (kl / res_ks) * res_kb_stride_lds + row * res_ks + kl % res_ks;
+                        for (int h = 0; h < hc_mult; ++h)
+                            pref_res[pj][h] = *reinterpret_cast<pref_vec*>(s_residual_rd_ptr + rb + h * res_h_stride_lds);
+                    }
+                    __builtin_amdgcn_sched_barrier(0);
+                }
                 for(int j = 0; j < band_j; j++) {
                     opus::vector_t<float, ds_read_vec> res;
                     using DTYPE_I_vec = opus::vector_t<DTYPE_I, ds_read_vec>;
-                    DTYPE_I_vec x_vec = *(reinterpret_cast<DTYPE_I_vec*>(s_x_rd_ptr + s_offset));
+                    DTYPE_I_vec x_vec;
+                    if constexpr (decode_pipeline) x_vec = pref_x[j];
+                    else x_vec = *(reinterpret_cast<DTYPE_I_vec*>(s_x_rd_ptr + s_offset));
                     DTYPE_I_vec residual_vec[hc_mult];
                     // k_local within the k-step; ds_read_vec == KS keeps each read
                     // inside exactly one kk run, so only the addressing changes.
                     [[maybe_unused]] const int res_kl = s_offset % tile_k;
                     [[maybe_unused]] const int res_row = b * mfma_m + lane_id % mfma_m;
-                    if constexpr (res_shuf) {
+                    if constexpr (decode_pipeline) {
+                        for (int h = 0; h < hc_mult; ++h) residual_vec[h] = pref_res[j][h];
+                    } else if constexpr (res_shuf) {
                         static_assert(ds_read_vec <= res_ks && res_ks % ds_read_vec == 0,
                                       "ds_read_vec must divide mhc_res_ks");
                         const int r_base = (res_kl / res_ks) * res_kb_stride_lds
@@ -2865,7 +2891,7 @@ namespace aiter {
                             residual_vec[h] = *(reinterpret_cast<DTYPE_I_vec*>(s_residual_rd_ptr + s_offset + h * tile_mk));
                         }
                     }
-                    s_wait_all_dscnt(opus::number<hc_mult>{});
+                    if constexpr (!decode_pipeline) s_wait_all_dscnt(opus::number<hc_mult>{});
                     for(int k = 0; k < ds_read_vec; k++) {
                         res[k] = static_cast<float>(x_vec[k]) * post_mix_v[b];
                     }
@@ -3083,58 +3109,84 @@ namespace aiter {
         auto tdm_store_nres_tile = [](int, int){};
 #endif
 
-        int i = 0;
-        for(; i + 2 * n_stages - 1 < k_loop; i += n_stages) {
-            opus::static_for<n_stages>([&](auto S) {
-                constexpr int s = S.value;
-                wait_load_cnt();
-                compute_store_tile(i + s, s, v_fn[s]);
-                nres_deposit_fence();
-                __builtin_amdgcn_s_barrier();
-                tdm_store_nres_tile(i + s, s);
-                lds_load_x_tile(i + s + n_stages, s);
-                lds_load_residual_tile(i + s + n_stages, s);
-                v_fn[s] = vgpr_load_fn_tile(i + s + n_stages);
-                __builtin_amdgcn_sched_barrier(0);
-            });
-        }
-
-        // Tail: at most 2*n_stages-1 stages left. Unrolled over the same slot
-        // sequence (slot = s % n_stages, compile-time) with two runtime guards:
-        //   k < k_loop            -- this stage exists at all
-        //   k + n_stages < k_loop -- the ring can still be refilled from this step
-        // Once refilling stops the outstanding count falls below n_stages-1, so
-        // wait_load_cnt()'s partial drain would no longer prove residency; those
-        // steps take the full drain instead. Conservative by at most one step (the
-        // k+n_stages == k_loop case still has n_stages-1 outstanding), which is
-        // exactly what the previous hand-rolled 2-stage tail did.
-        opus::static_for<2 * n_stages - 1>([&](auto S) {
-            constexpr int s = S.value;
-            const int k = i + s;
-            if (k < k_loop) {
-                constexpr int slot = s % n_stages;
-                if (k + n_stages < k_loop) {
+        if constexpr (decode_pipeline) {
+            // Publish the current TDM tile and finish the preceding tile's reads
+            // at one barrier. Only then overwrite the preceding LDS slot with
+            // the next tile. Its transfer overlaps the current tile's compute.
+            // Direct next_residual stores need no cross-wave LDS deposit.
+            for (int i = 0; i < k_loop; i += n_stages) {
+                opus::static_for<n_stages>([&](auto S) {
+                    constexpr int slot = S.value;
+                    const int k = i + slot;
+                    if (k < k_loop) {
+                        MHC_TDM_DRAIN();
+                        s_wait_all_loadcnt(0_I, opus::number<-1>{});
+                        __builtin_amdgcn_s_barrier();
+                        if (k + 1 < k_loop) {
+                            constexpr int next_slot = (slot + 1) % n_stages;
+                            lds_load_x_tile(k + 1, next_slot);
+                            lds_load_residual_tile(k + 1, next_slot);
+                            v_fn[next_slot] = vgpr_load_fn_tile(k + 1);
+                            __builtin_amdgcn_sched_barrier(0);
+                        }
+                        compute_store_tile(k, slot, v_fn[slot]);
+                    }
+                });
+            }
+        } else {
+            int i = 0;
+            for(; i + 2 * n_stages - 1 < k_loop; i += n_stages) {
+                opus::static_for<n_stages>([&](auto S) {
+                    constexpr int s = S.value;
                     wait_load_cnt();
-                    compute_store_tile(k, slot, v_fn[slot]);
+                    compute_store_tile(i + s, s, v_fn[s]);
                     nres_deposit_fence();
                     __builtin_amdgcn_s_barrier();
-                    tdm_store_nres_tile(k, slot);
-                    lds_load_x_tile(k + n_stages, slot);
-                    lds_load_residual_tile(k + n_stages, slot);
-                    v_fn[slot] = vgpr_load_fn_tile(k + n_stages);
-                } else {
-                    s_wait_all_loadcnt(0_I, 0_I);
-                    MHC_TDM_DRAIN();
-                    __builtin_amdgcn_s_barrier();
-                    compute_store_tile(k, slot, v_fn[slot]);
-                    if constexpr (nres_tdm) {
+                    tdm_store_nres_tile(i + s, s);
+                    lds_load_x_tile(i + s + n_stages, s);
+                    lds_load_residual_tile(i + s + n_stages, s);
+                    v_fn[s] = vgpr_load_fn_tile(i + s + n_stages);
+                    __builtin_amdgcn_sched_barrier(0);
+                });
+            }
+
+            // Tail: at most 2*n_stages-1 stages left. Unrolled over the same slot
+            // sequence (slot = s % n_stages, compile-time) with two runtime guards:
+            //   k < k_loop            -- this stage exists at all
+            //   k + n_stages < k_loop -- the ring can still be refilled from this step
+            // Once refilling stops the outstanding count falls below n_stages-1, so
+            // wait_load_cnt()'s partial drain would no longer prove residency; those
+            // steps take the full drain instead. Conservative by at most one step (the
+            // k+n_stages == k_loop case still has n_stages-1 outstanding), which is
+            // exactly what the previous hand-rolled 2-stage tail did.
+            opus::static_for<2 * n_stages - 1>([&](auto S) {
+                constexpr int s = S.value;
+                const int k = i + s;
+                if (k < k_loop) {
+                    constexpr int slot = s % n_stages;
+                    if (k + n_stages < k_loop) {
+                        wait_load_cnt();
+                        compute_store_tile(k, slot, v_fn[slot]);
                         nres_deposit_fence();
                         __builtin_amdgcn_s_barrier();
                         tdm_store_nres_tile(k, slot);
+                        lds_load_x_tile(k + n_stages, slot);
+                        lds_load_residual_tile(k + n_stages, slot);
+                        v_fn[slot] = vgpr_load_fn_tile(k + n_stages);
+                    } else {
+                        s_wait_all_loadcnt(0_I, 0_I);
+                        MHC_TDM_DRAIN();
+                        __builtin_amdgcn_s_barrier();
+                        compute_store_tile(k, slot, v_fn[slot]);
+                        if constexpr (nres_tdm) {
+                            nres_deposit_fence();
+                            __builtin_amdgcn_s_barrier();
+                            tdm_store_nres_tile(k, slot);
+                        }
                     }
                 }
-            }
-        });
+            });
+        }
         // Every next_residual TDM store must retire before the kernel ends.
         if constexpr (nres_tdm) { MHC_TDM_DRAIN(); }
 
@@ -3160,7 +3212,14 @@ namespace aiter {
             for (int b = 0; b < m_repeat; b++)
                 sqrsum_w[b] = cross_row_sum_4(sqrsum_part[b], lane_id);
         }
-        __syncthreads();  // (1) s_residual reads (last compute tile) done before reuse
+        if constexpr (decode_pipeline) {
+            // Only LDS is exchanged across waves here. next_residual stores
+            // can remain in flight until kernel completion.
+            s_wait_all_dscnt(0_I);
+            __builtin_amdgcn_s_barrier();
+        } else {
+            __syncthreads();
+        }  // (1) finish reads before scratch reuse
         if (warp_id != 0) {
             int base = (warp_id - 1) * warp_size * v_per_lane + lane_id * v_per_lane;
             int c = 0;
@@ -3172,7 +3231,12 @@ namespace aiter {
                 for (int b = 0; b < m_repeat; b++)
                     s_sq[((warp_id - 1) * mfma_m + lane_id) * m_repeat + b] = sqrsum_w[b];
         }
-        __syncthreads();  // (2) all deposits visible
+        if constexpr (decode_pipeline) {
+            s_wait_all_dscnt(0_I);
+            __builtin_amdgcn_s_barrier();
+        } else {
+            __syncthreads();
+        }  // (2) all LDS deposits visible
         if (warp_id == 0) {
             for (int w = 0; w < hc_mult - 1; w++) {
                 int base = w * warp_size * v_per_lane + lane_id * v_per_lane;
@@ -3201,7 +3265,7 @@ namespace aiter {
         }
     }
 
-#define MHC_FUSED_POST_PRE_GEMM_SQRSUM_KERNEL_IMPL_(num_warps, tile_m, tile_n, tile_k, store_nt) \
+#define MHC_FUSED_POST_PRE_GEMM_SQRSUM_KERNEL_IMPL_(num_warps, tile_m, tile_n, tile_k, store_nt, decode_direct_store) \
     AITER_DISPATCH_FLOATING16_TYPES_rmTorch(layer_input.dtype(), "mhc_fused_post_pre_gemm_sqrsum", [&] { \
         using DTYPE_I = typename hip2opus<scalar_t>::type; \
         int mb = (m + tile_m - 1) / tile_m; \
@@ -3211,7 +3275,7 @@ namespace aiter {
                     "hidden_size must be divisible by tile_k * split_k"); \
         AITER_CHECK(hidden_size >= (tile_k * split_k), \
                     "hidden_size must be >= tile_k * split_k (>=1 k-tile per split)"); \
-        mhc_fused_post_pre_gemm_sqrsum_kernel<DTYPE_I, num_warps, 4, tile_m, tile_n, tile_k, store_nt, MHC_FUSED_BF16> \
+        mhc_fused_post_pre_gemm_sqrsum_kernel<DTYPE_I, num_warps, 4, tile_m, tile_n, tile_k, store_nt, MHC_FUSED_BF16, decode_direct_store> \
             <<<grid, block, 0, stream>>>( \
                 reinterpret_cast<float*>(gemm_out_mul.data_ptr()), \
                 reinterpret_cast<float*>(gemm_out_sqrsum.data_ptr()), \
@@ -3230,9 +3294,9 @@ namespace aiter {
 
 #define MHC_FUSED_POST_PRE_GEMM_SQRSUM_KERNEL_IMPL(num_warps, tile_m, tile_n, tile_k) \
     if (m >= 8 * cu_num) { \
-        MHC_FUSED_POST_PRE_GEMM_SQRSUM_KERNEL_IMPL_(num_warps, tile_m, tile_n, tile_k, true); \
+        MHC_FUSED_POST_PRE_GEMM_SQRSUM_KERNEL_IMPL_(num_warps, tile_m, tile_n, tile_k, true, false); \
     } else { \
-        MHC_FUSED_POST_PRE_GEMM_SQRSUM_KERNEL_IMPL_(num_warps, tile_m, tile_n, tile_k, false); \
+        MHC_FUSED_POST_PRE_GEMM_SQRSUM_KERNEL_IMPL_(num_warps, tile_m, tile_n, tile_k, false, false); \
     }
 
 #define MHC_FUSED_POST_PRE_GEMM_SQRSUM_KERNEL_CASE(TM, TN, TK) \
@@ -3324,6 +3388,20 @@ namespace aiter {
 
         if (is_res_w_preshuffle_bf16) {
 #define MHC_FUSED_BF16 true
+            // Packed BF16 decode: direct stores and the single-barrier pipeline
+            // support both row tile sizes throughout the measured decode range.
+            if (WARP_SIZE == 32 && cu_num == 256 && m > 0 && m <= 1024
+                && (hidden_size == 4096 || hidden_size == 7168)
+                && tile_n == 32 && tile_k == 32) {
+                if (tile_m == 16) {
+                    MHC_FUSED_POST_PRE_GEMM_SQRSUM_KERNEL_IMPL_(4, 16, 32, 32, false, true);
+                    return;
+                }
+                if (tile_m == 32) {
+                    MHC_FUSED_POST_PRE_GEMM_SQRSUM_KERNEL_IMPL_(4, 32, 32, 32, false, true);
+                    return;
+                }
+            }
             MHC_FUSED_POST_PRE_GEMM_SQRSUM_KERNEL_DISPATCH(tile_k);
 #undef MHC_FUSED_BF16
         } else {

--- a/csrc/kernels/mhc_kernels.cu
+++ b/csrc/kernels/mhc_kernels.cu
@@ -1626,11 +1626,8 @@ namespace aiter {
 #endif
         static constexpr int x_async_load_threads = block_size * x_async_load_vec < residual_block ? block_size : residual_block / x_async_load_vec;
         static constexpr int x_load_waitcnt = residual_block / (x_async_load_threads * x_async_load_vec);
-        static_assert(x_async_load_threads % warp_size == 0,
-                      "x async loads must cover complete waves");
-        const bool loads_x = warp_id < x_async_load_threads / warp_size;
         auto lds_load_x_tile = [&](int k){
-            if (loads_x) {
+            if(threadIdx.x < x_async_load_threads) {
                 DTYPE_I* s_x_wr_ptr = s_x + (k & 1) * residual_block;
                 int offset = k * residual_block;
                 for(int i = 0; i < x_load_waitcnt; i++) {
@@ -1669,9 +1666,7 @@ namespace aiter {
         static_assert(residual_block % (warp_size * ds_read_vec) == 0, "residual_block must be divisible by warp_size * ds_read_vec");
         const int loop = sub_hidden_size / residual_block;
 
-        auto compute_store_tile = [&](int i, auto IsTail) {
-            constexpr int stores = residual_block / (warp_size * ds_read_vec);
-            vector_store_batch<DTYPE_I, ds_read_vec, stores, store_policy> output{g_out};
+        auto compute_store_tile = [&](int i) {
             DTYPE_I* s_x_rd_ptr = s_x + (i & 1) * residual_block;
             DTYPE_I* s_residual_rd_ptr = s_residual + (i & 1) * (hc_mult * residual_block);
             for(int j = 0; j < residual_block / (warp_size * ds_read_vec); j++) {
@@ -1692,9 +1687,8 @@ namespace aiter {
                         res[k] += static_cast<float>(residual_vec[h.value][k]) * comb_mix[h.value];
                     }
                 });
-                output.set(j, res, warp_id * hidden_size + i * residual_block + s_offset);
+                store_vector<DTYPE_I, float, ds_read_vec, store_policy>(g_out, res, warp_id * hidden_size + i * residual_block + s_offset);
             }
-            output.template finish<!IsTail.value>();
         };
 
         lds_load_x_tile(0);
@@ -1703,19 +1697,20 @@ namespace aiter {
             lds_load_x_tile(i + 1);
             lds_load_residual_tile(i + 1);
             __builtin_amdgcn_sched_barrier(0);
-            if (loads_x) {
+            if(threadIdx.x < x_async_load_threads) {
                 s_wait_all_loadcnt(opus::number<-1>{}, opus::number<x_load_waitcnt + residual_load_waitcnt>{});
             }
             else {
                 s_wait_all_loadcnt(opus::number<-1>{}, opus::number<residual_load_waitcnt>{});
             }
             __builtin_amdgcn_s_barrier();
-            compute_store_tile(i, opus::number<0>{});
+            compute_store_tile(i);
+            __builtin_amdgcn_s_barrier();
         }
         int i = loop - 1;
         s_wait_all_loadcnt(opus::number<-1>{}, 0_I);
         __builtin_amdgcn_s_barrier();
-        compute_store_tile(i, opus::number<1>{});
+        compute_store_tile(i);
     }
 
 
@@ -2813,15 +2808,13 @@ namespace aiter {
         static constexpr int fn_load_vec = 16 / sizeof(float);
         static constexpr int fn_load_waitcnt = tile_n * tile_k / (warp_size * fn_load_vec);
         using fp32xfntile = opus::array<fp32xtile, repeat_n>;
-        vector_load_token fn_loads[repeat_n];
         auto vgpr_load_fn_tile = [&](int k) {
             fp32xfntile v_fn;
             const int offset_base = lane_id % mfma_n * fn_stride + warp_id * hidden_size
                                   + lane_id / mfma_n * vec_tile + k * tile_k + k_split_offset;
             const int n_step = mfma_n * fn_stride;
             for(int n = 0; n < repeat_n; n++) {
-                v_fn[n] = load_vector_nbytes<float, vec_tile, 16, 0, false>(
-                    g_fn, offset_base + n * n_step, fn_loads[n]);
+                v_fn[n] = load_vector_nbytes<float, vec_tile, 16, 0, false>(g_fn, offset_base + n * n_step);
             }
             return v_fn;
         };
@@ -2906,8 +2899,6 @@ namespace aiter {
             // gfx1250 wave32 bf16 needs a 16-K/lane WMMA fragment = two band_j
             // iterations (2 x ds_read_vec) combined; band_j is even for tile_k in {32,64}.
             using pref_vec = opus::vector_t<DTYPE_I, ds_read_vec>;
-            vector_store_batch<DTYPE_I, ds_read_vec, decode_pipeline ? m_repeat * band_j : 1>
-                next_residual{g_nres};
             pref_vec pref_x[band_j], pref_res[band_j][hc_mult];
             auto prefetch_band = [&](int pb) {
                 if constexpr (batch_lds) {
@@ -2989,12 +2980,6 @@ namespace aiter {
                             nres_v[e] = static_cast<DTYPE_I>(res[e]);
                         }
                         *(reinterpret_cast<DTYPE_I_vec*>(s_nres_wr + w_off)) = nres_v;
-                    } else if constexpr (decode_pipeline) {
-                        const int p = b * band_j + j;
-                        int off = (int)(((int64_t)i * res_nkb + res_kl / res_ks) * res_kb_stride
-                                        + (int64_t)warp_id * res_head_stride)
-                                + res_row * res_ks + res_kl % res_ks;
-                        next_residual.set_if(p, res, off, res_row < m_oob);
                     } else if constexpr (res_shuf) {
                         // Rows past m_oob alias the next head's region (row is interior
                         // to the layout, so the buffer bound cannot cut them) -- drop
@@ -3106,10 +3091,6 @@ namespace aiter {
                     }
                 }
             }
-            if constexpr (decode_pipeline) {
-                wait_vector_loads(g_fn, fn_loads, i + 1 < k_loop);
-                next_residual.template finish<true, true>();
-            }
         };
 
         // gfx9 only: x and residual share the async counter, so the "leave in flight"
@@ -3198,14 +3179,14 @@ namespace aiter {
             // at one barrier. Only then overwrite the preceding LDS slot with
             // the next tile. Its transfer overlaps the current tile's compute.
             // Direct next_residual stores need no cross-wave LDS deposit.
-            MHC_TDM_DRAIN();
-            wait_vector_loads(g_fn, fn_loads);
-            __builtin_amdgcn_s_barrier();
             for (int i = 0; i < k_loop; i += n_stages) {
                 opus::static_for<n_stages>([&](auto S) {
                     constexpr int slot = S.value;
                     const int k = i + slot;
                     if (k < k_loop) {
+                        MHC_TDM_DRAIN();
+                        s_wait_all_loadcnt(0_I, opus::number<-1>{});
+                        __builtin_amdgcn_s_barrier();
                         if (k + 1 < k_loop) {
                             constexpr int next_slot = (slot + 1) % n_stages;
                             lds_load_x_tile(k + 1, next_slot);
@@ -3305,8 +3286,14 @@ namespace aiter {
             for (int b = 0; b < m_repeat; b++)
                 sqrsum_w[b] = cross_row_sum_4(sqrsum_part[b], lane_id);
         }
-        // Decode's last store packet already completed the scratch-reuse barrier.
-        if constexpr (!decode_pipeline) __syncthreads();
+        if constexpr (decode_pipeline) {
+            // Only LDS is exchanged across waves here. next_residual stores
+            // can remain in flight until kernel completion.
+            s_wait_all_dscnt(0_I);
+            __builtin_amdgcn_s_barrier();
+        } else {
+            __syncthreads();
+        }  // (1) finish reads before scratch reuse
         if (warp_id != 0) {
             int c = 0;
             for (int b = 0; b < m_repeat; b++)

--- a/csrc/kernels/mhc_kernels.cu
+++ b/csrc/kernels/mhc_kernels.cu
@@ -1626,8 +1626,11 @@ namespace aiter {
 #endif
         static constexpr int x_async_load_threads = block_size * x_async_load_vec < residual_block ? block_size : residual_block / x_async_load_vec;
         static constexpr int x_load_waitcnt = residual_block / (x_async_load_threads * x_async_load_vec);
+        static_assert(x_async_load_threads % warp_size == 0,
+                      "x async loads must cover complete waves");
+        const bool loads_x = warp_id < x_async_load_threads / warp_size;
         auto lds_load_x_tile = [&](int k){
-            if(threadIdx.x < x_async_load_threads) {
+            if (loads_x) {
                 DTYPE_I* s_x_wr_ptr = s_x + (k & 1) * residual_block;
                 int offset = k * residual_block;
                 for(int i = 0; i < x_load_waitcnt; i++) {
@@ -1666,7 +1669,9 @@ namespace aiter {
         static_assert(residual_block % (warp_size * ds_read_vec) == 0, "residual_block must be divisible by warp_size * ds_read_vec");
         const int loop = sub_hidden_size / residual_block;
 
-        auto compute_store_tile = [&](int i) {
+        auto compute_store_tile = [&](int i, auto IsTail) {
+            constexpr int stores = residual_block / (warp_size * ds_read_vec);
+            vector_store_batch<DTYPE_I, ds_read_vec, stores, store_policy> output{g_out};
             DTYPE_I* s_x_rd_ptr = s_x + (i & 1) * residual_block;
             DTYPE_I* s_residual_rd_ptr = s_residual + (i & 1) * (hc_mult * residual_block);
             for(int j = 0; j < residual_block / (warp_size * ds_read_vec); j++) {
@@ -1687,8 +1692,9 @@ namespace aiter {
                         res[k] += static_cast<float>(residual_vec[h.value][k]) * comb_mix[h.value];
                     }
                 });
-                store_vector<DTYPE_I, float, ds_read_vec, store_policy>(g_out, res, warp_id * hidden_size + i * residual_block + s_offset);
+                output.set(j, res, warp_id * hidden_size + i * residual_block + s_offset);
             }
+            output.template finish<!IsTail.value>();
         };
 
         lds_load_x_tile(0);
@@ -1697,20 +1703,19 @@ namespace aiter {
             lds_load_x_tile(i + 1);
             lds_load_residual_tile(i + 1);
             __builtin_amdgcn_sched_barrier(0);
-            if(threadIdx.x < x_async_load_threads) {
+            if (loads_x) {
                 s_wait_all_loadcnt(opus::number<-1>{}, opus::number<x_load_waitcnt + residual_load_waitcnt>{});
             }
             else {
                 s_wait_all_loadcnt(opus::number<-1>{}, opus::number<residual_load_waitcnt>{});
             }
             __builtin_amdgcn_s_barrier();
-            compute_store_tile(i);
-            __builtin_amdgcn_s_barrier();
+            compute_store_tile(i, opus::number<0>{});
         }
         int i = loop - 1;
         s_wait_all_loadcnt(opus::number<-1>{}, 0_I);
         __builtin_amdgcn_s_barrier();
-        compute_store_tile(i);
+        compute_store_tile(i, opus::number<1>{});
     }
 
 
@@ -2808,13 +2813,15 @@ namespace aiter {
         static constexpr int fn_load_vec = 16 / sizeof(float);
         static constexpr int fn_load_waitcnt = tile_n * tile_k / (warp_size * fn_load_vec);
         using fp32xfntile = opus::array<fp32xtile, repeat_n>;
+        vector_load_token fn_loads[repeat_n];
         auto vgpr_load_fn_tile = [&](int k) {
             fp32xfntile v_fn;
             const int offset_base = lane_id % mfma_n * fn_stride + warp_id * hidden_size
                                   + lane_id / mfma_n * vec_tile + k * tile_k + k_split_offset;
             const int n_step = mfma_n * fn_stride;
             for(int n = 0; n < repeat_n; n++) {
-                v_fn[n] = load_vector_nbytes<float, vec_tile, 16, 0, false>(g_fn, offset_base + n * n_step);
+                v_fn[n] = load_vector_nbytes<float, vec_tile, 16, 0, false>(
+                    g_fn, offset_base + n * n_step, fn_loads[n]);
             }
             return v_fn;
         };
@@ -2899,6 +2906,8 @@ namespace aiter {
             // gfx1250 wave32 bf16 needs a 16-K/lane WMMA fragment = two band_j
             // iterations (2 x ds_read_vec) combined; band_j is even for tile_k in {32,64}.
             using pref_vec = opus::vector_t<DTYPE_I, ds_read_vec>;
+            vector_store_batch<DTYPE_I, ds_read_vec, decode_pipeline ? m_repeat * band_j : 1>
+                next_residual{g_nres};
             pref_vec pref_x[band_j], pref_res[band_j][hc_mult];
             auto prefetch_band = [&](int pb) {
                 if constexpr (batch_lds) {
@@ -2980,6 +2989,12 @@ namespace aiter {
                             nres_v[e] = static_cast<DTYPE_I>(res[e]);
                         }
                         *(reinterpret_cast<DTYPE_I_vec*>(s_nres_wr + w_off)) = nres_v;
+                    } else if constexpr (decode_pipeline) {
+                        const int p = b * band_j + j;
+                        int off = (int)(((int64_t)i * res_nkb + res_kl / res_ks) * res_kb_stride
+                                        + (int64_t)warp_id * res_head_stride)
+                                + res_row * res_ks + res_kl % res_ks;
+                        next_residual.set_if(p, res, off, res_row < m_oob);
                     } else if constexpr (res_shuf) {
                         // Rows past m_oob alias the next head's region (row is interior
                         // to the layout, so the buffer bound cannot cut them) -- drop
@@ -3091,6 +3106,10 @@ namespace aiter {
                     }
                 }
             }
+            if constexpr (decode_pipeline) {
+                wait_vector_loads(g_fn, fn_loads, i + 1 < k_loop);
+                next_residual.template finish<true, true>();
+            }
         };
 
         // gfx9 only: x and residual share the async counter, so the "leave in flight"
@@ -3179,14 +3198,14 @@ namespace aiter {
             // at one barrier. Only then overwrite the preceding LDS slot with
             // the next tile. Its transfer overlaps the current tile's compute.
             // Direct next_residual stores need no cross-wave LDS deposit.
+            MHC_TDM_DRAIN();
+            wait_vector_loads(g_fn, fn_loads);
+            __builtin_amdgcn_s_barrier();
             for (int i = 0; i < k_loop; i += n_stages) {
                 opus::static_for<n_stages>([&](auto S) {
                     constexpr int slot = S.value;
                     const int k = i + slot;
                     if (k < k_loop) {
-                        MHC_TDM_DRAIN();
-                        s_wait_all_loadcnt(0_I, opus::number<-1>{});
-                        __builtin_amdgcn_s_barrier();
                         if (k + 1 < k_loop) {
                             constexpr int next_slot = (slot + 1) % n_stages;
                             lds_load_x_tile(k + 1, next_slot);
@@ -3286,14 +3305,8 @@ namespace aiter {
             for (int b = 0; b < m_repeat; b++)
                 sqrsum_w[b] = cross_row_sum_4(sqrsum_part[b], lane_id);
         }
-        if constexpr (decode_pipeline) {
-            // Only LDS is exchanged across waves here. next_residual stores
-            // can remain in flight until kernel completion.
-            s_wait_all_dscnt(0_I);
-            __builtin_amdgcn_s_barrier();
-        } else {
-            __syncthreads();
-        }  // (1) finish reads before scratch reuse
+        // Decode's last store packet already completed the scratch-reuse barrier.
+        if constexpr (!decode_pipeline) __syncthreads();
         if (warp_id != 0) {
             int c = 0;
             for (int b = 0; b < m_repeat; b++)

--- a/csrc/kernels/mhc_kernels.cu
+++ b/csrc/kernels/mhc_kernels.cu
@@ -15,6 +15,16 @@
 
 
 namespace aiter {
+    // Validate on the current tensor device (after HipDeviceGuard), including
+    // direct calls to the GEMM and reduction bindings that bypass Python.
+    static void check_mhc_res_preshuffle_arch(bool shuffled) {
+        if (shuffled) {
+            const auto arch = get_gpu_arch();
+            AITER_CHECK(arch == "gfx1250",
+                        "res_preshuffle=1 is only supported on gfx1250, got ", arch,
+                        "; use res_preshuffle=0");
+        }
+    }
 #if defined(__gfx1250__)
     static constexpr bool mhc_async_load_oob_guard = true;
 #else
@@ -61,7 +71,7 @@ namespace aiter {
         return (K0 / 16) * 16 + (K0 % 16) / 2;
     }
 
-    // ---- pre-shuffled residual layout (is_res_w_preshuffle_bf16) ----
+    // ---- pre-shuffled residual layout (res_preshuffle) ----
     //   resS[k / KS][head][row][k % KS],  KS = mhc_res_ks
     //   strides: kb -> hc_mult*m*KS,  head -> m*KS,  row -> KS,  kk -> 1
     // KS is a fixed constant, deliberately NOT derived from tile_m/tile_k: the
@@ -76,10 +86,6 @@ namespace aiter {
     // KS = 8 / 16 / 32). mhc_nres_tdm_store is what removes that, and is what
     // makes KS=32 the tuned value.
     static constexpr int mhc_res_ks = 32;
-    // ABLATION KNOB: 0 keeps the plain residual layout while leaving the bf16 fn gemm on,
-    // so the shuffle's own contribution can be measured. Must be kept in lockstep with
-    // MHC_RES_SHUFFLE in aiter/ops/mhc.py.
-    static constexpr bool mhc_res_shuffle = true;
     // gfx1250 + shuffled residual only: stage next_residual through LDS and write it
     // out with one 4D TDM store mirroring the residual load, instead of a scattered
     // buffer_store_b128 per lane. Buys 460 -> 325 us on the gemm at KS=32; costs
@@ -222,7 +228,7 @@ namespace aiter {
     mma_f32_16x16x4_fma((a), (b), (c))
 #endif
 
-    template <typename DTYPE_I, int num_warps, int tile_m, int tile_n, int tile_k, bool is_w_preshuffle_bf16 = false, bool vector_fn_load = false>
+    template <typename DTYPE_I, int num_warps, int tile_m, int tile_n, int tile_k, bool w_preshuffle_bf16 = false, bool vector_fn_load = false>
     __global__ __launch_bounds__(num_warps *  opus::get_warp_size(), 2)
     void mhc_pre_gemm_sqrsum_kernel(
         float* out,
@@ -261,7 +267,7 @@ namespace aiter {
         // The LDS test keeps tile_k=128 -- 67584 B/workgroup, past the 64 KiB limit --
         // degrading to the per-lane load instead of failing to launch, should gfx1250
         // ever dispatch it (get_mhc_pre_splitk offers only 64 off gfx9).
-        static constexpr bool x_tdm = mhc_pre_x_tdm && is_w_preshuffle_bf16
+        static constexpr bool x_tdm = mhc_pre_x_tdm && w_preshuffle_bf16
                                       && (x_tdm_lds_bytes <= 64 * 1024);
 #else
         static constexpr bool x_tdm = false;
@@ -848,20 +854,20 @@ namespace aiter {
                 if constexpr (x_tdm) { lds_load_x_tile((k) + 2, (LDS_SLOT)); }                     \
             }                                                                                      \
         } while (0)
-        // is_w_preshuffle_bf16: bf16 hi/lo MFMA; otherwise fp32 MFMA. The bf16 body (and the
+        // w_preshuffle_bf16: bf16 hi/lo MFMA; otherwise fp32 MFMA. The bf16 body (and the
         // gfx950-only mfma_f32_16x16x32_bf16 builtin) exists only in the gfx950 device
         // pass; every other arch compiles the fp32 path unconditionally, so the flag is
         // a no-op there (falls back to fp32).
 #if MHC_BF16_MFMA
 #define MHC_PRE_GEMM_STEP(BUF, LDS_SLOT, k, DO_PREFETCH, X_WAIT)                    \
-        if constexpr (is_w_preshuffle_bf16) {                                   \
+        if constexpr (w_preshuffle_bf16) {                                   \
             GEMM_LOOP_BODY_BF16(BUF, LDS_SLOT, k, DO_PREFETCH);           \
         } else {                                                          \
             GEMM_LOOP_BODY(BUF, LDS_SLOT, k, DO_PREFETCH, X_WAIT);               \
         }
 #elif defined(__gfx1250__)
 #define MHC_PRE_GEMM_STEP(BUF, LDS_SLOT, k, DO_PREFETCH, X_WAIT)                    \
-        if constexpr (is_w_preshuffle_bf16) {                                   \
+        if constexpr (w_preshuffle_bf16) {                                   \
             GEMM_LOOP_BODY_BF16_W32(BUF, LDS_SLOT, k, DO_PREFETCH, X_WAIT);       \
         } else {                                                          \
             GEMM_LOOP_BODY(BUF, LDS_SLOT, k, DO_PREFETCH, X_WAIT);               \
@@ -963,9 +969,9 @@ namespace aiter {
         aiter_tensor_t& out, // (split_k, m, hc_mult3) / (m, hc_mult3)
         aiter_tensor_t& sqrsum, // (split_k, m) / (m)
         aiter_tensor_t& x, // (m, hc_hidden_size)
-        aiter_tensor_t& fn, // (hc_mult3, hc_hidden_size) fp32; packed int32 BF16 hi/lo when is_w_preshuffle_bf16
+        aiter_tensor_t& fn, // (hc_mult3, hc_hidden_size) fp32; packed int32 BF16 hi/lo when w_preshuffle_bf16
         int tile_k = 128,
-        int is_w_preshuffle_bf16 = 0
+        int w_preshuffle_bf16 = 0
     )
     {
         AITER_CHECK(out.size(0) == sqrsum.size(0), "out and sqrsum must have the same number of split_k or m");
@@ -984,7 +990,7 @@ namespace aiter {
         const HipDeviceGuard device_guard(x.device_id);
         const hipStream_t stream = aiter::getCurrentHIPStream();
 
-        if (is_w_preshuffle_bf16) {
+        if (w_preshuffle_bf16) {
 #define MHC_PRE_BF16 true
             MHC_PRE_GEMM_SQRSUM_KERNEL_DISPATCH(tile_k);
 #undef MHC_PRE_BF16
@@ -1441,6 +1447,7 @@ namespace aiter {
                     "pre-shuffled residual needs hidden_size divisible by mhc_res_ks");
 
         const HipDeviceGuard device_guard(layer_input.device_id);
+        check_mhc_res_preshuffle_arch(res_preshuffle != 0);
         const hipStream_t stream = aiter::getCurrentHIPStream();
         const int cu_num = get_num_cu_func();
 
@@ -2452,6 +2459,18 @@ namespace aiter {
         } else { \
             MHC_PRE_BIG_FUSE_RM_KERNEL_IMPL(5, 4, 2, 4096, 512, 512, true); \
         } \
+    } else if (hidden_size == 5120) { \
+        if (m < 4 * cu_num) { \
+            if (WARP_SIZE == 32) { \
+                MHC_PRE_BIG_FUSE_RM_KERNEL_IMPL(9, 4, 1, 5120, 1024, 1024, false); \
+            } else { \
+                MHC_PRE_BIG_FUSE_RM_KERNEL_IMPL(5, 4, 1, 5120, 1024, 1024, false); \
+            } \
+        } else if (m <= 8 * cu_num) { \
+            MHC_PRE_BIG_FUSE_RM_KERNEL_IMPL(5, 4, 2, 5120, 512, 512, false); \
+        } else { \
+            MHC_PRE_BIG_FUSE_RM_KERNEL_IMPL(5, 4, 2, 5120, 512, 512, true); \
+        } \
     } else if (hidden_size == 2560) { \
         if (m < 4 * cu_num) { \
             MHC_PRE_BIG_FUSE_RM_KERNEL_IMPL(5, 4, 1, 2560, 512, 512, false); \
@@ -2469,7 +2488,33 @@ namespace aiter {
             MHC_PRE_BIG_FUSE_RM_KERNEL_IMPL(3, 4, 2, 1280, 256, 128, true); \
         } \
     } else { \
-        AITER_CHECK(false, "hidden_size only supports 7168, 4096, 2560 and 1280"); \
+        AITER_CHECK(false, "hidden_size only supports 7168, 5120, 4096, 2560 and 1280"); \
+    }
+
+    // Shuffled residual reduction on gfx1250 (validated at the entry point).
+    // Changing the row and warp counts balances split-K reduction against
+    // shuffled residual reads; the kernels handle partial row blocks.
+#define MHC_PRE_BIG_FUSE_RM_SHUFFLED_DISPATCH(hidden) \
+    if (m > 256 && m <= 512) { \
+        MHC_PRE_BIG_FUSE_RM_KERNEL_IMPL(9, 4, 2, hidden, 1024, 512, false); \
+        return; \
+    } else if (hidden == 7168 && m > 512 && m <= 768) { \
+        MHC_PRE_BIG_FUSE_RM_KERNEL_IMPL(9, 4, 1, hidden, 1024, 512, false); \
+        return; \
+    } else if (m > 512 && m <= 1024) { \
+        if (hidden == 7168) { \
+            MHC_PRE_BIG_FUSE_RM_KERNEL_IMPL(9, 4, 2, hidden, 1024, 512, false); \
+        } else { \
+            MHC_PRE_BIG_FUSE_RM_KERNEL_IMPL(9, 4, 2, hidden, 512, 512, false); \
+        } \
+        return; \
+    } else if (m >= 2048) { \
+        if (m > 8 * cu_num) { \
+            MHC_PRE_BIG_FUSE_RM_KERNEL_IMPL(9, 4, 2, hidden, 512, 512, true); \
+        } else { \
+            MHC_PRE_BIG_FUSE_RM_KERNEL_IMPL(9, 4, 2, hidden, 512, 512, false); \
+        } \
+        return; \
     }
 
     void mhc_pre_big_fuse_rmsnorm(
@@ -2502,13 +2547,26 @@ namespace aiter {
                     "pre-shuffled residual needs hidden_size divisible by mhc_res_ks");
 
         const HipDeviceGuard device_guard(out.device_id);
+        check_mhc_res_preshuffle_arch(res_preshuffle != 0);
         const hipStream_t stream = aiter::getCurrentHIPStream();
         const int cu_num = get_num_cu_func();
         
+        if (res_preshuffle) {
+            if (hidden_size == 4096) {
+                MHC_PRE_BIG_FUSE_RM_SHUFFLED_DISPATCH(4096);
+            } else if (hidden_size == 5120) {
+                MHC_PRE_BIG_FUSE_RM_SHUFFLED_DISPATCH(5120);
+            } else if (hidden_size == 7168) {
+                MHC_PRE_BIG_FUSE_RM_SHUFFLED_DISPATCH(7168);
+            }
+        }
+        // Fall back to the default configuration, retaining res_preshuffle.
+        // Both dispatches launch kernels that support the requested layout.
         MHC_PRE_BIG_FUSE_RM_KERNEL_DISPATCH(m);
     }
+#undef MHC_PRE_BIG_FUSE_RM_SHUFFLED_DISPATCH
 
-    template <typename DTYPE_I, int num_warps, int hc_mult, int tile_m, int tile_n, int tile_k, bool store_nt, bool is_res_w_preshuffle_bf16 = false, bool decode_direct_store = false>
+    template <typename DTYPE_I, int num_warps, int hc_mult, int tile_m, int tile_n, int tile_k, bool store_nt, bool w_preshuffle_bf16 = false, bool decode_direct_store = false, bool res_preshuffle = false>
     __global__ __launch_bounds__(num_warps * opus::get_warp_size(), 1)
     void mhc_fused_post_pre_gemm_sqrsum_kernel(
         float* out,
@@ -2546,13 +2604,13 @@ namespace aiter {
         // num_warps > 2: the store must be issued by a warp that owns no TDM load
         // (warps 0/1 issue residual/x), or that warp would carry n_stages loads +
         // n_stages stores = 4 tensor ops in flight, over the per-wave limit of 3.
-        static constexpr bool nres_tdm = mhc_nres_tdm_store && is_res_w_preshuffle_bf16
-                                         && mhc_res_shuffle && (num_warps > 2) && !decode_direct_store;
+        static constexpr bool nres_tdm = mhc_nres_tdm_store && w_preshuffle_bf16
+                                         && res_preshuffle && (num_warps > 2) && !decode_direct_store;
 #else
         static constexpr bool nres_tdm = false;
 #endif
 #if defined(__gfx1250__)
-        static constexpr bool decode_pipeline = decode_direct_store && is_res_w_preshuffle_bf16 && mhc_res_shuffle;
+        static constexpr bool decode_pipeline = decode_direct_store && w_preshuffle_bf16 && res_preshuffle;
 #else
         static constexpr bool decode_pipeline = false;
 #endif
@@ -2587,7 +2645,7 @@ namespace aiter {
         int residual_stride = hc_hidden_size;
         int fn_stride = hc_hidden_size;
         // Pre-shuffled residual (see mhc_res_ks): resS[k/KS][head][row][k%KS].
-        static constexpr bool res_shuf = is_res_w_preshuffle_bf16 && mhc_res_shuffle;
+        static constexpr bool res_shuf = res_preshuffle;
         static constexpr int res_ks = mhc_res_ks;
         static_assert(tile_k % res_ks == 0, "tile_k must be divisible by mhc_res_ks");
         static constexpr int res_nkb = tile_k / res_ks;              // kb blocks per k-step
@@ -2899,7 +2957,7 @@ namespace aiter {
         auto compute_store_tile = [&](int i, int slot, fp32xfntile& v_fn) {
             DTYPE_I* s_x_rd_ptr = s_x + slot * tile_mk;
             DTYPE_I* s_residual_rd_ptr = s_residual + slot * (hc_mult * tile_mk);
-            static constexpr bool batch_lds = decode_pipeline || (mhc_bf16_mma_avail && warp_size == 32 && is_res_w_preshuffle_bf16 && res_shuf && tile_k == 32);
+            static constexpr bool batch_lds = decode_pipeline || (mhc_bf16_mma_avail && warp_size == 32 && w_preshuffle_bf16 && res_shuf && tile_k == 32);
             static constexpr int ds_read_vec = 16 / sizeof(DTYPE_I);
             static constexpr int step = ds_read_vec;
             static constexpr int band_j = band_mk / (warp_size * ds_read_vec);
@@ -3047,7 +3105,7 @@ namespace aiter {
                             res_kl + k_split_offset);
                     }
                     s_offset += step;
-                    if constexpr (is_res_w_preshuffle_bf16 && mhc_bf16_mma_avail) {
+                    if constexpr (w_preshuffle_bf16 && mhc_bf16_mma_avail) {
 #if MHC_BF16_MFMA
                         // bf16 MFMA (wave64 CDNA): one mfma_f32_16x16x32_bf16 contracts
                         // ds_read_vec (=8) K-elems/lane x 4 lane-groups = 32 K, replacing
@@ -3323,7 +3381,7 @@ namespace aiter {
         static constexpr int v_per_lane = m_repeat * repeat_n * ovec;
         // Interleave aligned four-float groups across lanes for vector LDS access.
         auto reduction_offset = [&](int head, int c) {
-            if constexpr (mhc_bf16_mma_avail && warp_size == 32 && is_res_w_preshuffle_bf16) {
+            if constexpr (mhc_bf16_mma_avail && warp_size == 32 && w_preshuffle_bf16) {
                 return head * warp_size * v_per_lane + (c / 4) * warp_size * 4
                      + lane_id * 4 + c % 4;
             } else {
@@ -3398,7 +3456,7 @@ namespace aiter {
                     "hidden_size must be divisible by tile_k * split_k"); \
         AITER_CHECK(hidden_size >= (tile_k * split_k), \
                     "hidden_size must be >= tile_k * split_k (>=1 k-tile per split)"); \
-        mhc_fused_post_pre_gemm_sqrsum_kernel<DTYPE_I, num_warps, 4, tile_m, tile_n, tile_k, store_nt, MHC_FUSED_BF16, decode_direct_store> \
+        mhc_fused_post_pre_gemm_sqrsum_kernel<DTYPE_I, num_warps, 4, tile_m, tile_n, tile_k, store_nt, use_bf16, decode_direct_store, use_res_shuffle> \
             <<<grid, block, 0, stream>>>( \
                 reinterpret_cast<float*>(gemm_out_mul.data_ptr()), \
                 reinterpret_cast<float*>(gemm_out_sqrsum.data_ptr()), \
@@ -3458,7 +3516,8 @@ namespace aiter {
         int tile_m = 16,
         int tile_n = 32,
         int tile_k = 32,
-        int is_res_w_preshuffle_bf16 = 0)
+        int w_preshuffle_bf16 = 0,
+        int res_preshuffle = 0)
     {
         int m = layer_input.size(0);
         int hidden_size = layer_input.size(1);
@@ -3509,28 +3568,39 @@ namespace aiter {
         const hipStream_t stream = aiter::getCurrentHIPStream();
         dim3 block(block_size);
 
-        if (is_res_w_preshuffle_bf16) {
-#define MHC_FUSED_BF16 true
-            // Packed BF16 decode: direct stores and the single-barrier pipeline
-            // support both row tile sizes throughout the measured decode range.
-            if (WARP_SIZE == 32 && cu_num == 256 && m > 0 && m <= 1024
-                && (hidden_size == 4096 || hidden_size == 7168)
-                && tile_n == 32 && tile_k == 32) {
-                if (tile_m == 16) {
-                    MHC_FUSED_POST_PRE_GEMM_SQRSUM_KERNEL_IMPL_(4, 16, 32, 32, false, true);
-                    return;
-                }
-                if (tile_m == 32) {
-                    MHC_FUSED_POST_PRE_GEMM_SQRSUM_KERNEL_IMPL_(4, 32, 32, 32, false, true);
-                    return;
+        AITER_CHECK((w_preshuffle_bf16 == 0 || w_preshuffle_bf16 == 1)
+                        && (res_preshuffle == 0 || res_preshuffle == 1),
+                    "w_preshuffle_bf16 and res_preshuffle must be 0 or 1");
+        const bool packed = w_preshuffle_bf16;
+        const bool shuffled = res_preshuffle;
+        check_mhc_res_preshuffle_arch(shuffled);
+        auto dispatch = [&](auto bf16_tag, auto shuffle_tag) {
+            constexpr bool use_bf16 = decltype(bf16_tag)::value;
+            constexpr bool use_res_shuffle = decltype(shuffle_tag)::value;
+            if constexpr (use_bf16 && use_res_shuffle) {
+                // Packed BF16 decode: direct stores and the single-barrier pipeline
+                // support both row tile sizes throughout the measured decode range.
+                if (WARP_SIZE == 32 && cu_num == 256 && m > 0 && m <= 1024
+                    && (hidden_size == 4096 || hidden_size == 7168)
+                    && tile_n == 32 && tile_k == 32) {
+                    if (tile_m == 16) {
+                        MHC_FUSED_POST_PRE_GEMM_SQRSUM_KERNEL_IMPL_(4, 16, 32, 32, false, true);
+                        return;
+                    }
+                    if (tile_m == 32) {
+                        MHC_FUSED_POST_PRE_GEMM_SQRSUM_KERNEL_IMPL_(4, 32, 32, 32, false, true);
+                        return;
+                    }
                 }
             }
             MHC_FUSED_POST_PRE_GEMM_SQRSUM_KERNEL_DISPATCH(tile_k);
-#undef MHC_FUSED_BF16
+        };
+        if (packed) {
+            if (shuffled) dispatch(std::true_type{}, std::true_type{});
+            else dispatch(std::true_type{}, std::false_type{});
         } else {
-#define MHC_FUSED_BF16 false
-            MHC_FUSED_POST_PRE_GEMM_SQRSUM_KERNEL_DISPATCH(tile_k);
-#undef MHC_FUSED_BF16
+            if (shuffled) dispatch(std::false_type{}, std::true_type{});
+            else dispatch(std::false_type{}, std::false_type{});
         }
     }
 

--- a/csrc/kernels/mhc_kernels.cu
+++ b/csrc/kernels/mhc_kernels.cu
@@ -65,10 +65,31 @@ namespace aiter {
 #endif
 
 
-    // Float index of the 4-float run holding hi(K0 .. K0+7); the matching lo run is +8.
-    // Valid for any K0 that is a multiple of 8 -- every consumer's fragment start is.
+    // ---- packed BF16 fn layout (w_preshuffle_bf16) ----
+    // fn is stored block-interleaved: one block of mhc_fn_kb consecutive k elements
+    // occupies mhc_fn_kb floats, hi in the first half, lo in the second. A lane's fn
+    // fragment must therefore cover a WHOLE block, i.e.
+    //     vec_tile = tile_k / (warp_size / mfma_m)  >=  mhc_fn_kb.
+    //
+    // The block size is per-arch because that inequality binds differently per wave:
+    //   wave32 (gfx1250): vec_tile = tile_k/2 = 16 at tile_k=32, and its WMMA path
+    //     consumes a whole 16-float block as two verbatim fragments -- keep kb=16.
+    //   wave64 (gfx9):    vec_tile = tile_k/4 =  8 at tile_k=32. kb=16 would not fit,
+    //     which is what forced tile_k>=64 (and, before that, read the lo half past the
+    //     end of the register tile). kb=8 makes tile_k=32 legal again.
+    // Packer and consumer are compiled for the same arch, so they always agree.
+#if defined(__gfx1250__)
+    static constexpr int mhc_fn_kb = 16;
+#else
+    static constexpr int mhc_fn_kb = 8;
+#endif
+    static constexpr int mhc_fn_lo_off = mhc_fn_kb / 2;  // floats from hi run to lo run
+
+    // Float index of the 4-float run holding hi(K0 .. K0+7); the matching lo run is
+    // mhc_fn_lo_off floats later. Valid for any K0 that is a multiple of 8 -- every
+    // consumer's fragment start is. Device-side only (the constant is arch-dependent).
     __host__ __device__ constexpr inline int mhc_fn_hi_float(int K0) {
-        return (K0 / 16) * 16 + (K0 % 16) / 2;
+        return (K0 / mhc_fn_kb) * mhc_fn_kb + (K0 % mhc_fn_kb) / 2;
     }
 
     // ---- pre-shuffled residual layout (res_preshuffle) ----
@@ -148,9 +169,10 @@ namespace aiter {
         uint16_t* out16 = reinterpret_cast<uint16_t*>(fn_packed);
         const int64_t n_row = i / hc_hidden_size;
         const int64_t k = i % hc_hidden_size;
-        const int64_t base = n_row * (2 * (int64_t)hc_hidden_size) + (k / 16) * 32 + (k % 16);
-        out16[base]      = (uint16_t)hi_bits;
-        out16[base + 16] = (uint16_t)lo_bits;
+        const int64_t base = n_row * (2 * (int64_t)hc_hidden_size)
+                           + (k / mhc_fn_kb) * (2 * mhc_fn_kb) + (k % mhc_fn_kb);
+        out16[base]              = (uint16_t)hi_bits;
+        out16[base + mhc_fn_kb]  = (uint16_t)lo_bits;
     }
 
     // The packed hi/lo are encoded as bf16 -- the activation/MFMA element type the gemm
@@ -579,8 +601,8 @@ namespace aiter {
         // K_wanted = c*32 + (lane/mfma_n)*8 + e, exactly the K that x's v_a[c*8+e] holds,
         // so mfma_f32_16x16x32_bf16(fn, x_chunk) contracts the matching 32 K.
         static constexpr int n_chunks_bf16 = vec_tile / 8;
-        static_assert(!mhc_bf16_mma_avail || vec_tile % 8 == 0,
-                      "bf16 path needs vec_tile a multiple of 8");
+        static_assert(!mhc_bf16_mma_avail || vec_tile % mhc_fn_kb == 0,
+                      "bf16 path needs vec_tile a multiple of mhc_fn_kb");
 #if MHC_BF16_MFMA   // wave64 CDNA bf16 MFMA (gfx942 chained-K16 / gfx950 native K32)
         // Block-interleaved fn: this chunk's 8 logical K are consecutive from
         // K0 = 8*(c*mfma_k + lane/mfma_n), so hi(K0..K0+7) occupies the 4 consecutive
@@ -602,7 +624,7 @@ namespace aiter {
                     #pragma unroll
                     for (int t = 0; t < 4; t++) {
                         hi_raw[n][t] = *(s_fn_rd_ptr + fn_row * tile_k + ((hi_f + t) ^ mask));
-                        lo_raw[n][t] = *(s_fn_rd_ptr + fn_row * tile_k + ((hi_f + 8 + t) ^ mask));
+                        lo_raw[n][t] = *(s_fn_rd_ptr + fn_row * tile_k + ((hi_f + mhc_fn_lo_off + t) ^ mask));
                     }
                 } else {
                     // fn_vec_size == 4 pairs with fn_xor_shift == 2, so the mask's low two
@@ -610,7 +632,7 @@ namespace aiter {
                     *reinterpret_cast<fp32x4_t*>(hi_raw[n]) = *(reinterpret_cast<fp32x4_t*>(
                         s_fn_rd_ptr + fn_row * tile_k + (hi_f ^ mask)));
                     *reinterpret_cast<fp32x4_t*>(lo_raw[n]) = *(reinterpret_cast<fp32x4_t*>(
-                        s_fn_rd_ptr + fn_row * tile_k + ((hi_f + 8) ^ mask)));
+                        s_fn_rd_ptr + fn_row * tile_k + ((hi_f + mhc_fn_lo_off) ^ mask)));
                 }
             }
         };
@@ -672,8 +694,8 @@ namespace aiter {
         // position, so x_bf[c][i] = v_a[c*16+i]; fn is read at kk=c*16+i with the same
         // wave32 K_wanted the fp32 path uses, so fn_frag[i] and x_frag[i] share K.
         static constexpr int n_chunks_bf16_w32 = vec_tile / 16;
-        static_assert(!mhc_bf16_mma_avail || vec_tile % 16 == 0,
-                      "wave32 bf16 needs vec_tile a multiple of 16");
+        static_assert(!mhc_bf16_mma_avail || vec_tile % mhc_fn_kb == 0,
+                      "wave32 bf16 needs vec_tile a multiple of mhc_fn_kb");
         // Block-interleaved fn. The 16 logical K of one wave32 fragment are TWO runs of 8:
         //   run r (r=0,1):  K0 = k_group*8 + 32*c + 16*r
         // (x_vec_size=8, interleave_size=2). Each run's hi is 4 consecutive floats at
@@ -702,14 +724,14 @@ namespace aiter {
                                 s_fn_rd_ptr + fn_row * tile_k + (hi_f ^ mask));
                         *reinterpret_cast<f32x4_*>(lo_raw[n] + r * 4) =
                             *reinterpret_cast<const f32x4_*>(
-                                s_fn_rd_ptr + fn_row * tile_k + ((hi_f + 8) ^ mask));
+                                s_fn_rd_ptr + fn_row * tile_k + ((hi_f + mhc_fn_lo_off) ^ mask));
                     } else {
                         #pragma unroll
                         for (int t = 0; t < 4; t++) {
                             hi_raw[n][r * 4 + t] =
                                 *(s_fn_rd_ptr + fn_row * tile_k + ((hi_f + t) ^ mask));
                             lo_raw[n][r * 4 + t] =
-                                *(s_fn_rd_ptr + fn_row * tile_k + ((hi_f + 8 + t) ^ mask));
+                                *(s_fn_rd_ptr + fn_row * tile_k + ((hi_f + mhc_fn_lo_off + t) ^ mask));
                         }
                     }
                 }
@@ -2633,6 +2655,12 @@ namespace aiter {
         static constexpr int m_repeat = tile_m / mfma_m;
         static constexpr int band_mk = mfma_m * tile_k;
         static constexpr int vec_tile = tile_k / (warp_size / mfma_m);
+        // The packed-BF16 fn fragment must cover a whole interleave block; this is the
+        // guard the fused gemm was missing, and its absence read the lo half past the
+        // end of the register tile (silently: next_residual stayed correct while
+        // post/comb/layer_input went to NaN).
+        static_assert(!(w_preshuffle_bf16 && mhc_bf16_mma_avail) || vec_tile % mhc_fn_kb == 0,
+                      "packed BF16 fn needs vec_tile a multiple of mhc_fn_kb");
         static constexpr int repeat_n = tile_n / mfma_n;
         static constexpr int mma_pack_size = warp_size == 64 ? 1 : 2;
         using fp32xtile = opus::vector_t<float, vec_tile>;
@@ -3122,14 +3150,16 @@ namespace aiter {
                         for(int n = 0; n < repeat_n; n++) {
                             opus::vector_t<opus::bf16_t, ds_read_vec> fn_hi8, fn_lo8;
                             {
-                                // Fragment is 8 bf16 = 4 floats; block j/2 is [8 f32 hi][8 f32 lo]
-                                // and the wanted half sits at (j%2)*4 inside each.
+                                // Fragment is 8 bf16 = 4 floats of hi plus 4 of lo.
+                                // mhc_fn_hi_float locates the hi run for this j inside
+                                // the lane's window; the lo run is mhc_fn_lo_off later.
+                                // (At kb=16 that is the old (j/2)*16 + (j%2)*4.)
                                 using f32x4 = opus::vector_t<float, 4>;
-                                const int off = (j / 2) * 16 + (j % 2) * 4;
+                                const int off = mhc_fn_hi_float(j * ds_read_vec);
                                 f32x4 hi_raw, lo_raw;
                                 for (int e = 0; e < 4; e++) {
                                     hi_raw[e] = v_fn[n][off + e];
-                                    lo_raw[e] = v_fn[n][off + 8 + e];
+                                    lo_raw[e] = v_fn[n][off + mhc_fn_lo_off + e];
                                 }
                                 fn_hi8 = __builtin_bit_cast(opus::vector_t<opus::bf16_t, 8>, hi_raw);
                                 fn_lo8 = __builtin_bit_cast(opus::vector_t<opus::bf16_t, 8>, lo_raw);
@@ -3171,11 +3201,11 @@ namespace aiter {
                                     // sub-register extract/insert -- the very shift+mask this
                                     // layout exists to remove.
                                     using f32x8 = opus::vector_t<float, 8>;
-                                    const int off = ((j - 1) * ds_read_vec / 16) * 16;
+                                    const int off = mhc_fn_hi_float((j - 1) * ds_read_vec);
                                     f32x8 hi_raw, lo_raw;
                                     for (int e = 0; e < 8; e++) {
                                         hi_raw[e] = v_fn[n][off + e];
-                                        lo_raw[e] = v_fn[n][off + 8 + e];
+                                        lo_raw[e] = v_fn[n][off + mhc_fn_lo_off + e];
                                     }
                                     fn_hi = __builtin_bit_cast(opus::vector_t<opus::bf16_t, 16>, hi_raw);
                                     fn_lo = __builtin_bit_cast(opus::vector_t<opus::bf16_t, 16>, lo_raw);

--- a/csrc/kernels/mhc_kernels.cu
+++ b/csrc/kernels/mhc_kernels.cu
@@ -504,7 +504,7 @@ namespace aiter {
             if (n_idx == 0) {                                                                     \
                 for (int i = 0; i < vec_tile; i++)                                                \
                     sqrsum_part += v_af[i] * v_af[i];                                             \
-            }                                                                                     
+            }
 #define MHC_PRE_X_CONSUME_W32(BUF)                                                                \
             if (n_idx == 0) {                                                                     \
                 for (int i = 0; i < vec_tile; i++) {                                              \

--- a/csrc/kernels/mhc_kernels.cu
+++ b/csrc/kernels/mhc_kernels.cu
@@ -2807,7 +2807,14 @@ namespace aiter {
         
         static constexpr int fn_load_vec = 16 / sizeof(float);
         static constexpr int fn_load_waitcnt = tile_n * tile_k / (warp_size * fn_load_vec);
-        using fp32xfntile = opus::array<fp32xtile, repeat_n>;
+        // Decode fills each weight ring slot before its first use. Avoid
+        // opus::array's default zeroing of the not-yet-loaded second slot.
+        struct uninitialized_fn_tile {
+            fp32xtile data[repeat_n];
+            OPUS_D fp32xtile& operator[](int n) { return data[n]; }
+        };
+        using fp32xfntile = std::conditional_t<decode_pipeline, uninitialized_fn_tile,
+                                              opus::array<fp32xtile, repeat_n>>;
         auto vgpr_load_fn_tile = [&](int k) {
             fp32xfntile v_fn;
             const int offset_base = lane_id % mfma_n * fn_stride + warp_id * hidden_size
@@ -2953,12 +2960,56 @@ namespace aiter {
                         }
                     }
                     if constexpr (!batch_lds) s_wait_all_dscnt(opus::number<hc_mult>{});
-                    for(int k = 0; k < ds_read_vec; k++) {
-                        res[k] = static_cast<float>(x_vec[k]) * post_mix_v[b];
-                    }
-                    for(int h = 0; h < hc_mult; h++) {
+#if defined(__gfx1250__)
+                    if constexpr (decode_pipeline) {
+                        // OPSEL_HI broadcasts the coefficient's low DWORD to
+                        // both FP32 results without a duplicated coefficient VGPR.
+                        auto broadcast_operand = [](float value) {
+                            return __builtin_shufflevector(opus::fp32x2_t{value, 0.0f},
+                                                          opus::fp32x2_t{}, 0, -1);
+                        };
+                        for (int k = 0; k < ds_read_vec; k += 2) {
+                            opus::fp32x2_t a{static_cast<float>(residual_vec[0][k]),
+                                             static_cast<float>(residual_vec[0][k + 1])};
+                            opus::fp32x2_t c;
+                            asm("v_pk_mul_f32 %0, %1, %2 op_sel_hi:[0,1]"
+                                : "=v"(c) : "v"(broadcast_operand(comb_mix[b][0])), "v"(a));
+                            res[k] = c[0];
+                            res[k + 1] = c[1];
+                        }
+                        // Match the existing compiler contraction: round
+                        // residual[0]*comb[0], then FMA x*post into that value.
+                        // Reversing these terms changes the FP32 sqrsum.
+                        for (int k = 0; k < ds_read_vec; k += 2) {
+                            opus::fp32x2_t v{static_cast<float>(x_vec[k]),
+                                             static_cast<float>(x_vec[k + 1])};
+                            opus::fp32x2_t c{res[k], res[k + 1]};
+                            asm("v_pk_fma_f32 %0, %1, %2, %3 op_sel_hi:[0,1,1]"
+                                : "=v"(c) : "v"(broadcast_operand(post_mix_v[b])), "v"(v), "v"(c));
+                            res[k] = c[0];
+                            res[k + 1] = c[1];
+                        }
+                        for (int h = 1; h < hc_mult; ++h) {
+                            for (int k = 0; k < ds_read_vec; k += 2) {
+                                opus::fp32x2_t v{static_cast<float>(residual_vec[h][k]),
+                                                 static_cast<float>(residual_vec[h][k + 1])};
+                                opus::fp32x2_t c{res[k], res[k + 1]};
+                                asm("v_pk_fma_f32 %0, %1, %2, %3 op_sel_hi:[0,1,1]"
+                                    : "=v"(c) : "v"(broadcast_operand(comb_mix[b][h])), "v"(v), "v"(c));
+                                res[k] = c[0];
+                                res[k + 1] = c[1];
+                            }
+                        }
+                    } else
+#endif
+                    {
                         for(int k = 0; k < ds_read_vec; k++) {
-                            res[k] += static_cast<float>(residual_vec[h][k]) * comb_mix[b][h];
+                            res[k] = static_cast<float>(x_vec[k]) * post_mix_v[b];
+                        }
+                        for(int h = 0; h < hc_mult; h++) {
+                            for(int k = 0; k < ds_read_vec; k++) {
+                                res[k] += static_cast<float>(residual_vec[h][k]) * comb_mix[b][h];
+                            }
                         }
                     }
                     if(n_idx == 0) {

--- a/op_tests/mhc_att_min.py
+++ b/op_tests/mhc_att_min.py
@@ -1,0 +1,108 @@
+"""Minimal single-dispatch driver for ATT profiling of mhc_fused_post_pre_gemm_sqrsum.
+
+No reference, no checkAllclose, no perf loop -- just build the tensors and issue the
+fused kernel N times (default 1), so rocprofv3 -i inputs.json has exactly the dispatches
+it wants to trace and nothing else. Usage:
+
+    ROCR_VISIBLE_DEVICES=1 rocprofv3 -i ../inputs.json -d ./att-logs -- \
+        python3 op_tests/mhc_att_min.py -m 2048 -n 7168
+"""
+
+import argparse
+
+import torch
+
+import aiter
+from aiter import dtypes
+
+p = argparse.ArgumentParser()
+p.add_argument("-m", type=int, default=2048)
+p.add_argument("-n", "--hidden_size", type=int, default=7168)
+p.add_argument("--hc_mult", type=int, default=4)
+p.add_argument("--iters", type=int, default=1)
+p.add_argument("--res_w_preshuffle_bf16", action="store_true", default=True)
+p.add_argument(
+    "--no_res_w_preshuffle_bf16", dest="res_w_preshuffle_bf16", action="store_false"
+)
+p.add_argument("--fuse_rmsnorm", action="store_true", default=True)
+p.add_argument("--warmup", type=int, default=200, help="--bench: warm-up dispatches before timing")
+p.add_argument(
+    "--bench",
+    action="store_true",
+    help="Time mhc_fused_post_pre with run_perftest and print 'BENCH us=<x>' instead of "
+    "issuing --iters plain dispatches. Skips the torch reference and every checkAllclose, "
+    "which is what makes test_mhc.py ~50s per case; use it for A/B once correctness is "
+    "already established elsewhere.",
+)
+a = p.parse_args()
+
+m, hidden_size, hc_mult = a.m, a.hidden_size, a.hc_mult
+hc_mult3 = hc_mult * 2 + hc_mult * hc_mult
+hc_hidden_size = hc_mult * hidden_size
+
+torch.set_default_device("cuda")
+layer_input = torch.randn(m, hidden_size, dtype=dtypes.bf16)
+residual_in = torch.randn(m, hc_mult, hidden_size, dtype=dtypes.bf16)
+post_layer_mix = torch.randn(m, hc_mult, 1, dtype=dtypes.fp32)
+comb_res_mix = torch.randn(m, hc_mult, hc_mult, dtype=dtypes.fp32)
+fn = torch.randn(hc_mult3, hc_hidden_size, dtype=dtypes.fp32)
+hc_scale = torch.randn((3,), dtype=dtypes.fp32) * 0.1
+hc_base = torch.randn((hc_mult3,), dtype=dtypes.fp32) * 0.1
+norm_weight = torch.randn(hidden_size, dtype=dtypes.bf16) if a.fuse_rmsnorm else None
+
+kwargs = dict(
+    rms_eps=1e-6,
+    hc_pre_eps=1e-6,
+    hc_sinkhorn_eps=1e-6,
+    hc_post_mult_value=2.0,
+    sinkhorn_repeat=20,
+)
+if a.fuse_rmsnorm:
+    kwargs["norm_weight"] = norm_weight
+    kwargs["norm_eps"] = 1e-6
+
+pack_flag = 1 if a.res_w_preshuffle_bf16 else 0
+if pack_flag:
+    from aiter.ops.mhc import MHC_RES_SHUFFLE, mhc_pre_convert_fn, mhc_res_shuffle
+
+    fn_gemm = torch.empty(hc_mult3, hc_hidden_size, dtype=torch.int32)
+    mhc_pre_convert_fn(fn_gemm, fn)
+    # The flag also switches residual_in/next_residual to the pre-shuffled layout.
+    if MHC_RES_SHUFFLE:
+        residual_in = mhc_res_shuffle(residual_in)
+else:
+    fn_gemm = fn
+
+call = dict(
+    force_fused=True,
+    is_res_w_preshuffle_bf16=pack_flag,
+    **kwargs,
+)
+args_pos = (
+    layer_input,
+    residual_in,
+    post_layer_mix,
+    comb_res_mix,
+    fn_gemm,
+    hc_scale,
+    hc_base,
+)
+
+if a.bench:
+    from aiter.test_common import run_perftest
+
+    # Cold-start clocks make a bare run_perftest ~4x noisier than the same timing
+    # taken inside test_mhc.py (which happens to warm the GPU with the reference
+    # computation first): measured +-1.6% vs +-0.4% across repeats of one binary.
+    # Spin first so the A/B compares steady-state clocks.
+    for _ in range(a.warmup):
+        aiter.mhc_fused_post_pre(*args_pos, **call)
+    torch.cuda.synchronize()
+
+    _, us = run_perftest(aiter.mhc_fused_post_pre, *args_pos, **call)
+    print(f"BENCH us={us:.4f} m={m} hidden={hidden_size} preshuffle={pack_flag}")
+else:
+    for _ in range(a.iters):
+        aiter.mhc_fused_post_pre(*args_pos, **call)
+    torch.cuda.synchronize()
+    print(f"done: m={m} hidden={hidden_size} preshuffle={pack_flag} iters={a.iters}")

--- a/op_tests/mhc_att_min.py
+++ b/op_tests/mhc_att_min.py
@@ -20,10 +20,19 @@ p.add_argument("-m", type=int, default=2048)
 p.add_argument("-n", "--hidden_size", type=int, default=7168)
 p.add_argument("--hc_mult", type=int, default=4)
 p.add_argument("--iters", type=int, default=1)
-p.add_argument("--w_preshuffle_bf16", action=argparse.BooleanOptionalAction, default=True)
-p.add_argument("--res_preshuffle", "--res_shuffle", action=argparse.BooleanOptionalAction, default=False)
+p.add_argument(
+    "--w_preshuffle_bf16", action=argparse.BooleanOptionalAction, default=True
+)
+p.add_argument(
+    "--res_preshuffle",
+    "--res_shuffle",
+    action=argparse.BooleanOptionalAction,
+    default=False,
+)
 p.add_argument("--fuse_rmsnorm", action="store_true", default=True)
-p.add_argument("--warmup", type=int, default=200, help="--bench: warm-up dispatches before timing")
+p.add_argument(
+    "--warmup", type=int, default=200, help="--bench: warm-up dispatches before timing"
+)
 p.add_argument(
     "--bench",
     action="store_true",
@@ -48,13 +57,13 @@ hc_scale = torch.randn((3,), dtype=dtypes.fp32) * 0.1
 hc_base = torch.randn((hc_mult3,), dtype=dtypes.fp32) * 0.1
 norm_weight = torch.randn(hidden_size, dtype=dtypes.bf16) if a.fuse_rmsnorm else None
 
-kwargs = dict(
-    rms_eps=1e-6,
-    hc_pre_eps=1e-6,
-    hc_sinkhorn_eps=1e-6,
-    hc_post_mult_value=2.0,
-    sinkhorn_repeat=20,
-)
+kwargs = {
+    "rms_eps": 1e-6,
+    "hc_pre_eps": 1e-6,
+    "hc_sinkhorn_eps": 1e-6,
+    "hc_post_mult_value": 2.0,
+    "sinkhorn_repeat": 20,
+}
 if a.fuse_rmsnorm:
     kwargs["norm_weight"] = norm_weight
     kwargs["norm_eps"] = 1e-6
@@ -98,9 +107,13 @@ if a.bench:
     torch.cuda.synchronize()
 
     _, us = run_perftest(aiter.mhc_fused_post_pre, *args_pos, **call)
-    print(f"BENCH us={us:.4f} m={m} hidden={hidden_size} w_preshuffle_bf16={pack_flag} res_preshuffle={int(a.res_preshuffle)}")
+    print(
+        f"BENCH us={us:.4f} m={m} hidden={hidden_size} w_preshuffle_bf16={pack_flag} res_preshuffle={int(a.res_preshuffle)}"
+    )
 else:
     for _ in range(a.iters):
         aiter.mhc_fused_post_pre(*args_pos, **call)
     torch.cuda.synchronize()
-    print(f"done: m={m} hidden={hidden_size} w_preshuffle_bf16={pack_flag} res_preshuffle={int(a.res_preshuffle)} iters={a.iters}")
+    print(
+        f"done: m={m} hidden={hidden_size} w_preshuffle_bf16={pack_flag} res_preshuffle={int(a.res_preshuffle)} iters={a.iters}"
+    )

--- a/op_tests/mhc_att_min.py
+++ b/op_tests/mhc_att_min.py
@@ -20,10 +20,8 @@ p.add_argument("-m", type=int, default=2048)
 p.add_argument("-n", "--hidden_size", type=int, default=7168)
 p.add_argument("--hc_mult", type=int, default=4)
 p.add_argument("--iters", type=int, default=1)
-p.add_argument("--res_w_preshuffle_bf16", action="store_true", default=True)
-p.add_argument(
-    "--no_res_w_preshuffle_bf16", dest="res_w_preshuffle_bf16", action="store_false"
-)
+p.add_argument("--w_preshuffle_bf16", action=argparse.BooleanOptionalAction, default=True)
+p.add_argument("--res_preshuffle", "--res_shuffle", action=argparse.BooleanOptionalAction, default=False)
 p.add_argument("--fuse_rmsnorm", action="store_true", default=True)
 p.add_argument("--warmup", type=int, default=200, help="--bench: warm-up dispatches before timing")
 p.add_argument(
@@ -61,21 +59,21 @@ if a.fuse_rmsnorm:
     kwargs["norm_weight"] = norm_weight
     kwargs["norm_eps"] = 1e-6
 
-pack_flag = 1 if a.res_w_preshuffle_bf16 else 0
-if pack_flag:
-    from aiter.ops.mhc import MHC_RES_SHUFFLE, mhc_pre_convert_fn, mhc_res_shuffle
+from aiter.ops.mhc import mhc_pre_convert_fn, mhc_res_shuffle
 
+pack_flag = int(a.w_preshuffle_bf16)
+if pack_flag:
     fn_gemm = torch.empty(hc_mult3, hc_hidden_size, dtype=torch.int32)
     mhc_pre_convert_fn(fn_gemm, fn)
-    # The flag also switches residual_in/next_residual to the pre-shuffled layout.
-    if MHC_RES_SHUFFLE:
-        residual_in = mhc_res_shuffle(residual_in)
 else:
     fn_gemm = fn
+if a.res_preshuffle:
+    residual_in = mhc_res_shuffle(residual_in)
 
 call = dict(
     force_fused=True,
-    is_res_w_preshuffle_bf16=pack_flag,
+    w_preshuffle_bf16=a.w_preshuffle_bf16,
+    res_preshuffle=a.res_preshuffle,
     **kwargs,
 )
 args_pos = (
@@ -100,9 +98,9 @@ if a.bench:
     torch.cuda.synchronize()
 
     _, us = run_perftest(aiter.mhc_fused_post_pre, *args_pos, **call)
-    print(f"BENCH us={us:.4f} m={m} hidden={hidden_size} preshuffle={pack_flag}")
+    print(f"BENCH us={us:.4f} m={m} hidden={hidden_size} w_preshuffle_bf16={pack_flag} res_preshuffle={int(a.res_preshuffle)}")
 else:
     for _ in range(a.iters):
         aiter.mhc_fused_post_pre(*args_pos, **call)
     torch.cuda.synchronize()
-    print(f"done: m={m} hidden={hidden_size} preshuffle={pack_flag} iters={a.iters}")
+    print(f"done: m={m} hidden={hidden_size} w_preshuffle_bf16={pack_flag} res_preshuffle={int(a.res_preshuffle)} iters={a.iters}")

--- a/op_tests/test_mhc.py
+++ b/op_tests/test_mhc.py
@@ -460,7 +460,7 @@ def mhc_pre_norm_split_hip(
 
 @benchmark()
 def test_mhc_pre(
-    m, hidden_size, hc_mult, test_hc_head=False, fuse_rmsnorm=False, fn_pack_bf16=False
+    m, hidden_size, hc_mult, test_hc_head=False, fuse_rmsnorm=False, res_w_preshuffle_bf16=False
 ):
     if fuse_rmsnorm and test_hc_head:
         raise ValueError("fuse_rmsnorm and hc_head are mutually exclusive")
@@ -527,10 +527,10 @@ def test_mhc_pre(
     ret["hip_us"] = hip_us
 
     # bf16 GEMM path: pre-pack fn (fp32) -> int32 (hi<<16|lo) ONCE via mhc_pre_convert_fn
-    # (fn are constant weights), then run mhc_pre with is_fn_pack_bf16=1 so the gemm
+    # (fn are constant weights), then run mhc_pre with is_res_w_preshuffle_bf16=1 so the gemm
     # bit-extracts hi/lo instead of recomputing the fp32->bf16 split per (m_block, k).
     # On gfx950 this uses the native bf16 MFMA; gfx1250 the wave32 bf16 WMMA (UNVERIFIED).
-    if fn_pack_bf16:
+    if res_w_preshuffle_bf16:
         from aiter.ops.mhc import mhc_pre_convert_fn
 
         fn_packed = torch.empty(
@@ -547,7 +547,7 @@ def test_mhc_pre(
             fn_packed,
             hc_scale,
             hc_base,
-            is_fn_pack_bf16=1,
+            is_res_w_preshuffle_bf16=1,
             **hip_kwargs,
         )
         ret["hip_bf16_err"] = checkAllclose(
@@ -794,13 +794,12 @@ def test_mhc_post_pre(
     hc_mult,
     fuse_rmsnorm=False,
     large_m=False,
-    fn_pack_bf16=False,
-    fn_shuffle=False,
+    res_w_preshuffle_bf16=False,
 ):
     """Fused mhc_post + mhc_pre: HIP ``mhc_fused_post_pre`` vs ref / unfused HIP / Triton.
 
-    --fn_pack_bf16 toggles the gemm compute for ALL HIP paths (unfused, fused, large_m):
-    on -> pre-packed bf16 hi/lo MFMA (is_fn_pack_bf16=1); off -> fp32.
+    --res_w_preshuffle_bf16 toggles the gemm compute for ALL HIP paths (unfused, fused, large_m):
+    on -> pre-packed bf16 hi/lo MFMA (is_res_w_preshuffle_bf16=1); off -> fp32.
     """
     if hidden_size < 512:
         aiter.logger.info(
@@ -857,38 +856,37 @@ def test_mhc_post_pre(
     if fuse_rmsnorm:
         hip_kwargs["norm_weight"] = norm_weight
 
-    ret = {"fuse_rmsnorm": fuse_rmsnorm, "fn_pack_bf16": fn_pack_bf16}
-    if fn_shuffle:
-        ret["fn_shuffle"] = True
+    ret = {"fuse_rmsnorm": fuse_rmsnorm, "res_w_preshuffle_bf16": res_w_preshuffle_bf16}
 
-    # --fn_pack_bf16 toggles the gemm compute for all HIP paths: on -> pre-pack fn (fp32)
-    # into int32 (hi<<16|lo) ONCE via mhc_pre_convert_fn and run with is_fn_pack_bf16=1 so
+    # --res_w_preshuffle_bf16 toggles the gemm compute for all HIP paths: on -> pre-pack fn (fp32)
+    # into int32 (hi<<16|lo) ONCE via mhc_pre_convert_fn and run with is_res_w_preshuffle_bf16=1 so
     # the gemm bit-extracts hi/lo (gfx950 native bf16 MFMA; gfx1250 wave32 bf16 WMMA,
     # UNVERIFIED; other arches fall back to fp32); off -> plain fp32 fn.
-    if fn_pack_bf16:
-        from aiter.ops.mhc import mhc_pre_convert_fn
+    if res_w_preshuffle_bf16:
+        from aiter.ops.mhc import (
+            MHC_RES_SHUFFLE,
+            mhc_pre_convert_fn,
+            mhc_res_shuffle,
+            mhc_res_unshuffle,
+        )
 
         fn_gemm = torch.empty(
             fn.shape[0], fn.shape[1], dtype=torch.int32, device=fn.device
         )
         mhc_pre_convert_fn(fn_gemm, fn)
         pack_flag = 1
+        # The flag also switches the residual to the pre-shuffled layout
+        # res[k/KS][head][row][k%KS], which only the fused path understands. Convert at
+        # the call boundary here; in a real stack the conversion disappears because
+        # next_residual feeds the next layer's residual_in already shuffled. The unfused
+        # reference path below keeps the plain layout.
+        residual_in_fused = (
+            mhc_res_shuffle(residual_in) if MHC_RES_SHUFFLE else residual_in
+        )
     else:
         fn_gemm = fn
         pack_flag = 0
-
-    # --fn_shuffle preshuffles fn for the FUSED gemm only: fn[n][K] -> fnS[K//32][n][K%32]
-    # so a wave's fn tile is one contiguous run instead of 16 segments fn_stride apart.
-    # The unfused mhc_pre path stages fn through LDS with its own XOR swizzle and keeps
-    # the plain layout, so it still gets fn_gemm.
-    if fn_shuffle:
-        from aiter.ops.mhc import mhc_fn_shuffle_n_pad, mhc_pre_shuffle_fn_alloc
-
-        fn_fused = mhc_pre_shuffle_fn_alloc(fn, pack_flag)
-        fused_kwargs = {"fn_n_pad": mhc_fn_shuffle_n_pad(fn.shape[0])}
-    else:
-        fn_fused = fn_gemm
-        fused_kwargs = {}
+        residual_in_fused = residual_in
 
     (
         post_mix_unfused,
@@ -904,7 +902,7 @@ def test_mhc_post_pre(
         fn_gemm,
         hc_scale,
         hc_base,
-        is_fn_pack_bf16=pack_flag,
+        is_res_w_preshuffle_bf16=pack_flag,
         **hip_kwargs,
     )
 
@@ -916,15 +914,14 @@ def test_mhc_post_pre(
     ), fused_us = run_perftest(
         aiter.mhc_fused_post_pre,
         layer_input,
-        residual_in,
+        residual_in_fused,
         post_layer_mix,
         comb_res_mix,
-        fn_fused,
+        fn_gemm,
         hc_scale,
         hc_base,
         force_fused=True,
-        is_fn_pack_bf16=pack_flag,
-        **fused_kwargs,
+        is_res_w_preshuffle_bf16=pack_flag,
         **hip_kwargs,
     )
 
@@ -934,6 +931,8 @@ def test_mhc_post_pre(
         layer_input_ref, layer_input_unfused, msg="unfused/layer_input"
     )
     checkAllclose(next_residual_ref, next_residual_unfused, msg="unfused/next_residual")
+    if res_w_preshuffle_bf16 and MHC_RES_SHUFFLE:
+        next_residual_fused = mhc_res_unshuffle(next_residual_fused)
     checkAllclose(post_mix_ref, post_mix_fused, msg="fused/post_mix")
     checkAllclose(comb_mix_ref, comb_mix_fused, msg="fused/comb_mix")
     hip_fused_err = checkAllclose(
@@ -1015,7 +1014,7 @@ def test_mhc_post_pre(
                 fn_gemm,
                 hc_scale,
                 hc_base,
-                is_fn_pack_bf16=pack_flag,
+                is_res_w_preshuffle_bf16=pack_flag,
                 **hip_kwargs,
             )
             ret["large_m_us"] = large_m_us
@@ -1077,21 +1076,14 @@ parser.add_argument(
     "(gfx950, M>1024, mhc_fused_post_pre_large_m).",
 )
 parser.add_argument(
-    "--fn_pack_bf16",
+    "--res_w_preshuffle_bf16",
     action="store_true",
-    help="Use the bf16 (fn hi/lo pack) compute path (is_fn_pack_bf16=1). For mhc_pre this "
-    "adds hip_bf16_err/hip_bf16_us alongside fp32; for mhc_post_pre it switches ALL HIP "
-    "paths (unfused, fused, large_m) from fp32 to bf16. gfx950 native bf16 MFMA; gfx1250 "
-    "wave32 bf16 WMMA (UNVERIFIED); other arches fall back to fp32.",
-)
-
-parser.add_argument(
-    "--fn_shuffle",
-    action="store_true",
-    help="Preshuffle fn for the FUSED mhc_post_pre gemm (fn[n][K] -> fnS[K//32][n][K%32]) "
-    "so a wave's fn tile is one contiguous run instead of 16 segments fn_stride apart. "
-    "Combines with --fn_pack_bf16. Fused path only; the unfused mhc_pre path keeps the "
-    "plain layout.",
+    help="Pre-shuffled weight + residual bf16 path. fn is converted once by "
+    "mhc_pre_convert_fn into block-interleaved bf16 hi/lo (fn[n][k/16][0|1][k%16]) and the "
+    "gemm contracts it with two bf16 MMAs, no per-element unpacking; the fused path's "
+    "residual_in/next_residual additionally use resS[k/KS][head][row][k%KS] (converted at "
+    "the call boundary here). gfx950 native bf16 MFMA; gfx1250 wave32 bf16 WMMA; other "
+    "arches fall back to fp32.",
 )
 
 args = parser.parse_args()
@@ -1107,7 +1099,7 @@ for dtype in args.dtype:
                     hc_mult=hc_mult,
                     test_hc_head=args.hc_head,
                     fuse_rmsnorm=args.fuse_rmsnorm,
-                    fn_pack_bf16=args.fn_pack_bf16,
+                    res_w_preshuffle_bf16=args.res_w_preshuffle_bf16,
                 )
                 df.append(ret)
 df = pd.DataFrame(df)
@@ -1137,8 +1129,7 @@ if not args.hc_head:
                         hc_mult=hc_mult,
                         fuse_rmsnorm=args.fuse_rmsnorm,
                         large_m=args.largeM,
-                        fn_pack_bf16=args.fn_pack_bf16,
-                        fn_shuffle=args.fn_shuffle,
+                        res_w_preshuffle_bf16=args.res_w_preshuffle_bf16,
                     )
                     if ret.get("skipped"):
                         continue

--- a/op_tests/test_mhc.py
+++ b/op_tests/test_mhc.py
@@ -554,8 +554,6 @@ def test_mhc_pre(
             layer_input_ref, layer_input_bf16, msg="layer_input(bf16)"
         )
         ret["hip_bf16_us"] = hip_bf16_us
-        if hip_us and hip_bf16_us:
-            ret["bf16_speedup"] = hip_us / hip_bf16_us
     if fuse_rmsnorm:
         ret["hip_nofuse_us"] = hip_nofuse_us
         ret["TB/s"] = (
@@ -903,8 +901,9 @@ def test_mhc_post_pre(
     ret["hip_fused_err"] = hip_fused_err
 
     # bf16 compute path: pre-pack fn (fp32) -> int32 (hi<<16|lo) ONCE via mhc_pre_convert_fn,
-    # then run the fused kernel with is_fn_pack_bf16=1 so it bit-extracts hi/lo. gfx950 native
-    # bf16 MFMA; gfx1250 wave32 bf16 WMMA (UNVERIFIED); other arches fall back to fp32.
+    # then run with is_fn_pack_bf16=1 so the gemm bit-extracts hi/lo. Exercised on BOTH the
+    # unfused and fused paths. gfx950 native bf16 MFMA; gfx1250 wave32 bf16 WMMA (UNVERIFIED);
+    # other arches fall back to fp32.
     if fn_pack_bf16:
         from aiter.ops.mhc import mhc_pre_convert_fn
 
@@ -912,6 +911,36 @@ def test_mhc_post_pre(
             fn.shape[0], fn.shape[1], dtype=torch.int32, device=fn.device
         )
         mhc_pre_convert_fn(fn_packed, fn)
+
+        # unfused path (mhc_post + mhc_pre) with packed fn
+        (
+            post_mix_unfused_bf16,
+            comb_mix_unfused_bf16,
+            layer_input_unfused_bf16,
+            next_residual_unfused_bf16,
+        ), unfused_bf16_us = run_perftest(
+            mhc_post_pre_unfused_hip,
+            layer_input,
+            residual_in,
+            post_layer_mix,
+            comb_res_mix,
+            fn_packed,
+            hc_scale,
+            hc_base,
+            is_fn_pack_bf16=1,
+            **hip_kwargs,
+        )
+        ret["unfused_bf16_err"] = checkAllclose(
+            layer_input_ref, layer_input_unfused_bf16, msg="unfused/layer_input(bf16)"
+        )
+        checkAllclose(
+            next_residual_ref,
+            next_residual_unfused_bf16,
+            msg="unfused/next_residual(bf16)",
+        )
+        ret["unfused_bf16_us"] = unfused_bf16_us
+
+        # fused path with packed fn
         (
             _post_mix_bf16,
             _comb_mix_bf16,
@@ -937,8 +966,6 @@ def test_mhc_post_pre(
             next_residual_ref, next_residual_bf16, msg="fused/next_residual(bf16)"
         )
         ret["fused_bf16_us"] = fused_bf16_us
-        if fused_us and fused_bf16_us:
-            ret["bf16_speedup"] = fused_us / fused_bf16_us
     # print(f"next_residual_ref: {next_residual_ref}")
     # print(f"next_residual_fused: {next_residual_fused}")
 
@@ -1074,7 +1101,7 @@ parser.add_argument(
     "--fn_pack_bf16",
     action="store_true",
     help="Also run the bf16 (fn hi/lo pack) compute path (is_fn_pack_bf16=1) and add "
-    "hip_bf16_err/hip_bf16_us (mhc_pre) and fused_bf16_err/fused_bf16_us + bf16_speedup "
+    "hip_bf16_err/hip_bf16_us (mhc_pre) and unfused_bf16_*/fused_bf16_* "
     "(mhc_post_pre). gfx950 native bf16 MFMA; gfx1250 wave32 bf16 WMMA (UNVERIFIED); "
     "other arches fall back to fp32.",
 )

--- a/op_tests/test_mhc.py
+++ b/op_tests/test_mhc.py
@@ -791,7 +791,11 @@ def mhc_post_pre_unfused_hip(
 def test_mhc_post_pre(
     m, hidden_size, hc_mult, fuse_rmsnorm=False, large_m=False, fn_pack_bf16=False
 ):
-    """Fused mhc_post + mhc_pre: HIP ``mhc_fused_post_pre`` vs ref / unfused HIP / Triton."""
+    """Fused mhc_post + mhc_pre: HIP ``mhc_fused_post_pre`` vs ref / unfused HIP / Triton.
+
+    --fn_pack_bf16 toggles the gemm compute for ALL HIP paths (unfused, fused, large_m):
+    on -> pre-packed bf16 hi/lo MFMA (is_fn_pack_bf16=1); off -> fp32.
+    """
     if hidden_size < 512:
         aiter.logger.info(
             "skip mhc_post_pre: hidden_size=%s < 512 (big_fuse dispatch)", hidden_size
@@ -847,6 +851,24 @@ def test_mhc_post_pre(
     if fuse_rmsnorm:
         hip_kwargs["norm_weight"] = norm_weight
 
+    ret = {"fuse_rmsnorm": fuse_rmsnorm, "fn_pack_bf16": fn_pack_bf16}
+
+    # --fn_pack_bf16 toggles the gemm compute for all HIP paths: on -> pre-pack fn (fp32)
+    # into int32 (hi<<16|lo) ONCE via mhc_pre_convert_fn and run with is_fn_pack_bf16=1 so
+    # the gemm bit-extracts hi/lo (gfx950 native bf16 MFMA; gfx1250 wave32 bf16 WMMA,
+    # UNVERIFIED; other arches fall back to fp32); off -> plain fp32 fn.
+    if fn_pack_bf16:
+        from aiter.ops.mhc import mhc_pre_convert_fn
+
+        fn_gemm = torch.empty(
+            fn.shape[0], fn.shape[1], dtype=torch.int32, device=fn.device
+        )
+        mhc_pre_convert_fn(fn_gemm, fn)
+        pack_flag = 1
+    else:
+        fn_gemm = fn
+        pack_flag = 0
+
     (
         post_mix_unfused,
         comb_mix_unfused,
@@ -858,9 +880,10 @@ def test_mhc_post_pre(
         residual_in,
         post_layer_mix,
         comb_res_mix,
-        fn,
+        fn_gemm,
         hc_scale,
         hc_base,
+        is_fn_pack_bf16=pack_flag,
         **hip_kwargs,
     )
 
@@ -875,10 +898,11 @@ def test_mhc_post_pre(
         residual_in,
         post_layer_mix,
         comb_res_mix,
-        fn,
+        fn_gemm,
         hc_scale,
         hc_base,
         force_fused=True,
+        is_fn_pack_bf16=pack_flag,
         **hip_kwargs,
     )
 
@@ -894,78 +918,10 @@ def test_mhc_post_pre(
         layer_input_ref, layer_input_fused, msg="fused/layer_input"
     )
     checkAllclose(next_residual_ref, next_residual_fused, msg="fused/next_residual")
-    ret = {"fuse_rmsnorm": fuse_rmsnorm}
     ret["unfused_us"] = unfused_us
     ret["hip_unfused_err"] = hip_unfused_err
     ret["fused_us"] = fused_us
     ret["hip_fused_err"] = hip_fused_err
-
-    # bf16 compute path: pre-pack fn (fp32) -> int32 (hi<<16|lo) ONCE via mhc_pre_convert_fn,
-    # then run with is_fn_pack_bf16=1 so the gemm bit-extracts hi/lo. Exercised on BOTH the
-    # unfused and fused paths. gfx950 native bf16 MFMA; gfx1250 wave32 bf16 WMMA (UNVERIFIED);
-    # other arches fall back to fp32.
-    if fn_pack_bf16:
-        from aiter.ops.mhc import mhc_pre_convert_fn
-
-        fn_packed = torch.empty(
-            fn.shape[0], fn.shape[1], dtype=torch.int32, device=fn.device
-        )
-        mhc_pre_convert_fn(fn_packed, fn)
-
-        # unfused path (mhc_post + mhc_pre) with packed fn
-        (
-            post_mix_unfused_bf16,
-            comb_mix_unfused_bf16,
-            layer_input_unfused_bf16,
-            next_residual_unfused_bf16,
-        ), unfused_bf16_us = run_perftest(
-            mhc_post_pre_unfused_hip,
-            layer_input,
-            residual_in,
-            post_layer_mix,
-            comb_res_mix,
-            fn_packed,
-            hc_scale,
-            hc_base,
-            is_fn_pack_bf16=1,
-            **hip_kwargs,
-        )
-        ret["unfused_bf16_err"] = checkAllclose(
-            layer_input_ref, layer_input_unfused_bf16, msg="unfused/layer_input(bf16)"
-        )
-        checkAllclose(
-            next_residual_ref,
-            next_residual_unfused_bf16,
-            msg="unfused/next_residual(bf16)",
-        )
-        ret["unfused_bf16_us"] = unfused_bf16_us
-
-        # fused path with packed fn
-        (
-            _post_mix_bf16,
-            _comb_mix_bf16,
-            layer_input_bf16,
-            next_residual_bf16,
-        ), fused_bf16_us = run_perftest(
-            aiter.mhc_fused_post_pre,
-            layer_input,
-            residual_in,
-            post_layer_mix,
-            comb_res_mix,
-            fn_packed,
-            hc_scale,
-            hc_base,
-            force_fused=True,
-            is_fn_pack_bf16=1,
-            **hip_kwargs,
-        )
-        ret["fused_bf16_err"] = checkAllclose(
-            layer_input_ref, layer_input_bf16, msg="fused/layer_input(bf16)"
-        )
-        checkAllclose(
-            next_residual_ref, next_residual_bf16, msg="fused/next_residual(bf16)"
-        )
-        ret["fused_bf16_us"] = fused_bf16_us
     # print(f"next_residual_ref: {next_residual_ref}")
     # print(f"next_residual_fused: {next_residual_fused}")
 
@@ -1034,9 +990,10 @@ def test_mhc_post_pre(
                 residual_in,
                 post_layer_mix,
                 comb_res_mix,
-                fn,
+                fn_gemm,
                 hc_scale,
                 hc_base,
+                is_fn_pack_bf16=pack_flag,
                 **hip_kwargs,
             )
             ret["large_m_us"] = large_m_us
@@ -1100,10 +1057,10 @@ parser.add_argument(
 parser.add_argument(
     "--fn_pack_bf16",
     action="store_true",
-    help="Also run the bf16 (fn hi/lo pack) compute path (is_fn_pack_bf16=1) and add "
-    "hip_bf16_err/hip_bf16_us (mhc_pre) and unfused_bf16_*/fused_bf16_* "
-    "(mhc_post_pre). gfx950 native bf16 MFMA; gfx1250 wave32 bf16 WMMA (UNVERIFIED); "
-    "other arches fall back to fp32.",
+    help="Use the bf16 (fn hi/lo pack) compute path (is_fn_pack_bf16=1). For mhc_pre this "
+    "adds hip_bf16_err/hip_bf16_us alongside fp32; for mhc_post_pre it switches ALL HIP "
+    "paths (unfused, fused, large_m) from fp32 to bf16. gfx950 native bf16 MFMA; gfx1250 "
+    "wave32 bf16 WMMA (UNVERIFIED); other arches fall back to fp32.",
 )
 
 args = parser.parse_args()

--- a/op_tests/test_mhc.py
+++ b/op_tests/test_mhc.py
@@ -526,10 +526,17 @@ def test_mhc_pre(
     ret["hip_err"] = hip_err
     ret["hip_us"] = hip_us
 
-    # bf16 (fn hi/lo pack) GEMM path: same mhc_pre but is_fn_pack_bf16=1. On gfx950 this
-    # uses the native bf16 MFMA; on gfx1250 the wave32 bf16 WMMA (UNVERIFIED); on other
-    # arches it falls back to fp32 (so err/us == the fp32 columns).
+    # bf16 GEMM path: pre-pack fn (fp32) -> int32 (hi<<16|lo) ONCE via mhc_pre_convert_fn
+    # (fn are constant weights), then run mhc_pre with is_fn_pack_bf16=1 so the gemm
+    # bit-extracts hi/lo instead of recomputing the fp32->bf16 split per (m_block, k).
+    # On gfx950 this uses the native bf16 MFMA; gfx1250 the wave32 bf16 WMMA (UNVERIFIED).
     if fn_pack_bf16:
+        from aiter.ops.mhc import mhc_pre_convert_fn
+
+        fn_packed = torch.empty(
+            fn.shape[0], fn.shape[1], dtype=torch.int32, device=fn.device
+        )
+        mhc_pre_convert_fn(fn_packed, fn)
         (
             _post_mix_bf16,
             _comb_mix_bf16,
@@ -537,7 +544,7 @@ def test_mhc_pre(
         ), hip_bf16_us = run_perftest(
             aiter.mhc_pre,
             residual,
-            fn,
+            fn_packed,
             hc_scale,
             hc_base,
             is_fn_pack_bf16=1,
@@ -895,10 +902,16 @@ def test_mhc_post_pre(
     ret["fused_us"] = fused_us
     ret["hip_fused_err"] = hip_fused_err
 
-    # bf16 (fn hi/lo pack) compute path: same fused kernel but is_fn_pack_bf16=1. gfx950
-    # native bf16 MFMA; gfx1250 wave32 bf16 WMMA (UNVERIFIED); other arches fall back to
-    # fp32 (err/us == the fp32 fused columns).
+    # bf16 compute path: pre-pack fn (fp32) -> int32 (hi<<16|lo) ONCE via mhc_pre_convert_fn,
+    # then run the fused kernel with is_fn_pack_bf16=1 so it bit-extracts hi/lo. gfx950 native
+    # bf16 MFMA; gfx1250 wave32 bf16 WMMA (UNVERIFIED); other arches fall back to fp32.
     if fn_pack_bf16:
+        from aiter.ops.mhc import mhc_pre_convert_fn
+
+        fn_packed = torch.empty(
+            fn.shape[0], fn.shape[1], dtype=torch.int32, device=fn.device
+        )
+        mhc_pre_convert_fn(fn_packed, fn)
         (
             _post_mix_bf16,
             _comb_mix_bf16,
@@ -910,7 +923,7 @@ def test_mhc_post_pre(
             residual_in,
             post_layer_mix,
             comb_res_mix,
-            fn,
+            fn_packed,
             hc_scale,
             hc_base,
             force_fused=True,

--- a/op_tests/test_mhc.py
+++ b/op_tests/test_mhc.py
@@ -789,7 +789,13 @@ def mhc_post_pre_unfused_hip(
 
 @benchmark()
 def test_mhc_post_pre(
-    m, hidden_size, hc_mult, fuse_rmsnorm=False, large_m=False, fn_pack_bf16=False
+    m,
+    hidden_size,
+    hc_mult,
+    fuse_rmsnorm=False,
+    large_m=False,
+    fn_pack_bf16=False,
+    fn_shuffle=False,
 ):
     """Fused mhc_post + mhc_pre: HIP ``mhc_fused_post_pre`` vs ref / unfused HIP / Triton.
 
@@ -852,6 +858,8 @@ def test_mhc_post_pre(
         hip_kwargs["norm_weight"] = norm_weight
 
     ret = {"fuse_rmsnorm": fuse_rmsnorm, "fn_pack_bf16": fn_pack_bf16}
+    if fn_shuffle:
+        ret["fn_shuffle"] = True
 
     # --fn_pack_bf16 toggles the gemm compute for all HIP paths: on -> pre-pack fn (fp32)
     # into int32 (hi<<16|lo) ONCE via mhc_pre_convert_fn and run with is_fn_pack_bf16=1 so
@@ -868,6 +876,19 @@ def test_mhc_post_pre(
     else:
         fn_gemm = fn
         pack_flag = 0
+
+    # --fn_shuffle preshuffles fn for the FUSED gemm only: fn[n][K] -> fnS[K//32][n][K%32]
+    # so a wave's fn tile is one contiguous run instead of 16 segments fn_stride apart.
+    # The unfused mhc_pre path stages fn through LDS with its own XOR swizzle and keeps
+    # the plain layout, so it still gets fn_gemm.
+    if fn_shuffle:
+        from aiter.ops.mhc import mhc_fn_shuffle_n_pad, mhc_pre_shuffle_fn_alloc
+
+        fn_fused = mhc_pre_shuffle_fn_alloc(fn, pack_flag)
+        fused_kwargs = {"fn_n_pad": mhc_fn_shuffle_n_pad(fn.shape[0])}
+    else:
+        fn_fused = fn_gemm
+        fused_kwargs = {}
 
     (
         post_mix_unfused,
@@ -898,11 +919,12 @@ def test_mhc_post_pre(
         residual_in,
         post_layer_mix,
         comb_res_mix,
-        fn_gemm,
+        fn_fused,
         hc_scale,
         hc_base,
         force_fused=True,
         is_fn_pack_bf16=pack_flag,
+        **fused_kwargs,
         **hip_kwargs,
     )
 
@@ -1063,6 +1085,15 @@ parser.add_argument(
     "wave32 bf16 WMMA (UNVERIFIED); other arches fall back to fp32.",
 )
 
+parser.add_argument(
+    "--fn_shuffle",
+    action="store_true",
+    help="Preshuffle fn for the FUSED mhc_post_pre gemm (fn[n][K] -> fnS[K//32][n][K%32]) "
+    "so a wave's fn tile is one contiguous run instead of 16 segments fn_stride apart. "
+    "Combines with --fn_pack_bf16. Fused path only; the unfused mhc_pre path keeps the "
+    "plain layout.",
+)
+
 args = parser.parse_args()
 
 df = []
@@ -1107,6 +1138,7 @@ if not args.hc_head:
                         fuse_rmsnorm=args.fuse_rmsnorm,
                         large_m=args.largeM,
                         fn_pack_bf16=args.fn_pack_bf16,
+                        fn_shuffle=args.fn_shuffle,
                     )
                     if ret.get("skipped"):
                         continue

--- a/op_tests/test_mhc.py
+++ b/op_tests/test_mhc.py
@@ -460,7 +460,7 @@ def mhc_pre_norm_split_hip(
 
 @benchmark()
 def test_mhc_pre(
-    m, hidden_size, hc_mult, test_hc_head=False, fuse_rmsnorm=False, res_w_preshuffle_bf16=False
+    m, hidden_size, hc_mult, test_hc_head=False, fuse_rmsnorm=False, w_preshuffle_bf16=False
 ):
     if fuse_rmsnorm and test_hc_head:
         raise ValueError("fuse_rmsnorm and hc_head are mutually exclusive")
@@ -527,10 +527,10 @@ def test_mhc_pre(
     ret["hip_us"] = hip_us
 
     # bf16 GEMM path: pre-pack fn (fp32) -> int32 (hi<<16|lo) ONCE via mhc_pre_convert_fn
-    # (fn are constant weights), then run mhc_pre with is_res_w_preshuffle_bf16=1 so the gemm
+    # (fn are constant weights), then run mhc_pre with is_w_preshuffle_bf16=1 so the gemm
     # bit-extracts hi/lo instead of recomputing the fp32->bf16 split per (m_block, k).
     # On gfx950 this uses the native bf16 MFMA; gfx1250 the wave32 bf16 WMMA (UNVERIFIED).
-    if res_w_preshuffle_bf16:
+    if w_preshuffle_bf16:
         from aiter.ops.mhc import mhc_pre_convert_fn
 
         fn_packed = torch.empty(
@@ -547,7 +547,7 @@ def test_mhc_pre(
             fn_packed,
             hc_scale,
             hc_base,
-            is_res_w_preshuffle_bf16=1,
+            is_w_preshuffle_bf16=1,
             **hip_kwargs,
         )
         ret["hip_bf16_err"] = checkAllclose(
@@ -799,7 +799,8 @@ def test_mhc_post_pre(
     """Fused mhc_post + mhc_pre: HIP ``mhc_fused_post_pre`` vs ref / unfused HIP / Triton.
 
     --res_w_preshuffle_bf16 toggles the gemm compute for ALL HIP paths (unfused, fused, large_m):
-    on -> pre-packed bf16 hi/lo MFMA (is_res_w_preshuffle_bf16=1); off -> fp32.
+    on -> pre-packed BF16 hi/lo compute; off -> fp32.
+    Only the fused path additionally switches the residual to a shuffled layout.
     """
     if hidden_size < 512:
         aiter.logger.info(
@@ -859,7 +860,7 @@ def test_mhc_post_pre(
     ret = {"fuse_rmsnorm": fuse_rmsnorm, "res_w_preshuffle_bf16": res_w_preshuffle_bf16}
 
     # --res_w_preshuffle_bf16 toggles the gemm compute for all HIP paths: on -> pre-pack fn (fp32)
-    # into int32 (hi<<16|lo) ONCE via mhc_pre_convert_fn and run with is_res_w_preshuffle_bf16=1 so
+    # into int32 BF16 hi/lo ONCE via mhc_pre_convert_fn and enable BF16 GEMM so
     # the gemm bit-extracts hi/lo (gfx950 native bf16 MFMA; gfx1250 wave32 bf16 WMMA,
     # UNVERIFIED; other arches fall back to fp32); off -> plain fp32 fn.
     if res_w_preshuffle_bf16:
@@ -902,7 +903,7 @@ def test_mhc_post_pre(
         fn_gemm,
         hc_scale,
         hc_base,
-        is_res_w_preshuffle_bf16=pack_flag,
+        is_w_preshuffle_bf16=pack_flag,
         **hip_kwargs,
     )
 
@@ -1099,7 +1100,7 @@ for dtype in args.dtype:
                     hc_mult=hc_mult,
                     test_hc_head=args.hc_head,
                     fuse_rmsnorm=args.fuse_rmsnorm,
-                    res_w_preshuffle_bf16=args.res_w_preshuffle_bf16,
+                    w_preshuffle_bf16=args.res_w_preshuffle_bf16,
                 )
                 df.append(ret)
 df = pd.DataFrame(df)

--- a/op_tests/test_mhc.py
+++ b/op_tests/test_mhc.py
@@ -460,7 +460,12 @@ def mhc_pre_norm_split_hip(
 
 @benchmark()
 def test_mhc_pre(
-    m, hidden_size, hc_mult, test_hc_head=False, fuse_rmsnorm=False, w_preshuffle_bf16=False
+    m,
+    hidden_size,
+    hc_mult,
+    test_hc_head=False,
+    fuse_rmsnorm=False,
+    w_preshuffle_bf16=False,
 ):
     if fuse_rmsnorm and test_hc_head:
         raise ValueError("fuse_rmsnorm and hc_head are mutually exclusive")

--- a/op_tests/test_mhc.py
+++ b/op_tests/test_mhc.py
@@ -527,7 +527,7 @@ def test_mhc_pre(
     ret["hip_us"] = hip_us
 
     # bf16 GEMM path: pre-pack fn (fp32) -> int32 (hi<<16|lo) ONCE via mhc_pre_convert_fn
-    # (fn are constant weights), then run mhc_pre with is_w_preshuffle_bf16=1 so the gemm
+    # (fn are constant weights), then run mhc_pre with w_preshuffle_bf16=1 so the gemm
     # bit-extracts hi/lo instead of recomputing the fp32->bf16 split per (m_block, k).
     # On gfx950 this uses the native bf16 MFMA; gfx1250 the wave32 bf16 WMMA (UNVERIFIED).
     if w_preshuffle_bf16:
@@ -547,7 +547,7 @@ def test_mhc_pre(
             fn_packed,
             hc_scale,
             hc_base,
-            is_w_preshuffle_bf16=1,
+            w_preshuffle_bf16=1,
             **hip_kwargs,
         )
         ret["hip_bf16_err"] = checkAllclose(
@@ -794,13 +794,13 @@ def test_mhc_post_pre(
     hc_mult,
     fuse_rmsnorm=False,
     large_m=False,
-    res_w_preshuffle_bf16=False,
+    w_preshuffle_bf16=False,
+    res_preshuffle=False,
 ):
     """Fused mhc_post + mhc_pre: HIP ``mhc_fused_post_pre`` vs ref / unfused HIP / Triton.
 
-    --res_w_preshuffle_bf16 toggles the gemm compute for ALL HIP paths (unfused, fused, large_m):
-    on -> pre-packed BF16 hi/lo compute; off -> fp32.
-    Only the fused path additionally switches the residual to a shuffled layout.
+    --w_preshuffle_bf16 selects packed BF16 hi/lo compute for all HIP paths.
+    --res_shuffle independently selects the fused residual input/output layout.
     """
     if hidden_size < 512:
         aiter.logger.info(
@@ -857,37 +857,23 @@ def test_mhc_post_pre(
     if fuse_rmsnorm:
         hip_kwargs["norm_weight"] = norm_weight
 
-    ret = {"fuse_rmsnorm": fuse_rmsnorm, "res_w_preshuffle_bf16": res_w_preshuffle_bf16}
+    from aiter.ops.mhc import mhc_pre_convert_fn, mhc_res_shuffle, mhc_res_unshuffle
 
-    # --res_w_preshuffle_bf16 toggles the gemm compute for all HIP paths: on -> pre-pack fn (fp32)
-    # into int32 BF16 hi/lo ONCE via mhc_pre_convert_fn and enable BF16 GEMM so
-    # the gemm bit-extracts hi/lo (gfx950 native bf16 MFMA; gfx1250 wave32 bf16 WMMA,
-    # UNVERIFIED; other arches fall back to fp32); off -> plain fp32 fn.
-    if res_w_preshuffle_bf16:
-        from aiter.ops.mhc import (
-            MHC_RES_SHUFFLE,
-            mhc_pre_convert_fn,
-            mhc_res_shuffle,
-            mhc_res_unshuffle,
-        )
-
-        fn_gemm = torch.empty(
-            fn.shape[0], fn.shape[1], dtype=torch.int32, device=fn.device
-        )
+    packed = w_preshuffle_bf16
+    shuffled = res_preshuffle
+    ret = {
+        "fuse_rmsnorm": fuse_rmsnorm,
+        "w_preshuffle_bf16": bool(packed),
+        "res_preshuffle": bool(shuffled),
+    }
+    pack_flag = int(packed)
+    # Pack weights and change residual layout independently, outside the timed call.
+    if packed:
+        fn_gemm = torch.empty_like(fn, dtype=torch.int32)
         mhc_pre_convert_fn(fn_gemm, fn)
-        pack_flag = 1
-        # The flag also switches the residual to the pre-shuffled layout
-        # res[k/KS][head][row][k%KS], which only the fused path understands. Convert at
-        # the call boundary here; in a real stack the conversion disappears because
-        # next_residual feeds the next layer's residual_in already shuffled. The unfused
-        # reference path below keeps the plain layout.
-        residual_in_fused = (
-            mhc_res_shuffle(residual_in) if MHC_RES_SHUFFLE else residual_in
-        )
     else:
         fn_gemm = fn
-        pack_flag = 0
-        residual_in_fused = residual_in
+    residual_in_fused = mhc_res_shuffle(residual_in) if shuffled else residual_in
 
     (
         post_mix_unfused,
@@ -903,7 +889,7 @@ def test_mhc_post_pre(
         fn_gemm,
         hc_scale,
         hc_base,
-        is_w_preshuffle_bf16=pack_flag,
+        w_preshuffle_bf16=pack_flag,
         **hip_kwargs,
     )
 
@@ -922,7 +908,8 @@ def test_mhc_post_pre(
         hc_scale,
         hc_base,
         force_fused=True,
-        is_res_w_preshuffle_bf16=pack_flag,
+        w_preshuffle_bf16=w_preshuffle_bf16,
+        res_preshuffle=res_preshuffle,
         **hip_kwargs,
     )
 
@@ -932,7 +919,7 @@ def test_mhc_post_pre(
         layer_input_ref, layer_input_unfused, msg="unfused/layer_input"
     )
     checkAllclose(next_residual_ref, next_residual_unfused, msg="unfused/next_residual")
-    if res_w_preshuffle_bf16 and MHC_RES_SHUFFLE:
+    if shuffled:
         next_residual_fused = mhc_res_unshuffle(next_residual_fused)
     checkAllclose(post_mix_ref, post_mix_fused, msg="fused/post_mix")
     checkAllclose(comb_mix_ref, comb_mix_fused, msg="fused/comb_mix")
@@ -1015,7 +1002,8 @@ def test_mhc_post_pre(
                 fn_gemm,
                 hc_scale,
                 hc_base,
-                is_res_w_preshuffle_bf16=pack_flag,
+                w_preshuffle_bf16=w_preshuffle_bf16,
+                res_preshuffle=False,
                 **hip_kwargs,
             )
             ret["large_m_us"] = large_m_us
@@ -1054,10 +1042,10 @@ parser.add_argument(
     "--hidden_size",
     type=int,
     nargs="*",
-    choices=[1280, 2560, 4096, 7168],
-    default=[1280, 2560, 4096, 7168],
+    choices=[4096, 5120, 7168],
+    default=[4096, 5120, 7168],
     help="""hidden_size.
-    e.g.: -hidden_size 1024""",
+    e.g.: -n 5120""",
 )
 _mode_group = parser.add_mutually_exclusive_group()
 _mode_group.add_argument(
@@ -1077,17 +1065,24 @@ parser.add_argument(
     "(gfx950, M>1024, mhc_fused_post_pre_large_m).",
 )
 parser.add_argument(
-    "--res_w_preshuffle_bf16",
-    action="store_true",
-    help="Pre-shuffled weight + residual bf16 path. fn is converted once by "
-    "mhc_pre_convert_fn into block-interleaved bf16 hi/lo (fn[n][k/16][0|1][k%16]) and the "
-    "gemm contracts it with two bf16 MMAs, no per-element unpacking; the fused path's "
-    "residual_in/next_residual additionally use resS[k/KS][head][row][k%KS] (converted at "
-    "the call boundary here). gfx950 native bf16 MFMA; gfx1250 wave32 bf16 WMMA; other "
-    "arches fall back to fp32.",
+    "--w_preshuffle_bf16",
+    action=argparse.BooleanOptionalAction,
+    default=False,
+    help="Enable BF16 hi/lo GEMM with pre-packed weights, independently of residual layout.",
+)
+parser.add_argument(
+    "--res_shuffle",
+    "--res_preshuffle",
+    dest="res_preshuffle",
+    action=argparse.BooleanOptionalAction,
+    default=False,
+    help="Use shuffled residual input/output in the fused path (gfx1250 only), "
+    "independently of GEMM compute.",
 )
 
 args = parser.parse_args()
+if not args.hc_head and args.res_preshuffle and get_gfx_runtime() != "gfx1250":
+    parser.error("residual shuffle is only supported on gfx1250; use --no-res_shuffle")
 
 df = []
 for dtype in args.dtype:
@@ -1100,7 +1095,7 @@ for dtype in args.dtype:
                     hc_mult=hc_mult,
                     test_hc_head=args.hc_head,
                     fuse_rmsnorm=args.fuse_rmsnorm,
-                    w_preshuffle_bf16=args.res_w_preshuffle_bf16,
+                    w_preshuffle_bf16=args.w_preshuffle_bf16,
                 )
                 df.append(ret)
 df = pd.DataFrame(df)
@@ -1130,7 +1125,8 @@ if not args.hc_head:
                         hc_mult=hc_mult,
                         fuse_rmsnorm=args.fuse_rmsnorm,
                         large_m=args.largeM,
-                        res_w_preshuffle_bf16=args.res_w_preshuffle_bf16,
+                        w_preshuffle_bf16=args.w_preshuffle_bf16,
+                        res_preshuffle=args.res_preshuffle,
                     )
                     if ret.get("skipped"):
                         continue

--- a/op_tests/test_mhc_compile.py
+++ b/op_tests/test_mhc_compile.py
@@ -1,0 +1,50 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2026, Advanced Micro Devices, Inc. All rights reserved.
+"""Validate the mutation contract of the allocating mHC entry points."""
+
+import pytest
+import torch
+
+import aiter
+
+OPS = ("mhc_pre", "mhc_fused_post_pre", "mhc_fused_post_pre_large_m")
+
+
+@pytest.mark.parametrize("name", OPS)
+def test_mhc_inputs_are_readonly(name):
+    op = getattr(torch.ops.aiter, name).default
+    assert all(
+        arg.alias_info is None or not arg.alias_info.is_write
+        for arg in op._schema.arguments
+    )
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires a ROCm GPU")
+@pytest.mark.parametrize("name", OPS)
+@pytest.mark.parametrize("with_norm", [False, True])
+def test_mhc_compile_contract(name, with_norm):
+    # Exercise both fused decode and split post/pre prefill implementations.
+    m = 1024 if name.endswith("large_m") else 65
+    h = 1280
+    device = "cuda"
+    residual = torch.randn(m, 4, h, device=device, dtype=torch.bfloat16)
+    fn = torch.randn(24, 4 * h, device=device, dtype=torch.float32) * 0.01
+    scale = torch.full((3,), 0.1, device=device)
+    base = torch.zeros(24, device=device)
+    kwargs = {"hc_post_mult_value": 2.0}
+    if with_norm:
+        kwargs["norm_weight"] = torch.ones(h, device=device, dtype=torch.bfloat16)
+    if name == "mhc_pre":
+        args = (residual, fn, scale, base)
+    else:
+        post, comb, x = aiter.mhc_pre(residual, fn, scale, base, **kwargs)
+        args = (x, residual, post.squeeze(-1), comb, fn, scale, base)
+    op = getattr(torch.ops.aiter, name).default
+    # Checks actual writes/aliases against the schema and verifies compiled
+    # execution against eager, including dynamic-shape functionalization.
+    torch.library.opcheck(
+        op,
+        args,
+        kwargs,
+        test_utils=("test_schema", "test_faketensor", "test_aot_dispatch_dynamic"),
+    )


### PR DESCRIPTION
Superseded by https://github.com/ROCm/aiter/pull/5412 so this change is submitted directly from `jun/mhc_gfx1250`. The replacement contains the same complete BF16 mHC implementation and compiler-copy fix.

Add packed BF16 hi/lo computation for mHC pre and fused post/pre, together with the fn packing API used by ATOM. FP32 fn weights are split into BF16 hi/lo components so the GEMM can use BF16 matrix instructions while preserving the contribution of the low component. `mhc_shuffle_fn` chooses the packing block width for the GPU architecture: 16 on gfx1250 and 8 on wave64 targets.

The complete mHC implementation in this PR includes:
- BF16 weight packing and kernel/API support, with independent `w_preshuffle_bf16` and `res_preshuffle` controls. BF16 computation also supports ordinary residual layout and the large-M post + pre fallback.
- gfx1250 kernel and launch-policy tuning, including residual staging, LDS prefetch, coefficient loads, and post-kernel occupancy selection. Optional shuffled-residual execution remains separate from BF16 weights.
- Updated mHC benchmarks and kernel tests, plus opt-in `AITER_DEBUG_INFO=1` device debug information for instruction/source profiling.
- A compiler-copy fix: declare `mhc_pre`, `mhc_fused_post_pre`, and `mhc_fused_post_pre_large_m` as read-only on their inputs. They allocate their outputs; the previous default schema marked all tensor inputs as writable and caused unnecessary functionalization work around tracing markers.

Validation on gfx1250 / PyTorch 2.11.0+ROCm:
- `python -m pytest -q op_tests/test_mhc_compile.py`: **9 passed**, covering mutation/alias contracts, FakeTensor metadata, and dynamic AOT execution, with and without RMSNorm.
- BF16 vs FP32 numerical checks passed for hidden sizes 1280/4096/7168 and token counts 1/65/1024. CPU packing-layout checks cover gfx1250, gfx950, and gfx942; GPU execution was tested on gfx1250.
- Combined with ATOM, M=65/1024/16384 and H=7168 pass for both FP32 and BF16, with plain residuals: compiled outputs match eager bitwise, inputs remain unchanged, generated code and GPU traces contain no extra copy kernels, and CUDA graph replay remains correct after changing the input.

ATOM integration and graph-marker fix: https://github.com/ROCm/ATOM/pull/2194
