### PR TITLE
[Triton/Gluon] [GFX12] A4W4 MOE tune/optimize

### DIFF
--- a/aiter/ops/triton/_gluon_kernels/gfx1250/moe/moe_op_gemm_a4w4.py
+++ b/aiter/ops/triton/_gluon_kernels/gfx1250/moe/moe_op_gemm_a4w4.py
@@ -622,13 +622,18 @@ def _moe_gemm_a4w4_prefill(
     EP_SCATTER: gl.constexpr = False,
     # Row extent of the combine window, so an out-of-range index is droppable.
     Y_ROWS=0,
+    PRELOAD_X_SCALES: gl.constexpr = False,
+    XS_SLAB_COLS: gl.constexpr = 0,
 ):
     MX_PACK_DIVISOR: gl.constexpr = 32
     gl.static_assert(
         BLOCK_K % MX_PACK_DIVISOR == 0, "BLOCK_K must be a multiple of MX_PACK_DIVISOR"
     )
 
-    if X_SCALES_TDM:
+    # Preloading takes x scales out of the loop entirely
+    if PRELOAD_X_SCALES:
+        NUM_TDM_OPS: gl.constexpr = 3
+    elif X_SCALES_TDM:
         # via TDM: w, w scales, x, x scales
         NUM_TDM_OPS: gl.constexpr = 4
     else:
