### PR TITLE
Publish gfx950 tiles for flash_kda K2 and sparse_attention_dsv4 prefill

### DIFF
--- a/aiter/ops/triton/_triton_kernels/attention/sparse_attention_dsv4.py
+++ b/aiter/ops/triton/_triton_kernels/attention/sparse_attention_dsv4.py
@@ -3,6 +3,10 @@ import triton
 import triton.language as tl
 
 from aiter.ops.triton.utils._triton.kernel_repr import make_kernel_repr
+from aiter.ops.triton.utils.tuned_config_utils import (
+    autotune_enabled,
+    get_tuned_kernel_config,
+)
 
 # =====================================================================
 # Utility
@@ -24,6 +28,19 @@ def _get_lds_limit():
 
 
 _LDS_LIMIT = _get_lds_limit()
+
+# Tuning is opt-in; unit tests and production launch the tile published for this device.
+SPARSE_ATTENTION_DSV4_TRITON_AUTOTUNE: bool = autotune_enabled("SPARSE_ATTENTION_DSV4")
+_PREFILL_TUNED = get_tuned_kernel_config(
+    "attention",
+    "SPARSE_ATTENTION_DSV4",
+    "_sparse_attn_prefill_kernel",
+    triton.Config(
+        {"BLOCK_H": 32, "BLOCK_K": 16, "waves_per_eu": 0, "matrix_instr_nonkdim": 16},
+        num_warps=4,
+        num_stages=1,
+    ),
+)
 
 
 # ---------------------------------------------------------------------------
