### PR TITLE
[Triton/Gluon] Do not autotune for the FA port in unit tests

### DIFF
--- a/aiter/ops/triton/_triton_kernels/flash_attn_triton_amd/utils.py
+++ b/aiter/ops/triton/_triton_kernels/flash_attn_triton_amd/utils.py
@@ -149,7 +149,8 @@ except Exception as e:  # noqa: BLE001
 #
 # Set via: FLASH_ATTENTION_TRITON_AMD_DEBUG=0|1|2
 DEBUG: int = int(os.environ.get("FLASH_ATTENTION_TRITON_AMD_DEBUG", "0"))
-if AUTOTUNE != "off" or DEBUG > 0:
+# Printing every autotune result is debug output; it must not be forced on for the whole process.
+if DEBUG > 0:
     os.environ["TRITON_PRINT_AUTOTUNING"] = "1"
 if DEBUG >= 2:
     os.environ["TRITON_INTERPRET"] = "1"

--- a/op_tests/triton_tests/__init__.py
+++ b/op_tests/triton_tests/__init__.py
@@ -5,7 +5,10 @@ import sys
 
 # Under pytest, silence aiter's INFO chatter (e.g. checkAllclose "passed~") unless the caller
 # set AITER_LOG_LEVEL; aiter/__init__.py reads it once, on the first import triggered below.
-if "pytest" in sys.modules and "AITER_LOG_LEVEL" not in os.environ:
-    os.environ["AITER_LOG_LEVEL"] = "WARNING"
+if "pytest" in sys.modules:
+    if "AITER_LOG_LEVEL" not in os.environ:
+        os.environ["AITER_LOG_LEVEL"] = "WARNING"
+    # Unit tests run the Dao-AI flash-attention port on its fixed default configs, not autotuning.
+    os.environ.setdefault("FLASH_ATTENTION_TRITON_AMD_AUTOTUNE", "0")
 
 from op_tests.triton_tests.utils import *


### PR DESCRIPTION
flash_attn_triton_amd tunes by default and forced TRITON_PRINT_AUTOTUNING=1 on the whole process.
Printing now needs FLASH_ATTENTION_TRITON_AMD_DEBUG, and pytest runs the port on its fixed configs
(FLASH_ATTENTION_TRITON_AMD_AUTOTUNE=0 from the triton_tests package).