### PR TITLE
[Triton/Gluon] Keep padded V heads and d_v<=16 off the num_stages=3 configs

### DIFF
--- a/aiter/ops/triton/_triton_kernels/attention/mha.py
+++ b/aiter/ops/triton/_triton_kernels/attention/mha.py
@@ -955,14 +955,22 @@ def _get_config(
     config = load_config_json(f"{cfg_dir}/DEFAULT.json")
     fwd_cfg = config["fwd"]
     has_dropout_or_fp32 = enable_dropout or dtype == torch.float32
+    pipelining_unsafe = head_dim_v is not None and (
+        head_dim_v <= 16 or head_dim_v != triton.next_power_of_2(head_dim_v)
+    )
     # TODO: pe + dropout is not tuned
     if has_pe and has_dropout_or_fp32 and "pe_dropout_or_fp32" in fwd_cfg:
         return fwd_cfg["pe_dropout_or_fp32"]
-    elif has_pe and "pe" in fwd_cfg:
+    elif has_pe and not pipelining_unsafe and "pe" in fwd_cfg:
         return fwd_cfg["pe"]
     elif enable_dropout or dtype == torch.float32:
         return fwd_cfg["dropout_or_fp32"]
-    elif head_dim_v is not None and 16 < head_dim_v <= 64 and "small_head" in fwd_cfg:
+    elif (
+        head_dim_v is not None
+        and 16 < head_dim_v <= 64
+        and not pipelining_unsafe
+        and "small_head" in fwd_cfg
+    ):
         # Mid-small V head dims (16 < d <= 64) hit a num_stages=1 software-pipelining
         # pathology on this backend (e.g. ~3x slower at d64). Using num_stages=3
         # recovers performance and is numerically verified for these dims, but


### PR DESCRIPTION
On Triton 3.8 gfx950 the num_stages=3 entries return wrong results for padded V heads (d=33/40, causal) and are nondeterministic for d_v<=16 (PE); num_stages=2 trips an LLVM assertion. Those shapes now route to the num_stages=1 entries (14 test_mha + 3 test_mha_with_pe failures).
