### PR TITLE
[Perf] Optimize MiniMax M3 MXFP8 route quantization

### DIFF
--- a/aiter/fused_moe.py
+++ b/aiter/fused_moe.py
@@ -380,6 +380,7 @@ def _moe_sorting_impl(
     dispatch_policy,
     use_opus,
     return_local_topk_ids=False,
+    return_reverse_sorted=False,
     accumulate=True,
     output_aux=False,
     output=None,
@@ -426,20 +427,21 @@ def _moe_sorting_impl(
     else:
         moe_buf = torch.empty((0, 0), dtype=moebuf_dtype, device=device)
     local_topk_ids = torch.empty_like(topk_ids) if return_local_topk_ids else None
-    if return_local_topk_ids:
+    if return_local_topk_ids or return_reverse_sorted:
         # CK sorting does not emit local ids; use Opus so callers do not need a slow
-        # Python-side remap or a hard failure when local expert ids are required.
+        # Python-side remap or reverse-map reconstruction.
         use_opus = True
 
     aux_m_indices = None
     aux_reverse_sorted = None
-    if output_aux:
+    if output_aux or return_reverse_sorted:
         use_opus = True
+        aux_reverse_sorted = torch.empty(M * topk, dtype=dtypes.i32, device=device)
+    if output_aux:
         dispatch_policy = 1
         aux_m_indices = torch.empty(
             max_num_tokens_padded, dtype=dtypes.i32, device=device
         )
-        aux_reverse_sorted = torch.empty(M * topk, dtype=dtypes.i32, device=device)
 
     if use_opus:
         ws_size = aiter.moe_sorting_opus_get_workspace_size(
@@ -486,8 +488,12 @@ def _moe_sorting_impl(
     ret = (sorted_ids, sorted_weights, sorted_expert_ids, num_valid_ids, moe_buf)
     if output_aux:
         return (*ret, aux_m_indices, aux_reverse_sorted)
+    if return_local_topk_ids and return_reverse_sorted:
+        return (*ret, local_topk_ids, aux_reverse_sorted)
     if return_local_topk_ids:
         return (*ret, local_topk_ids)
+    if return_reverse_sorted:
+        return (*ret, aux_reverse_sorted)
     return ret
 
 
@@ -558,6 +564,7 @@ def moe_sorting(
     num_local_tokens=None,
     dispatch_policy=0,
     return_local_topk_ids=False,
+    return_reverse_sorted=False,
     accumulate=True,
     flat=False,
     output_aux=False,
@@ -567,6 +574,7 @@ def moe_sorting(
         not _USE_CK_MOE_SORTING
         and _USE_FLYDSL_MOE_SORTING
         and not return_local_topk_ids
+        and not return_reverse_sorted
         and not flat
         and not output_aux
         and dispatch_policy == 0
@@ -603,6 +611,7 @@ def moe_sorting(
             dispatch_policy,
             use_opus=not _USE_CK_MOE_SORTING,
             return_local_topk_ids=return_local_topk_ids,
+            return_reverse_sorted=return_reverse_sorted,
             accumulate=accumulate,
             output_aux=output_aux,
             output=output,
@@ -1209,6 +1218,22 @@ def _fused_moe_impl(
         "gfx942",
         "gfx950",
     ), f"FLAT fmoe asm kernels are gfx942/gfx950-only; refusing to launch on {get_gfx()}. "
+    use_mxfp8_route_quant = (
+        not metadata.run_1stage
+        and not metadata.flat
+        and quant_type == QuantType.per_1x32
+        and q_dtype_a == dtypes.fp8
+        and q_dtype_w == dtypes.fp8
+        and global_E == 129
+        and model_dim == 6144
+        and inter_dim in (384, 768)
+        and topk == 5
+        and M <= 32
+        and gate_mode == GateMode.INTERLEAVE
+        and expert_mask is None
+        and not _USE_CK_MOE_SORTING
+        and os.environ.get("AITER_MXFP8_ROUTE_QUANT", "1") == "1"
+    )
 
     sort_m_indices = None
     sort_reverse_sorted = None
@@ -1273,11 +1298,22 @@ def _fused_moe_impl(
             num_local_tokens,
             moe_sorting_dispatch_policy,
             return_local_topk_ids=need_local_topk_ids,
+            return_reverse_sorted=use_mxfp8_route_quant,
             accumulate=not stage2_uses_route_reduce(metadata.stage2),
             flat=metadata.flat,
             output=None if metadata.flat else output,
         )
-        if need_local_topk_ids:
+        if use_mxfp8_route_quant:
+            (
+                sorted_ids,
+                sorted_weights,
+                sorted_expert_ids,
+                num_valid_ids,
+                moe_buf,
+                sort_reverse_sorted,
+            ) = sorting_ret
+            local_topk_ids = None
+        elif need_local_topk_ids:
             (
                 sorted_ids,
                 sorted_weights,
@@ -3494,6 +3530,16 @@ def fused_moe_2stages(
                 num_valid_ids=num_valid_ids,
                 token_num=token_num,
                 cols=model_dim,
+            )
+        elif reverse_sorted is not None and w1.dtype == dtypes.fp8:
+            from aiter.ops.quant import fused_dynamic_mxfp8_quant_moe_route
+
+            a1, a1_scale = fused_dynamic_mxfp8_quant_moe_route(
+                hidden_states,
+                sorted_ids=sorted_ids,
+                reverse_sorted=reverse_sorted,
+                token_num=token_num,
+                topk=topk,
             )
         else:
             # stage1 input is not topk-replicated, so M==token_num and the HIP

--- a/aiter/ops/quant.py
+++ b/aiter/ops/quant.py
@@ -929,6 +929,19 @@ def fused_dynamic_mx_quant_moe_sort_hip_bounded(
 
 
 @compile_ops("module_quant", develop=True)
+def fused_dynamic_mxfp8_quant_moe_route_hip(
+    out: torch.Tensor,
+    scales: torch.Tensor,
+    input: torch.Tensor,
+    reverse_sorted: torch.Tensor,
+    token_num: int,
+    topk: int,
+    group_size: int = 32,
+) -> None:
+    """Quantize each token once and scatter its e8m0 scale to routed rows."""
+
+
+@compile_ops("module_quant", develop=True)
 def quant_mxfp4(
     inp: torch.Tensor,
     out_packed: torch.Tensor,
@@ -1170,6 +1183,44 @@ def fused_dynamic_mx_quant_moe_sort(
         mxfp4_moe_sort_hip(
             scale, scale_per_token, sorted_ids, num_valid_ids, token_num, N
         )
+    return out, scale
+
+
+def fused_dynamic_mxfp8_quant_moe_route(
+    input: torch.Tensor,
+    sorted_ids: torch.Tensor,
+    reverse_sorted: torch.Tensor,
+    token_num: int,
+    topk: int,
+    group_size: int = 32,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Quantize token-major BF16/FP16 input once and scatter scales by route."""
+    if input.shape[0] != token_num:
+        raise ValueError(
+            f"stage1 input rows ({input.shape[0]}) must equal token_num ({token_num})"
+        )
+    if sorted_ids.device != input.device or reverse_sorted.device != input.device:
+        raise ValueError("input, sorted_ids, and reverse_sorted must share a device")
+    if reverse_sorted.dtype != dtypes.i32 or reverse_sorted.numel() < token_num * topk:
+        raise ValueError(
+            "reverse_sorted must be a contiguous int32 tensor with token_num*topk entries"
+        )
+    if not reverse_sorted.is_contiguous():
+        raise ValueError("reverse_sorted must be contiguous")
+    if group_size != 32:
+        raise ValueError(f"only group_size=32 is supported, got {group_size}")
+
+    cols = input.shape[-1]
+    scale_cols = ((cols + group_size - 1) // group_size + 7) // 8 * 8
+    out = torch.empty((token_num, cols), dtype=dtypes.fp8, device=input.device)
+    scale = torch.empty(
+        ((sorted_ids.shape[0] + 31) // 32 * 32, scale_cols),
+        dtype=dtypes.fp8_e8m0,
+        device=input.device,
+    )
+    fused_dynamic_mxfp8_quant_moe_route_hip(
+        out, scale, input, reverse_sorted, token_num, topk, group_size
+    )
     return out, scale
 
 

--- a/csrc/include/quant.h
+++ b/csrc/include/quant.h
@@ -129,6 +129,15 @@ void fused_dynamic_mx_quant_moe_sort_hip_bounded(
     int group_size = 32,
     std::optional<aiter_tensor_t> sorted_weights = std::nullopt);
 
+void fused_dynamic_mxfp8_quant_moe_route_hip(
+    aiter_tensor_t& out,
+    aiter_tensor_t& scales,
+    const aiter_tensor_t& input,
+    const aiter_tensor_t& reverse_sorted,
+    int token_num,
+    int topk,
+    int group_size = 32);
+
 void mxfp4_moe_sort_hip(aiter_tensor_t& out_scale,
                          const aiter_tensor_t& scale,
                          const aiter_tensor_t& sorted_ids,

--- a/csrc/include/rocm_ops.hpp
+++ b/csrc/include/rocm_ops.hpp
@@ -1710,6 +1710,15 @@ namespace py = pybind11;
           py::arg("num_experts_upper_bound"),                            \
           py::arg("group_size")     = 32,                                \
           py::arg("sorted_weights") = py::none());                       \
+    m.def("fused_dynamic_mxfp8_quant_moe_route_hip",                     \
+          &aiter::fused_dynamic_mxfp8_quant_moe_route_hip,               \
+          py::arg("out"),                                                \
+          py::arg("scales"),                                             \
+          py::arg("input"),                                              \
+          py::arg("reverse_sorted"),                                     \
+          py::arg("token_num"),                                          \
+          py::arg("topk"),                                               \
+          py::arg("group_size") = 32);                                   \
     m.def("mxfp4_moe_sort_hip",                                          \
           &aiter::mxfp4_moe_sort_hip,                                    \
           py::arg("out_scale"),                                          \

--- a/csrc/kernels/quant_kernels.cu
+++ b/csrc/kernels/quant_kernels.cu
@@ -1902,6 +1902,93 @@ __global__ void fused_mx_quant_moe_sort_kernel(
     }
 }
 
+template <typename DTYPE_I, int block_size, int thread_data_size = 16>
+__global__ void fused_mxfp8_quant_moe_route_kernel(
+    opus::fp8_t* __restrict__ out,
+    uint8_t* __restrict__ scale,
+    DTYPE_I const* __restrict__ input,
+    int32_t const* __restrict__ reverse_sorted,
+    const int32_t num_tokens,
+    const int32_t topk,
+    const int32_t cols,
+    const int32_t group_size,
+    const int32_t scale_rows,
+    const int32_t input_stride,
+    const int32_t num_col_tiles)
+{
+    const int32_t token_idx  = blockIdx.x / num_col_tiles;
+    const int32_t col_tile   = blockIdx.x % num_col_tiles;
+    const int32_t col_offset = col_tile * block_size * thread_data_size;
+    if(token_idx >= num_tokens)
+    {
+        return;
+    }
+
+    const int32_t num_thread_per_group = group_size / thread_data_size;
+    const int32_t scale_k =
+        col_offset / group_size + threadIdx.x / num_thread_per_group;
+    const int32_t tile_cols = min(cols - col_offset, block_size * thread_data_size);
+    static constexpr int32_t vec_size_i =
+        thread_data_size == 0 ? 16 / sizeof(DTYPE_I) : thread_data_size;
+    static constexpr int32_t load_chunk_bytes =
+        (sizeof(DTYPE_I) * vec_size_i % 16 == 0
+             ? 16
+             : (sizeof(DTYPE_I) * vec_size_i % 8 == 0 ? 8 : 4));
+    using vec_i = opus::vector_t<DTYPE_I, vec_size_i>;
+    using vec_f = opus::vector_t<float, vec_size_i>;
+
+    const int32_t scaleN_valid = (cols + group_size - 1) / group_size;
+    const int32_t scaleN_pad   = ((scaleN_valid + 7) / 8) * 8;
+    auto buffer_input = opus::make_gmem<DTYPE_I>(
+        input + static_cast<int64_t>(token_idx) * input_stride + col_offset,
+        tile_cols * sizeof(DTYPE_I));
+    vec_i vec_input = load_vector_nbytes<DTYPE_I, vec_size_i, load_chunk_bytes, RT>(
+        buffer_input, threadIdx.x * vec_size_i);
+    vec_f vec_input_f;
+    float* input_f_ptr = reinterpret_cast<float*>(&vec_input_f);
+    float absMax       = 1e-10f;
+#pragma unroll
+    for(int j = 0; j < vec_size_i; j++)
+    {
+        vec_input_f[j] = static_cast<float>(vec_input[j]);
+        absMax         = max(absMax, abs(vec_input_f[j]));
+    }
+    absMax = multithread_reduce(absMax, aiter::Max(), num_thread_per_group);
+
+    constexpr aiter::MxDtype kHwFp8Dtype =
+#if defined(__gfx942__)
+        aiter::MxDtype::FP8_E4M3_FNUZ;
+#else
+        aiter::MxDtype::FP8_E4M3;
+#endif
+    const float row_scale =
+        aiter::fp_f32_to_e8m0_scale<aiter::kDefaultMxScaleRoundMode, kHwFp8Dtype>(
+            absMax);
+
+    if(threadIdx.x % num_thread_per_group == 0 && scale_k < scaleN_valid)
+    {
+        const uint8_t bs_e8m0 =
+            (__builtin_bit_cast(uint32_t, row_scale) >> 23) & 0xFF;
+        for(int32_t route = 0; route < topk; route++)
+        {
+            const int32_t sorted_row = reverse_sorted[token_idx * topk + route];
+            if(sorted_row >= 0 && sorted_row < scale_rows)
+            {
+                const int32_t addr =
+                    aiter::mx_scale_shuffle_idx(scaleN_pad, sorted_row, scale_k);
+                scale[addr] = bs_e8m0;
+            }
+        }
+    }
+
+    scaled_quant_vgpr_impl<float, opus::fp8_t, thread_data_size>(
+        out + static_cast<int64_t>(token_idx) * cols + col_offset,
+        input_f_ptr,
+        &row_scale,
+        tile_cols,
+        0);
+}
+
 
 #define FUSED_MX_QUANT_MOE_SORT_KERNEL_IMPL(DTYPE_O, THREAD_DATA, BLOCK_SIZE)                       \
     AITER_DISPATCH_FLOATING16_TYPES_rmTorch(input.dtype(), "fused_mx_quant_moe_sort_kernel", [&] {  \
@@ -2076,6 +2163,85 @@ void fused_dynamic_mx_quant_moe_sort_hip_bounded(aiter_tensor_t& output,
                                              group_size,
                                              sorted_weights,
                                              padded_rows_upper_bound);
+}
+
+void fused_dynamic_mxfp8_quant_moe_route_hip(aiter_tensor_t& output,
+                                             aiter_tensor_t& scale,
+                                             const aiter_tensor_t& input,
+                                             const aiter_tensor_t& reverse_sorted,
+                                             int token_num,
+                                             int topk,
+                                             int group_size)
+{
+    AITER_CHECK(output.dtype() == AITER_DTYPE_fp8, __func__, " output must be fp8");
+    AITER_CHECK(reverse_sorted.dtype() == AITER_DTYPE_i32,
+                __func__,
+                " reverse_sorted must be int32");
+    AITER_CHECK(scale.dtype() == AITER_DTYPE_fp8_e8m0 ||
+                    scale.dtype() == AITER_DTYPE_u8,
+                __func__,
+                " scale must use byte e8m0 storage");
+    AITER_CHECK(output.device_id == input.device_id &&
+                    scale.device_id == input.device_id &&
+                    reverse_sorted.device_id == input.device_id,
+                __func__,
+                " all tensors must be on the same device");
+    AITER_CHECK(reverse_sorted.numel() >= static_cast<int64_t>(token_num) * topk,
+                __func__,
+                " reverse_sorted is too small");
+    AITER_CHECK(token_num > 0, __func__, " token_num must be positive");
+    AITER_CHECK(topk > 0, __func__, " topk must be positive");
+    AITER_CHECK(group_size == 32, __func__, " only group_size=32 is supported");
+    AITER_CHECK(output.is_contiguous() && scale.is_contiguous() &&
+                    reverse_sorted.is_contiguous(),
+                __func__,
+                " output, scale, and reverse_sorted must be contiguous");
+    AITER_CHECK(input.stride(-1) == 1, __func__, " input rows must be contiguous");
+
+    const int cols         = input.size(-1);
+    const int input_stride = input.stride(-2);
+    const int scale_rows   = scale.size(0);
+    const int scale_cols   = (cols / group_size + 7) / 8 * 8;
+    AITER_CHECK(input.size(0) >= token_num, __func__, " input has too few rows");
+    AITER_CHECK(scale_rows > 0, __func__, " scale must have at least one row");
+    AITER_CHECK(output.numel() >= static_cast<int64_t>(token_num) * cols,
+                __func__,
+                " output is too small");
+    AITER_CHECK(scale.dim() == 2 && scale.size(1) >= scale_cols,
+                __func__,
+                " scale has insufficient columns");
+    AITER_CHECK(scale.numel() >= static_cast<int64_t>(scale_rows) * scale_cols,
+                __func__,
+                " scale storage is too small");
+    AITER_CHECK(cols % group_size == 0, __func__, " input width must be group aligned");
+    static constexpr int route_block_size = 256;
+    static constexpr int route_thread_data = 8;
+    static constexpr int cols_per_block = route_block_size * route_thread_data;
+    const int num_col_tiles = (cols + cols_per_block - 1) / cols_per_block;
+    HipDeviceGuard device_guard(input.device_id);
+    const hipStream_t stream = aiter::getCurrentHIPStream();
+    AITER_DISPATCH_FLOATING16_TYPES_rmTorch(
+        input.dtype(), "fused_mxfp8_quant_moe_route_kernel", [&] {
+            using input_dtype = typename aiter::hip2opus<scalar_t>::type;
+            fused_mxfp8_quant_moe_route_kernel<
+                input_dtype,
+                route_block_size,
+                route_thread_data>
+                <<<dim3(token_num * num_col_tiles),
+                   dim3(route_block_size),
+                   0,
+                   stream>>>(reinterpret_cast<opus::fp8_t*>(output.data_ptr()),
+                             reinterpret_cast<uint8_t*>(scale.data_ptr()),
+                             reinterpret_cast<input_dtype const*>(input.data_ptr()),
+                             reinterpret_cast<int32_t const*>(reverse_sorted.data_ptr()),
+                             token_num,
+                             topk,
+                             cols,
+                             group_size,
+                             scale_rows,
+                             input_stride,
+                             num_col_tiles);
+        });
 }
 
 // Perf gate threshold for the coalesced LDS-staged store path in

--- a/op_tests/test_moe_mxfp8_route_quant.py
+++ b/op_tests/test_moe_mxfp8_route_quant.py
@@ -1,0 +1,94 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+import pytest
+import torch
+
+from aiter import dtypes
+from aiter.fused_moe import moe_sorting
+from aiter.jit.utils.chip_info import get_gfx
+from aiter.ops.quant import (
+    fused_dynamic_mxfp8_quant_moe_route,
+    fused_dynamic_mxfp8_quant_moe_sort,
+)
+
+pytestmark = [
+    pytest.mark.skipif(not torch.cuda.is_available(), reason="requires a ROCm device"),
+    pytest.mark.skipif(get_gfx() != "gfx950", reason="requires gfx950 MXFP8"),
+]
+
+
+def _scale_indices(rows, valid_cols, padded_cols):
+    row = rows.to(torch.int64)[:, None]
+    col = torch.arange(valid_cols, device=rows.device, dtype=torch.int64)[None, :]
+    return (
+        (row // 32 * padded_cols) * 32
+        + (col // 8) * 256
+        + (col % 4) * 64
+        + (row % 16) * 4
+        + (col % 8 // 4) * 2
+        + (row % 32 // 16)
+    ).reshape(-1)
+
+
+@pytest.mark.parametrize("tokens", [1, 8, 32])
+def test_route_quant_matches_sorted_row_quant(tokens):
+    torch.manual_seed(tokens)
+    hidden_dim, experts, topk = 6144, 129, 5
+    hidden = torch.randn((tokens, hidden_dim), dtype=dtypes.bf16, device="cuda")
+    topk_ids = torch.topk(
+        torch.rand((tokens, experts), device="cuda"), topk, dim=-1
+    ).indices.to(dtypes.i32)
+    topk_weights = torch.rand((tokens, topk), dtype=torch.float32, device="cuda")
+    (
+        sorted_ids,
+        sorted_weights,
+        _,
+        num_valid_ids,
+        _,
+        reverse_sorted,
+    ) = moe_sorting(
+        topk_ids,
+        topk_weights,
+        experts,
+        hidden_dim,
+        dtypes.bf16,
+        block_size=32,
+        return_reverse_sorted=True,
+    )
+
+    expected_out, expected_scale = fused_dynamic_mxfp8_quant_moe_sort(
+        hidden,
+        sorted_ids,
+        num_valid_ids,
+        tokens,
+        topk,
+        32,
+        sorted_weights=sorted_weights,
+        num_experts_upper_bound=experts,
+    )
+    actual_out, actual_scale = fused_dynamic_mxfp8_quant_moe_route(
+        hidden, sorted_ids, reverse_sorted, tokens, topk
+    )
+    torch.cuda.synchronize()
+
+    assert torch.equal(expected_out.view(torch.uint8), actual_out.view(torch.uint8))
+    indices = _scale_indices(reverse_sorted, hidden_dim // 32, expected_scale.shape[1])
+    assert torch.equal(
+        expected_scale.view(torch.uint8).reshape(-1)[indices],
+        actual_scale.view(torch.uint8).reshape(-1)[indices],
+    )
+
+    if tokens == 8:
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph):
+            graph_out, graph_scale = fused_dynamic_mxfp8_quant_moe_route(
+                hidden, sorted_ids, reverse_sorted, tokens, topk
+            )
+        graph.replay()
+        torch.cuda.synchronize()
+        assert torch.equal(expected_out.view(torch.uint8), graph_out.view(torch.uint8))
+        assert torch.equal(
+            expected_scale.view(torch.uint8).reshape(-1)[indices],
+            graph_scale.view(torch.uint8).reshape(-1)[indices],
+        )


### PR DESCRIPTION
## Summary

- add a token-parallel MXFP8 stage1 quantizer for MiniMax-M3 that quantizes each hidden row once instead of once per routed expert
- reuse the Opus sorter's reverse route map to scatter byte-exact e8m0 scales into the existing GEMM layout
- split each 6144-wide token over three CTAs to improve low-M occupancy
- enable only for the exact MiniMax-M3 MXFP8 shape at M<=32; M64+, EP, flat, one-stage, CK sorting, and non-interleaved paths keep the existing implementation
- retain `AITER_MXFP8_ROUTE_QUANT=0` as an opt-out

No tuned CSV changes are required.

## Performance

MI355X (`gfx950`, 256 CUs), full `fused_moe` HIP Graph replay over M=1/2/4/8/16/32/64 and inter=384/768:

- random routing: 1.0129x geomean (0.9864x min, 1.0277x max)
- balanced routing: 1.0006x geomean (0.9879x min, 1.0170x max)
- hotspot routing: 1.0308x geomean (0.9984x min, 1.0954x max)
- combined routing geomean: about 1.015x

M64 uses the existing path and is included in the reported gate.

## Validation

- byte-exact FP8 payload and routed e8m0 scale comparison at M=1/8/32
- CUDA/HIP Graph capture and replay test
- MiniMax-M3 public `fused_moe` coverage at M=1/8/32/64 for inter=384/768
- random, balanced, and hotspot routing graph A/B
- Black, Ruff 0.16.0, Python syntax, and `git diff --check`
- rebuilt `module_quant` from source on gfx950

A full model accuracy run was not performed because this cluster currently has only the MiniMax-M3-MXFP4 checkpoint, not an MXFP8 checkpoint. The quant payload and scale outputs are byte-identical to the existing implementation.