### PR TITLE
Tune gfx942 BF16 sliding-window unified-attention decode

### DIFF
--- a/aiter/ops/triton/configs/gfx942/triton/attention/unified_attention/DEFAULT.json
+++ b/aiter/ops/triton/configs/gfx942/triton/attention/unified_attention/DEFAULT.json
@@ -3,6 +3,7 @@
     "attn_2d": [
       "D",
       "Q",
+      "SW",
       "DT"
     ],
     "attn_3d": [
@@ -40,6 +41,14 @@
       "waves_per_eu": 2,
       "TILE_SIZE_MIN": 32,
       "TILE_SIZE_MAX": 64
+    },
+    "D_GEQ_256.Q_LEQ_1.SW.DT_bf16_bf16": {
+      "BLOCK_M": 16,
+      "num_warps": 4,
+      "num_stages": 3,
+      "waves_per_eu": 1,
+      "TILE_SIZE_MIN": 32,
+      "TILE_SIZE_MAX": 32
     },
     "D_GEQ_256.Q_LEQ_1": {
       "BLOCK_M": 16,


### PR DESCRIPTION
## Summary

Add a gfx942 unified-attention config for BF16, head-dim 256, single-token sliding-window decode. This is the dominant attention shape in Gemma 4 31B on MI325X (50 of 60 layers), and also matches Gemma-family sliding attention with a 1024-token window.

Adding `SW` to the lookup schema keeps this leaf separate from global attention, while `DT_bf16_bf16` prevents it from overriding the existing FP8 configuration. Other head dimensions, prefill, gfx950, and other architectures retain their existing entries.

## MI325X benchmark

Shape: 32 query heads, 16 KV heads, head dim 256, sliding window 1024, 8K paged context, block size 64. The test uses the current `ROCm/aiter` main wrapper and Triton kernel at `fcf34226d`; only this JSON differs between the two runs.

| Batch | Existing config | Tuned config | Speedup |
|---:|---:|---:|---:|
| 1 | 198.92 us | 52.96 us | 3.76x |
| 8 | 231.12 us | 59.54 us | 3.88x |
| 16 | 328.29 us | 77.62 us | 4.23x |
| 32 | 552.54 us | 161.44 us | 3.42x |

For comparison, vLLM v0.28's in-tree Triton unified-attention implementation measures 59.87/63.89/78.47/166.53 us at B1/B8/B16/B32. The tuned AITER config reaches the same performance range.

D512 global attention is unchanged. A tested D512 specialization was slower and is not included.

## Numerics

Existing versus tuned output at B=1/8/16/32 with the same 8K shape:

- all outputs finite
- maximum absolute difference: 0.00097656
- cosine similarity: 0.9999992-0.9999993
- passes `atol=5e-3, rtol=5e-3`
