### PR TITLE
[FlyDSL] feat(comm-fused-moe): log activated runner configuration

### DIFF
--- a/aiter/ops/flydsl/comm_fused_moe_host.py
+++ b/aiter/ops/flydsl/comm_fused_moe_host.py
@@ -2,6 +2,7 @@
 """Production host runtime for communication-fused FlyDSL MoE."""
 
 import csv
+import logging
 import math
 import re
 from dataclasses import MISSING, dataclass, fields
@@ -43,6 +44,8 @@ _ACT_TYPE = "ActivationType.Silu"
 _DTYPE = "torch.bfloat16"
 _Q_DTYPE_A = "torch.float8_e4m3fn"
 _Q_DTYPE_W = "torch.float4_e2m1fn_x2"
+
+logger = logging.getLogger("aiter")
 _Q_TYPE = "QuantType.per_1x32"
 
 
@@ -824,8 +827,11 @@ def create_runner(tp_group, config: PipelineConfig):
 
 
 class _LazyRunners:
-    def __init__(self, tp_group, configs: dict[int, PipelineConfig]) -> None:
+    def __init__(
+        self, tp_group, shape: ShapeKey, configs: dict[int, PipelineConfig]
+    ) -> None:
         self.tp_group = tp_group
+        self.shape = shape
         self.configs = configs
         self.instances = {}
 
@@ -834,7 +840,30 @@ class _LazyRunners:
 
     def __getitem__(self, tokens: int):
         if tokens not in self.instances:
-            self.instances[tokens] = create_runner(self.tp_group, self.configs[tokens])
+            config = self.configs[tokens]
+            if int(self.tp_group.rank_in_group) == 0:
+                lookup_key = (
+                    self.shape.gfx,
+                    self.shape.cu_num,
+                    tokens,
+                    self.shape.model_dim,
+                    self.shape.inter_dim,
+                    self.shape.experts,
+                    self.shape.topk,
+                    self.shape.act_type,
+                    self.shape.dtype,
+                    self.shape.q_dtype_a,
+                    self.shape.q_dtype_w,
+                    self.shape.q_type,
+                    self.shape.use_g1u1,
+                    self.shape.doweight_stage1,
+                )
+                logger.info(
+                    "[comm-fused-moe] activate kernel=%s for %s",
+                    config_name(config),
+                    lookup_key,
+                )
+            self.instances[tokens] = create_runner(self.tp_group, config)
         return self.instances[tokens]
 
 
@@ -850,5 +879,5 @@ def create_flydsl_comm_fused_runners(*, tp_group, model_dim, inter_dim, experts,
     )
     key = (id(tp_group), shape)
     if key not in _RUNNER_CACHE:
-        _RUNNER_CACHE[key] = _LazyRunners(tp_group, winners_for(shape))
+        _RUNNER_CACHE[key] = _LazyRunners(tp_group, shape, winners_for(shape))
     return _RUNNER_CACHE[key]


### PR DESCRIPTION
## Motivation

Communication-fused MoE currently has no explicit AITER log showing whether a
fused runner was actually instantiated. The existing message:

```text
[aiter] [fused_moe] using 2stage (...)
```

describes the ordinary Stage1/Stage2 configuration and can also appear when
the communication-fused runtime reuses the ordinary Stage1 path. As a result,
server and CI logs cannot unambiguously confirm that a comm-fused kernel was
selected.

Add a cold-path log that identifies the actual communication-fused kernel and
its lookup shape. This makes it possible to distinguish:

- a real comm-fused runner activation;
- ordinary Stage2 + TP fallback;
- a configured bucket that was not used.

## Technical Details

- Add a rank-0 INFO log when a communication-fused runner is instantiated for
  the first time.
- Include the selected bucket's generated kernel name.
- Include the complete tuning lookup key:
  - GPU architecture;
  - CU count;
  - token bucket;
  - model and intermediate dimensions;
  - expert count and top-k;
  - activation and quantization types;
  - `use_g1u1`;
  - `doweight_stage1`.
- Keep the log in `_LazyRunners.__getitem__()` behind the existing
  first-instantiation check.
- Do not add logs to ordinary or fallback dispatch.
- Do not modify the ATOM runtime or the kernel implementation.
- Only TP rank 0 emits the message to avoid duplicate logs from all TP ranks.

Example:

```text
[aiter] [comm-fused-moe] activate kernel=flydsl_comm_moe2_... for ('gfx950', 256, 8, 7168, 384, 384, 6, 'ActivationType.Silu', 'torch.bfloat16', 'torch.float8_e4m3fn', 'torch.float4_e2m1fn_x2', 'QuantType.per_1x32', 1, 0)
```

The message is emitted during runner initialization, typically during eager
first use or CUDA Graph capture. It is not emitted during steady-state
execution or CUDA Graph replay.

## Test Plan

- Run Black on the changed Python file.
- Run Ruff on the changed Python file.
- Run `git diff --check`.
- Verify that the change only affects the runner-instantiation logging path.
- Verify that ordinary/fallback paths do not call `_LazyRunners.__getitem__()`
  and therefore do not emit the comm-fused message.

## Test Result

- Black: passed.
- Ruff: passed.
- `git diff --check`: passed.
- Working tree: clean after commit and rebase.
- No kernel code, dispatch parameters, synchronization, or generated-kernel
  implementation was changed.
- No steady-state performance benchmark was required because the log executes
  only once per instantiated bucket on the cold path.

## Submission Checklist

- [ ] Look over the contributing guidelines at
  https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