@@ -228,6 +245,10 @@ def _combine_topk_swa_indices_ragged_kernel(
 
 def _prefill_prune_configs(configs, named_args, **kwargs):
     BLOCK_D = kwargs.get("BLOCK_D", named_args.get("BLOCK_D"))
+    if not SPARSE_ATTENTION_DSV4_TRITON_AUTOTUNE:
+        cfg = _PREFILL_TUNED
+        if BLOCK_D * cfg.kwargs["BLOCK_K"] * 2 * cfg.num_stages <= _LDS_LIMIT:
+            return [cfg]
     pruned = []
     for cfg in configs:
         bk = cfg.kwargs["BLOCK_K"]

--- a/aiter/ops/triton/_triton_kernels/chunk_delta_attn/chunk_delta_attn_utils.py
+++ b/aiter/ops/triton/_triton_kernels/chunk_delta_attn/chunk_delta_attn_utils.py
@@ -12,7 +12,10 @@ import os
 import torch
 import triton
 
-from aiter.ops.triton.utils.tuned_config_utils import get_tuned_kernel_config
+from aiter.ops.triton.utils.tuned_config_utils import (
+    autotune_enabled,
+    get_tuned_kernel_config,
+)
 
 SUPPORTS_AUTOTUNE_CACHE = (
     "cache_results" in inspect.signature(triton.autotune).parameters
@@ -22,19 +25,7 @@ autotune_cache_kwargs: dict = (
     {"cache_results": _FLA_CACHE_RESULTS} if SUPPORTS_AUTOTUNE_CACHE else {}
 )
 
-CHUNK_DELTA_ATTN_TRITON_AUTOTUNE: bool = os.getenv(
-    "CHUNK_DELTA_ATTN_TRITON_AUTOTUNE", "0"
-).lower() in ("1", "true", "yes", "on")
-
-
-def chunk_delta_attn_autotune_configs(
-    configs: list,
-    default_config=None,
-) -> list:
-    """Return configs for @triton.autotune."""
-    if CHUNK_DELTA_ATTN_TRITON_AUTOTUNE:
-        return configs
-    return [default_config if default_config is not None else configs[0]]
+CHUNK_DELTA_ATTN_TRITON_AUTOTUNE: bool = autotune_enabled("CHUNK_DELTA_ATTN")
 
 
 def chunk_delta_attn_tuned_config(

--- a/aiter/ops/triton/_triton_kernels/chunk_delta_attn/flash_kda.py
+++ b/aiter/ops/triton/_triton_kernels/chunk_delta_attn/flash_kda.py
@@ -56,6 +56,7 @@ import triton.language as tl
 from aiter.ops.triton._triton_kernels.chunk_delta_attn.chunk_delta_attn_utils import (
     CHUNK_DELTA_ATTN_TRITON_AUTOTUNE,
     autotune_cache_kwargs,
+    chunk_delta_attn_tuned_config,
     exp,
     exp2,
     input_guard,
@@ -308,25 +309,32 @@ def _flash_kda_prepare_kernel(
     tl.store(ws_inv_mqk + cc_off, b_INV)
 
 
-# K2 keeps three configs even with the global autotune flag off, where the other
-# kernels here fall back to one. Its parallelism is only num_segments * H *
-# (W / BW), so the best BW swings with head count: a pinned BW=32 costs ~1.4x at
-# H=16 and turns the path into a regression against the default pipeline. Three
-# configs is a cheap first-call sweep, and the result is cached.
-_K2_CONFIGS: list = (
-    [
-        triton.Config({"BW": BW}, num_warps=nw, num_stages=ns)
-        for BW in [16, 32, 64]
-        for nw in [2, 4]
-        for ns in [1, 2]
-    ]
-    if CHUNK_DELTA_ATTN_TRITON_AUTOTUNE
-    else [
+# K2's parallelism is only num_segments * H * (W / BW), so the best BW is set by the
+# segment count: one segment wants BW=16 (4x the blocks of BW=64), many want BW=64.
+_K2_CONFIGS: list = [
+    triton.Config({"BW": BW}, num_warps=nw, num_stages=ns)
+    for BW in [16, 32, 64]
+    for nw in [2, 4]
+    for ns in [1, 2]
+]
+_K2_TUNED = {
+    "single_seg": chunk_delta_attn_tuned_config(
+        "_flash_kda_segment_kernel_single_seg",
         triton.Config({"BW": 16}, num_warps=2, num_stages=2),
-        triton.Config({"BW": 32}, num_warps=2, num_stages=2),
-        triton.Config({"BW": 64}, num_warps=4, num_stages=2),
-    ]
-)
+    ),
+    "multi_seg": chunk_delta_attn_tuned_config(
+        "_flash_kda_segment_kernel_multi_seg",
+        triton.Config({"BW": 64}, num_warps=2, num_stages=2),
+    ),
+}
+
+
+def _k2_prune(configs, named_args, **kwargs):
+    """Tuning on: benchmark every config; off: the published tile for this segment class."""
+    if CHUNK_DELTA_ATTN_TRITON_AUTOTUNE:
+        return configs
+    segs_class = kwargs.get("NUM_SEGS_CLASS", named_args.get("NUM_SEGS_CLASS"))
+    return [_K2_TUNED["single_seg" if segs_class <= 1 else "multi_seg"]]
 
 
 def _seg_occupancy_class(num_segs: int) -> int:
@@ -349,6 +357,7 @@ def _seg_occupancy_class(num_segs: int) -> int:
     # and unsegmented schedules collide and whichever runs first sets the
     # config for both, a result the on-disk cache then keeps.
     key=["H", "K", "W", "C", "HAS_V", "COMPUTE_OUTPUT", "NUM_SEGS_CLASS"],
+    prune_configs_by={"early_config_prune": _k2_prune},
     **autotune_cache_kwargs,
 )
 @triton.jit

--- a/aiter/ops/triton/_triton_kernels/chunk_delta_attn/flash_kda.py
+++ b/aiter/ops/triton/_triton_kernels/chunk_delta_attn/flash_kda.py
@@ -56,7 +56,6 @@ import triton.language as tl
 from aiter.ops.triton._triton_kernels.chunk_delta_attn.chunk_delta_attn_utils import (
     CHUNK_DELTA_ATTN_TRITON_AUTOTUNE,
     autotune_cache_kwargs,
-    chunk_delta_attn_autotune_configs,
     exp,
     exp2,
     input_guard,
@@ -65,6 +64,7 @@ from aiter.ops.triton._triton_kernels.chunk_delta_attn.chunk_delta_attn_utils im
 from aiter.ops.triton._triton_kernels.chunk_delta_attn.utils.index import (
     prepare_chunk_indices,
 )
+from aiter.ops.triton.utils.tuned_config_utils import autotune_configs
 
 # On by default. `flash_kda_supported` decides per call and anything outside the
 # restrictions above keeps the default pipeline, so this switch only exists to
@@ -98,7 +98,8 @@ FLASH_KDA_INV_BLOCK: int = 16
     }
 )
 @triton.autotune(
-    configs=chunk_delta_attn_autotune_configs(
+    configs=autotune_configs(
+        "CHUNK_DELTA_ATTN",
         [
             triton.Config({}, num_warps=nw, num_stages=ns)
             for nw in [2, 4]

--- a/aiter/ops/triton/_triton_kernels/chunk_delta_attn/gate.py
+++ b/aiter/ops/triton/_triton_kernels/chunk_delta_attn/gate.py
@@ -21,6 +21,7 @@ from aiter.ops.triton._triton_kernels.chunk_delta_attn.chunk_delta_attn_utils im
     input_guard,
     softplus,
 )
+from aiter.ops.triton.utils.tuned_config_utils import autotune_configs
 
 _BETA_SIGMOID_BLOCK_SIZE = 2048
 _BETA_SIGMOID_NUM_WARPS = 8
@@ -67,12 +68,15 @@ def beta_sigmoid_fwd(x: torch.Tensor) -> torch.Tensor:
     }
 )
 @triton.autotune(
-    configs=[
-        triton.Config({"BT": BT}, num_warps=nw, num_stages=ns)
-        for BT in BT_LIST
-        for nw in NUM_WARPS_AUTOTUNE
-        for ns in [2, 3]
-    ],
+    configs=autotune_configs(
+        "CHUNK_DELTA_ATTN",
+        [
+            triton.Config({"BT": BT}, num_warps=nw, num_stages=ns)
+            for BT in BT_LIST
+            for nw in NUM_WARPS_AUTOTUNE
+            for ns in [2, 3]
+        ],
+    ),
     key=["H", "D"],
     **autotune_cache_kwargs,
 )

--- a/aiter/ops/triton/_triton_kernels/chunk_delta_attn/gla_output.py
+++ b/aiter/ops/triton/_triton_kernels/chunk_delta_attn/gla_output.py
@@ -17,7 +17,6 @@ import triton.language as tl
 
 from aiter.ops.triton._triton_kernels.chunk_delta_attn.chunk_delta_attn_utils import (
     autotune_cache_kwargs,
-    chunk_delta_attn_autotune_configs,
     chunk_delta_attn_tuned_config,
     exp,
     exp2,
@@ -26,6 +25,7 @@ from aiter.ops.triton._triton_kernels.chunk_delta_attn.chunk_delta_attn_utils im
 from aiter.ops.triton._triton_kernels.chunk_delta_attn.utils.index import (
     prepare_chunk_indices,
 )
+from aiter.ops.triton.utils.tuned_config_utils import autotune_configs
 
 # The BV=128 / num_stages=3 tile this kernel came with wants up to 123KB of LDS,
 # which a 64KB device (gfx942, gfx90a) cannot launch at all. Unpipelined, this one
@@ -41,7 +41,8 @@ _FALLBACK_O_CONFIG = triton.Config({"BK": 64, "BV": 64}, num_warps=4, num_stages
     }
 )
 @triton.autotune(
-    configs=chunk_delta_attn_autotune_configs(
+    configs=autotune_configs(
+        "CHUNK_DELTA_ATTN",
         [
             triton.Config({"BK": BK, "BV": BV}, num_warps=nw, num_stages=ns)
             for BK in [32, 64]

--- a/aiter/ops/triton/_triton_kernels/chunk_delta_attn/intra_attn.py
+++ b/aiter/ops/triton/_triton_kernels/chunk_delta_attn/intra_attn.py
@@ -23,7 +23,6 @@ from aiter.ops.triton._triton_kernels.chunk_delta_attn.chunk_delta_attn_utils im
     IS_GATHER_SUPPORTED,
     IS_TF32_SUPPORTED,
     autotune_cache_kwargs,
-    chunk_delta_attn_autotune_configs,
     exp2,
     input_guard,
 )
@@ -33,6 +32,7 @@ from aiter.ops.triton._triton_kernels.chunk_delta_attn.utils.index import (
 from aiter.ops.triton._triton_kernels.chunk_delta_attn.wy_fast import (
     recompute_w_u_fwd,
 )
+from aiter.ops.triton.utils.tuned_config_utils import autotune_configs
 
 if IS_TF32_SUPPORTED:
     SOLVE_TRIL_DOT_PRECISION = tl.constexpr("tf32")
@@ -57,7 +57,8 @@ else:
     }
 )
 @triton.autotune(
-    configs=chunk_delta_attn_autotune_configs(
+    configs=autotune_configs(
+        "CHUNK_DELTA_ATTN",
         [
             triton.Config({"BH": BH, "BK": BK}, num_warps=nw)
             for BH in [1, 2, 4, 8]
@@ -225,7 +226,8 @@ def _chunk_delta_attn_fwd_intra_token_parallel(
     }
 )
 @triton.autotune(
-    configs=chunk_delta_attn_autotune_configs(
+    configs=autotune_configs(
+        "CHUNK_DELTA_ATTN",
         [
             triton.Config({}, num_warps=nw, num_stages=ns)
             for nw in [1, 2, 4, 8]
@@ -368,7 +370,8 @@ def chunk_delta_attn_fwd_kernel_intra_sub_chunk(
     }
 )
 @triton.autotune(
-    configs=chunk_delta_attn_autotune_configs(
+    configs=autotune_configs(
+        "CHUNK_DELTA_ATTN",
         [
             triton.Config({"BK": BK}, num_warps=nw)
             for BK in [32, 64]

--- a/aiter/ops/triton/_triton_kernels/chunk_delta_attn/utils/cumsum.py
+++ b/aiter/ops/triton/_triton_kernels/chunk_delta_attn/utils/cumsum.py
@@ -11,7 +11,6 @@ import triton.language as tl
 from aiter.ops.triton._triton_kernels.chunk_delta_attn.chunk_delta_attn_utils import (
     autotune_cache_kwargs,
     check_shared_mem,
-    chunk_delta_attn_autotune_configs,
     exp,
     input_guard,
     softplus,
@@ -19,6 +18,7 @@ from aiter.ops.triton._triton_kernels.chunk_delta_attn.chunk_delta_attn_utils im
 from aiter.ops.triton._triton_kernels.chunk_delta_attn.utils.index import (
     prepare_chunk_indices,
 )
+from aiter.ops.triton.utils.tuned_config_utils import autotune_configs
 
 BS_LIST = [32, 64] if check_shared_mem() else [16, 32]
 
@@ -32,7 +32,8 @@ BS_LIST = [32, 64] if check_shared_mem() else [16, 32]
     }
 )
 @triton.autotune(
-    configs=chunk_delta_attn_autotune_configs(
+    configs=autotune_configs(
+        "CHUNK_DELTA_ATTN",
         [triton.Config({"BS": BS}, num_warps=nw) for BS in BS_LIST for nw in [2, 4, 8]],
         default_config=triton.Config({"BS": 64}, num_warps=2),
     ),

--- a/aiter/ops/triton/_triton_kernels/chunk_delta_attn/wy_fast.py
+++ b/aiter/ops/triton/_triton_kernels/chunk_delta_attn/wy_fast.py
@@ -19,13 +19,13 @@ import triton.language as tl
 
 from aiter.ops.triton._triton_kernels.chunk_delta_attn.chunk_delta_attn_utils import (
     autotune_cache_kwargs,
-    chunk_delta_attn_autotune_configs,
     exp2,
     input_guard,
 )
 from aiter.ops.triton._triton_kernels.chunk_delta_attn.utils.index import (
     prepare_chunk_indices,
 )
+from aiter.ops.triton.utils.tuned_config_utils import autotune_configs
 
 _BK_DEFAULT = 64
 _BV_DEFAULT = 64
@@ -39,7 +39,8 @@ _BV_DEFAULT = 64
     }
 )
 @triton.autotune(
-    configs=chunk_delta_attn_autotune_configs(
+    configs=autotune_configs(
+        "CHUNK_DELTA_ATTN",
         [
             triton.Config({}, num_warps=nw, num_stages=ns)
             for nw in [2, 4, 8]

--- a/aiter/ops/triton/_triton_kernels/fusions/attn_res.py
+++ b/aiter/ops/triton/_triton_kernels/fusions/attn_res.py
@@ -1,21 +1,16 @@
 # SPDX-License-Identifier: MIT
 # Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
 
-import os
 
 import triton
 import triton.language as tl
 
 from aiter.ops.triton.utils._triton.kernel_repr import make_kernel_repr
+from aiter.ops.triton.utils.tuned_config_utils import autotune_enabled
 
 # Dev-time tuning escape hatch (off by default). See the block below the kernel
 # for what this actually does and why it's not the production path.
-ATTN_RES_TRITON_AUTOTUNE: bool = os.getenv("ATTN_RES_TRITON_AUTOTUNE", "0").lower() in (
-    "1",
-    "true",
-    "yes",
-    "on",
-)
+ATTN_RES_TRITON_AUTOTUNE: bool = autotune_enabled("ATTN_RES")
 
 
 _attnres_fwd_kernel_repr = make_kernel_repr(

--- a/aiter/ops/triton/_triton_kernels/gated_delta_rule/decode/fused_sigmoid_gating_recurrent.py
+++ b/aiter/ops/triton/_triton_kernels/gated_delta_rule/decode/fused_sigmoid_gating_recurrent.py
@@ -4,9 +4,9 @@ import triton.language as tl
 
 from aiter.ops.triton._triton_kernels.gated_delta_rule.gated_delta_rule_utils import (
     autotune_cache_kwargs,
-    gated_delta_rule_autotune_configs,
     input_guard,
 )
+from aiter.ops.triton.utils.tuned_config_utils import autotune_configs
 
 
 def is_cuda():
@@ -39,7 +39,7 @@ def get_autotune_config():
     }
 )
 @triton.autotune(
-    configs=gated_delta_rule_autotune_configs(get_autotune_config()),
+    configs=autotune_configs("GATED_DELTA_RULE", get_autotune_config()),
     key=["K", "V"],
     **autotune_cache_kwargs,
 )

--- a/aiter/ops/triton/_triton_kernels/gated_delta_rule/gated_delta_rule_utils.py
+++ b/aiter/ops/triton/_triton_kernels/gated_delta_rule/gated_delta_rule_utils.py
@@ -17,6 +17,8 @@ import torch
 import triton
 from packaging import version
 
+from aiter.ops.triton.utils.tuned_config_utils import autotune_enabled
+
 logger = logging.getLogger(__name__)
 
 # Autotune cache support
@@ -48,31 +50,12 @@ autotune_cache_kwargs = (
     {"cache_results": FLA_CACHE_RESULTS} if SUPPORTS_AUTOTUNE_CACHE else {}
 )
 
-GATED_DELTA_RULE_TRITON_AUTOTUNE = os.environ.get(
-    "GATED_DELTA_RULE_TRITON_AUTOTUNE", "0"
-).lower() in ("1", "true", "yes", "on")
+GATED_DELTA_RULE_TRITON_AUTOTUNE = autotune_enabled("GATED_DELTA_RULE")
 
 # log2(e) == 1/ln(2). Converts natural-log gate values to log2 space so
 # kernels can use exp2 instead of exp. Python/wrapper-only: pass into kernels
 # as a constexpr scale (e.g. G_SCALE); never reference inside @triton.jit kernels.
 RCP_LN2: float = math.log2(math.e)
-
-
-def gated_delta_rule_autotune_configs(
-    configs: list[triton.Config], default_config: triton.Config | None = None
-) -> list[triton.Config]:
-    """
-    Select Triton autotune configs based on the gated delta rule env flag.
-
-    When ``GATED_DELTA_RULE_TRITON_AUTOTUNE`` is enabled, return the full config
-    list so ``@triton.autotune`` benchmarks candidate kernels. When disabled,
-    return only ``default_config`` (or the first config) to skip tuning overhead
-    while keeping the decorator shape uniform across decode and prefill kernels.
-    """
-    if GATED_DELTA_RULE_TRITON_AUTOTUNE:
-        return configs
-    cfg = default_config if default_config is not None else configs[0]
-    return [cfg]
 
 
 @lru_cache(maxsize=1)

--- a/aiter/ops/triton/_triton_kernels/gated_delta_rule/prefill/chunk_delta_h.py
+++ b/aiter/ops/triton/_triton_kernels/gated_delta_rule/prefill/chunk_delta_h.py
@@ -20,7 +20,6 @@ from aiter.ops.triton._triton_kernels.gated_delta_rule.gated_delta_rule_utils im
     RCP_LN2,
     autotune_cache_kwargs,
     check_shared_mem,
-    gated_delta_rule_autotune_configs,
 )
 from aiter.ops.triton._triton_kernels.gated_delta_rule.utils import (
     GatedDeltaRulePrefillMetadata,
@@ -29,6 +28,7 @@ from aiter.ops.triton._triton_kernels.gated_delta_rule.utils import (
     prepare_rebased_cu_seqlens,
 )
 from aiter.ops.triton._triton_kernels.gated_delta_rule.utils.op import exp
+from aiter.ops.triton.utils.tuned_config_utils import autotune_configs
 
 NUM_WARPS = [2, 4] if IS_NVIDIA_HOPPER else [2, 4, 8, 16]
 # Workaround: AMD ROCm Triton compiler fails with num_stages=4 in stream pipeline
@@ -52,13 +52,14 @@ def _gate_exp(x, USE_EXP2: tl.constexpr):
     }
 )
 @triton.autotune(
-    configs=gated_delta_rule_autotune_configs(
+    configs=autotune_configs(
+        "GATED_DELTA_RULE",
         [
             triton.Config({"BV": BV}, num_warps=num_warps, num_stages=num_stages)
             for num_warps in [2, 4]
             for num_stages in NUM_STAGES_FWD
             for BV in [32, 64]
-        ]
+        ],
     ),
     key=["H", "K", "V", "BT", "TRANSPOSE_STATE"],
     **autotune_cache_kwargs,
@@ -316,7 +317,8 @@ def chunk_gated_delta_rule_fwd_kernel_h_blockdim64(
     }
 )
 @triton.autotune(
-    configs=gated_delta_rule_autotune_configs(
+    configs=autotune_configs(
+        "GATED_DELTA_RULE",
         [
             triton.Config({"BV": BV}, num_warps=num_warps, num_stages=num_stages)
             for num_warps in [2, 4]
@@ -324,7 +326,7 @@ def chunk_gated_delta_rule_fwd_kernel_h_blockdim64(
                 [3, 2] if IS_AMD else ([4, 3, 2] if check_shared_mem("ampere") else [1])
             )
             for BV in [64, 32]
-        ]
+        ],
     ),
     key=["H", "K", "V", "BT", "BV", "USE_G"],
     **autotune_cache_kwargs,
@@ -657,13 +659,14 @@ def chunk_gated_delta_rule_fwd_h(
     }
 )
 @triton.autotune(
-    configs=gated_delta_rule_autotune_configs(
+    configs=autotune_configs(
+        "GATED_DELTA_RULE",
         [
             triton.Config({"BV": BV}, num_warps=num_warps, num_stages=num_stages)
             for num_warps in [2, 4]
             for num_stages in NUM_STAGES_FWD
             for BV in [16, 32, 64]
-        ]
+        ],
     ),
     key=["H", "K", "V", "BT", "IS_VARLEN"],
     **autotune_cache_kwargs,
@@ -970,13 +973,14 @@ def chunk_gated_delta_rule_fwd_h_opt(
     }
 )
 @triton.autotune(
-    configs=gated_delta_rule_autotune_configs(
+    configs=autotune_configs(
+        "GATED_DELTA_RULE",
         [
             triton.Config({"BV": BV}, num_warps=num_warps, num_stages=num_stages)
             for num_warps in [2, 4]
             for num_stages in NUM_STAGES_FWD
             for BV in [16, 32, 64]
-        ]
+        ],
     ),
     key=["H", "K", "V", "BT", "IS_VARLEN"],
     **autotune_cache_kwargs,

--- a/aiter/ops/triton/_triton_kernels/gated_delta_rule/prefill/chunk_o.py
+++ b/aiter/ops/triton/_triton_kernels/gated_delta_rule/prefill/chunk_o.py
@@ -16,7 +16,6 @@ from aiter.ops.triton._triton_kernels.gated_delta_rule.gated_delta_rule_utils im
     IS_NVIDIA_HOPPER,
     autotune_cache_kwargs,
     check_shared_mem,
-    gated_delta_rule_autotune_configs,
 )
 from aiter.ops.triton._triton_kernels.gated_delta_rule.utils import (
     GatedDeltaRulePrefillMetadata,
@@ -24,6 +23,7 @@ from aiter.ops.triton._triton_kernels.gated_delta_rule.utils import (
     prepare_rebased_cu_seqlens,
 )
 from aiter.ops.triton._triton_kernels.gated_delta_rule.utils.op import exp
+from aiter.ops.triton.utils.tuned_config_utils import autotune_configs
 
 BKV_LIST = [64, 128] if check_shared_mem() else [32, 64]
 NUM_WARPS = [2, 4] if IS_NVIDIA_HOPPER else [2, 4, 8]
@@ -75,12 +75,13 @@ def _bp_st2d(base, R, C, rs, cs, r0, c0, val, BR: tl.constexpr, BC: tl.constexpr
     }
 )
 @triton.autotune(
-    configs=gated_delta_rule_autotune_configs(
+    configs=autotune_configs(
+        "GATED_DELTA_RULE",
         [
             triton.Config({"BK": 128, "BV": 128}, num_warps=8, num_stages=3),
             triton.Config({"BK": 64, "BV": 64}, num_warps=4, num_stages=3),
             triton.Config({"BK": 32, "BV": 32}, num_warps=2, num_stages=3),
-        ]
+        ],
     ),
     key=["H", "K", "V", "BT"],
     **autotune_cache_kwargs,
@@ -193,12 +194,13 @@ def chunk_fwd_kernel_o(
     }
 )
 @triton.autotune(
-    configs=gated_delta_rule_autotune_configs(
+    configs=autotune_configs(
+        "GATED_DELTA_RULE",
         [
             triton.Config({}, num_warps=num_warps, num_stages=num_stages)
             for num_warps in NUM_WARPS
             for num_stages in [2, 3, 4]
-        ]
+        ],
     ),
     key=["H", "K", "V", "BT", "BK", "BV", "USE_G", "USE_G_GAMMA", "USE_DW"],
     **autotune_cache_kwargs,
@@ -392,12 +394,13 @@ def chunk_bwd_kernel_dqkwg(
     }
 )
 @triton.autotune(
-    configs=gated_delta_rule_autotune_configs(
+    configs=autotune_configs(
+        "GATED_DELTA_RULE",
         [
             triton.Config({}, num_warps=num_warps, num_stages=num_stages)
             for num_warps in NUM_WARPS
             for num_stages in [2, 3, 4]
-        ]
+        ],
     ),
     key=["H", "K", "V", "BT", "BK", "BV", "USE_G", "USE_G_GAMMA"],
     **autotune_cache_kwargs,
@@ -494,12 +497,13 @@ def chunk_bwd_kernel_dv(
     }
 )
 @triton.autotune(
-    configs=gated_delta_rule_autotune_configs(
+    configs=autotune_configs(
+        "GATED_DELTA_RULE",
         [
             triton.Config({}, num_warps=num_warps, num_stages=num_stages)
             for num_warps in NUM_WARPS
             for num_stages in [2, 3, 4]
-        ]
+        ],
     ),
     key=["H", "K", "V", "BT", "BK", "BV", "USE_G"],
     **autotune_cache_kwargs,
@@ -630,7 +634,8 @@ def chunk_fwd_o(
     }
 )
 @triton.autotune(
-    configs=gated_delta_rule_autotune_configs(
+    configs=autotune_configs(
+        "GATED_DELTA_RULE",
         [
             triton.Config(
                 {"BK": BK, "BV": BV}, num_warps=num_warps, num_stages=num_stages
@@ -639,7 +644,7 @@ def chunk_fwd_o(
             for BV in BKV_LIST
             for num_warps in NUM_WARPS
             for num_stages in [2, 3, 4]
-        ]
+        ],
     ),
     key=["H", "K", "V", "BT", "IS_VARLEN"],
     **autotune_cache_kwargs,
@@ -802,7 +807,8 @@ def chunk_fwd_o_opt(
     }
 )
 @triton.autotune(
-    configs=gated_delta_rule_autotune_configs(
+    configs=autotune_configs(
+        "GATED_DELTA_RULE",
         [
             triton.Config(
                 {"BK": BK, "BV": BV}, num_warps=num_warps, num_stages=num_stages
@@ -811,7 +817,7 @@ def chunk_fwd_o_opt(
             for BV in BKV_LIST
             for num_warps in NUM_WARPS
             for num_stages in [2, 3, 4]
-        ]
+        ],
     ),
     key=["H", "K", "V", "BT", "IS_VARLEN"],
     **autotune_cache_kwargs,

--- a/aiter/ops/triton/_triton_kernels/gated_delta_rule/prefill/fused_cumsum_kkt.py
+++ b/aiter/ops/triton/_triton_kernels/gated_delta_rule/prefill/fused_cumsum_kkt.py
@@ -6,7 +6,6 @@ from aiter.ops.triton._triton_kernels.gated_delta_rule.gated_delta_rule_utils im
     IS_AMD,
     RCP_LN2,
     autotune_cache_kwargs,
-    gated_delta_rule_autotune_configs,
 )
 from aiter.ops.triton._triton_kernels.gated_delta_rule.utils import (
     GatedDeltaRulePrefillMetadata,
@@ -14,6 +13,7 @@ from aiter.ops.triton._triton_kernels.gated_delta_rule.utils import (
     prepare_rebased_cu_seqlens,
 )
 from aiter.ops.triton._triton_kernels.gated_delta_rule.utils.op import exp
+from aiter.ops.triton.utils.tuned_config_utils import autotune_configs
 
 
 @triton.jit
@@ -163,7 +163,8 @@ _CUMSUM_KKT_DEFAULT_CONFIG = triton.Config({"BK": 32}, num_warps=4, num_stages=2
 
 @triton.heuristics({"IS_VARLEN": lambda args: args["cu_seqlens"] is not None})
 @triton.autotune(
-    configs=gated_delta_rule_autotune_configs(
+    configs=autotune_configs(
+        "GATED_DELTA_RULE",
         _CUMSUM_KKT_CONFIGS,
         default_config=_CUMSUM_KKT_DEFAULT_CONFIG,
     ),

--- a/aiter/ops/triton/_triton_kernels/gated_delta_rule/prefill/fused_solve_tril_recompute.py
+++ b/aiter/ops/triton/_triton_kernels/gated_delta_rule/prefill/fused_solve_tril_recompute.py
@@ -18,7 +18,6 @@ import triton.language as tl
 from aiter.ops.triton._triton_kernels.gated_delta_rule.gated_delta_rule_utils import (
     IS_AMD,
     autotune_cache_kwargs,
-    gated_delta_rule_autotune_configs,
 )
 from aiter.ops.triton._triton_kernels.gated_delta_rule.utils import (
     GatedDeltaRulePrefillMetadata,
@@ -30,6 +29,7 @@ from aiter.ops.triton._triton_kernels.gated_delta_rule.utils.solve_tril import (
     FLA_TRIL_PRECISION,
     solve_tril,
 )
+from aiter.ops.triton.utils.tuned_config_utils import autotune_configs
 
 # solve_tril + recompute_w_u dispatch threshold in chunks (NT). At or below
 # this the single fused kernel is used; above it the split path
@@ -124,7 +124,8 @@ def _bp_st2d(
 
 @triton.heuristics({"IS_VARLEN": lambda args: args["cu_seqlens"] is not None})
 @triton.autotune(
-    configs=gated_delta_rule_autotune_configs(
+    configs=autotune_configs(
+        "GATED_DELTA_RULE",
         _SOLVE_TRIL_RECOMPUTE_CONFIGS,
         default_config=_SOLVE_TRIL_RECOMPUTE_DEFAULT_CONFIG,
     ),
@@ -485,7 +486,8 @@ _RECOMPUTE_WU_HM_DEFAULT_CONFIG = triton.Config(
 
 @triton.heuristics({"IS_VARLEN": lambda args: args["cu_seqlens"] is not None})
 @triton.autotune(
-    configs=gated_delta_rule_autotune_configs(
+    configs=autotune_configs(
+        "GATED_DELTA_RULE",
         _RECOMPUTE_WU_HM_CONFIGS,
         default_config=_RECOMPUTE_WU_HM_DEFAULT_CONFIG,
     ),

--- a/aiter/ops/triton/_triton_kernels/gated_delta_rule/utils/cumsum.py
+++ b/aiter/ops/triton/_triton_kernels/gated_delta_rule/utils/cumsum.py
@@ -21,6 +21,7 @@ from aiter.ops.triton._triton_kernels.gated_delta_rule.gated_delta_rule_utils im
 from aiter.ops.triton._triton_kernels.gated_delta_rule.utils.index import (
     prepare_chunk_indices,
 )
+from aiter.ops.triton.utils.tuned_config_utils import autotune_configs
 
 BS_LIST = [32, 64] if check_shared_mem() else [16, 32]
 
@@ -32,7 +33,10 @@ BS_LIST = [32, 64] if check_shared_mem() else [16, 32]
     }
 )
 @triton.autotune(
-    configs=[triton.Config({}, num_warps=num_warps) for num_warps in [1, 2, 4, 8]],
+    configs=autotune_configs(
+        "GATED_DELTA_RULE",
+        [triton.Config({}, num_warps=num_warps) for num_warps in [1, 2, 4, 8]],
+    ),
     key=["B", "H", "BT", "IS_VARLEN", "REVERSE"],
     **autotune_cache_kwargs,
 )
@@ -95,11 +99,14 @@ def chunk_local_cumsum_scalar_kernel(
     }
 )
 @triton.autotune(
-    configs=[
-        triton.Config({"BS": BS}, num_warps=num_warps)
-        for BS in BS_LIST
-        for num_warps in [2, 4, 8]
-    ],
+    configs=autotune_configs(
+        "GATED_DELTA_RULE",
+        [
+            triton.Config({"BS": BS}, num_warps=num_warps)
+            for BS in BS_LIST
+            for num_warps in [2, 4, 8]
+        ],
+    ),
     key=["B", "H", "S", "BT", "IS_VARLEN", "REVERSE"],
     **autotune_cache_kwargs,
 )

--- a/aiter/ops/triton/_triton_kernels/gated_delta_rule/utils/l2norm.py
+++ b/aiter/ops/triton/_triton_kernels/gated_delta_rule/utils/l2norm.py
@@ -19,6 +19,7 @@ from aiter.ops.triton._triton_kernels.gated_delta_rule.gated_delta_rule_utils im
     autotune_cache_kwargs,
     input_guard,
 )
+from aiter.ops.triton.utils.tuned_config_utils import autotune_configs
 
 # Backward-pass autotune config space. Forward kernels deliberately do not
 # autotune (see ``l2norm_fwd_kernel`` for the rationale); only the bwd
@@ -66,9 +67,10 @@ def l2norm_fwd_kernel1(
 
 
 @triton.autotune(
-    configs=[
-        triton.Config({}, num_warps=num_warps) for num_warps in NUM_WARPS_AUTOTUNE
-    ],
+    configs=autotune_configs(
+        "GATED_DELTA_RULE",
+        [triton.Config({}, num_warps=num_warps) for num_warps in NUM_WARPS_AUTOTUNE],
+    ),
     key=["D"],
     **autotune_cache_kwargs,
 )
@@ -138,11 +140,14 @@ def l2norm_fwd_kernel(
 
 
 @triton.autotune(
-    configs=[
-        triton.Config({"BT": BT}, num_warps=num_warps)
-        for num_warps in [1, 2, 4, 8, 16]
-        for BT in BT_LIST
-    ],
+    configs=autotune_configs(
+        "GATED_DELTA_RULE",
+        [
+            triton.Config({"BT": BT}, num_warps=num_warps)
+            for num_warps in [1, 2, 4, 8, 16]
+            for BT in BT_LIST
+        ],
+    ),
     key=["D", "NB"],
     **autotune_cache_kwargs,
 )

--- a/aiter/ops/triton/_triton_kernels/gated_delta_rule/utils/solve_tril.py
+++ b/aiter/ops/triton/_triton_kernels/gated_delta_rule/utils/solve_tril.py
@@ -18,7 +18,6 @@ import triton.language as tl
 from aiter.ops.triton._triton_kernels.gated_delta_rule.gated_delta_rule_utils import (
     IS_TMA_SUPPORTED,
     autotune_cache_kwargs,
-    gated_delta_rule_autotune_configs,
     input_guard,
 )
 from aiter.ops.triton._triton_kernels.gated_delta_rule.utils.index import (
@@ -27,6 +26,7 @@ from aiter.ops.triton._triton_kernels.gated_delta_rule.utils.index import (
 from aiter.ops.triton._triton_kernels.gated_delta_rule.utils.op import (
     make_tensor_descriptor,
 )
+from aiter.ops.triton.utils.tuned_config_utils import autotune_configs
 
 FLA_TRIL_PRECISION = os.environ.get("FLA_TRIL_PRECISION", "ieee")
 assert FLA_TRIL_PRECISION in [
@@ -71,7 +71,8 @@ def _bp_st2d(base, R, C, rs, r0, c0, val, BR: tl.constexpr, BC: tl.constexpr):
     }
 )
 @triton.autotune(
-    configs=gated_delta_rule_autotune_configs(
+    configs=autotune_configs(
+        "GATED_DELTA_RULE",
         [
             triton.Config(
                 {"DOT_PRECISION": "ieee"}, num_warps=num_warps, num_stages=num_stages
@@ -160,7 +161,8 @@ def solve_tril_16x16_kernel(
     }
 )
 @triton.autotune(
-    configs=gated_delta_rule_autotune_configs(
+    configs=autotune_configs(
+        "GATED_DELTA_RULE",
         [
             triton.Config(
                 {"DOT_PRECISION": DOT_PRECISION},
@@ -306,7 +308,8 @@ def merge_16x16_to_32x32_inverse_kernel(
     }
 )
 @triton.autotune(
-    configs=gated_delta_rule_autotune_configs(
+    configs=autotune_configs(
+        "GATED_DELTA_RULE",
         [
             triton.Config(
                 {"DOT_PRECISION": DOT_PRECISION},

--- a/aiter/ops/triton/_triton_kernels/gated_delta_rule/utils/wy_representation.py
+++ b/aiter/ops/triton/_triton_kernels/gated_delta_rule/utils/wy_representation.py
@@ -15,12 +15,12 @@ import triton.language as tl
 
 from aiter.ops.triton._triton_kernels.gated_delta_rule.gated_delta_rule_utils import (
     autotune_cache_kwargs,
-    gated_delta_rule_autotune_configs,
 )
 from aiter.ops.triton._triton_kernels.gated_delta_rule.utils.index import (
     prepare_chunk_indices,
 )
 from aiter.ops.triton._triton_kernels.gated_delta_rule.utils.op import exp
+from aiter.ops.triton.utils.tuned_config_utils import autotune_configs
 
 
 @triton.heuristics(
@@ -30,12 +30,15 @@ from aiter.ops.triton._triton_kernels.gated_delta_rule.utils.op import exp
     }
 )
 @triton.autotune(
-    configs=[
-        triton.Config({"BK": BK}, num_warps=num_warps, num_stages=num_stages)
-        for BK in [32, 64, 128]
-        for num_warps in [2, 4, 8]
-        for num_stages in [2, 3, 4]
-    ],
+    configs=autotune_configs(
+        "GATED_DELTA_RULE",
+        [
+            triton.Config({"BK": BK}, num_warps=num_warps, num_stages=num_stages)
+            for BK in [32, 64, 128]
+            for num_warps in [2, 4, 8]
+            for num_stages in [2, 3, 4]
+        ],
+    ),
     key=["H", "K", "BT", "IS_VARLEN"],
     **autotune_cache_kwargs,
 )
@@ -159,7 +162,8 @@ def chunk_scaled_dot_kkt_fwd(
     }
 )
 @triton.autotune(
-    configs=gated_delta_rule_autotune_configs(
+    configs=autotune_configs(
+        "GATED_DELTA_RULE",
         [
             triton.Config({}, num_warps=num_warps, num_stages=num_stages)
             for num_warps in [2, 4, 8]

--- a/aiter/ops/triton/configs/gfx950/triton/attention/chunk_delta_attn/DEFAULT.json
+++ b/aiter/ops/triton/configs/gfx950/triton/attention/chunk_delta_attn/DEFAULT.json
@@ -4,5 +4,15 @@
         "BV": 128,
         "num_warps": 8,
         "num_stages": 3
+    },
+    "_flash_kda_segment_kernel_single_seg": {
+        "BW": 16,
+        "num_warps": 2,
+        "num_stages": 2
+    },
+    "_flash_kda_segment_kernel_multi_seg": {
+        "BW": 64,
+        "num_warps": 2,
+        "num_stages": 2
     }
 }

--- a/aiter/ops/triton/configs/gfx950/triton/attention/sparse_attention_dsv4/DEFAULT.json
+++ b/aiter/ops/triton/configs/gfx950/triton/attention/sparse_attention_dsv4/DEFAULT.json
@@ -1,0 +1,10 @@
+{
+    "_sparse_attn_prefill_kernel": {
+        "BLOCK_H": 64,
+        "BLOCK_K": 16,
+        "waves_per_eu": 0,
+        "matrix_instr_nonkdim": 16,
+        "num_warps": 4,
+        "num_stages": 1
+    }
+}

--- a/aiter/ops/triton/utils/tuned_config_utils.py
+++ b/aiter/ops/triton/utils/tuned_config_utils.py
@@ -7,6 +7,7 @@ device, on top of the shared core in ``config_utils``.
 """
 
 import functools
+import os
 
 import triton
 
@@ -21,6 +22,28 @@ from aiter.ops.triton.utils.config_utils import (
     _dtype_dir,
     load_config_json,
 )
+
+
+def autotune_enabled(family: str) -> bool:
+    """``<FAMILY>_TRITON_AUTOTUNE=1`` opts a kernel family into runtime tuning; off by default."""
+    return os.getenv(f"{family}_TRITON_AUTOTUNE", "0").lower() in (
+        "1",
+        "true",
+        "yes",
+        "on",
+    )
+
+
+def autotune_configs(
+    family: str,
+    configs: list[triton.Config],
+    default_config: triton.Config | None = None,
+) -> list[triton.Config]:
+    """Config list for ``@triton.autotune``: every candidate while the family tunes, else
+    only ``default_config`` (or ``configs[0]``) so nothing is benchmarked at launch."""
+    if autotune_enabled(family):
+        return configs
+    return [default_config if default_config is not None else configs[0]]
 
 
 @functools.lru_cache(maxsize=1024 if USE_LRU_CACHE else 0)

--- a/aiter/ops/triton/utils/tuned_config_utils.py
+++ b/aiter/ops/triton/utils/tuned_config_utils.py
@@ -26,7 +26,7 @@ from aiter.ops.triton.utils.config_utils import (
 
 def autotune_enabled(family: str) -> bool:
     """``<FAMILY>_TRITON_AUTOTUNE=1`` opts a kernel family into runtime tuning; off by default."""
-    return os.getenv(f"{family}_TRITON_AUTOTUNE", "0").lower() in (
+    return os.getenv(f"{family}_TRITON_AUTOTUNE", "0").strip().lower() in (
         "1",
         "true",
         "yes",
@@ -41,6 +41,8 @@ def autotune_configs(
 ) -> list[triton.Config]:
     """Config list for ``@triton.autotune``: every candidate while the family tunes, else
     only ``default_config`` (or ``configs[0]``) so nothing is benchmarked at launch."""
+    # An empty list would hand Triton nothing to tune and make the configs[0] fallback raise.
+    assert configs, f"{family}: autotune_configs called with an empty config list"
     if autotune_enabled(family):
         return configs
     return [default_config if default_config is not None else configs[0]]


### PR DESCRIPTION
Both kernels benchmarked their config lists on first call. They now read the tile measured
offline (configs/gfx950/triton/attention/*/DEFAULT.json) inside prune_configs_by -- K2 keyed by
segment class -- so Triton launches without tuning; <FAMILY>_TRITON_AUTOTUNE=1 re-enables the sweep.