### PR TITLE
[CI] CI: require label for extended tests

### DIFF
--- a/.github/workflows/extended-test.yaml
+++ b/.github/workflows/extended-test.yaml
@@ -23,11 +23,7 @@ jobs:
     if: >-
       github.event.pull_request.head.repo.fork == false &&
       github.event.pull_request.head.repo.full_name == github.repository &&
-      (
-        contains(github.event.pull_request.title, 'gfx1250') ||
-        contains(github.event.pull_request.title, 'GFX1250') ||
-        contains(github.event.pull_request.labels.*.name, 'ci:extended-test')
-      ) &&
+      contains(github.event.pull_request.labels.*.name, 'ci:extended-test') &&
       (github.event.action != 'labeled' || github.event.label.name == 'ci:extended-test')
     runs-on: linux-aiter-build-mi250
 


### PR DESCRIPTION
## Summary
- Temporarily remove title-based extended test dispatch for `gfx1250`/`GFX1250` PR titles.
- Keep explicit `ci:extended-test` label dispatch unchanged.

## Validation
- Parsed `.github/workflows/extended-test.yaml` with Python YAML.
- Ran bash syntax checks for all workflow `run:` blocks.
- Ran actionlint, ignoring only the existing custom runner label warning for `linux-aiter-build-mi250`.
- Ran `git diff --check`.