### PR TITLE
[Triton/Gluon] Unified attention: opt-in prefill configs for head sizes 129+

### DIFF
--- a/aiter/ops/triton/configs/gfx950/triton/attention/unified_attention/DEFAULT.json
+++ b/aiter/ops/triton/configs/gfx950/triton/attention/unified_attention/DEFAULT.json
@@ -131,6 +131,50 @@
       "TILE_SIZE_MAX": 64
     }
   },
+  "attn_2d.OPT_IN": {
+    "D_GEQ_256.Q_GEQ_256.DT_fp8_fp8": {
+      "BLOCK_M": 128,
+      "num_warps": 4,
+      "num_stages": 2,
+      "waves_per_eu": 1,
+      "TILE_SIZE_MIN": 64,
+      "TILE_SIZE_MAX": 64,
+      "LARGE_KV": {
+        "num_stages": 1,
+        "waves_per_eu": 2,
+        "llvm_fn_attrs": "amdgpu-sched-strategy=iterative-minreg"
+      }
+    },
+    "D_GEQ_129.Q_GEQ_256.DT_fp8_fp8": {
+      "BLOCK_M": 128,
+      "num_warps": 4,
+      "num_stages": 2,
+      "waves_per_eu": 1,
+      "TILE_SIZE_MIN": 64,
+      "TILE_SIZE_MAX": 64,
+      "LARGE_KV": {
+        "num_stages": 1,
+        "waves_per_eu": 2,
+        "llvm_fn_attrs": "amdgpu-sched-strategy=iterative-minreg"
+      }
+    },
+    "D_GEQ_256.Q_GEQ_256": {
+      "BLOCK_M": 128,
+      "num_warps": 4,
+      "num_stages": 2,
+      "waves_per_eu": 1,
+      "TILE_SIZE_MIN": 64,
+      "TILE_SIZE_MAX": 64
+    },
+    "D_GEQ_129.Q_GEQ_256": {
+      "BLOCK_M": 128,
+      "num_warps": 4,
+      "num_stages": 2,
+      "waves_per_eu": 1,
+      "TILE_SIZE_MIN": 64,
+      "TILE_SIZE_MAX": 64
+    }
+  },
   "attn_3d": {
     "D_GEQ_512": {
       "BLOCK_M": 16,

--- a/aiter/ops/triton/utils/unified_attention_utils.py
+++ b/aiter/ops/triton/utils/unified_attention_utils.py
@@ -25,15 +25,26 @@ that exists: LEQ bounds ascending, then GEQ descending, then "any". So the
 leftmost axis wins: D before Q is what makes head_size outrank max_seqlen_q.
 Dtypes fall back too: DT_fp8_fp8, then DT_fp8_any, DT_any_fp8, then "any".
 
+Because the leftmost axis wins outright, D_GEQ_256 beats D_GEQ_129.Q_GEQ_256 at
+head_size 256 despite saying less. An entry narrowing a rightward axis has to be
+repeated at every bound of a leftward one, which is why some keys differ only in
+that.
+
 A section with no axes, like reduce above, is just a config.
 
 Tile size and number of splits (segments) are derived from the following parameters:
 TILE_SIZE_MIN/MAX, and MIN_SEGMENTS/MAX_SEGMENTS/SEGMENTS_PER_CU.
+
+An "<op>.OPT_IN" section holds entries that exist only when the user opts in
+(_load); a LARGE_KV block inside one applies only above a KV cache size
+(_resolve_large_kv).
 """
 
 import copy
+import dataclasses
 import functools
 import itertools
+import os
 
 import torch
 import triton
@@ -43,7 +54,10 @@ from aiter.ops.triton.utils.config_utils import (
     load_config_json,
     resolve_config_dir,
 )
+from aiter.ops.triton.utils.logger import AiterTritonLogger
 from aiter.ops.triton.utils.types import e4m3_dtype
+
+_LOGGER = AiterTritonLogger()
 
 _CONFIG_NAME = "UNIFIED-ATTENTION"
 _OPS = ("attn_2d", "attn_3d", "reduce", "kv_split")
@@ -140,6 +154,80 @@ def _lookup(table: dict, axes: tuple, values: dict) -> tuple:
     )
 
 
+# Opt-in section suffix, and the env var that admits it. Unset, the table loads
+# exactly as written. These configs trade occupancy for registers and are tuned
+# against one shape family, so whether that suits a deployment is its own call.
+_OPT_IN = ".OPT_IN"
+
+_USE_OPT_IN = os.environ.get("AITER_TRITON_UA_FAST_PATH", "") not in (
+    "",
+    "0",
+    "false",
+    "False",
+)
+
+_LARGE_KV = "LARGE_KV"
+
+# Below this the backend indexes the cache with 32-bit buffer ops, and against
+# that different code the LARGE_KV overrides invert: gfx950 d=256 prefill runs
+# 6.2 -> 4.7ms above the limit, 5.2 -> 14.9ms below. The crossover is exact.
+_BUFFER_OP_LIMIT = 2**31
+
+# Compiler options only newer Triton takes, so a LARGE_KV block naming one is
+# skipped where the backend has no such option.
+_OPTIONAL_COMPILER_OPTIONS = frozenset(("llvm_fn_attrs", "schedule_hint"))
+
+
+@functools.lru_cache(maxsize=1)
+def _compiler_option_names() -> frozenset:
+    """Compiler options the installed Triton takes as launch kwargs, if askable."""
+    try:
+        from triton.compiler.compiler import make_backend
+        from triton.runtime.driver import driver
+
+        backend = make_backend(driver.active.get_current_target())
+        return frozenset(f.name for f in dataclasses.fields(backend.parse_options({})))
+    except (ImportError, AttributeError, TypeError, RuntimeError):
+        # older Triton, unfamiliar backend, or no GPU: decline rather than risk
+        # a launch the backend rejects
+        return frozenset()
+
+
+def _resolve_large_kv(config: dict, params) -> dict:
+    """Apply an entry's LARGE_KV overrides, if the cache is large enough for them.
+
+    They lose about threefold below _BUFFER_OP_LIMIT, and cost bf16 sixfold at
+    any size, so only DT_fp8_fp8 entries carry them. Counting elements rather
+    than bytes leaves a borderline cache on the safe side of the limit.
+    """
+    large_kv = config.pop(_LARGE_KV, None)
+    if large_kv is None:
+        return config
+
+    unsupported = sorted(
+        _OPTIONAL_COMPILER_OPTIONS.intersection(large_kv) - _compiler_option_names()
+    )
+    if unsupported:
+        _LOGGER.warning(
+            "unified attention: this Triton takes no %s, so the opt-in entry's "
+            "large-KV overrides are unavailable",
+            ", ".join(unsupported),
+        )
+        return config
+
+    if params.k.numel() < _BUFFER_OP_LIMIT:
+        _LOGGER.debug(
+            "unified attention: KV cache of %d elements is under the %d the "
+            "large-KV overrides need",
+            params.k.numel(),
+            _BUFFER_OP_LIMIT,
+        )
+        return config
+
+    config.update(large_kv)
+    return config
+
+
 def compute_tile_params(config: dict, block_size: int) -> dict:
     """Derive TILE_SIZE from the tuned bounds and the runtime page size."""
     if "TILE_SIZE_MIN" not in config and "TILE_SIZE_MAX" not in config:
@@ -186,6 +274,16 @@ def compute_segment_params(config: dict, params) -> dict:
     return config
 
 
+def _derive(config: dict, params) -> dict:
+    """Fill in the parts of a config that depend on the launch, not the key.
+
+    Only the trailing compute_tile_params call can be a repeat: it re-derives
+    TILE_SIZE if the large-KV overrides moved its bounds, and is a no-op if not.
+    """
+    config = compute_segment_params(config, params)
+    return compute_tile_params(_resolve_large_kv(config, params), params.block_size)
+
+
 def _axis_values(
     head_size,
     max_seqlen_q,
@@ -224,7 +322,13 @@ def _load(op: str, backend, arch) -> tuple:
         f"{_CONFIG_NAME}[{op}] in {cfg_dir}: schema names unknown axes {unknown} "
         f"(known: {sorted(_AXIS_KIND)})"
     )
-    return config[op], axes, cfg_dir
+
+    table = config[op]
+    if _USE_OPT_IN:
+        # A merge, not an edit: an opt-in key may be new to the table, and then
+        # has to enter the lookup as a candidate rather than replace a config.
+        table = {**table, **config.get(op + _OPT_IN, {})}
+    return table, axes, cfg_dir
 
 
 @functools.lru_cache(maxsize=1024 if USE_LRU_CACHE else 0)
@@ -292,9 +396,9 @@ def get_unified_attention_config(
         backend,
         arch,
     )
-    # NUM_SEGMENTS is derived out here rather than in the cached lookup: it
-    # reads the launch's program count, which is not part of the cache key.
-    return compute_segment_params(copy.deepcopy(config), params)
+    # Derived out here, not in the cached lookup: these read the launch's
+    # program count and KV cache, neither of which is in the cache key.
+    return _derive(copy.deepcopy(config), params)
 
 
 def explain(op: str, params, backend: str = "triton", arch: str | None = None) -> str:
@@ -311,9 +415,7 @@ def explain(op: str, params, backend: str = "triton", arch: str | None = None) -
         params.kv_cache_dtype,
     )
     key, config = _lookup(table, axes, values)
-    derived = compute_segment_params(
-        compute_tile_params(dict(config), params.block_size), params
-    )
+    derived = _derive(compute_tile_params(dict(config), params.block_size), params)
 
     lines = [
         f"{_CONFIG_NAME}[{op}]  {cfg_dir}",

--- a/aiter/ops/triton/utils/unified_attention_utils.py
+++ b/aiter/ops/triton/utils/unified_attention_utils.py
@@ -159,12 +159,7 @@ def _lookup(table: dict, axes: tuple, values: dict) -> tuple:
 # against one shape family, so whether that suits a deployment is its own call.
 _OPT_IN = ".OPT_IN"
 
-_USE_OPT_IN = os.environ.get("AITER_TRITON_UA_FAST_PATH", "") not in (
-    "",
-    "0",
-    "false",
-    "False",
-)
+_USE_OPT_IN = os.environ.get("AITER_TRITON_UA_FAST_PATH", "") == "1"
 
 _LARGE_KV = "LARGE_KV"
 


### PR DESCRIPTION
## Motivation

This PR covers a Triton regression raised in https://github.com/ROCm/aiter/issues/4137: Unified attention prefill regressed on gfx950 for head sizes 129 and above. On the Qwen3.5-397B debug shape the kernel went from about 4ms on Triton 3.6 to 16ms on 3.7 and 12ms on 3.8. This is due to three separate problems:

**Register pressure.** At `BLOCK_M=128` a head size in 129-255 pads to a 256-element accumulator, and the kernel needs about 470 VGPRs (it uses no LDS at all). `waves_per_eu=2` caps the budget at 256, so the excess spills to scratch inside the KV loop.

**An LLVM scheduler regression in Triton >= 3.7.** The same config that fit on 3.6 does not on 3.7+, which is what turned this from latent to visible. TTIR and TTGIR are byte-identical across the three versions and the LLVM IR instruction mix is the same; only the scratch size differs, so it is the AMDGPU machine scheduler producing longer live ranges, not anything in Triton's own passes.

**Config shadowing.** Because the lookup gives the leftmost axis priority, `D_GEQ_256` outranks `Q_GEQ_256`, so head sizes 256+ in prefill were picking a `BLOCK_M=16` entry meant for decode. That is why `d=256` was slower than `d=192` despite doing less work per program.

The goal is to fix all three without changing the default behavior so when a fix eventually lands in Triton, this change does not end up regressing the performance. The tuned configs trade occupancy for registers against one measured shape family, so they are exposed as an opt-in rather than made the default.

## Technical Details

Two files change: the gfx950 `DEFAULT.json` and `unified_attention_utils.py`.

**An opt-in config section.** A new `attn_2d.OPT_IN` section holds the retuned prefill entries and is merged into the lookup only when `AITER_TRITON_UA_FAST_PATH=1`. With the variable unset nothing changes: the section is never consulted, and all five pre-existing sections of `DEFAULT.json` are byte-identical to before. The core fix in these entries is `waves_per_eu=1`, which lifts the VGPR budget from 256 to 512 and eliminates the spill. It is scoped to head sizes 129+ (`D_GEQ_129` / `D_GEQ_256` keys) because sizes below that never spilled, and halving their occupancy target only costs them speed.

**The AMD backend workaround.** On top of the register fix, the opt-in entries can pass `amdgpu-sched-strategy=iterative-minreg` through Triton's `llvm_fn_attrs` option. This overrides the AMDGPU machine scheduler with a register-minimising strategy, recovering a further ~25% on large caches. It is not unconditionally good, so it sits in a `LARGE_KV` sub-block behind three guards:

- **Cache size.** Under `2**31` elements the backend indexes the cache with 32-bit buffer ops instead of 64-bit global loads. Against that different code the attribute costs about 3x rather than saving 25%. The guard counts elements, so if what the backend really tests is bytes, a borderline cache is declined rather than wrongly taken.
- **Dtype.** The overrides pay off for fp8 and cost bf16 about sixfold, so only the `DT_fp8_fp8` keys carry them.
- **Triton support.** `llvm_fn_attrs` is read off the backend's own options rather than inferred from a version number, and the block is skipped with a warning where the option does not exist.

## Test Plan

A standalone harness replays the Qwen3.5-397B debug shape and swaps configs through the lookup:

- **Coverage sweep** across head sizes 64-512, both prefill and decode, small (128-block) and large (4795-block) KV caches, fp8 and bf16, with the flag both unset and set. Each run reports the matched config entry, p50 latency, and the compiled kernel's scratch (register spill) bytes.
- **Guard tests** that exercise each of the three `LARGE_KV` gates: large cache with the option supported (applies), small cache (size guard declines), and a backend without `llvm_fn_attrs` (support guard declines). Also asserts the `LARGE_KV` sub-block never leaks into the launched config.
- **Numerics check** comparing the opt-in base and the large-KV overrides for bitwise-identical output, since the overrides only move scheduling and occupancy.
- **Regression guard on the default** by diffing every pre-existing section of `DEFAULT.json` against `HEAD` to confirm the flag-off path is untouched.

## Test Result

All pre-existing `DEFAULT.json` sections are byte-identical to `HEAD`; the only addition is `attn_2d.OPT_IN`. The guard tests pass (overrides apply only on a large fp8 cache with a supporting Triton, and never leak), and the opt-in base and large-KV overrides are bitwise identical.

gfx950, fp8, prefill. Small cache is 128 blocks, large is 4795. Each cell is p50 latency in ms (±0.1-0.2 ms run to run), with kernel scratch (register spill) in bytes in parentheses; "unchanged" means the opt-in section holds no entry for that head size, so the flag has no effect.

| head size | off, small cache (ms) | off, large cache (ms) | on, small cache (ms) | on, large cache (ms) |
|---|---|---|---|---|
| 64, 128 | 2.5-2.9 | 2.5-3.1 | unchanged | unchanged |
| 160, 192, 224 | 5.2-5.3 (132 B) | 12.1-12.2 (288 B) | 5.3 (0 B) | 4.6 (20 B) |
| 256 | 10.0 | 12.5 | 5.2 (0 B) | 4.7 (20 B) |
| 512 | 24.8 | 28.9 | unchanged | unchanged |

bf16, same shape, large cache is 2400 blocks. bf16 stays on the opt-in base config, since the large-KV overrides do not apply to it:

| head size | off, small cache (ms) | off, large cache (ms) | on, small cache (ms) | on, large cache (ms) |
|---|---|---|---|---|
| 192 | 11.7 (236 B) | 31.1 (920 B) | 7.1 (0 B) | 8.7 (0 B) |
| 256 | 25.0 | 34.8 | 7.2 (0 B) | 8.7 (0 B) |

Spill drops from up to 920 B to at most 20 B on every affected head size (0 B except on the fp8 large cache, where the minreg override leaves 20 B). The `d=256` bf16 row is the shadowing fix on its own; the `d=192` row is the register fix, worth 3.6x on the large cache. Decode is untouched under both settings, as are head sizes 64, 128 and 512.

## Notes and follow-ups

- The opt-in section has four entries where two would do. `D_GEQ_256` shadows `D_GEQ_129.Q_GEQ_256`, so the config has to be repeated at each `D` bound, and again split by dtype because only fp8 takes the `LARGE_KV` block.
- These configs were tuned against one shape family. `waves_per_eu=1` trades occupancy for registers, which is why this is opt-in rather than the default.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/TheRock/blob/main/GOVERNANCE.md#pull-requests.