@@ -809,11 +814,51 @@ def _moe_gemm_a4w4_prefill(
     w_buffer = gl.allocate_shared_memory(
         w_desc.dtype, shape=[NUM_BUFFERS] + w_desc.block_shape, layout=w_desc.layout
     )
-    x_scales_buffer = gl.allocate_shared_memory(
-        x_scales_desc.dtype,
-        shape=[NUM_BUFFERS] + x_scales_desc.block_shape,
-        layout=x_scales_desc.layout,
-    )
+    if PRELOAD_X_SCALES:
+        XS_SLAB_LAYOUT: gl.constexpr = gl.SwizzledSharedLayout(
+            vec=1, per_phase=1, max_phase=1, order=[1, 0]
+        )
+        XS_SLOTS: gl.constexpr = XS_SLAB_COLS // MX_SCALE_BLOCK_K
+        xs_offs_kg = gl.arange(
+            0, MX_SCALE_BLOCK_K, layout=gl.SliceLayout(0, DOT_LAYOUT_X_SCALES)
+        )
+        xs_zeros_row = gl.zeros(
+            (PACKED_BLOCK_M_X,),
+            dtype=gl.int32,
+            layout=gl.SliceLayout(1, DOT_LAYOUT_X_SCALES),
+        )
+        gl.static_assert(
+            XS_SLAB_COLS % MX_SCALE_BLOCK_K == 0,
+            "XS_SLAB_COLS must be a whole number of MX_SCALE_BLOCK_K tiles",
+        )
+        gl.static_assert(XS_SLOTS >= 1, "x-scale slab needs at least one slot")
+        x_scales_slab = gl.allocate_shared_memory(
+            x_scales_desc.dtype,
+            shape=[PACKED_BLOCK_M_X, XS_SLAB_COLS],
+            layout=XS_SLAB_LAYOUT,
+        )
+        if GatherIndx is None:
+            xs_slab_desc = gl.amd.gfx1250.tdm.make_tensor_descriptor(
+                base=XMxScale,
+                shape=(M, gl.cdiv(K, MX_PACK_DIVISOR)),
+                strides=(stride_x_mx_m, stride_x_mx_k),
+                block_shape=(PACKED_BLOCK_M_X, XS_SLAB_COLS),
+                layout=XS_SLAB_LAYOUT,
+            )
+        else:
+            xs_slab_desc = gl.amd.gfx1250.tdm.make_tensor_descriptor(
+                base=XMxScale,
+                shape=(num_tokens, gl.cdiv(K, MX_PACK_DIVISOR)),
+                strides=(stride_x_mx_m, stride_x_mx_k),
+                block_shape=(PACKED_BLOCK_M_X, XS_SLAB_COLS),
+                layout=XS_SLAB_LAYOUT,
+            )
+    else:
+        x_scales_buffer = gl.allocate_shared_memory(
+            x_scales_desc.dtype,
+            shape=[NUM_BUFFERS] + x_scales_desc.block_shape,
+            layout=x_scales_desc.layout,
+        )
     w_scales_buffer = gl.allocate_shared_memory(
         w_scales_desc.dtype,
         shape=[NUM_BUFFERS] + w_scales_desc.block_shape,
@@ -825,6 +870,16 @@ def _moe_gemm_a4w4_prefill(
 
     num_k_iter = gl.cdiv(K, BLOCK_K)
 
+    if PRELOAD_X_SCALES:
+        if GatherIndx is None:
+            gl.amd.gfx1250.tdm.async_load(
+                xs_slab_desc, [offs_x_m, 0], x_scales_slab
+            )
+        else:
+            gl.amd.gfx1250.tdm.async_gather(
+                xs_slab_desc, offs_x_m, x_scales_slab
+            )
+
     # prologue: fill NUM_BUFFERS LDS slots via TDM
     for _ in gl.static_range(NUM_BUFFERS):
         if GatherIndx is None:
@@ -833,7 +888,7 @@ def _moe_gemm_a4w4_prefill(
                 [offs_x_m, 0],
                 x_buffer.index(load_idx % NUM_BUFFERS),
             )
-            if X_SCALES_TDM:
+            if X_SCALES_TDM and not PRELOAD_X_SCALES:
                 gl.amd.gfx1250.tdm.async_load(
                     x_scales_desc,
                     [offs_x_m, 0],
@@ -845,7 +900,7 @@ def _moe_gemm_a4w4_prefill(
                 offs_x_m,
                 x_buffer.index(load_idx % NUM_BUFFERS),
             )
-            if X_SCALES_TDM:
+            if X_SCALES_TDM and not PRELOAD_X_SCALES:
                 gl.amd.gfx1250.tdm.async_gather(
                     x_scales_desc,
                     offs_x_m,
@@ -861,7 +916,7 @@ def _moe_gemm_a4w4_prefill(
             [offs_w_n_scale, 0],
             w_scales_buffer.index(load_idx % NUM_BUFFERS),
         )
-        if not X_SCALES_TDM:
+        if not X_SCALES_TDM and not PRELOAD_X_SCALES:
             gl.amd.gfx1250.async_copy.global_to_shared(
                 x_scales_buffer.index(load_idx % NUM_BUFFERS),
                 x_scales_ptrs,
@@ -873,7 +928,7 @@ def _moe_gemm_a4w4_prefill(
         x_desc = gl.amd.gfx1250.tdm.update_tensor_descriptor(
             x_desc, add_offsets=[0, PACKED_BLOCK_K_X], clamp_bounds=CLAMP_BOUNDS
         )
-        if X_SCALES_TDM:
+        if X_SCALES_TDM and not PRELOAD_X_SCALES:
             x_scales_desc = gl.amd.gfx1250.tdm.update_tensor_descriptor(
                 x_scales_desc,
                 add_offsets=[0, MX_SCALE_BLOCK_K],
@@ -892,7 +947,7 @@ def _moe_gemm_a4w4_prefill(
 
     # preload tile 0 from LDS into registers
     gl.amd.gfx1250.tdm.async_wait((NUM_BUFFERS - 1) * NUM_TDM_OPS)
-    if not X_SCALES_TDM:
+    if not X_SCALES_TDM and not PRELOAD_X_SCALES:
         gl.amd.gfx1250.async_copy.wait_group(NUM_BUFFERS - 1)
     cur_x = x_buffer.index(wmma_idx % NUM_BUFFERS).load(layout=DOT_LAYOUT_X)
     if PRESHUFFLE_WEIGHTS:
@@ -913,9 +968,16 @@ def _moe_gemm_a4w4_prefill(
             .permute((1, 0))
             .load(layout=DOT_LAYOUT_W)
         )
-    cur_x_scales = x_scales_buffer.index(wmma_idx % NUM_BUFFERS).load(
-        layout=DOT_LAYOUT_X_SCALES
-    )
+    if PRELOAD_X_SCALES:
+        cur_x_scales = x_scales_slab.gather(
+            ((wmma_idx % XS_SLOTS) * MX_SCALE_BLOCK_K + xs_offs_kg)[None, :]
+            + xs_zeros_row[:, None],
+            1,
+        )
+    else:
+        cur_x_scales = x_scales_buffer.index(wmma_idx % NUM_BUFFERS).load(
+            layout=DOT_LAYOUT_X_SCALES
+        )
     if SWIZZLE_MX_SCALE == "GFX1250_SCALE":
         cur_w_scales = (
             unswizzle_scales_gfx1250(
@@ -950,7 +1012,7 @@ def _moe_gemm_a4w4_prefill(
                 [offs_x_m, 0],
                 x_buffer.index(load_idx % NUM_BUFFERS),
             )
-            if X_SCALES_TDM:
+            if X_SCALES_TDM and not PRELOAD_X_SCALES:
                 gl.amd.gfx1250.tdm.async_load(
                     x_scales_desc,
                     [offs_x_m, 0],
@@ -962,7 +1024,7 @@ def _moe_gemm_a4w4_prefill(
                 offs_x_m,
                 x_buffer.index(load_idx % NUM_BUFFERS),
             )
-            if X_SCALES_TDM:
+            if X_SCALES_TDM and not PRELOAD_X_SCALES:
                 gl.amd.gfx1250.tdm.async_gather(
                     x_scales_desc,
                     offs_x_m,
@@ -978,7 +1040,7 @@ def _moe_gemm_a4w4_prefill(
             [offs_w_n_scale, 0],
             w_scales_buffer.index(load_idx % NUM_BUFFERS),
         )
-        if not X_SCALES_TDM:
+        if not X_SCALES_TDM and not PRELOAD_X_SCALES:
             gl.amd.gfx1250.async_copy.global_to_shared(
                 x_scales_buffer.index(load_idx % NUM_BUFFERS),
                 x_scales_ptrs,
@@ -990,7 +1052,7 @@ def _moe_gemm_a4w4_prefill(
         x_desc = gl.amd.gfx1250.tdm.update_tensor_descriptor(
             x_desc, add_offsets=[0, PACKED_BLOCK_K_X], clamp_bounds=CLAMP_BOUNDS
         )
-        if X_SCALES_TDM:
+        if X_SCALES_TDM and not PRELOAD_X_SCALES:
             x_scales_desc = gl.amd.gfx1250.tdm.update_tensor_descriptor(
                 x_scales_desc,
                 add_offsets=[0, MX_SCALE_BLOCK_K],
@@ -1008,7 +1070,7 @@ def _moe_gemm_a4w4_prefill(
 
         # wait for next tile to be filled
         gl.amd.gfx1250.tdm.async_wait((NUM_BUFFERS - 1) * NUM_TDM_OPS)
-        if not X_SCALES_TDM:
+        if not X_SCALES_TDM and not PRELOAD_X_SCALES:
             gl.amd.gfx1250.async_copy.wait_group(NUM_BUFFERS - 1)
 
         # load next tile from LDS into registers
@@ -1031,9 +1093,16 @@ def _moe_gemm_a4w4_prefill(
                 .permute((1, 0))
                 .load(layout=DOT_LAYOUT_W)
             )
-        next_x_scales = x_scales_buffer.index(wmma_idx % NUM_BUFFERS).load(
-            layout=DOT_LAYOUT_X_SCALES
-        )
+        if PRELOAD_X_SCALES:
+            next_x_scales = x_scales_slab.gather(
+                ((wmma_idx % XS_SLOTS) * MX_SCALE_BLOCK_K + xs_offs_kg)[None, :]
+                + xs_zeros_row[:, None],
+                1,
+            )
+        else:
+            next_x_scales = x_scales_buffer.index(wmma_idx % NUM_BUFFERS).load(
+                layout=DOT_LAYOUT_X_SCALES
+            )
         if SWIZZLE_MX_SCALE == "GFX1250_SCALE":
             next_w_scales = (
                 unswizzle_scales_gfx1250(
@@ -1095,7 +1164,7 @@ def _moe_gemm_a4w4_prefill(
         gl.amd.gfx1250.tdm.async_wait(
             (NUM_BUFFERS - 2 - k_ep) * NUM_TDM_OPS + TDM_BIAS_WAIT
         )
-        if not X_SCALES_TDM:
+        if not X_SCALES_TDM and not PRELOAD_X_SCALES:
             gl.amd.gfx1250.async_copy.wait_group(NUM_BUFFERS - 2 - k_ep)
 
         # load next tile from LDS into registers
@@ -1118,9 +1187,16 @@ def _moe_gemm_a4w4_prefill(
                 .permute((1, 0))
                 .load(layout=DOT_LAYOUT_W)
             )
-        next_x_scales = x_scales_buffer.index(wmma_idx % NUM_BUFFERS).load(
-            layout=DOT_LAYOUT_X_SCALES
-        )
+        if PRELOAD_X_SCALES:
+            next_x_scales = x_scales_slab.gather(
+                ((wmma_idx % XS_SLOTS) * MX_SCALE_BLOCK_K + xs_offs_kg)[None, :]
+                + xs_zeros_row[:, None],
+                1,
+            )
+        else:
+            next_x_scales = x_scales_buffer.index(wmma_idx % NUM_BUFFERS).load(
+                layout=DOT_LAYOUT_X_SCALES
+            )
         if SWIZZLE_MX_SCALE == "GFX1250_SCALE":
             next_w_scales = (
                 unswizzle_scales_gfx1250(

--- a/aiter/ops/triton/_gluon_kernels/gfx1250/moe/moe_op_gemm_a4w4.py
+++ b/aiter/ops/triton/_gluon_kernels/gfx1250/moe/moe_op_gemm_a4w4.py
@@ -624,6 +624,10 @@ def _moe_gemm_a4w4_prefill(
     Y_ROWS=0,
     PRELOAD_X_SCALES: gl.constexpr = False,
     XS_SLAB_COLS: gl.constexpr = 0,
+    # Warm L2 with the first this-many K-tiles of w during the prologue.
+    # 0 disables. Costs no LDS, unlike raising NUM_BUFFERS, which would
+    # cost a whole workgroup per CU on both prefill GEMMs.
+    L2_PREFETCH_DISTANCE: gl.constexpr = 0,
 ):
     MX_PACK_DIVISOR: gl.constexpr = 32
     gl.static_assert(
@@ -944,6 +948,12 @@ def _moe_gemm_a4w4_prefill(
         )
 
         load_idx += 1
+
+    if L2_PREFETCH_DISTANCE > 0:
+        for pf_j in gl.static_range(L2_PREFETCH_DISTANCE):
+            gl.amd.gfx1250.tdm.prefetch(
+                w_desc, [offs_w_n, pf_j * SHUFFLED_BLOCK_K_W]
+            )
 
     # preload tile 0 from LDS into registers
     gl.amd.gfx1250.tdm.async_wait((NUM_BUFFERS - 1) * NUM_TDM_OPS)

--- a/aiter/ops/triton/_gluon_kernels/gfx1250/moe/moe_op_gemm_a4w4.py
+++ b/aiter/ops/triton/_gluon_kernels/gfx1250/moe/moe_op_gemm_a4w4.py
@@ -20,8 +20,14 @@ _MOE_GEMM_A4W4_REPR_KEYS = [
     "EP_SCATTER",
 ]
 
+_MOE_GEMM_A4W4_PREFILL_REPR_KEYS = _MOE_GEMM_A4W4_REPR_KEYS + [
+    "PRELOAD_X_SCALES",
+    "XS_SLAB_COLS",
+    "L2_PREFETCH_DISTANCE",
+]
+
 _moe_gemm_a4w4_prefill_repr = make_kernel_repr(
-    "_moe_gemm_a4w4_prefill", _MOE_GEMM_A4W4_REPR_KEYS
+    "_moe_gemm_a4w4_prefill", _MOE_GEMM_A4W4_PREFILL_REPR_KEYS
 )
 
 _moe_gemm_a4w4_decode_repr = make_kernel_repr(

--- a/aiter/ops/triton/_gluon_kernels/gfx1250/moe/moe_op_gemm_a4w4.py
+++ b/aiter/ops/triton/_gluon_kernels/gfx1250/moe/moe_op_gemm_a4w4.py
@@ -876,13 +876,9 @@ def _moe_gemm_a4w4_prefill(
 
     if PRELOAD_X_SCALES:
         if GatherIndx is None:
-            gl.amd.gfx1250.tdm.async_load(
-                xs_slab_desc, [offs_x_m, 0], x_scales_slab
-            )
+            gl.amd.gfx1250.tdm.async_load(xs_slab_desc, [offs_x_m, 0], x_scales_slab)
         else:
-            gl.amd.gfx1250.tdm.async_gather(
-                xs_slab_desc, offs_x_m, x_scales_slab
-            )
+            gl.amd.gfx1250.tdm.async_gather(xs_slab_desc, offs_x_m, x_scales_slab)
 
     # prologue: fill NUM_BUFFERS LDS slots via TDM
     for _ in gl.static_range(NUM_BUFFERS):
@@ -951,9 +947,7 @@ def _moe_gemm_a4w4_prefill(
 
     if L2_PREFETCH_DISTANCE > 0:
         for pf_j in gl.static_range(L2_PREFETCH_DISTANCE):
-            gl.amd.gfx1250.tdm.prefetch(
-                w_desc, [offs_w_n, pf_j * SHUFFLED_BLOCK_K_W]
-            )
+            gl.amd.gfx1250.tdm.prefetch(w_desc, [offs_w_n, pf_j * SHUFFLED_BLOCK_K_W])
 
     # preload tile 0 from LDS into registers
     gl.amd.gfx1250.tdm.async_wait((NUM_BUFFERS - 1) * NUM_TDM_OPS)

--- a/aiter/ops/triton/configs/gfx1250/gluon/moe/a4w4/DEFAULT.json
+++ b/aiter/ops/triton/configs/gfx1250/gluon/moe/a4w4/DEFAULT.json
@@ -2188,5 +2188,77 @@
         "block_k": 256,
         "num_buffers": 2,
         "num_warps": 4
+    },
+    "bm16_n1536_k7168_tiny": {
+        "block_n": 128,
+        "block_k": 512,
+        "num_buffers": 2,
+        "num_warps": 4
+    },
+    "bm16_n7168_k768_tiny": {
+        "block_n": 128,
+        "block_k": 512,
+        "num_buffers": 2,
+        "num_warps": 4
+    },
+    "bm16_n1536_k7168_small": {
+        "block_n": 128,
+        "block_k": 512,
+        "num_buffers": 2,
+        "num_warps": 4
+    },
+    "bm16_n7168_k768_small": {
+        "block_n": 128,
+        "block_k": 512,
+        "num_buffers": 1,
+        "num_warps": 4
+    },
+    "bm16_n1536_k7168_medium": {
+        "block_n": 256,
+        "block_k": 512,
+        "num_buffers": 1,
+        "num_warps": 4
+    },
+    "bm16_n7168_k768_medium": {
+        "block_n": 128,
+        "block_k": 512,
+        "num_buffers": 2,
+        "num_warps": 4
+    },
+    "bm16_n1536_k7168_medium2": {
+        "block_n": 128,
+        "block_k": 512,
+        "num_buffers": 1,
+        "num_warps": 4
+    },
+    "bm16_n7168_k768_medium2": {
+        "block_n": 256,
+        "block_k": 256,
+        "num_buffers": 1,
+        "num_warps": 4
+    },
+    "bm16_n1536_k7168_large": {
+        "block_n": 128,
+        "block_k": 512,
+        "num_buffers": 2,
+        "num_warps": 4
+    },
+    "bm16_n7168_k768_large": {
+        "block_n": 256,
+        "block_k": 256,
+        "num_buffers": 1,
+        "num_warps": 4
+    },
+    "bm16_n1536_k7168_xlarge": {
+        "block_n": 128,
+        "block_k": 512,
+        "num_buffers": 2,
+        "num_warps": 4
+    },
+    "bm16_n7168_k768_xlarge": {
+        "block_n": 256,
+        "block_k": 256,
+        "num_buffers": 1,
+        "num_warps": 4
     }
 }

--- a/aiter/ops/triton/moe/moe_op_gemm_a4w4.py
+++ b/aiter/ops/triton/moe/moe_op_gemm_a4w4.py
@@ -568,6 +568,21 @@ def moe_gemm_a4w4(
         clamp_bounds = (K % config["block_k"] != 0) or (
             triton.cdiv(K, config["block_k"]) < config["num_buffers"]
         )
+        XS_SLAB_MAX_BYTES = 32 * 1024
+        xs_slab_cols = triton.next_power_of_2(
+            triton.cdiv(K, MXFP4_QUANT_BLOCK_SIZE)
+        )
+        x_scales_preload = (
+            not clamp_bounds
+            and config["block_m"] <= 32
+            and K > 1024
+            and config["block_m"] * (config["block_k"] // MXFP4_QUANT_BLOCK_SIZE)
+            <= 256
+            and config["block_m"] * xs_slab_cols <= XS_SLAB_MAX_BYTES
+            and config["num_ctas"] == 1
+        )
+        if not x_scales_preload:
+            xs_slab_cols = 0
         # launch gluon kernel
         _moe_gemm_a4w4_prefill[(grid,)](
             y_ptr,
@@ -616,6 +631,8 @@ def moe_gemm_a4w4(
             UPCAST_INDICES=should_upcast_indices(x, w, y_ptr),
             X_SCALES_TDM=x_scales_tdm,
             CLAMP_BOUNDS=clamp_bounds,
+            PRELOAD_X_SCALES=x_scales_preload,
+            XS_SLAB_COLS=xs_slab_cols,
             **layouts,
             YMxScale=y_scale,
             stride_y_mx_m=stride_y_mx_m,

--- a/aiter/ops/triton/moe/moe_op_gemm_a4w4.py
+++ b/aiter/ops/triton/moe/moe_op_gemm_a4w4.py
@@ -623,8 +623,10 @@ def moe_gemm_a4w4(
         # prefetches before the K loop, so it only pays off once the loop is
         # long enough to absorb it -- hence the 4x rule.
         num_k_iter = triton.cdiv(K, config["block_k"])
-        l2_prefetch_distance = 4
-        if (
+        l2_prefetch_distance = (
+            4 if preshuffle_weights and swizzle_mx_scale == "GFX1250_SCALE" else 0
+        )
+        if l2_prefetch_distance and (
             num_k_iter < 4 * l2_prefetch_distance
             or config["num_buffers"] + l2_prefetch_distance - 1 >= num_k_iter
         ):

--- a/aiter/ops/triton/moe/moe_op_gemm_a4w4.py
+++ b/aiter/ops/triton/moe/moe_op_gemm_a4w4.py
@@ -23,11 +23,10 @@ from aiter.ops.triton.moe.reduce import (
     scatter_grouped,
     validate_reduce_out,
 )
+from aiter.ops.triton.utils._triton import arch_info
 from aiter.ops.triton.utils._triton.arch_info import get_arch
 from aiter.ops.triton.utils.gemm_config_utils import pick_gemm_num_stages
 from aiter.ops.triton.utils.moe_config_utils import get_moe_dispatch
-
-_LDS_BYTES_PER_WGP = 327680
 
 
 def _prefill_lds_bytes(config, x_scales_preload, xs_slab_cols):
@@ -51,7 +50,8 @@ def _prefill_lds_bytes(config, x_scales_preload, xs_slab_cols):
 
 
 def _workgroups_per_wgp(lds_bytes):
-    return max(1, _LDS_BYTES_PER_WGP // max(1, lds_bytes))
+    cap = arch_info._LDS_CAP_BYTES[get_arch()]
+    return max(1, cap // max(1, lds_bytes))
 
 
 # -----------------------------------------------------------------------------
@@ -604,13 +604,10 @@ def moe_gemm_a4w4(
             and config["block_m"] * (config["block_k"] // MXFP4_QUANT_BLOCK_SIZE) <= 256
             and config["block_m"] * xs_slab_cols <= XS_SLAB_MAX_BYTES
             and config["num_ctas"] == 1
-        )
-        # Only vetoed for the layouts _prefill_lds_bytes actually models.
-        if (
-            x_scales_preload
             and preshuffle_weights
             and swizzle_mx_scale == "GFX1250_SCALE"
-        ):
+        )
+        if x_scales_preload:
             wgs_with = _workgroups_per_wgp(
                 _prefill_lds_bytes(config, True, xs_slab_cols)
             )

--- a/aiter/ops/triton/moe/moe_op_gemm_a4w4.py
+++ b/aiter/ops/triton/moe/moe_op_gemm_a4w4.py
@@ -26,6 +26,7 @@ from aiter.ops.triton.moe.reduce import (
 from aiter.ops.triton.utils._triton.arch_info import get_arch
 from aiter.ops.triton.utils.gemm_config_utils import pick_gemm_num_stages
 from aiter.ops.triton.utils.moe_config_utils import get_moe_dispatch
+
 _LDS_BYTES_PER_WGP = 327680
 
 
@@ -595,15 +596,12 @@ def moe_gemm_a4w4(
             triton.cdiv(K, config["block_k"]) < config["num_buffers"]
         )
         XS_SLAB_MAX_BYTES = 32 * 1024
-        xs_slab_cols = triton.next_power_of_2(
-            triton.cdiv(K, MXFP4_QUANT_BLOCK_SIZE)
-        )
+        xs_slab_cols = triton.next_power_of_2(triton.cdiv(K, MXFP4_QUANT_BLOCK_SIZE))
         x_scales_preload = (
             not clamp_bounds
             and config["block_m"] <= 32
             and K > 1024
-            and config["block_m"] * (config["block_k"] // MXFP4_QUANT_BLOCK_SIZE)
-            <= 256
+            and config["block_m"] * (config["block_k"] // MXFP4_QUANT_BLOCK_SIZE) <= 256
             and config["block_m"] * xs_slab_cols <= XS_SLAB_MAX_BYTES
             and config["num_ctas"] == 1
         )
@@ -630,8 +628,8 @@ def moe_gemm_a4w4(
         num_k_iter = triton.cdiv(K, config["block_k"])
         l2_prefetch_distance = 4
         if (
-            num_k_iter < 4 * l2_prefetch_distance or
-            config["num_buffers"] + l2_prefetch_distance - 1 >= num_k_iter
+            num_k_iter < 4 * l2_prefetch_distance
+            or config["num_buffers"] + l2_prefetch_distance - 1 >= num_k_iter
         ):
             l2_prefetch_distance = 0
         # launch gluon kernel

--- a/aiter/ops/triton/moe/moe_op_gemm_a4w4.py
+++ b/aiter/ops/triton/moe/moe_op_gemm_a4w4.py
@@ -26,6 +26,32 @@ from aiter.ops.triton.moe.reduce import (
 from aiter.ops.triton.utils._triton.arch_info import get_arch
 from aiter.ops.triton.utils.gemm_config_utils import pick_gemm_num_stages
 from aiter.ops.triton.utils.moe_config_utils import get_moe_dispatch
+_LDS_BYTES_PER_WGP = 327680
+
+
+def _prefill_lds_bytes(config, x_scales_preload, xs_slab_cols):
+    # Check for prefill kernel's LDS budget, this determines if we can afford x_scales_preload without losing occupancy
+    # please keep in sync with whatever the layout the prefill kernel is using
+    bm, bn, bk = config["block_m"], config["block_n"], config["block_k"]
+    nb = config["num_buffers"]
+    mx_scale_block_k = bk // MXFP4_QUANT_BLOCK_SIZE
+    # x: [bm, bk//2] with 16 pad elements between each of the bm intervals
+    x_buf = nb * (bm * (bk // 2) + (bm - 1) * 16)
+    # w / w-scales: identity swizzle, so exactly their (preshuffled) extents
+    w_buf = nb * bn * (bk // 2)
+    w_scales_buf = nb * bn * mx_scale_block_k
+    if x_scales_preload:
+        x_scales_buf = bm * xs_slab_cols
+    else:
+        x_scales_buf = nb * bm * mx_scale_block_k
+    # +32 is inter-allocation alignment, measured at 16-32B. Rounded up so
+    # this never overstates how many workgroups fit.
+    return x_buf + w_buf + w_scales_buf + x_scales_buf + 32
+
+
+def _workgroups_per_wgp(lds_bytes):
+    return max(1, _LDS_BYTES_PER_WGP // max(1, lds_bytes))
+
 
 # -----------------------------------------------------------------------------
 #                    Matrix Multiplication + Outer Gather/Scatter
@@ -581,8 +607,33 @@ def moe_gemm_a4w4(
             and config["block_m"] * xs_slab_cols <= XS_SLAB_MAX_BYTES
             and config["num_ctas"] == 1
         )
+        # Only vetoed for the layouts _prefill_lds_bytes actually models.
+        if (
+            x_scales_preload
+            and preshuffle_weights
+            and swizzle_mx_scale == "GFX1250_SCALE"
+        ):
+            wgs_with = _workgroups_per_wgp(
+                _prefill_lds_bytes(config, True, xs_slab_cols)
+            )
+            wgs_without = _workgroups_per_wgp(
+                _prefill_lds_bytes(config, False, xs_slab_cols)
+            )
+            if wgs_with < wgs_without:
+                x_scales_preload = False
         if not x_scales_preload:
             xs_slab_cols = 0
+
+        # L2 prefetch distance, in K-tiles. The ramp is a fixed burst of
+        # prefetches before the K loop, so it only pays off once the loop is
+        # long enough to absorb it -- hence the 4x rule.
+        num_k_iter = triton.cdiv(K, config["block_k"])
+        l2_prefetch_distance = 4
+        if (
+            num_k_iter < 4 * l2_prefetch_distance or
+            config["num_buffers"] + l2_prefetch_distance - 1 >= num_k_iter
+        ):
+            l2_prefetch_distance = 0
         # launch gluon kernel
         _moe_gemm_a4w4_prefill[(grid,)](
             y_ptr,
@@ -633,6 +684,7 @@ def moe_gemm_a4w4(
             CLAMP_BOUNDS=clamp_bounds,
             PRELOAD_X_SCALES=x_scales_preload,
             XS_SLAB_COLS=xs_slab_cols,
+            L2_PREFETCH_DISTANCE=l2_prefetch_distance,
             **layouts,
             YMxScale=y_scale,
             stride_y_mx_m=stride_y_mx_m,

--- a/op_tests/op_benchmarks/triton/bench_moe_gemm_a4w4_cudagraph.py
+++ b/op_tests/op_benchmarks/triton/bench_moe_gemm_a4w4_cudagraph.py
@@ -31,6 +31,17 @@ that feeds each layer -- is built once outside the timed region, mirroring the
 build()/fn() split in mi450-scripts/run_moe_a4w4.py so the numbers are
 comparable to that runner (which benches one projection per invocation).
 
+--ep shards the experts the way expert parallelism does: --experts TOTAL is
+the count across all ranks, and this process benches ONE rank, holding weights
+for TOTAL/--ep of them. Tokens are still routed over all TOTAL experts, so a
+rank sees roughly top-k/--ep live gates per token and the rest are dead slots --
+which is what sets the tile geometry, and it is not reproducible by shrinking
+either the expert count or the batch alone. The DSV4 EP4 decode step is
+`--M 2048 --experts 384 6 --ep 4 --routed-experts 384 --balance`: 2048 real
+tokens, 12288 gate slots, block_m 32 from 12288/384, a 96-expert histogram with
+32 rows each. Default --ep 1, i.e. the plain single-rank `routing()` path,
+unchanged.
+
 `moe_gemm_a4w4` defaults to the gluon kernels on gfx1250 --
 _moe_gemm_a4w4_decode when routing picks block_m == 16 and _moe_gemm_a4w4_prefill
 otherwise -- and the triton kernel elsewhere. --backend pins one instead (gluon
@@ -53,7 +64,14 @@ from aiter.ops.triton.moe.moe_op_gemm_a4w4 import (
     moe_gemm_a4w4,
     mxfp4_quant,
 )
-from aiter.ops.triton.moe.moe_routing.routing import _USE_HERD, routing
+from aiter.ops.triton.moe.moe_routing.routing import (
+    _USE_HERD,
+    ExptData,
+    RoutingData,
+    _compute_expt_data_internal,
+    ep_sort_routing,
+    routing,
+)
 from aiter.ops.triton.moe.quant_moe import downcast_to_mxfp
 from aiter.ops.triton.utils._triton.arch_info import get_arch
 from aiter.ops.triton.utils.shuffle import moe_weight_decode_view, shuffle_scale_moe
@@ -206,7 +224,7 @@ def quantize(x, dtype):
         return x, scale
 
 
-def pin_routed_experts(logits, n_routed, n_expts_act):
+def pin_routed_experts(logits, n_routed, n_expts_act, balance=False):
     """Route to exactly `n_routed` experts -- a pin, not a cap.
 
     Masking the logits down to a random pool of `n_routed` experts only bounds
@@ -226,20 +244,84 @@ def pin_routed_experts(logits, n_routed, n_expts_act):
     `batch * n_expts_act` routed rows cannot reach more experts than there are
     rows, so the pool shrinks to fit a tiny batch; the returned count is what
     was actually pinned.
+
+    ``balance`` deals the routes round-robin instead of at random, giving every
+    pinned expert the same row count (+-1) and hence completely full block_m
+    tiles -- see the comment on the branch below for why that changes timing.
+
+    Returns ``(masked_logits, n_pinned, pool)``. The pool is the expert ids that
+    were pinned, which under expert parallelism is the only way to know how many
+    of them this rank actually owns.
     """
     n_tokens, n_expts_tot = logits.shape
     dev = logits.device
     n_pinned = min(n_routed, n_tokens * n_expts_act)
     pool = torch.randperm(n_expts_tot, device=dev)[:n_pinned]
 
-    slot = torch.arange(n_pinned, device=dev)
-    score = torch.rand((n_tokens, n_pinned), device=dev)
-    score[slot % n_tokens, slot] += 1.0
-    keep = pool[score.topk(n_expts_act, dim=-1).indices]
+    if balance:
+        # Round-robin
+        flat = torch.arange(n_tokens * n_expts_act, device=dev)
+        keep = pool[flat % n_pinned].view(n_tokens, n_expts_act)
+    else:
+        slot = torch.arange(n_pinned, device=dev)
+        score = torch.rand((n_tokens, n_pinned), device=dev)
+        score[slot % n_tokens, slot] += 1.0
+        keep = pool[score.topk(n_expts_act, dim=-1).indices]
 
     masked = torch.full_like(logits, float("-inf"))
     masked.scatter_(1, keep, logits.gather(1, keep))
-    return masked, n_pinned
+    return masked, n_pinned, pool
+
+
+def ep_routing(logits, n_expts_act, n_expts_local):
+    """
+    Routing for ONE rank of an expert-parallel layer, from GLOBAL logits.
+    """
+    batch, n_expts_tot = logits.shape
+    dev = logits.device
+    n_gates = batch * n_expts_act
+
+    # Global top-k. The weights only scale moe2's reduction and nothing here is
+    # timed, so a softmax over the selected scores is close enough.
+    vals, dispatch_ids = torch.topk(logits, n_expts_act, dim=-1)
+    dispatch_weights = torch.softmax(vals.float(), dim=-1)
+    dispatch_ids = dispatch_ids.to(torch.int32)
+
+    # global id -> local id, -1 for an expert another rank owns. One entry
+    # longer than the global count: ep_sort_routing clamps ids into the map and
+    # reads the global count back as `numel() - 1`, which is the convention ATOM
+    # passes it.
+    expert_map = torch.full((n_expts_tot + 1,), -1, dtype=torch.int32, device=dev)
+    expert_map[:n_expts_local] = torch.arange(
+        n_expts_local, dtype=torch.int32, device=dev
+    )
+
+    # block_m off the GLOBAL expert count -- see the docstring.
+    tokens_per_expt = max(1, n_gates // n_expts_tot)
+    block_m = max(16, min(triton.next_power_of_2(tokens_per_expt), 128))
+    expt_data_bufs = _compute_expt_data_internal(n_expts_local, n_gates, block_m, dev)
+    token_offs_raw, token_offs_pad, block_pid_map = expt_data_bufs[:3]
+
+    # No mori staging buffer here, so every row is real -- but still a device
+    # tensor, which is the form ep_sort_routing's row mask expects.
+    num_local_tokens = torch.tensor([batch], dtype=torch.int32, device=dev)
+
+    hist_full, topk_indx, gate_indx, gate_scal, gate_valid, _ = ep_sort_routing(
+        dispatch_weights,
+        dispatch_ids,
+        expert_map,
+        n_expts_local,
+        num_local_tokens,
+        batch,
+        n_expts_act,
+        n_gates,
+        expt_data_bufs,
+    )
+    # the tail bin holds the sentinel (non-local) count, which gets no tile
+    hist = hist_full[:n_expts_local]
+    expt_data = ExptData(hist, token_offs_raw, token_offs_pad, block_pid_map)
+    rdata = RoutingData(block_m, gate_scal, hist, n_expts_local, n_expts_act, expt_data)
+    return rdata, topk_indx, gate_indx, gate_valid
 
 
 def backend_name(backend=None):
@@ -271,17 +353,40 @@ def bench_mlp_single_weight_init(
     routed_experts,
     rep,
     layers=LAYERS,
+    balance=False,
+    fused_quant=False,
+    ep=1,
 ):
     rank = 0
     dev = f"cuda:{rank}"
 
     assert dim2 % TP == 0, f"{dim2=}, {TP=}, dim2 must be divisible by TP"
+    # --experts TOTAL is the global count; this process holds one rank's shard.
+    assert ep >= 1, f"--ep must be positive, got {ep}"
+    assert n_expts_tot % ep == 0, (
+        f"--experts TOTAL ({n_expts_tot}) must divide evenly into --ep ({ep}) "
+        "equal shards"
+    )
+    n_expts_local = n_expts_tot // ep
     assert x_dtype == "mx4", f"FP4 (E2M1) is disabled for x_dtype, got {x_dtype}"
     assert w_dtype == "mx4", f"FP4 (E2M1) is disabled for x_dtype, got {w_dtype}"
     if preshuffle:
         assert (
             get_arch() == "gfx1250"
         ), f"--preshuffle needs the gfx1250 gluon kernel, got {get_arch()}"
+    if fused_quant:
+        # moe_gemm_a4w4 asserts the gluon backend for out_mx_quant (the triton
+        # kernel has no gfx1250 epilogue and would return unwritten scales), and
+        # the swiglu halving must leave the packed width 32-aligned.
+        assert backend_name(backend) == "gluon", (
+            "--fused-quant needs the gluon backend for out_mx_quant, got "
+            f"{backend_name(backend)}"
+        )
+        n_out = (dim2 // TP) // 2  # apply_swiglu=True halves N
+        assert n_out % 32 == 0, (
+            f"--fused-quant needs the post-swiglu width {n_out} to be a multiple "
+            "of 32 (aiter: out_mx_quant requires N_out % 32 == 0)"
+        )
     if routed_experts is not None:
         # every token needs n_expts_act distinct experts, so the pool can't be smaller
         assert n_expts_act <= routed_experts <= n_expts_tot, (
@@ -298,14 +403,15 @@ def bench_mlp_single_weight_init(
     assert set(layers) <= set(LAYERS), f"unknown layer(s) in {layers=}"
 
     # -- init data --
-    # weights
+    # The router scores every GLOBAL expert (that is what picks the tile
+    # geometry), but the expert weights are only this rank's shard.
     wg = torch.randn((dim1, n_expts_tot), device=dev)
-    w1 = torch.randn((n_expts_tot, dim1, dim2 // TP), device=dev)
-    w2 = torch.randn((n_expts_tot, dim2 // TP // 2, dim1), device=dev)
+    w1 = torch.randn((n_expts_local, dim1, dim2 // TP), device=dev)
+    w2 = torch.randn((n_expts_local, dim2 // TP // 2, dim1), device=dev)
     # biases
     bg = torch.randn((n_expts_tot,), device=dev)
-    b1 = torch.randn((n_expts_tot, dim2 // TP), device=dev)
-    b2 = torch.randn((n_expts_tot, dim1), device=dev)
+    b1 = torch.randn((n_expts_local, dim2 // TP), device=dev)
+    b2 = torch.randn((n_expts_local, dim1), device=dev)
 
     # -- numerics --
     wg, _ = quantize(wg, "bf16")
@@ -322,10 +428,18 @@ def bench_mlp_single_weight_init(
     # -- routing + layer-1 activations: built once, outside the timed region --
     x = torch.randn((batch, dim1), dtype=torch.bfloat16, device=dev)
     logits = gemm_a16w16(x, wg.T, bg)
-    n_pinned = None
+    n_pinned = pool = None
     if routed_experts is not None:
-        logits, n_pinned = pin_routed_experts(logits, routed_experts, n_expts_act)
-    rdata, gather_indx, scatter_indx = routing(logits, n_expts_act)
+        logits, n_pinned, pool = pin_routed_experts(
+            logits, routed_experts, n_expts_act, balance=balance
+        )
+    gate_valid = None
+    if ep == 1:
+        rdata, gather_indx, scatter_indx = routing(logits, n_expts_act)
+    else:
+        rdata, gather_indx, scatter_indx, gate_valid = ep_routing(
+            logits, n_expts_act, n_expts_local
+        )
     x1, x1_scale = mxfp4_quant(x)
 
     def layer1():
@@ -340,14 +454,19 @@ def bench_mlp_single_weight_init(
             swizzle_mx_scale=swizzle_mx_scale1,
             preshuffle_weights=preshuffle,
             apply_swiglu=True,
+            out_mx_quant=fused_quant,
             backend=backend,
         )
 
-    # layer 2 reads layer 1's swiglu output; quantize it once here so the timed
-    # region holds only the two GEMMs. This doubles as the compile warmup.
     y1 = layer1()
-    y1_bytes = y1.numel() * y1.element_size()
-    x2, x2_scale = mxfp4_quant(y1)
+    if fused_quant:
+        x2, x2_scale = y1
+        y1_bytes_alloc = (
+            x2.numel() * x2.element_size() + x2_scale.numel() * x2_scale.element_size()
+        )
+    else:
+        y1_bytes_alloc = y1.numel() * y1.element_size()
+        x2, x2_scale = mxfp4_quant(y1)
     del y1
 
     def layer2():
@@ -359,6 +478,9 @@ def bench_mlp_single_weight_init(
             b2,
             rdata,
             scatter_indx=scatter_indx,
+            # under EP most gate slots belong to other ranks and no GEMM here
+            # ever writes them; None (every gate live) is right for --ep 1
+            gate_valid=gate_valid,
             swizzle_mx_scale=swizzle_mx_scale2,
             preshuffle_weights=preshuffle,
             backend=backend,
@@ -376,25 +498,35 @@ def bench_mlp_single_weight_init(
     # weights + matmul output for traffic. mx scales (~1/16 of the weight bytes)
     # and the moe2 scatter reduction are not counted; the reduction's runtime is
     # inside moe_gemm_a4w4 and so is inside the measurement.
-    n_tokens = gather_indx.shape[0]  # routed rows == batch * n_expts_act
-    routed = int((rdata.expt_data.hist > 0).sum())  # experts that got >= 1 token
+    n_gates = gather_indx.shape[0]  # every gate slot == batch * n_expts_act
+    # Rows this rank's GEMM really computes. Equal to n_gates at --ep 1; under EP
+    # the dead slots get no tile, so the activation buffers are sized for n_gates
+    # but only this fraction of them is ever touched.
+    n_rows = int(rdata.expt_data.hist.sum())
+    live_frac = n_rows / n_gates
+    routed = int((rdata.expt_data.hist > 0).sum())  # LOCAL experts with >= 1 row
     if n_pinned is not None:
-        assert (
-            routed == n_pinned
-        ), f"--routed-experts pinned {n_pinned} experts, routing used {routed}"
+        # under EP the pin is over the global set; only the local slice lands here
+        expected = n_pinned if ep == 1 else int((pool < n_expts_local).sum())
+        assert routed == expected, (
+            f"--routed-experts pinned {n_pinned} experts"
+            + (f", {expected} of them local," if ep > 1 else ",")
+            + f" routing used {routed}"
+        )
 
     def w_bytes(w):
-        return (w.numel() * w.element_size() // n_expts_tot) * routed
+        return (w.numel() * w.element_size() // n_expts_local) * routed
 
-    moe1_flops = 2 * n_tokens * (dim2 // TP) * dim1  # N = dim2 // TP, K = dim1
+    y1_bytes = int(y1_bytes_alloc * live_frac)
+    moe1_flops = 2 * n_rows * (dim2 // TP) * dim1  # N = dim2 // TP, K = dim1
     moe1_bytes = x1.numel() * x1.element_size() + w_bytes(w1) + y1_bytes
-    moe2_flops = 2 * n_tokens * dim1 * (dim2 // TP // 2)  # N = dim1, K = dim2/TP/2
+    moe2_flops = 2 * n_rows * dim1 * (dim2 // TP // 2)  # N = dim1, K = dim2/TP/2
     # y2 is the scatter-compressed [batch, dim1] result; the GEMM writes the
-    # uncompressed [n_tokens, dim1] rows the reduction then combines.
+    # uncompressed [n_rows, dim1] rows the reduction then combines.
     moe2_bytes = (
-        x2.numel() * x2.element_size()
+        int(x2.numel() * x2.element_size() * live_frac)
         + w_bytes(w2)
-        + n_tokens * dim1 * y2.element_size()
+        + n_rows * dim1 * y2.element_size()
     )
 
     # -- benchmark: each projection on its own, then the pair back to back,
@@ -439,6 +571,9 @@ def bench_mlp(
     rep,
     layers=LAYERS,
     num_weight_inits=1,
+    balance=False,
+    fused_quant=False,
+    ep=1,
 ):
     all_results = []
     for i in range(num_weight_inits):
@@ -456,6 +591,9 @@ def bench_mlp(
             routed_experts,
             rep,
             layers,
+            balance=balance,
+            fused_quant=fused_quant,
+            ep=ep,
         )
         all_results.append(result)
 
@@ -492,6 +630,9 @@ def roofline_mlp(
     rep,
     layers=LAYERS,
     num_weight_inits=1,
+    balance=False,
+    fused_quant=False,
+    ep=1,
     name="",
 ):
     # Put all outputs under logs/<name>/ and write a CSV file (not a directory-as-stem).
@@ -506,6 +647,12 @@ def roofline_mlp(
     )
     if routed_experts is not None:
         stem += f"-routed={routed_experts}"
+    if balance:
+        stem += "-balanced"
+    if fused_quant:
+        stem += "-fusedquant"
+    if ep > 1:
+        stem += f"-ep{ep}"
     stem += f"-{backend_name(backend)}"
     if preshuffle:
         stem += "-preshuffled"
@@ -528,6 +675,9 @@ def roofline_mlp(
         rep,  # fixed args
         layers,
         num_weight_inits,
+        balance=balance,  # forwarded to bench_mlp via compute_roofline's **kwargs
+        fused_quant=fused_quant,
+        ep=ep,
         bench_fn=bench_mlp,  # function to benchmark
         intensity_proxy_name="batch",  # intensity proxy name
         intensity_proxy_values=batch_sizes,  # intensity proxy values to sweep
@@ -564,11 +714,26 @@ def parse_args(args: list[str] | None = None):
         nargs=2,
         required=True,
         metavar=("TOTAL", "TOPK"),
-        help="TOTAL is how many experts the layer holds; TOPK is how many of "
-        "them each token is routed to. TOTAL sets the weight tensors' expert "
-        "dim, TOPK multiplies the row count each GEMM sees (batch * TOPK "
-        "routed rows). Use --routed-experts to pin how many of the TOTAL "
-        "actually receive tokens.",
+        help="TOTAL is how many experts the layer holds ACROSS ALL EP RANKS; "
+        "TOPK is how many of them each token is routed to. TOTAL sets the tile "
+        "geometry (tokens per expert is batch*TOPK/TOTAL) and, at --ep 1, the "
+        "weight tensors' expert dim; with --ep N the weights hold TOTAL/N. TOPK "
+        "multiplies the row count each GEMM sees (batch * TOPK gate slots). Use "
+        "--routed-experts to pin how many of the TOTAL actually receive tokens.",
+    )
+    parser.add_argument(
+        "--ep",
+        type=int,
+        default=1,
+        help="Expert-parallel world size to simulate. --experts TOTAL is then "
+        "the global count and this process benches ONE rank holding TOTAL/EP "
+        "experts, while tokens are still routed over all TOTAL -- so a rank sees "
+        "~TOPK/EP live gates per token and the rest are dead slots, exactly as "
+        "after ATOM's mori all-to-all (minus the transport). This is the only "
+        "way to get the production tile geometry: block_m comes from the GLOBAL "
+        "expert count and the histogram from the LOCAL one, which no single "
+        "routing() call can produce. DSV4 EP4 decode is '--M 2048 --experts 384 "
+        "6 --ep 4 --routed-experts 384 --balance'. Default 1 (no sharding).",
     )
     parser.add_argument(
         "--backend",
@@ -582,6 +747,29 @@ def parse_args(args: list[str] | None = None):
         action=argparse.BooleanOptionalAction,
         default=False,
         help="Preshuffle the mxfp4 weights for the gfx1250 gluon kernel (default: False).",
+    )
+    parser.add_argument(
+        "--fused-quant",
+        action="store_true",
+        default=False,
+        help="Have GEMM1 emit MXFP4 straight from its epilogue (out_mx_quant, "
+        "i.e. HAS_MX_OUT_1) instead of writing bf16 and requantizing in a "
+        "separate launch. This is what ATOM runs on gfx1250, and it moves the "
+        "requant INSIDE moe1's measurement -- expect moe1 to get slower and the "
+        "separate launch to vanish. GEMM2 cannot do it: aiter restricts "
+        "out_mx_quant to GEMM1-style calls with no scatter. gluon only.",
+    )
+    parser.add_argument(
+        "--balance",
+        action="store_true",
+        default=False,
+        help="Deal the routed experts round-robin so every one receives the same "
+        "number of rows, instead of drawing them at random. Fills every block_m "
+        "tile, which is what a load-balanced production step does; the random "
+        "default leaves ~45%% of experts spilling into a second near-empty tile "
+        "(1.45x more tile work on the DSV4 EP decode shape). Also makes the "
+        "histogram deterministic run-to-run. Implies --routed-experts (defaults "
+        "to all experts).",
     )
     parser.add_argument(
         "--routed-experts",
@@ -652,7 +840,16 @@ def main(args: list[str] | None = None) -> None:
         TP=1,
         preshuffle=parsed_args.preshuffle,
         backend=parsed_args.backend,
-        routed_experts=parsed_args.routed_experts,
+        routed_experts=(
+            parsed_args.routed_experts
+            if parsed_args.routed_experts is not None
+            # pin_routed_experts is the only thing that deals routes, so a
+            # balanced run has to go through it: default the pool to every expert.
+            else (total_experts if parsed_args.balance else None)
+        ),
+        balance=parsed_args.balance,
+        fused_quant=parsed_args.fused_quant,
+        ep=parsed_args.ep,
         rep=parsed_args.rep,
         # dedupe, keeping the canonical report order rather than argv order
         layers=tuple(n for n in LAYERS if n in parsed_args.layers),

--- a/op_tests/op_benchmarks/triton/bench_moe_gemm_a4w4_cudagraph.py
+++ b/op_tests/op_benchmarks/triton/bench_moe_gemm_a4w4_cudagraph.py
@@ -13,6 +13,14 @@ and reported as three rows, keyed by the `layer` column:
 over and over, so its weights stay cache-resident in a way the real layer does
 not. Compare like with like.
 
+--multi-gpu adds a fourth, `combine`, and changes where moe2's rows go: into
+mori's real combine staging window on the peer ranks, through the fused
+EP_SCATTER epilogue production compiles, instead of a local output buffer. It
+needs --ep > 1, that many GPUs, one --M, and torchrun --nproc-per-node=--ep.
+The DISPATCH is not simulated -- each rank keeps its own rows and fabricates the
+recv layout a dispatch would have produced -- so what it adds over plain --ep is
+the peer-memory write traffic and the cross-device barrier, not the all-to-all.
+
 --layers picks which of those are measured, e.g. `--layers moe1 moe2` to skip
 the back-to-back run, or `--layers moe1` for one projection on its own. The
 setup is unchanged either way (moe2 needs moe1's output to quantize, so layer 1
@@ -52,8 +60,10 @@ preshuffle.
 import argparse
 import csv
 import inspect
+import os
 from itertools import chain
 from pathlib import Path
+from types import SimpleNamespace
 
 import torch
 import triton
@@ -76,8 +86,10 @@ from aiter.ops.triton.moe.quant_moe import downcast_to_mxfp
 from aiter.ops.triton.utils._triton.arch_info import get_arch
 from aiter.ops.triton.utils.shuffle import moe_weight_decode_view, shuffle_scale_moe
 
-# measurable layers, in report order; see the module docstring
+# measurable layers, in report order; see the module docstring. "combine" only
+# exists under --multi-gpu, where there is a real mori combine to measure.
 LAYERS = ("moe1", "moe2", "total")
+MG_LAYERS = ("moe1", "moe2", "combine", "total")
 
 
 def compute_roofline(
@@ -103,11 +115,28 @@ def compute_roofline(
         args_list.insert(pos_index, val)
         return bench_fn(*args_list, **kwargs)
 
+    # Under --multi-gpu every rank shares one stdout, so nothing is printed
+    # where it is produced: each line is gathered and rank 0 emits the whole set
+    # in rank order, as ONE write. Printing per rank interleaves mid-line -- the
+    # banner alone was three writes -- and no amount of flushing fixes that.
+    mori = kwargs.get("mori")
+
+    def emit(line):
+        if mori is None:
+            print(line, flush=True)
+            return
+        lines = [None] * mori.world
+        mori.dist.all_gather_object(lines, line, group=mori.group)
+        if mori.rank == 0:
+            print(
+                "\n".join(f"[rank {r}] {ln}" for r, ln in enumerate(lines)),
+                flush=True,
+            )
+
     # collect performance data
     perfs = []
-    print("=========================================")
-    print(f"{out_path}...")
-    print("=========================================")
+    bar = "=" * 41
+    emit(f"{bar}\n{out_path}...\n{bar}" if mori is None else f"{out_path}")
 
     for val in intensity_proxy_values:
         perf = inject_proxy_and_call(val, args, kwargs)
@@ -121,7 +150,7 @@ def compute_roofline(
             f"{lp['bytes'] / lp['latency_ms'] * 1e-9:#.4g} TB/s"
             for name, lp in perf["layers"].items()
         )
-        print(
+        emit(
             f"{intensity_proxy_name}: {val:5d} | {groups} | "
             f"{perf['kernel']} block_m={perf['block_m']} "
             f"routed_experts={perf['routed_experts']}"
@@ -273,7 +302,7 @@ def pin_routed_experts(logits, n_routed, n_expts_act, balance=False):
     return masked, n_pinned, pool
 
 
-def ep_routing(logits, n_expts_act, n_expts_local):
+def ep_routing(logits, n_expts_act, n_expts_local, rank=0, ep_scatter_geometry=None):
     """
     Routing for ONE rank of an expert-parallel layer, from GLOBAL logits.
     """
@@ -292,7 +321,8 @@ def ep_routing(logits, n_expts_act, n_expts_local):
     # reads the global count back as `numel() - 1`, which is the convention ATOM
     # passes it.
     expert_map = torch.full((n_expts_tot + 1,), -1, dtype=torch.int32, device=dev)
-    expert_map[:n_expts_local] = torch.arange(
+    lo = rank * n_expts_local
+    expert_map[lo : lo + n_expts_local] = torch.arange(
         n_expts_local, dtype=torch.int32, device=dev
     )
 
@@ -306,7 +336,7 @@ def ep_routing(logits, n_expts_act, n_expts_local):
     # tensor, which is the form ep_sort_routing's row mask expects.
     num_local_tokens = torch.tensor([batch], dtype=torch.int32, device=dev)
 
-    hist_full, topk_indx, gate_indx, gate_scal, gate_valid, _ = ep_sort_routing(
+    hist_full, topk_indx, gate_indx, gate_scal, gate_valid, dst_row = ep_sort_routing(
         dispatch_weights,
         dispatch_ids,
         expert_map,
@@ -316,12 +346,119 @@ def ep_routing(logits, n_expts_act, n_expts_local):
         n_expts_act,
         n_gates,
         expt_data_bufs,
+        ep_scatter_geometry=ep_scatter_geometry,
     )
     # the tail bin holds the sentinel (non-local) count, which gets no tile
     hist = hist_full[:n_expts_local]
     expt_data = ExptData(hist, token_offs_raw, token_offs_pad, block_pid_map)
     rdata = RoutingData(block_m, gate_scal, hist, n_expts_local, n_expts_act, expt_data)
-    return rdata, topk_indx, gate_indx, gate_valid
+    return rdata, topk_indx, gate_indx, gate_valid, dst_row
+
+
+# ---------------------------------------------------------------------------
+# --multi-gpu: GEMM2 delivering into mori's real combine staging window
+# ---------------------------------------------------------------------------
+def init_mori_combine(rank, world, group, hidden, mtpr, inter, experts, topk):
+    """
+    The least mori that gives GEMM2 a real place to scatter to.
+    """
+    import torch.distributed as dist
+    from mori.cco import Communicator
+
+    from aiter import ActivationType, QuantType
+    from aiter.ops.flydsl.kernels.mega_moe_gfx1250 import MegaMoEGfx1250
+    from aiter.ops.flydsl.kernels.mega_moe_gfx1250.types import _from_gpu_ptr
+    from aiter.ops.flydsl.moe_common import GateMode
+
+    # ATOM's _cco_per_rank_vmm: every rank could send all its tokens to one peer
+    # (world * mtpr recv slots), times 2x headroom for tokens + combine buffers.
+    tok_bytes = mtpr * hidden * 2  # bf16 wire
+    win_bytes = world * tok_bytes * 2 + (1 << 24)
+    per_rank_vmm = 2 * win_bytes + (1 << 28)
+
+    # collective: rank 0 mints the id, everyone joins the same cco fabric
+    uid = Communicator.get_unique_id() if rank == 0 else None
+    objs = [uid]
+    dist.broadcast_object_list(objs, src=0, group=group)
+    comm = Communicator.init(world, rank, objs[0], per_rank_vmm=per_rank_vmm)
+    comm.barrier()
+
+    mega = MegaMoEGfx1250(
+        communicator=comm,
+        rank=rank,
+        world_size=world,
+        model_dim=hidden,
+        inter_dim=inter,
+        experts=experts,
+        topk=topk,
+        max_tokens_per_rank=mtpr,
+        activation=ActivationType.Silu,
+        gate_mode=GateMode.INTERLEAVE.value,
+        quant_type=QuantType.per_1x32,
+        swiglu_limit=10.0,
+    )
+    # Read once here, where every rank is aligned and a barrier follows:
+    # create_dev_comm() may be COLLECTIVE, so it cannot be done lazily from a
+    # per-rank branch. Same contract ATOM's init_mega_transport honours.
+    per_rank_size = int(comm.create_dev_comm().per_rank_size)
+    comm.barrier()
+
+    cfg = mega._config
+    slot_stride = cfg.combine_slot_stride_bytes
+    assert per_rank_size % slot_stride == 0, (
+        f"per_rank_size={per_rank_size} is not a multiple of the combine slot "
+        f"stride {slot_stride}; one row index cannot address both peer and slot"
+    )
+    peer_rows = per_rank_size // slot_stride
+    # local_ptr is this rank's alias of comb_inp; step back to peer 0's. Sized to
+    # end at the LAST peer's last slot, not a round world*peer_rows, whose tail
+    # would run past the flat space.
+    base = mega._arena.local_ptr("comb_inp") - cfg.rank * per_rank_size
+    rows = (cfg.world_size - 1) * peer_rows + cfg.max_tokens_per_rank * cfg.topk
+    stride_elems = slot_stride // 2  # bf16 wire
+    view = _from_gpu_ptr(base, (rows * stride_elems,), torch.bfloat16).as_strided(
+        (rows, cfg.hidden_dim), (stride_elems, 1)
+    )
+    return mega, view, peer_rows
+
+
+def mori_src_token_map(batch, world, dev):
+    return torch.arange(batch, dtype=torch.int32, device=dev)
+
+
+def do_bench_cudagraph_synced(fn, rep, group):
+    import torch.distributed as dist
+
+    with torch.cuda.stream(torch.cuda.Stream()):
+        fn()  # warmup
+        start, end = (torch.cuda.Event(enable_timing=True) for _ in range(2))
+        start.record()
+        for _ in range(5):
+            fn()
+        end.record()
+        torch.cuda.synchronize()
+        estimate_ms = start.elapsed_time(end) / 5
+
+        agreed = torch.tensor([estimate_ms], dtype=torch.float64)
+        dist.all_reduce(agreed, op=dist.ReduceOp.MAX, group=group)
+        estimate_ms = float(agreed[0])
+        n_repeat = 1000 if estimate_ms == 0 else max(1, int(rep / estimate_ms))
+
+        g = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(g):
+            for _ in range(n_repeat):
+                fn()
+        torch.cuda.synchronize()
+
+        times = []
+        for _ in range(10):
+            start, end = (torch.cuda.Event(enable_timing=True) for _ in range(2))
+            start.record()
+            g.replay()
+            end.record()
+            torch.cuda.synchronize()
+            times.append(start.elapsed_time(end) / n_repeat)
+    return sum(times) / len(times)
 
 
 def backend_name(backend=None):
@@ -356,9 +493,11 @@ def bench_mlp_single_weight_init(
     balance=False,
     fused_quant=False,
     ep=1,
+    mori=None,
 ):
-    rank = 0
-    dev = f"cuda:{rank}"
+    # mori is the --multi-gpu bundle from init_mori_combine (None = single rank)
+    rank = 0 if mori is None else mori.rank
+    dev = f"cuda:{torch.cuda.current_device()}"
 
     assert dim2 % TP == 0, f"{dim2=}, {TP=}, dim2 must be divisible by TP"
     # --experts TOTAL is the global count; this process holds one rank's shard.
@@ -368,6 +507,14 @@ def bench_mlp_single_weight_init(
         "equal shards"
     )
     n_expts_local = n_expts_tot // ep
+    if mori is not None:
+        assert (
+            ep == mori.world
+        ), f"--multi-gpu needs --ep == world size, {ep} != {mori.world}"
+        assert batch == mori.batch, (
+            "--multi-gpu sizes the symmetric arena from a single --M; got "
+            f"{batch} against the {mori.batch} it was built for"
+        )
     assert x_dtype == "mx4", f"FP4 (E2M1) is disabled for x_dtype, got {x_dtype}"
     assert w_dtype == "mx4", f"FP4 (E2M1) is disabled for x_dtype, got {w_dtype}"
     if preshuffle:
@@ -400,9 +547,16 @@ def bench_mlp_single_weight_init(
             "undoes; unset AITER_TRITON_USE_HERD"
         )
     assert layers, "at least one layer must be selected"
-    assert set(layers) <= set(LAYERS), f"unknown layer(s) in {layers=}"
+    _known = MG_LAYERS if mori is not None else LAYERS
+    assert set(layers) <= set(_known), f"unknown layer(s) in {layers=}"
 
     # -- init data --
+    if mori is not None:
+        # Every rank must agree on which rank owns each gate, or the staging
+        # window gets slots written twice and slots never written. Same seed ->
+        # same logits -> same routing; the ranks then differ only in which
+        # 1/ep slice of the experts they hold. See mori_src_token_map.
+        torch.manual_seed(0)
     # The router scores every GLOBAL expert (that is what picks the tile
     # geometry), but the expert weights are only this rank's shard.
     wg = torch.randn((dim1, n_expts_tot), device=dev)
@@ -434,12 +588,34 @@ def bench_mlp_single_weight_init(
             logits, routed_experts, n_expts_act, balance=balance
         )
     gate_valid = None
+    ep_scatter = None
     if ep == 1:
         rdata, gather_indx, scatter_indx = routing(logits, n_expts_act)
     else:
-        rdata, gather_indx, scatter_indx, gate_valid = ep_routing(
-            logits, n_expts_act, n_expts_local
+        geometry = None
+        if mori is not None:
+            from aiter.ops.triton.moe.moe_routing.routing import EpScatterGeometry
+
+            geometry = EpScatterGeometry(
+                src_token_map=mori_src_token_map(batch, mori.world, dev),
+                max_tokens_per_rank=batch // mori.world,
+                peer_rows=mori.peer_rows,
+            )
+        rdata, gather_indx, scatter_indx, gate_valid, dst_row = ep_routing(
+            logits,
+            n_expts_act,
+            n_expts_local,
+            rank=rank,
+            ep_scatter_geometry=geometry,
         )
+        if mori is not None:
+            from aiter.ops.triton.moe.reduce import EpCombineScatter
+
+            # GEMM2 stops reducing locally and places its un-reduced rows into
+            # the window instead -- straight from the epilogue (EP_SCATTER_1),
+            # which is what production compiles and what a local output buffer
+            # cannot show.
+            ep_scatter = EpCombineScatter(out=mori.view, dst_row=dst_row)
     x1, x1_scale = mxfp4_quant(x)
 
     def layer1():
@@ -481,17 +657,35 @@ def bench_mlp_single_weight_init(
             # under EP most gate slots belong to other ranks and no GEMM here
             # ever writes them; None (every gate live) is right for --ep 1
             gate_valid=gate_valid,
+            ep_scatter=ep_scatter,
             swizzle_mx_scale=swizzle_mx_scale2,
             preshuffle_weights=preshuffle,
             backend=backend,
         )
 
     y2 = layer2()
+
+    if mori is None:
+        combine = None
+    else:
+        from aiter.ops.flydsl.kernels.mega_moe_gfx1250.mega_moe import Routing
+
+        mega_routing = Routing(
+            token_count=batch // mori.world,
+            reverse_source_view=mori_src_token_map(batch, mori.world, dev),
+        )
+
+        def combine():
+            return mori.mega._combine(mega_routing)
+
+        combine()
     torch.cuda.synchronize()
 
     def both():
         layer1()
         layer2()
+        if combine is not None:
+            combine()
 
     # -- analytic FLOPs / bytes, matching run_moe_a4w4.py and the proton metadata
     # the kernel itself reports: 2*M*N*K per GEMM, and activations + routed-expert
@@ -533,20 +727,31 @@ def bench_mlp_single_weight_init(
     # keeping only what `layers` asked for (in LAYERS order, not argv order).
     # `total` is NOT moe1 + moe2 -- an isolated projection replays one kernel
     # over and over, so its weights stay hotter than they are in the real layer.
+    # insertion order is report order, so keep it in MG_LAYERS order
     to_bench = {
         "moe1": (layer1, moe1_flops, moe1_bytes),
         "moe2": (layer2, moe2_flops, moe2_bytes),
-        "total": (both, moe1_flops + moe2_flops, moe1_bytes + moe2_bytes),
     }
-    measured = {
-        name: {
-            "latency_ms": triton.testing.do_bench_cudagraph(f, rep=rep),
-            "flops": flops,
-            "bytes": byts,
-        }
-        for name, (f, flops, byts) in to_bench.items()
-        if name in layers
-    }
+    if combine is not None:
+        # no matmul in it; the traffic is topk staged slots in, one row out
+        mtpr = batch // mori.world
+        to_bench["combine"] = (combine, 0, mtpr * (n_expts_act + 1) * dim1 * 2)
+    to_bench["total"] = (both, moe1_flops + moe2_flops, moe1_bytes + moe2_bytes)
+
+    measured = {}
+    for name, (f, flops, byts) in to_bench.items():
+        if name not in layers:
+            continue
+        if mori is None:
+            latency_ms = triton.testing.do_bench_cudagraph(f, rep=rep)
+        else:
+            # Line the ranks up first: anything holding a cross-device barrier
+            # otherwise charges its peers' skew to whoever arrives early, and
+            # that lands in the warmup estimate that sets the replay count.
+            torch.cuda.synchronize()
+            mori.dist.barrier(group=mori.group)
+            latency_ms = do_bench_cudagraph_synced(f, rep, mori.group)
+        measured[name] = {"latency_ms": latency_ms, "flops": flops, "bytes": byts}
 
     return {
         "layers": measured,
@@ -574,6 +779,7 @@ def bench_mlp(
     balance=False,
     fused_quant=False,
     ep=1,
+    mori=None,
 ):
     all_results = []
     for i in range(num_weight_inits):
@@ -594,6 +800,7 @@ def bench_mlp(
             balance=balance,
             fused_quant=fused_quant,
             ep=ep,
+            mori=mori,
         )
         all_results.append(result)
 
@@ -633,6 +840,7 @@ def roofline_mlp(
     balance=False,
     fused_quant=False,
     ep=1,
+    mori=None,
     name="",
 ):
     # Put all outputs under logs/<name>/ and write a CSV file (not a directory-as-stem).
@@ -653,10 +861,14 @@ def roofline_mlp(
         stem += "-fusedquant"
     if ep > 1:
         stem += f"-ep{ep}"
+    if mori is not None:
+        # one file per rank: the ranks share a filesystem and their numbers
+        # differ (barrier skew is real signal, not noise to average away)
+        stem += f"-mori-rank{mori.rank}of{mori.world}"
     stem += f"-{backend_name(backend)}"
     if preshuffle:
         stem += "-preshuffled"
-    if tuple(layers) != LAYERS:
+    if tuple(layers) != (MG_LAYERS if mori is not None else LAYERS):
         # a partial run holds a subset of the rows, so give it its own file
         stem += "-layers=" + "+".join(layers)
     out_csv = out_dir / f"{stem}.csv"
@@ -678,6 +890,7 @@ def roofline_mlp(
         balance=balance,  # forwarded to bench_mlp via compute_roofline's **kwargs
         fused_quant=fused_quant,
         ep=ep,
+        mori=mori,
         bench_fn=bench_mlp,  # function to benchmark
         intensity_proxy_name="batch",  # intensity proxy name
         intensity_proxy_values=batch_sizes,  # intensity proxy values to sweep
@@ -783,14 +996,29 @@ def parse_args(args: list[str] | None = None):
         "i.e. random routing over all experts.",
     )
     parser.add_argument(
+        "--multi-gpu",
+        action="store_true",
+        default=False,
+        help="Have GEMM2 deliver its rows into mori's real combine staging "
+        "window -- PEER memory on the other EP ranks, through the fused "
+        "EP_SCATTER epilogue production compiles -- instead of a local output "
+        "buffer, and measure the mori combine that drains it as an extra "
+        "'combine' row. Needs --ep > 1, at least --ep visible GPUs, exactly one "
+        "--M, and torchrun with --nproc-per-node equal to --ep. Only GEMM2 and "
+        "the combine change; moe1 is untouched. The dispatch is NOT simulated: "
+        "each rank keeps its own rows and fabricates the recv layout a dispatch "
+        "would have produced, so what this adds over plain --ep is the peer-"
+        "memory write traffic and the cross-device barrier, not the all-to-all.",
+    )
+    parser.add_argument(
         "--layers",
         nargs="+",
-        choices=LAYERS,
-        default=list(LAYERS),
+        choices=MG_LAYERS,
+        default=None,
         help="Which layers to measure: moe1 (up projection), moe2 (down "
         "projection), total (both back to back). E.g. '--layers moe1 moe2' to "
         "skip the back-to-back run, or '--layers moe1' for one projection "
-        "alone. Default: all three.",
+        "alone. combine needs --multi-gpu. Default: all of them.",
     )
     parser.add_argument(
         "--rep",
@@ -829,6 +1057,62 @@ def main(args: list[str] | None = None) -> None:
         batch_sizes_moe = parsed_args.M
     quantized_dtypes = ["mx4", "mx4"]
 
+    all_layers = MG_LAYERS if parsed_args.multi_gpu else LAYERS
+    layers = parsed_args.layers if parsed_args.layers is not None else list(all_layers)
+    bad = set(layers) - set(all_layers)
+    assert not bad, f"{sorted(bad)} needs --multi-gpu"
+
+    mori = None
+    if parsed_args.multi_gpu:
+        import torch.distributed as dist
+
+        ep = parsed_args.ep
+        assert ep > 1, "--multi-gpu is only meaningful with --ep > 1"
+        assert torch.cuda.device_count() >= ep, (
+            f"--multi-gpu --ep {ep} needs at least {ep} GPUs, this machine has "
+            f"{torch.cuda.device_count()}"
+        )
+        assert len(batch_sizes_moe) == 1, (
+            "--multi-gpu sizes mori's symmetric arena once, so it takes exactly "
+            f"one --M; got {batch_sizes_moe}"
+        )
+        batch = batch_sizes_moe[0]
+        assert batch % ep == 0, (
+            f"--M {batch} must divide by --ep {ep}: a recv buffer holds "
+            "max_tokens_per_rank rows from each of ep peers"
+        )
+        rank = int(os.environ["RANK"])
+        world = int(os.environ["WORLD_SIZE"])
+        assert world == ep, (
+            f"--multi-gpu needs one process per EP rank: WORLD_SIZE={world} "
+            f"against --ep {ep}. Launch with torchrun --nproc-per-node={ep}."
+        )
+        torch.cuda.set_device(int(os.environ.get("LOCAL_RANK", rank)))
+        dist.init_process_group(
+            backend="cpu:gloo,cuda:nccl", rank=rank, world_size=world
+        )
+        group = dist.new_group(backend="gloo")
+        mega, view, peer_rows = init_mori_combine(
+            rank,
+            world,
+            group,
+            hidden=dim1,
+            mtpr=batch // world,
+            inter=dim2 // 2,
+            experts=total_experts,
+            topk=active_experts,
+        )
+        mori = SimpleNamespace(
+            mega=mega,
+            view=view,
+            peer_rows=peer_rows,
+            rank=rank,
+            world=world,
+            group=group,
+            batch=batch,
+            dist=dist,
+        )
+
     roofline_mlp(
         batch_sizes_moe,
         dim1,
@@ -850,12 +1134,18 @@ def main(args: list[str] | None = None) -> None:
         balance=parsed_args.balance,
         fused_quant=parsed_args.fused_quant,
         ep=parsed_args.ep,
+        mori=mori,
         rep=parsed_args.rep,
         # dedupe, keeping the canonical report order rather than argv order
-        layers=tuple(n for n in LAYERS if n in parsed_args.layers),
+        layers=tuple(n for n in all_layers if n in layers),
         num_weight_inits=parsed_args.num_weight_inits,
         name="moe_gemm_a4w4",
     )
+
+    if mori is not None:
+        mori.dist.barrier(group=mori.group)
+        mega.close()
+        mori.dist.destroy_process_group()
 
 
 if __name__ == "__main__":

--- a/op_tests/triton_tests/moe/test_moe_gemm_a4w4.py
+++ b/op_tests/triton_tests/moe/test_moe_gemm_a4w4.py
@@ -226,6 +226,8 @@ class Case:
             Case(16, 1024, 1024, 128, 4, preshuffle_weights=True),
             Case(1024, 7168, 2048, 256, 8, hbm_swizzling=True, preshuffle_weights=True),
             Case(256, 1024, 1024, 8, 4, preshuffle_weights=True),
+            Case(16, 1536, 7168, 256, 8, hbm_swizzling=True, preshuffle_weights=True),
+            Case(16, 7168, 768, 256, 8, hbm_swizzling=True, preshuffle_weights=True),
         ]
     ],
 )


### PR DESCRIPTION
```
perf from a08-1, DSV4-Pro EP4 M=2048
                                                     runtime (us)  bw (TB/s)
x_scales_preload = l2_prefetch = False
_moe_gemm_a4w4_prefill_BLOCK_M_32_BLOCK_N_512_BLOCK  165.04        13.91     
_moe_gemm_a4w4_prefill_BLOCK_M_32_BLOCK_N_256_BLOCK   88.65        13.22     

x_scales_preload = True, l2_prefetch = False
_moe_gemm_a4w4_prefill_BLOCK_M_32_BLOCK_N_512_BLOCK  162.16        14.16     
_moe_gemm_a4w4_prefill_BLOCK_M_32_BLOCK_N_256_BLOCK   88.69        13.22     

x_scales_preload = l2_prefetch = True
_moe_gemm_a4w4_prefill_BLOCK_M_32_BLOCK_N_512_BLOCK  160.68        14.29     
_moe_gemm_a4w4_prefill_BLOCK_M_32_BLOCK_N_256_BLOCK   89.13        13.15     
```

```
Before tunning

DSV4-Pro TP4 M=16
_moe_gemm_a4w4_decode_BLOCK_M_16_BLOCK_N_128_BLOCK_    41.62   13.51    
_moe_gemm_a4w4_decode_BLOCK_M_16_BLOCK_N_128_BLOCK_    22.47   12.56    
_reduce_grouped_BLOCK_N_512_EVEN_N_1_K_6_APPLY_SWIG     5.13            

DSV4-Pro TP4 M=64
_moe_gemm_a4w4_decode_BLOCK_M_16_BLOCK_N_128_BLOCK_   127.50   17.64    
_moe_gemm_a4w4_decode_BLOCK_M_16_BLOCK_N_128_BLOCK_    65.89   17.13    
_reduce_grouped_BLOCK_N_512_EVEN_N_1_K_6_APPLY_SWIG     5.17            

After tunning

DSV4-Pro TP4 M=16
_moe_gemm_a4w4_decode_BLOCK_M_16_BLOCK_N_256_BLOCK_    39.74   14.15     
_moe_gemm_a4w4_decode_BLOCK_M_16_BLOCK_N_128_BLOCK_    22.80   12.38     
_reduce_grouped_BLOCK_N_512_EVEN_N_1_K_6_APPLY_SWIG     5.13             

DSV4-Pro TP4 M=64
_moe_gemm_a4w4_decode_BLOCK_M_16_BLOCK_N_128_BLOCK_   125.84   17.87     
_moe_gemm_a4w4_decode_BLOCK_M_16_BLOCK_N_256_BLOCK_    64.90   17.39     
_reduce_grouped_BLOCK_N_512_EVEN_N_1_K_6_APPLY_SWIG     5.45             
```

in addition EP bench is supported

```
cd /app/aiter/op_tests/op_benchmarks/triton

# single GPU EP4 simulation
python3 bench_moe_gemm_a4w4_cudagraph.py \
  --M 2048 --shape 7168 6144 --experts 384 6 --ep 4 --routed-experts 384 \
  --balance --fused-quant --preshuffle

# multi-GPU EP4 simulation, requires MORI and requires real multiple GPUs
torchrun --nproc-per-node=4 \
  bench_moe_gemm_a4w4_cudagraph.py --M 2048 --shape 7168 6144 \
  --experts 384 6 --ep 4 --routed-experts 384 --balance --fused-quant \
  --preshuffle --multi-gpu
```