### PR TITLE
[Triton] gemm_a16w16: replace the racy N=256,K=7168 M_LEQ_32 tile; guard tl.assume(stride_ck)

### DIFF
--- a/aiter/ops/triton/_triton_kernels/gemm/basic/gemm_a16w16.py
+++ b/aiter/ops/triton/_triton_kernels/gemm/basic/gemm_a16w16.py
@@ -78,7 +78,8 @@ def _gemm_a16_w16_kernel(
     tl.assume(stride_ak > 0)
     tl.assume(stride_bk > 0)
     tl.assume(stride_bn > 0)
-    tl.assume(stride_ck > 0)
+    if NUM_KSPLIT > 1:
+        tl.assume(stride_ck > 0)
     tl.assume(stride_cm > 0)
     tl.assume(stride_cn > 0)
 

--- a/aiter/ops/triton/configs/gfx950/triton/gemm/gemm_a16w16/GEMM-A16W16-N=256-K=7168.json
+++ b/aiter/ops/triton/configs/gfx950/triton/gemm/gemm_a16w16/GEMM-A16W16-N=256-K=7168.json
@@ -24,16 +24,16 @@
     "NUM_KSPLIT": 14
   },
   "M_LEQ_32": {
-    "BLOCK_SIZE_M": 16,
+    "BLOCK_SIZE_M": 32,
     "BLOCK_SIZE_N": 16,
     "BLOCK_SIZE_K": 256,
     "GROUP_SIZE_M": 1,
-    "num_warps": 8,
-    "num_stages": 2,
-    "waves_per_eu": 8,
+    "num_warps": 4,
+    "num_stages": 3,
+    "waves_per_eu": 2,
     "matrix_instr_nonkdim": 16,
-    "cache_modifier": null,
-    "NUM_KSPLIT": 16
+    "cache_modifier": ".cg",
+    "NUM_KSPLIT": 14
   },
   "M_LEQ_64": {
     "BLOCK_SIZE_M": 32,


### PR DESCRIPTION
The tuned 16x16x256/8-warp/2-stage split-K entry miscompiles on Triton 3.8 gfx950 (nondeterministic partials in TT layout; standalone repro). It is replaced by the already-tuned neighbouring entry, validated 10 M x 3 layouts x 10 trials. The kernel also stops asserting stride_ck > 0 when it is 0.