### PR TITLE
[FlyDSL] feat(ep): TDM dispatch for gfx1250

### DIFF
--- a/aiter/ops/flydsl/dispatch_combine_v2/README.md
+++ b/aiter/ops/flydsl/dispatch_combine_v2/README.md
@@ -1,0 +1,92 @@
+# cco-LSA intranode MoE dispatch / combine (ops v2, FlyDSL)
+
+Intranode (single-node, EP8) MoE dispatch + combine built on **mori-cco LSA**
+(intra-node P2P over the flat symmetric VA) and **FlyDSL** device kernels. A
+mori-parity reimplementation that swaps the mori-shmem provider for cco-LSA:
+peer addresses are computed in-kernel via `cco.Window(arena).lsa_ptr(pe, off)`,
+no host P2P tables. Reference = ROCm/FlyDSL PR #522
+(`dispatch_combine_intranode_{kernel,op}.py`).
+
+Supported token dtypes: **bf16**, **f32**, **fp8** (gather-only; OCP e4m3 on
+gfx950, e4m3**fnuz** max 240 on gfx942) and **fp4** (e2m1, gather-only,
+**gfx950-only** — the `cvt_scalef32_*_fp4` intrinsics don't exist on gfx942).
+Combine: gather (UseP2PRead) **and** scatter (`_nop2p`); weighted combine
+(`out_weights`); StdMoE (ConvertDispatchOutput / ConvertCombineInput, standalone
++ wired into the op); fp8 combine-wire **quant** (`fp8_direct_cast` **and**
+`fp8_blockwise`, scatter-only — distinct from the plain fp8 token dtype, which
+keeps a bf16 external payload); per-token scales forwarding;
+`max_total_recv_tokens` cap; mori-parity host op-layer + per-device,
+dtype-aware tuning table. Not done: `skip_stage1` (FlyDSL-only).
+
+> **Test-only, not a mori API (yet).** These modules import each other by
+> top-level name (`from intranode_kernels import ...`, `import flydsl_prims as P`)
+> and have no `__init__.py`; they only resolve after the tests do
+> `sys.path.insert(0, <this dir>)`. There is no `mori.ops.dispatch_combine_v2`
+> package export, so `import mori.ops.dispatch_combine_v2.dispatch_combine_op`
+> will fail. Use it via the test/bench harnesses below. Wiring it in as a real
+> package (relative imports + `__init__.py` + `ops/__init__.py` export) is a
+> follow-up.
+
+## Layout
+
+| file | role |
+|---|---|
+| `flydsl_prims.py` | device primitives: system atomics / ordered stores / fences / volatile-spin waits |
+| `intranode_kernels.py` | all FlyDSL intranode kernel factories: `make_dispatch` (+scales/replay), `make_combine` (gather) / `make_combine_scatter` (`_nop2p`, bf16/f32/fp8/fp4), `make_convert_dispatch_output` / `make_convert_combine_input` (StdMoE), `make_local_expert_count` |
+| `dispatch_combine_op.py` | `SymmArena` + `EpDispatchCombineOp` / `EpDispatchCombineConfig` (+`.tuned()`) / `EpDispatchRoutingHandle` — mori-parity host op-layer (scales, scatter/quant combine, StdMoE, recv cap, LEC, reset, replay) |
+| `tuning_configs.py` | per-(world,hidden,topk) block/warp lookup |
+
+Tests/bench live under `tests/python/ops/dispatch_combine_v2/`:
+
+| file | role |
+|---|---|
+| `test_dispatch_combine_v2_intranode.py` | pytest wrapper: runs `test_op.py` under torchrun for the representative modes and asserts every line PASS |
+| `test_op.py` | EP8 op-layer test (gather/scatter, quant, StdMoE, recv-cap, scales, LEC, reset, replay) |
+| `bench_dispatch_combine.py` | eager + CUDA-graph perf bench + e2e correctness. Envs: `DTYPE=bf16\|f32\|fp8\|fp4`, `COMBINE=gather\|scatter`, `QUANT=none\|fp8_direct_cast\|fp8_blockwise`, `STDMOE=1`, `SCALE_DIM`, `SWEEP`, `DISP_BLOCK`/`COMB_BLOCK`, `WARP_NUM`/`COMB_WARP`, `MODE`, `TUNED` |
+| `run_bench.sh` | bench launcher (runs `bench_dispatch_combine.py` in the container) |
+
+(Each script inlines a tiny torchrun/gloo `Dist` bootstrap — gloo only carries the cco unique-id and pass/fail counts.)
+
+## Run (inside the container, 8 GPUs)
+
+`torchrun --standalone` uses a localhost rendezvous, so no socket-iface env is
+needed. Intranode only (no GDA/RDMA).
+
+```bash
+cd tests/python/ops/dispatch_combine_v2
+
+pytest test_dispatch_combine_v2_intranode.py -v                       # EP8 correctness (all modes)
+torchrun --standalone --nproc_per_node=8 test_op.py                   # op-layer correctness (env-driven)
+torchrun --standalone --nproc_per_node=8 bench_dispatch_combine.py    # perf + e2e correctness
+```
+
+Config via env: `HIDDEN`, `TOPK`, `EPR`, `SWEEP`, `DTYPE`, `COMBINE`, `QUANT`,
+`DISP_BLOCK`/`COMB_BLOCK`, `WARP_NUM`/`COMB_WARP`, `MODE=eager|graph|both`, `TUNED`.
+
+## Design notes
+
+- **dispatch**: per (token, k) dedup same-dest-PE via ballot; lane0 remote
+  `atomic_add` allocates a recv slot; publish origin id + idx/wts + 16B dual-issue
+  token copy to the peer; grid barrier; per-peer count signal; collect `total_recv`.
+- **combine** (gather, = mori `UseP2PRead`): cross-device entry barrier, then each
+  local token gathers its k expert outputs **remotely** from `peer.out_tok[dest_tok_id]`
+  and reduces in f32. Register-light i32 reads (2 bf16 / `v2f32` accumulate) + 2-way
+  unroll keep VGPRs low so 16 warps/block run at high occupancy to hide xGMI read
+  latency; remote reads are latency-bound so combine needs ~128 blocks, while
+  dispatch's posted writes saturate at ~64 blocks (half the CUs).
+- Self-written volatile/atomic spin-waits (`flydsl_prims.spin_until_*`) — mori-shmem's
+  `wait_until_*` assert on a cco-only stack. Counters self-reset in-kernel → CUDAGraph-safe.
+
+## Perf (EP8, hidden=7168, top-k=8, 256 experts; dispatch 64blk / combine 128blk × 16warp, CUDA-graph, bf16)
+
+Per-rank bandwidth = `recv_tok * per_token_bytes / time` (the bench sizes the
+payload per dtype, `hidden*2` for bf16). Indicative bf16 numbers on **MI308X
+(gfx942)** xGMI:
+
+| tok/rank | dispatch | combine |
+|---:|---:|---:|
+| 512  | 268 GB/s | 213 GB/s |
+| 2048 | 306 GB/s | 294 GB/s |
+| 8192 | 314 GB/s | 323 GB/s |
+
+Cross-impl (v2 vs mori v1) latency tables for fp8/fp4 are in PR ROCm/mori#448.

--- a/aiter/ops/flydsl/dispatch_combine_v2/__init__.py
+++ b/aiter/ops/flydsl/dispatch_combine_v2/__init__.py
@@ -1,0 +1,17 @@
+# Vendored from mori python/mori/ops/dispatch_combine_v2 (cco-LSA v2 EP dispatch/combine).
+# The op/kernel layer lives here so gfx1250 kernel development happens in aiter; the
+# underlying cco communication substrate (mori.cco.Communicator + libmori_cco*.{so,bc})
+# and mori.jit/mori.tensor_utils remain installed-mori runtime dependencies.
+from .dispatch_combine_op import (
+    SymmArena,
+    EpDispatchCombineConfig,
+    EpDispatchCombineOp,
+    EpDispatchRoutingHandle,
+)
+
+__all__ = [
+    "SymmArena",
+    "EpDispatchCombineConfig",
+    "EpDispatchCombineOp",
+    "EpDispatchRoutingHandle",
+]

--- a/aiter/ops/flydsl/dispatch_combine_v2/dispatch_combine_op.py
+++ b/aiter/ops/flydsl/dispatch_combine_v2/dispatch_combine_op.py
@@ -1,0 +1,1748 @@
+# Copyright © Advanced Micro Devices, Inc. All rights reserved.
+#
+# MIT License
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+"""Host op-layer for the cco-LSA intranode dispatch/combine kernels. One SymmArena
+window holds the symmetric staging; per-rank metadata are plain device tensors."""
+from dataclasses import dataclass
+import math
+import os
+
+import torch
+
+import flydsl.expr as fx
+from mori.tensor_utils import from_gpu_ptr
+
+from .intranode_kernels_tdm import (
+    make_dispatch_tdm,
+    tdm_max_warps,
+    tdm_stage_capacity,
+)
+from .intranode_kernels import (
+    xdb_flag_slots,
+    make_dispatch,
+    make_combine,
+    make_combine_scatter,
+    make_combine_fused_reduce,
+    make_convert_dispatch_output,
+    make_convert_combine_input,
+    make_local_expert_count,
+)
+
+_COMBINE_QUANT_TYPES = ("none", "fp8_direct_cast", "fp8_blockwise")
+
+_DT = {
+    torch.bfloat16: 2,
+    torch.float32: 4,
+    torch.float8_e4m3fnuz: 1,
+    torch.float8_e4m3fn: 1,
+}
+_FP8_DTYPES = (torch.float8_e4m3fnuz, torch.float8_e4m3fn)
+
+
+def _align_up(x, a):
+    return (x + a - 1) // a * a
+
+
+class SymmArena:
+    """One cco symmetric window carved into named, aligned sub-regions. A kernel
+    reaches peer pe's copy of region R via cco.Window(handle).lsa_ptr(pe, off_R)."""
+
+    _ALIGN = 256
+
+    def __init__(self, comm, regions):
+        self._comm = comm
+        self._offsets = {}
+        self._sizes = {}
+        off = 0
+        for name, nbytes in regions:
+            off = _align_up(off, self._ALIGN)
+            self._offsets[name] = off
+            self._sizes[name] = nbytes
+            off += nbytes
+        self._total = max(_align_up(off, self._ALIGN), self._ALIGN)
+        self._mem = comm.alloc_mem(self._total)
+        self._win = comm.register_window(self._mem.ptr, self._total)
+
+    @property
+    def handle(self):
+        return self._win.handle
+
+    @property
+    def total_bytes(self):
+        return self._total
+
+    def offset(self, name):
+        return self._offsets[name]
+
+    def local_ptr(self, name):
+        return self._win.local_ptr + self._offsets[name]
+
+    def zero(self, name=None):
+        """Zero the whole window, or just region `name` (zero-copy int8 torch view)."""
+        if name is None:
+            ptr, nbytes = self._win.local_ptr, self._total
+        else:
+            ptr, nbytes = self.local_ptr(name), self._sizes[name]
+        from_gpu_ptr(ptr, (nbytes,), torch.int8).zero_()
+
+    def close(self):
+        """Free the symmetric window (deregister before freeing the backing mem)."""
+        self._win.close()
+        self._mem.close()
+
+
+# GEMM1 a8w4 sort_block_m; push-group CAP and finalize tile metadata align to it.
+_PUSH_GROUP_TILE_M = 64
+
+# ``pg_ov_bar`` layout, in i32 slots. Slots 0..15 are the protocol barrier arrival
+# counters plus the debug scratch; then the work-stealing heads, one per shard on
+# its own 64 B line so the shards do not ping-pong one line between CUs; then the
+# plan-ready replicas, spaced a full 128 B apart because that wait is taken by
+# every CTA in the grid at once and a shared line serialises the whole launch;
+# then the same treatment for the producer barriers' release side. Keep in sync
+# with the WORK_/PLAN_/BREL_ constants in
+# kernels/push_group_overlap_stage1_gfx1250.py.
+PG_OV_WORK_SLOT = 16
+PG_OV_WORK_SHARDS = 8
+PG_OV_WORK_STRIDE = 16
+PG_OV_PLAN_SLOT = 256
+PG_OV_PLAN_STRIDE = 32
+PG_OV_PLAN_FANOUT_MAX = 64
+# Release replicas for the producer-wide barriers. Arriving on a counter and then
+# spinning on that same counter makes every producer's poll miss against every
+# other producer's atomic, which is quadratic in the producer count: measured
+# free at 32 producers and 284 us/layer at 128. The last arriver instead posts a
+# monotonic phase to these lines and the others only ever read their own.
+PG_OV_BREL_SLOT = PG_OV_PLAN_SLOT + PG_OV_PLAN_FANOUT_MAX * PG_OV_PLAN_STRIDE
+PG_OV_BREL_STRIDE = 32
+PG_OV_BREL_FANOUT = 64
+# One replica bank per barrier (zero, count, route-order): sharing a bank would
+# let a CTA still leaving one barrier read the next one's release.
+PG_OV_BREL_PHASES = 3
+# Optional group counters for the arrival side (see BAR_GROUP in
+# kernels/push_group_overlap_stage1_gfx1250.py). Off by default, so this bank is
+# normally dead space; it is 12 KB and the arena is per-rank, not per-layer.
+PG_OV_BARR_SLOT = (
+    PG_OV_BREL_SLOT + PG_OV_BREL_PHASES * PG_OV_BREL_FANOUT * PG_OV_BREL_STRIDE
+)
+PG_OV_BARR_GROUPS = 32
+PG_OV_BARR_STRIDE = 32
+PG_OV_BAR_SLOTS = (
+    PG_OV_BARR_SLOT + PG_OV_BREL_PHASES * PG_OV_BARR_GROUPS * PG_OV_BARR_STRIDE
+)
+
+
+def _push_group_regions(cfg, tile_m=_PUSH_GROUP_TILE_M):
+    """Extra symmetric regions for fixed-slot push-group dispatch (empty when off).
+
+    * ``pg_running[local_expert]`` -- per-expert landing cursor (atomic_add target).
+    * ``pg_rowmap[grouped_row]``   -- (rrows+1, 2) i32 map dispatch emits for the
+      downstream gemm2 scatter epilogue: col0 = ``origin_pe*slot_stride +
+      origin_lid*topk + k`` (the peer comb_inp slot), col1 = f32 route weight bits.
+      Indexed by the SAME fixed-slot row (``local_expert*CAP + cursor``) the gemm2
+      TDM kernel derives from ``tile_row_base``, so ep_rowmap==pg_rowmap needs no
+      remap. Empty/padding slots carry col0 = -1 (dropped in the scatter)."""
+    if not cfg.push_group:
+        return []
+    rrows = cfg.num_experts_per_rank * cfg.effective_cap_per_expert
+    return [
+        ("pg_running", cfg.num_experts_per_rank * 4),
+        ("pg_rowmap", (rrows + 1) * 2 * 4),
+    ]
+
+
+def _push_group_overlap_regions(cfg):
+    """Extra symmetric regions for the fused dispatch->GEMM1 overlap stage-1
+    (empty unless push_group_overlap). All of them are graph-safe without a
+    host-side memset: see the reset argument on each entry.
+
+    * ``pg_ov_count[parity][src_rank][global_expert]`` -- the all-gathered route
+      count matrix. Every rank pushes its whole per-global-expert histogram to
+      every peer, so both roles are then computable locally with no second hop:
+      as a SOURCE, ``base[ge] = sum(count[s][ge] for s < rank)``; as a
+      DESTINATION, ``total[le] = sum(count[s][rank*EPR+le] for s)``. Parity
+      double-buffering is what makes the plain overwrite safe -- a peer can be at
+      most one layer ahead (its layer L+1 counts need ours), never two.
+    * ``pg_ov_count_done[src_rank]`` -- monotonic arrival counter, one
+      ``atomic_add`` per source per layer. Monotonic (never reset) so it survives
+      CUDA-graph replay, where a host-supplied epoch would repeat.
+    * ``pg_ov_tile_arrived[local_expert][tile]`` -- additive per-tile row arrival.
+      Zeroed at the top of each stage-1 launch by the producers, which is
+      race-free: a peer only writes here after it observes our count publication,
+      and that publication is release-ordered after the zeroing.
+    * ``pg_ov_tile_expected[local_expert][tile]`` -- planner-written row count the
+      consumer waits for. Local-only, rewritten every layer.
+    * ``pg_ov_entry`` -- the ticket counter. One ``atomic_add`` per CTA per launch
+      hands out both the CTA role and the launch generation, so roles go to the
+      CTAs that are actually resident first. Thread 0 broadcasts the ticket to
+      the rest of its block over LDS, so no global slot is needed.
+    * ``pg_ov_bar`` -- monotonic grid-barrier counters for the producer CTAs
+      (compared against ``(generation+1)*dispatch_ctas``, hence no reset). Slots 0
+      and 1 are the two protocol barriers; the rest are spare, and the debug
+      builds use them for diagnostics that must not collide with peer traffic.
+      The tail (slot ``PG_OV_WORK_SLOT`` onwards) holds the GEMM1 work-stealing
+      heads, one per shard on its own 64 B line; the planner zeroes them before
+      it publishes the plan, which is the only point at which no CTA can be
+      pulling from them.
+    * ``pg_ov_plan_ready`` -- monotonic; the planner bumps it once the tile
+      schedule and ``pg_ov_my_base`` are visible, and every other CTA waits on it.
+    * ``pg_ov_my_base[global_expert]`` -- this rank's first destination row within
+      each expert, i.e. the exclusive prefix over lower-numbered source ranks. The
+      planner derives it once so producers do not each redo the prefix sum.
+    * ``pg_ov_hist`` / ``pg_ov_route_slot`` -- local scratch: this rank's route
+      histogram and, per (token,k) route, its index within this rank's rows for
+      that expert. The payload pass needs the latter to reconstruct the row the
+      count pass reserved.
+    * ``pg_ov_route_order`` -- the routes counting-sorted by destination expert
+      (``order[local_base[expert] + slot] = route``). Pushing in this order is
+      what makes the destination's early tiles fill first, so its GEMM1 can start
+      while the later experts are still in flight.
+    """
+    if not (cfg.push_group and cfg.push_group_overlap):
+        return []
+    e_local = cfg.num_experts_per_rank
+    e_total = cfg.world_size * e_local
+    tiles = cfg.num_experts_per_rank * cfg.push_group_overlap_tiles_per_expert
+    return [
+        ("pg_ov_count", 2 * cfg.world_size * e_total * 4),
+        ("pg_ov_count_done", cfg.world_size * 4),
+        ("pg_ov_tile_arrived", tiles * 4),
+        ("pg_ov_tile_expected", tiles * 4),
+        ("pg_ov_entry", 4),
+        ("pg_ov_bar", PG_OV_BAR_SLOTS * 4),
+        ("pg_ov_plan_ready", 4),
+        ("pg_ov_my_base", e_total * 4),
+        ("pg_ov_hist", e_total * 4),
+        (
+            "pg_ov_route_slot",
+            cfg.max_num_inp_token_per_rank * cfg.num_experts_per_token * 4,
+        ),
+        (
+            "pg_ov_route_order",
+            cfg.max_num_inp_token_per_rank * cfg.num_experts_per_token * 4,
+        ),
+    ]
+
+
+def _validate_overlap_ctas(*, grid_ctas, dispatch_ctas):
+    """Split the stage-1 mega grid into (producers, planner, consumers).
+
+    ``dispatch_ctas`` is the whole dispatch half INCLUDING the planner, which is
+    role 0 -- the same partition the kernel derives from a CTA's ticket. The roles
+    are handed out by ticket order, not blockIdx, so they can only land on CTAs
+    that are already resident; a producer that never got a slot would deadlock the
+    consumers spinning on the payload it owes.
+    """
+    dispatch_ctas = int(dispatch_ctas)
+    grid_ctas = int(grid_ctas)
+    producers = dispatch_ctas - 1
+    consumer_ctas = grid_ctas - dispatch_ctas
+    if producers < 1:
+        raise ValueError(
+            f"dispatch_ctas={dispatch_ctas} leaves no producer after the planner"
+        )
+    if consumer_ctas < PG_OV_WORK_SHARDS:
+        # A work-queue shard only hands out items i == shard (mod SHARDS), so a
+        # shard nobody pulls from is a set of tiles nobody computes.
+        raise ValueError(
+            f"need at least {PG_OV_WORK_SHARDS} consumer CTAs (one per work "
+            f"shard): grid={grid_ctas} leaves {consumer_ctas} after "
+            f"{dispatch_ctas} dispatch CTAs"
+        )
+    return producers, 1, consumer_ctas
+
+
+@dataclass
+class EpDispatchCombineConfig:
+    rank: int
+    world_size: int
+    hidden_dim: int
+    max_num_inp_token_per_rank: int
+    num_experts_per_rank: int
+    num_experts_per_token: int
+    # Base token dtype; dispatch_data_type / combine_data_type override per-op
+    # (None => data_type). Asymmetric (fp8 dispatch -> bf16 combine) is gather-only.
+    data_type: torch.dtype = torch.bfloat16
+    dispatch_data_type: torch.dtype = None
+    combine_data_type: torch.dtype = None
+    # Per-token quant scales forwarded verbatim to dest out_scales (0 disables).
+    scale_dim: int = 0
+    scale_type_size: int = 0
+    # "gather" (UseP2PRead) or "scatter" (mori _nop2p, fp8 compression home).
+    combine_mode: str = "gather"
+    # Combine-side wire quantization (scatter-only; distinct from the dispatch
+    # token dtype). Forcing it != "none" switches combine_mode to scatter.
+    combine_quant_type: str = "none"  # none | fp8_direct_cast | fp8_blockwise
+    # Geometry: None => auto (tuned schedule from tuning_configs in __post_init__);
+    # pin any to opt out. Combine's warp count is kept separate from dispatch's.
+    dispatch_block_num: int = None
+    combine_block_num: int = None
+    dispatch_warp_num_per_block: int = None
+    combine_warp_num_per_block: int = None
+    # Optional per-token plan: (max_tok_inclusive | None, disp_block, disp_warp,
+    # comb_block, comb_warp) buckets; the op precompiles the distinct (block, warp)
+    # variants and picks one at runtime. None => auto or single-shot fallback.
+    schedule: tuple = None
+    enable_std_moe: bool = False
+    max_total_recv_tokens: int = 0  # mori maxTotalRecvTokens; 0 = worst-case ws*M
+    # Fixed-slot push-group dispatch->GEMM1 fusion (explicit end-to-end switch;
+    # replaces the AITER_EP_PUSH_GROUP env). When True: dispatch lands tokens
+    # grouped per local expert, GEMM1 reads A contiguously (no consumer gather),
+    # GEMM2 scatters via pg_rowmap. gfx1250 a8w4 only; default off.
+    push_group: bool = False
+    # Per-local-expert fixed-slot row capacity (only consulted when push_group=True).
+    #   0 (default) => worst-case ws*max_tok_per_rank: every token could hit one
+    #                  expert, so no routing skew can ever drop a token.
+    #   >0          => caller-pinned capacity (aligned up to tile_m). The caller
+    #                  guarantees the real peak per-expert load fits; a peak above
+    #                  cap_per_expert silently DROPS the overflow (finalize clamp).
+    #                  Smaller cap => fewer padding tiles => faster, at that risk.
+    cap_per_expert: int = 0
+    # push_group + pre-quantized (fp8) tokens: the sender's scale is linear, but the
+    # consuming GEMM wants it WMMA-preshuffled, and the preshuffled position depends
+    # on the row's slot within its destination expert. Set this to the GEMM's
+    # tile_m//16 to have dispatch apply that permutation as it scatters the scale,
+    # which removes the receiver-side quant+repack pass entirely. 0 => linear scale.
+    push_group_scale_wmma_rep: int = 0
+    # Fuse the push-group dispatch INTO GEMM1 as one stage-1 mega kernel so the
+    # P2P payload transfer of later M-tiles overlaps the GEMM1 compute of earlier
+    # arrived ones. Requires push_group + send-side quant (push_group_scale_wmma_rep
+    # > 0): the wire must carry fp8 + e8m0 only, never bf16 alongside it. Default
+    # off; the existing dispatch -> finalize -> GEMM1 sequence stays the fallback.
+    push_group_overlap: bool = False
+    # Which dispatch transport to build: "vector" is the portable per-lane 16 B
+    # copy, "tdm" the gfx1250 Tensor-Data-Mover port of mori's
+    # ep_intranode_1250x (block-local counting + one remote atomic per
+    # (block, peer) + bulk metadata + DMA payload). "auto" picks vector, so
+    # nothing changes for existing callers; env AITER_EP_DISPATCH_TDM=1 flips
+    # the auto default for A/B runs. The two produce interchangeable state, so
+    # combine / replay / the routing handle do not care which ran.
+    dispatch_transport: str = "auto"
+
+    def __post_init__(self):
+        # all-or-none: setting only one silently defaults the other to data_type.
+        if (self.dispatch_data_type is None) != (self.combine_data_type is None):
+            raise ValueError(
+                "dispatch_data_type / combine_data_type must be set together "
+                "(all-or-none): got dispatch_data_type="
+                f"{self.dispatch_data_type}, combine_data_type={self.combine_data_type}. "
+                "Set data_type alone for a symmetric op, or set both explicitly for "
+                "asymmetric dispatch/combine dtypes."
+            )
+        if self.combine_quant_type not in _COMBINE_QUANT_TYPES:
+            raise ValueError(
+                f"combine_quant_type must be one of {_COMBINE_QUANT_TYPES}, "
+                f"got {self.combine_quant_type!r}"
+            )
+        if self.dispatch_transport not in ("auto", "vector", "tdm"):
+            raise ValueError(
+                "dispatch_transport must be auto|vector|tdm, "
+                f"got {self.dispatch_transport!r}"
+            )
+        if self.dispatch_transport == "auto":
+            self.dispatch_transport = (
+                "tdm" if os.environ.get("AITER_EP_DISPATCH_TDM") == "1" else "vector"
+            )
+        if self.dispatch_transport == "tdm":
+            # Each of these has its own staging region / slot arithmetic that the
+            # TDM kernel does not carry; failing loudly beats silently dropping
+            # scales or landing tokens in the wrong group.
+            unsupported = [
+                name
+                for name, on in (
+                    ("scale_dim", self.scale_dim > 0),
+                    ("push_group", self.push_group),
+                    ("fp4 tokens", self.is_fp4),
+                )
+                if on
+            ]
+            if unsupported:
+                raise ValueError(
+                    "dispatch_transport='tdm' does not implement "
+                    + ", ".join(unsupported)
+                    + "; use dispatch_transport='vector'"
+                )
+        if self.combine_mode not in ("gather", "scatter", "scatter_fused"):
+            raise ValueError(
+                "combine_mode must be gather|scatter|scatter_fused, "
+                f"got {self.combine_mode!r}"
+            )
+        if self.combine_quant_type != "none":
+            self.combine_mode = "scatter"
+        # The dispatch grid barrier iterates peers as range(lane, npes, wave) and
+        # resets inside the loop, correct only when npes <= wavefront.
+        if self.world_size > 64:
+            raise ValueError(
+                f"intranode op supports world_size <= 64, got {self.world_size}"
+            )
+        # Token copy moves whole 16 B (vec4) chunks; per-token size must be 16 B aligned.
+        if self.token_nbytes % 16 != 0:
+            raise ValueError(
+                f"per-token transport bytes must be 16 B aligned (vec4 copy); "
+                f"hidden_dim={self.hidden_dim}, dispatch_dtype={self.dispatch_dtype} -> "
+                f"token_nbytes={self.token_nbytes}"
+            )
+        if self.push_group_overlap:
+            if not self.push_group:
+                raise ValueError("push_group_overlap requires push_group=True")
+            if self.push_group_scale_wmma_rep <= 0:
+                raise ValueError(
+                    "push_group_overlap requires send-side quant "
+                    "(push_group_scale_wmma_rep > 0): the fused stage-1 pushes fp8 "
+                    "payload + e8m0 scale straight into GEMM1's layout, so there is "
+                    "no receiver-side quant pass to fall back on"
+                )
+            tile_m = self.push_group_overlap_tile_m
+            if self.effective_cap_per_expert % tile_m:
+                raise ValueError(
+                    f"push_group_overlap needs cap ({self.effective_cap_per_expert}) "
+                    f"to be a multiple of tile_m ({tile_m})"
+                )
+        if self.is_asymmetric_dtype:
+            # asymmetric dtype (separate disp_out/comb_stg buffers): non-quant /
+            # non-StdMoE. Every combine mode is fine as long as the return wire is
+            # sized off combine_dtype, which is what wire_elem_size / the combine
+            # builders use; combine_quant_type would be a second, conflicting say
+            # over that wire, and StdMoE's convert kernels are bf16-only.
+            if self.combine_quant_type != "none" or self.enable_std_moe:
+                raise ValueError(
+                    "combine_data_type (asymmetric dtype) requires "
+                    "combine_quant_type=none, enable_std_moe=False"
+                )
+            if torch.float4_e2m1fn_x2 in (self.dispatch_dtype, self.combine_dtype):
+                raise ValueError(
+                    "asymmetric dispatch/combine dtype does not support fp4"
+                )
+            if self.combine_token_nbytes % 16 != 0:
+                raise ValueError(
+                    f"combine per-token bytes must be 16 B aligned; combine_data_type="
+                    f"{self.combine_data_type} -> {self.combine_token_nbytes}"
+                )
+        self._resolve_geometry()
+
+    def _resolve_geometry(self):
+        """Fill block/warp/schedule. Tuned-by-default: if the caller pinned nothing,
+        pull the tuned geometry from tuning_configs.lookup; if any field is pinned,
+        honor it and fill the rest with the single-shot fallback (no schedule)."""
+        pinned = self.schedule is not None or any(
+            g is not None
+            for g in (
+                self.dispatch_block_num,
+                self.combine_block_num,
+                self.dispatch_warp_num_per_block,
+                self.combine_warp_num_per_block,
+            )
+        )
+        if not pinned:
+            from .tuning_configs import lookup
+
+            t = lookup(
+                self.world_size,
+                self.hidden_dim,
+                self.num_experts_per_token,
+                dtype=self.dtype_str,
+            )
+            self.dispatch_block_num = t["dispatch_block_num"]
+            self.combine_block_num = t["combine_block_num"]
+            self.dispatch_warp_num_per_block = t["dispatch_warp_num_per_block"]
+            self.combine_warp_num_per_block = t["combine_warp_num_per_block"]
+            self.schedule = t["schedule"]
+        else:
+            # explicit geometry: fill any unset field with the single-shot default
+            if self.dispatch_block_num is None:
+                self.dispatch_block_num = 64
+            if self.combine_block_num is None:
+                self.combine_block_num = 80
+            if self.dispatch_warp_num_per_block is None:
+                self.dispatch_warp_num_per_block = 16
+            if self.combine_warp_num_per_block is None:
+                self.combine_warp_num_per_block = 4
+
+    @property
+    def is_scatter(self):
+        return self.combine_mode in ("scatter", "scatter_fused")
+
+    @property
+    def is_fused(self):
+        """gemm2-fused scatter: gemm2 P2P-writes weighted per-(token,k) results into
+        comb_inp; combine only barriers + sums. No Stage-1 write, no gather_reduce."""
+        return self.combine_mode == "scatter_fused"
+
+    @property
+    def fp8_direct_cast(self):
+        return self.combine_quant_type == "fp8_direct_cast"
+
+    @property
+    def fp8_blockwise(self):
+        return self.combine_quant_type == "fp8_blockwise"
+
+    @property
+    def combine_scale_dim(self):
+        """Per-token block count for fp8_blockwise combine (block_elems=128)."""
+        return self.hidden_dim // 128 if self.fp8_blockwise else 0
+
+    @property
+    def wire_elem_size(self):
+        """comb_inp transport element size: 1 byte for fp8 paths, else the COMBINE
+        element size (not the dispatch one -- a narrow dispatch dtype must not
+        shrink the return wire that gemm2's epilogue writes)."""
+        return (
+            1
+            if self.combine_quant_type in ("fp8_direct_cast", "fp8_blockwise")
+            else self.combine_elem_size
+        )
+
+    @property
+    def tdm_gather_scatter(self):
+        """gemm2-fused P2P scatter via TDM gather-store. The felix TDM GEMM2's
+        fused epilogue always scatters via the TDM gather-store, which requires a
+        pow2-padded comb_inp slot so the per-slot stride divides the 4GB-aligned
+        per-rank symmetric window (lets gemm2 fold (pe,slot) into a single TDM
+        gather row index). Tied to the same switch that selects the felix TDM
+        GEMM2 (AITER_EP_SCATTER_TDM, default on); set it to 0 to fall back onto
+        the grouped/contiguous mxscale gemm2 (unpadded buffer_store scatter)."""
+        return self.is_fused and os.environ.get("AITER_EP_SCATTER_TDM", "1") in (
+            "1",
+            "true",
+            "True",
+            "yes",
+            "on",
+        )
+
+    @property
+    def comb_inp_slot_nbytes(self):
+        """Per-(token,k) comb_inp slot stride in bytes. Padded up to a power of
+        two for the TDM gather-store fused path; else the natural hidden row
+        size (hidden_dim * wire_elem_size)."""
+        base = self.hidden_dim * self.wire_elem_size
+        if self.tdm_gather_scatter:
+            p = 1
+            while p < base:
+                p <<= 1
+            return p
+        return base
+
+    @classmethod
+    def tuned(cls, **kwargs):
+        """Build a config with geometry from tuning_configs (unless overridden in
+        kwargs). Back-compat alias; the plain constructor is also tuned-by-default."""
+        from .tuning_configs import lookup
+
+        dt = kwargs.get("data_type", torch.bfloat16)
+        dtype = (
+            "fp4"
+            if dt == torch.float4_e2m1fn_x2
+            else ("fp8" if dt in _FP8_DTYPES else "bf16")
+        )
+        t = lookup(
+            kwargs["world_size"],
+            kwargs["hidden_dim"],
+            kwargs["num_experts_per_token"],
+            dtype=dtype,
+        )
+        for k, v in t.items():
+            kwargs.setdefault(k, v)
+        return cls(**kwargs)
+
+    @property
+    def dispatch_dtype(self):
+        """Dispatch transport dtype (== data_type unless dispatch_data_type set)."""
+        return (
+            self.dispatch_data_type
+            if self.dispatch_data_type is not None
+            else self.data_type
+        )
+
+    @property
+    def is_fp4(self):
+        return self.dispatch_dtype == torch.float4_e2m1fn_x2
+
+    @property
+    def is_fp8(self):
+        return self.dispatch_dtype in _FP8_DTYPES
+
+    @property
+    def elem_size(self):
+        # fp4 is 0.5 B/elem; return a nominal 1 (kernels use the fp4 flag +
+        # token_nbytes for actual sizing, never elem_size for fp4 token buffers).
+        return 1 if self.is_fp4 else _DT[self.dispatch_dtype]
+
+    @property
+    def token_nbytes(self):
+        """Per-token transport bytes (fp4 packs 2 e2m1/byte -> hidden/2)."""
+        return self.hidden_dim // 2 if self.is_fp4 else self.hidden_dim * self.elem_size
+
+    @property
+    def combine_dtype(self):
+        """Combine transport dtype (== data_type unless combine_data_type set)."""
+        return (
+            self.combine_data_type
+            if self.combine_data_type is not None
+            else self.data_type
+        )
+
+    @property
+    def combine_elem_size(self):
+        cdt = self.combine_dtype
+        return 1 if cdt == torch.float4_e2m1fn_x2 else _DT[cdt]
+
+    @property
+    def combine_token_nbytes(self):
+        cdt = self.combine_dtype
+        return (
+            self.hidden_dim // 2
+            if cdt == torch.float4_e2m1fn_x2
+            else self.hidden_dim * self.combine_elem_size
+        )
+
+    @property
+    def is_asymmetric_dtype(self):
+        return self.dispatch_dtype != self.combine_dtype
+
+    @property
+    def dtype_str(self):
+        """Token/dispatch dtype key for tuning_configs.lookup (fp4/fp8/default)."""
+        if self.is_fp4:
+            return "fp4"
+        if self.is_fp8:
+            return "fp8"
+        return "bf16"
+
+    @property
+    def max_recv(self):
+        """Sentinel / sender-side atomic-add allocation bound (always ws*M)."""
+        return self.world_size * self.max_num_inp_token_per_rank
+
+    @property
+    def effective_max_recv_per_rank(self):
+        if self.max_total_recv_tokens <= 0:
+            return self.max_num_inp_token_per_rank
+        per = (self.max_total_recv_tokens + self.world_size - 1) // self.world_size
+        return min(per, self.max_num_inp_token_per_rank)
+
+    @property
+    def effective_max_recv(self):
+        """Recv-slot cap passed to the kernels as max_recv (mori MaxNumTokensToRecv)."""
+        return self.world_size * self.effective_max_recv_per_rank
+
+    @property
+    def effective_cap_per_expert(self) -> int:
+        """Per-local-expert fixed-slot row capacity, aligned up to the GEMM1 tile_m.
+
+        ``cap_per_expert=0`` (default) => worst-case ``world_size*max_tok_per_rank``:
+        one expert could receive every token, so this can never drop. ``>0`` uses the
+        caller's pinned value (correctness is the caller's responsibility -- a real
+        peak per-expert load above it is silently dropped in finalize).
+
+        A padding M-tile (expert==n_experts sentinel) early-exits at the kernel's
+        ``if expert < n_experts`` guard -- it does NOT run the N/K mainloop -- so
+        over-provisioning costs empty-workgroup dispatch, not padded compute.
+        """
+        tile_m = _PUSH_GROUP_TILE_M
+        base = (
+            int(self.cap_per_expert)
+            if self.cap_per_expert > 0
+            else self.world_size * self.max_num_inp_token_per_rank
+        )
+        base = max(tile_m, base)
+        return ((base + tile_m - 1) // tile_m) * tile_m
+
+    @property
+    def push_group_overlap_tile_m(self) -> int:
+        """GEMM1 M-tile the overlap arrival counters are keyed on. It is the same
+        knob as the send-side scale preshuffle geometry (wmma_rep = tile_m//16),
+        so the two can never drift apart."""
+        return self.push_group_scale_wmma_rep * 16
+
+    @property
+    def push_group_overlap_tiles_per_expert(self) -> int:
+        return self.effective_cap_per_expert // self.push_group_overlap_tile_m
+
+
+class EpDispatchRoutingHandle:
+    """Per-call routing snapshot.
+
+    disp_dest_tok_id_map: forward (src_tok,k)->dest flat slot (tok_map).
+    disp_tok_id_to_src_tok_id_local: reverse recv-slot->src token (tis).
+    inter_node_*: empty placeholders (intranode-only; kept for 5-tensor shape parity).
+
+    The reverse map is materialized LAZILY on first access: recv_to_src_token is
+    written by peers via P2P during dispatch and is only visible after the caller's
+    post-dispatch barrier, so cloning it eagerly would race those writes.
+    """
+
+    def __init__(
+        self,
+        disp_dest_tok_id_map,
+        inter_node_disp_dest_tok_id_map,
+        inter_node_disp_send_map,
+        total_recv_token_num,
+        disp_tok_id_to_src_tok_id_local=None,
+        cur_rank_num_token=0,
+        *,
+        reverse_src_view=None,
+    ):
+        self.disp_dest_tok_id_map = disp_dest_tok_id_map
+        self.inter_node_disp_dest_tok_id_map = inter_node_disp_dest_tok_id_map
+        self.inter_node_disp_send_map = inter_node_disp_send_map
+        self.total_recv_token_num = total_recv_token_num
+        self.cur_rank_num_token = cur_rank_num_token
+        # Either an already-materialized reverse map (from_tensors round-trip) or
+        # a live arena view to clone on first access (dispatch()).
+        self._reverse_cache = disp_tok_id_to_src_tok_id_local
+        self._reverse_src_view = reverse_src_view
+
+    @property
+    def disp_tok_id_to_src_tok_id_local(self):
+        if self._reverse_cache is None:
+            # First access (post-barrier): clone off the arena before the next
+            # dispatch overwrites the region.
+            self._reverse_cache = self._reverse_src_view.clone()
+        return self._reverse_cache
+
+    def tensors(self):
+        return (
+            self.disp_dest_tok_id_map,
+            self.inter_node_disp_dest_tok_id_map,
+            self.inter_node_disp_send_map,
+            self.total_recv_token_num,
+            self.disp_tok_id_to_src_tok_id_local,
+        )
+
+    @classmethod
+    def from_tensors(cls, tensors, cur_rank_num_token=0):
+        return cls(*tensors, cur_rank_num_token=cur_rank_num_token)
+
+
+class EpDispatchCombineOp:
+    def __init__(self, cfg: EpDispatchCombineConfig, comm):
+        self.cfg = cfg
+        self.comm = comm
+        device = torch.device("cuda", torch.cuda.current_device())
+        self.dev = device
+        elem_size = cfg.elem_size
+        is_fp4 = cfg.is_fp4
+        is_fp8 = cfg.is_fp8
+        token_nbytes = cfg.token_nbytes  # per-token transport bytes (fp4 = hidden/2)
+        # The restriction is about the COMBINE wire: a scatter combine accumulates
+        # into the peer slot, which the fp4/fp8 accumulators do not implement (that
+        # is what combine_quant_type=fp8_direct_cast is for). A narrow dispatch dtype
+        # with a bf16 combine is fine -- dispatch is a pure byte mover and the two
+        # directions carry independent buffers -- and is how the push path sends
+        # pre-quantized tokens.
+        combine_is_narrow = cfg.combine_dtype == torch.float4_e2m1fn_x2 or (
+            cfg.combine_dtype in _FP8_DTYPES
+        )
+        if (is_fp4 or is_fp8) and cfg.is_scatter and combine_is_narrow:
+            raise ValueError(
+                "plain fp4/fp8 token dtype is gather-only for a symmetric op "
+                "(fp8 quant uses combine_quant_type=fp8_direct_cast, not data_type); "
+                "set combine_data_type=bf16 for a narrow-dispatch / wide-combine op"
+            )
+        topk = cfg.num_experts_per_token
+        hidden_dim = cfg.hidden_dim
+        max_tok_per_rank = cfg.max_num_inp_token_per_rank
+        recv_cap = cfg.effective_max_recv  # recv-slot cap (== ws*M unless capped)
+        self._recv_cap = recv_cap
+
+        self._scale_bytes = cfg.scale_dim * cfg.scale_type_size
+        self._scale_num_i32 = (self._scale_bytes + 3) // 4
+        self._enable_scales = self._scale_bytes > 0
+
+        # push-group fixed-slot: recv-side regions grow from recv-order (recv_cap
+        # rows) to grouped [num_local_experts, CAP] rows so tokens land grouped.
+        self._push_group = cfg.push_group
+        self._pg_initialized = False
+        self._pg_ov_initialized = False
+        self._push_group_cap = cfg.effective_cap_per_expert if cfg.push_group else 0
+        rrows = (
+            cfg.num_experts_per_rank * self._push_group_cap
+            if cfg.push_group
+            else recv_cap
+        )
+        self._pg_recv_rows = rrows
+
+        regions = [
+            ("tok_off", 4),
+            ("recv_num", cfg.world_size * 4),
+            ("recv_to_src_token", rrows * 4),
+            ("out_idx", rrows * topk * 4),
+            ("out_wts", rrows * topk * 4),
+            # disp_out: dispatch dest / expert-GEMM input, kept separate from comb_stg
+            # so combine's copy-in never clobbers the dispatched tokens.
+            ("disp_out", rrows * token_nbytes),
+            # comb_stg: combine staging (post-expert results that peers gather).
+            ("comb_stg", recv_cap * cfg.combine_token_nbytes),
+            ("cross_device_barrier", cfg.world_size * 8),
+        ]
+        if self._enable_scales:
+            regions.append(("out_scales", rrows * self._scale_num_i32 * 4))
+        regions += _push_group_regions(cfg)
+        regions += _push_group_overlap_regions(cfg)
+        # scatter combine needs its own staging regions
+        if cfg.is_scatter:
+            wire_elem_size = cfg.wire_elem_size
+            if cfg.is_fused:
+                # per-(origin_token, k): this rank's own M tokens x topk slots; each
+                # (token,k) is written exactly once by the owner rank's gemm2 (the
+                # expert k of that token lives on one rank) -> no cross-rank collision.
+                # Weights are pre-multiplied in gemm2, so no comb_wts region.
+                regions.append(
+                    ("comb_inp", max_tok_per_rank * topk * cfg.comb_inp_slot_nbytes)
+                )
+            else:
+                regions.append(
+                    (
+                        "comb_inp",
+                        cfg.world_size * max_tok_per_rank * hidden_dim * wire_elem_size,
+                    )
+                )
+                regions.append(
+                    ("comb_wts", cfg.world_size * max_tok_per_rank * topk * 4)
+                )
+                if cfg.fp8_blockwise:
+                    regions.append(
+                        (
+                            "comb_scales",
+                            cfg.world_size
+                            * max_tok_per_rank
+                            * cfg.combine_scale_dim
+                            * 4,
+                        )
+                    )
+        self.arena = SymmArena(comm, regions)
+        self.arena.zero()
+
+        self.token_dest_map = torch.full(
+            (max_tok_per_rank * topk,), -1, dtype=torch.int32, device=device
+        )
+        self._empty_i32 = torch.empty(
+            0, dtype=torch.int32, device=device
+        )  # inter-node placeholders
+        self.dest_pe_counter = torch.zeros(
+            cfg.world_size, dtype=torch.int32, device=device
+        )
+        self.dispatch_barrier = torch.zeros(1, dtype=torch.int32, device=device)
+        self.total_recv = torch.zeros(1, dtype=torch.int32, device=device)
+        self.combine_barrier = torch.zeros(1, dtype=torch.int32, device=device)
+        # Per-block xdb flag counters for the gather combine entry barrier: one
+        # i64 per block, fixed at xdb_flag_slots (== CU count, the max combine
+        # block_num). Every block owns a private counter and block 0 fills the
+        # unused tail so all stay in lockstep across calls with different
+        # block_num. The scatter/fused combines only use slot 0.
+        self.cross_device_flag = torch.ones(
+            xdb_flag_slots, dtype=torch.int64, device=device
+        )
+        c_dt = cfg.combine_dtype  # combine output dtype
+        c_elem = cfg.combine_elem_size
+        if c_dt == torch.float4_e2m1fn_x2:  # fp4 combine outputs fp4 (hidden/2 B/token)
+            self.combine_out = torch.zeros(
+                max_tok_per_rank * (hidden_dim // 2), dtype=torch.int8, device=device
+            )
+        elif c_dt in _FP8_DTYPES:  # fp8 combine outputs fp8 (1 byte/elem)
+            self.combine_out = torch.zeros(
+                max_tok_per_rank * hidden_dim, dtype=torch.int8, device=device
+            )
+        else:
+            self.combine_out = torch.zeros(
+                max_tok_per_rank * hidden_dim,
+                dtype=torch.int16 if c_elem == 2 else torch.int32,
+                device=device,
+            )
+        self.combine_out_weights = torch.zeros(
+            max_tok_per_rank * topk, dtype=torch.float32, device=device
+        )
+
+        arena = self.arena
+        # Distinct (block, warp) variants to precompile; a per-token schedule picks
+        # the best at runtime, else single-shot. Scatter combine is not schedule-tuned.
+        schedule = cfg.schedule
+        if schedule:
+            dispatch_specs = sorted({(db, dw) for (_, db, dw, _, _) in schedule})
+            combine_specs = sorted({(cb, cw) for (_, _, _, cb, cw) in schedule})
+        else:
+            dispatch_specs = [(cfg.dispatch_block_num, cfg.dispatch_warp_num_per_block)]
+            combine_specs = [(cfg.combine_block_num, cfg.combine_warp_num_per_block)]
+        # Pin the dispatch geometry via DISPATCH_BW (e.g. "32,8"), mirroring
+        # SCATTER_COMB_BW below. Pinning one spec makes _pick fall back to it for
+        # every token count, which is what a sweep wants.
+        #
+        # Measured on gfx1250 across bs=8/128/512 and both push_group paths: the
+        # only thing block_num controls is whether block*warp covers the
+        # cur_tok*topk work items in one grid-stride pass. Above coverage it is
+        # flat (bs=8 ran the same from 8 to 128 blocks), because the Phase-2 grid
+        # barrier is paced by how late the slowest payload block arrives, not by
+        # the per-block atomic on disp_bar. Below coverage each extra pass costs
+        # ~40% (bs=128 went 73 -> 102 -> 133 us at 96 -> 64 -> 32 blocks). So
+        # tune for coverage while latency-bound and ignore the block count.
+        _disp_bw = os.environ.get("DISPATCH_BW")
+        if _disp_bw:
+            dispatch_specs = [tuple(int(x) for x in _disp_bw.split(","))]
+        if cfg.is_scatter:
+            # Scatter combine hits an all-block grid barrier mid-kernel (Stage 1
+            # write -> barrier -> Stage 3 read). With the gather-tuned (block=80,
+            # warp=4) that barrier serializes badly (occupancy-bound: too many
+            # blocks to co-reside, so the grid barrier spins). Far fewer blocks with
+            # more warps per block (8x16) keeps all blocks resident and roughly
+            # halves the scatter combine kernel time. Override via SCATTER_COMB_BW
+            # (e.g. "16,16") to retune for a different token count / hidden dim.
+            _b, _w = 8, 16
+            _bw = os.environ.get("SCATTER_COMB_BW")
+            if _bw:
+                _b, _w = (int(x) for x in _bw.split(","))
+                combine_specs = [(_b, _w)]
+            elif cfg.is_fused:
+                # The fused combine is an xdb barrier + a light topk sum. Only the
+                # first npes lanes now touch the system-scope xdb flag, so additional
+                # waves are useful bandwidth workers instead of multiplying barrier
+                # traffic. Re-tuned after that change: keep 8 blocks through 32
+                # tokens (16 regresses at bs8), then 16/32/64 blocks win through
+                # 256/1024/larger counts. The next doubling is flat at 128 and
+                # regresses at 512/2048 because comb_bar starts dominating again.
+                # Override via SCATTER_COMB_BW for other token/hidden shapes.
+                self._fused_comb_tiers = [
+                    (32, (8, 16)),
+                    (256, (16, 16)),
+                    (1024, (32, 16)),
+                    (None, (64, 16)),
+                ]
+                combine_specs = [s for _, s in self._fused_comb_tiers]
+            else:
+                combine_specs = [(_b, _w)]
+        self._dispatch_specs = dispatch_specs
+        self._combine_specs = combine_specs
+
+        self._dispatch_kwargs = dict(
+            rank=cfg.rank,
+            npes=cfg.world_size,
+            experts_per_rank=cfg.num_experts_per_rank,
+            experts_per_token=topk,
+            hidden_dim=hidden_dim,
+            hidden_elem_size=elem_size,
+            max_tok_per_rank=max_tok_per_rank,
+            max_recv=recv_cap,
+            off_tok_off=arena.offset("tok_off"),
+            off_recv_num=arena.offset("recv_num"),
+            off_tis=arena.offset("recv_to_src_token"),
+            off_out_idx=arena.offset("out_idx"),
+            off_out_wts=arena.offset("out_wts"),
+            off_out_tok=arena.offset("disp_out"),
+            off_out_scales=arena.offset("out_scales") if self._enable_scales else 0,
+            scale_dim=cfg.scale_dim,
+            scale_type_size=cfg.scale_type_size,
+            fp4=is_fp4,
+            push_group=cfg.push_group,
+            push_group_cap=self._push_group_cap,
+            off_pg_running=arena.offset("pg_running") if cfg.push_group else 0,
+            off_pg_rowmap=arena.offset("pg_rowmap") if cfg.push_group else 0,
+            push_group_scale_wmma_rep=cfg.push_group_scale_wmma_rep,
+        )
+        # (block, warp) -> compiled dispatch / combine kernel.
+        self._dispatch_variants = {
+            (b, w): make_dispatch(
+                block_num=b, warp_num_per_block=w, **self._dispatch_kwargs
+            )
+            for (b, w) in dispatch_specs
+        }
+        self._dispatch_replay_variants = {}  # lazily compiled per (block, warp)
+
+        # TDM transport: same kwargs minus the knobs it does not implement, plus
+        # its own staging pool. FINALIZE gathers each route's metadata into a
+        # (block, peer)-contiguous run there so META can ship it in bulk; the
+        # pool is sized for the widest precompiled geometry, since a narrower
+        # grid only ever addresses a prefix of it.
+        self._dispatch_tdm_variants = {}
+        self._tdm_stage = None
+        if cfg.dispatch_transport == "tdm":
+            tdm_kwargs = {
+                k: v
+                for k, v in self._dispatch_kwargs.items()
+                if k
+                not in (
+                    "off_out_scales",
+                    "scale_dim",
+                    "scale_type_size",
+                    "fp4",
+                    "push_group",
+                    "push_group_cap",
+                    "off_pg_running",
+                    "off_pg_rowmap",
+                    "push_group_scale_wmma_rep",
+                )
+            }
+            # The schedule is tuned against the vector transport, which holds no
+            # per-warp LDS, so it can name a warp width this one cannot build
+            # (32 warps of a 7168-wide bf16 tile want 448 KB of a 320 KB budget).
+            # Clamp the width, keep the tuned block count, and keep the caller's
+            # spec as the key so _pick still resolves.
+            max_warps = tdm_max_warps(
+                hidden_dim=hidden_dim,
+                hidden_elem_size=elem_size,
+                npes=cfg.world_size,
+            )
+            tdm_geom = {(b, w): (b, min(w, max_warps)) for (b, w) in dispatch_specs}
+            slots = max(
+                tdm_stage_capacity(
+                    npes=cfg.world_size,
+                    experts_per_token=topk,
+                    max_tok_per_rank=max_tok_per_rank,
+                    block_num=b,
+                    warp_num_per_block=w,
+                )[1]
+                for (b, w) in tdm_geom.values()
+            )
+            dev = torch.cuda.current_device()
+            self._tdm_stage = (
+                torch.empty(slots * topk, dtype=torch.int32, device=dev),  # indices
+                torch.empty(slots * topk, dtype=torch.int32, device=dev),  # weights
+                torch.empty(slots, dtype=torch.int32, device=dev),  # srcmap
+            )
+            _built = {}
+            for spec, geom in tdm_geom.items():
+                if geom not in _built:
+                    _built[geom] = make_dispatch_tdm(
+                        block_num=geom[0],
+                        warp_num_per_block=geom[1],
+                        **tdm_kwargs,
+                    )
+                self._dispatch_tdm_variants[spec] = _built[geom]
+        if cfg.is_fused:
+            # gemm2 already P2P-wrote weighted per-(token,k) results into comb_inp;
+            # combine only barriers (wait for peers' writes) + sums the topk slots.
+            self._combine_variants = {
+                (b, w): make_combine_fused_reduce(
+                    rank=cfg.rank,
+                    npes=cfg.world_size,
+                    experts_per_token=topk,
+                    hidden_dim=hidden_dim,
+                    hidden_elem_size=cfg.combine_elem_size,
+                    max_tok_per_rank=max_tok_per_rank,
+                    block_num=b,
+                    warp_num_per_block=w,
+                    off_comb_inp=arena.offset("comb_inp"),
+                    off_xdb_mem=arena.offset("cross_device_barrier"),
+                    slot_stride_nbytes=cfg.comb_inp_slot_nbytes,
+                )
+                for (b, w) in combine_specs
+            }
+        elif cfg.is_scatter:
+            self._combine_variants = {
+                (b, w): make_combine_scatter(
+                    rank=cfg.rank,
+                    npes=cfg.world_size,
+                    experts_per_token=topk,
+                    hidden_dim=hidden_dim,
+                    hidden_elem_size=cfg.combine_elem_size,
+                    max_tok_per_rank=max_tok_per_rank,
+                    max_recv=recv_cap,
+                    block_num=b,
+                    warp_num_per_block=w,
+                    off_out_tok=arena.offset("comb_stg"),
+                    off_comb_inp=arena.offset("comb_inp"),
+                    off_tis=arena.offset("recv_to_src_token"),
+                    off_xdb_mem=arena.offset("cross_device_barrier"),
+                    off_out_wts=arena.offset("out_wts"),
+                    off_comb_wts=arena.offset("comb_wts"),
+                    off_comb_scales=(
+                        arena.offset("comb_scales") if cfg.fp8_blockwise else 0
+                    ),
+                    fp8_direct_cast=cfg.fp8_direct_cast,
+                    fp8_blockwise=cfg.fp8_blockwise,
+                    scale_dim=cfg.combine_scale_dim,
+                    reset_total_recv=False,
+                )
+                for (b, w) in combine_specs
+            }
+        else:
+            self._combine_variants = {
+                (b, w): make_combine(
+                    rank=cfg.rank,
+                    npes=cfg.world_size,
+                    experts_per_token=topk,
+                    hidden_dim=hidden_dim,
+                    hidden_elem_size=cfg.combine_elem_size,
+                    max_tok_per_rank=max_tok_per_rank,
+                    max_recv=recv_cap,
+                    block_num=b,
+                    warp_num_per_block=w,
+                    off_out_tok=arena.offset("comb_stg"),
+                    off_xdb_mem=arena.offset("cross_device_barrier"),
+                    off_out_wts=arena.offset("out_wts"),
+                    reset_total_recv=True,
+                    fp4=(cfg.combine_dtype == torch.float4_e2m1fn_x2),
+                )
+                for (b, w) in combine_specs
+            }
+
+        self._local_expert_count_buf = torch.zeros(
+            cfg.num_experts_per_rank, dtype=torch.int32, device=device
+        )
+        self._local_expert_count = make_local_expert_count(
+            rank=cfg.rank,
+            experts_per_rank=cfg.num_experts_per_rank,
+            experts_per_token=topk,
+            block_num=cfg.dispatch_block_num,
+            warp_num_per_block=cfg.dispatch_warp_num_per_block,
+        )
+
+        if cfg.enable_std_moe:
+            assert elem_size == 2, "StdMoE convert path is bf16-only"
+            experts_per_rank = cfg.num_experts_per_rank
+            max_tok_per_expert = cfg.world_size * max_tok_per_rank
+            self._max_tok_per_expert = max_tok_per_expert
+            self.packed_x = torch.zeros(
+                experts_per_rank * max_tok_per_expert * hidden_dim,
+                dtype=torch.int16,
+                device=device,
+            )
+            self.packed_count = torch.zeros(
+                experts_per_rank, dtype=torch.int32, device=device
+            )
+            self.packed_src = torch.zeros(
+                experts_per_rank * max_tok_per_expert, dtype=torch.int32, device=device
+            )
+            self.slot_map = torch.full(
+                (recv_cap * topk,), -1, dtype=torch.int64, device=device
+            )
+            self._convert_dispatch = make_convert_dispatch_output(
+                rank=cfg.rank,
+                experts_per_rank=experts_per_rank,
+                experts_per_token=topk,
+                hidden_dim=hidden_dim,
+                hidden_elem_size=elem_size,
+                max_tok_per_expert=max_tok_per_expert,
+                block_num=cfg.dispatch_block_num,
+                warp_num_per_block=cfg.dispatch_warp_num_per_block,
+            )
+            self._convert_combine = make_convert_combine_input(
+                rank=cfg.rank,
+                experts_per_rank=experts_per_rank,
+                experts_per_token=topk,
+                hidden_dim=hidden_dim,
+                hidden_elem_size=elem_size,
+                max_tok_per_expert=max_tok_per_expert,
+                block_num=cfg.combine_block_num,
+                warp_num_per_block=cfg.combine_warp_num_per_block,
+            )
+        self._closed = False
+
+    def close(self):
+        """Free this op's symmetric arena window. Call (or use as a context
+        manager) when the op is discarded but its Communicator lives on —
+        otherwise the arena stays in comm._resources until the comm is destroyed."""
+        if self._closed:
+            return
+        self._closed = True
+        self.arena.close()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        self.close()
+
+    def recv_tokens(self):
+        """Arena disp_out [max_recv, hidden] (dispatch dest / expert-GEMM input).
+        Separate from comb_stg, so combine's copy-in never overwrites it — the
+        expert can read this in place without a defensive .clone().
+        fp4 packs 2 e2m1 per float4_e2m1fn_x2 element -> last dim is hidden/2."""
+        cols = self.cfg.hidden_dim // 2 if self.cfg.is_fp4 else self.cfg.hidden_dim
+        return from_gpu_ptr(
+            self.arena.local_ptr("disp_out"),
+            (self._recv_cap, cols),
+            self.cfg.dispatch_dtype,
+        )
+
+    def combine_in_view(self):
+        """comb_stg as combine dtype [max_recv, hidden] — combine()'s copy target."""
+        cdt = self.cfg.combine_dtype
+        cols = (
+            self.cfg.hidden_dim // 2
+            if cdt == torch.float4_e2m1fn_x2
+            else self.cfg.hidden_dim
+        )
+        return from_gpu_ptr(
+            self.arena.local_ptr("comb_stg"), (self._recv_cap, cols), cdt
+        )
+
+    def convert_dispatch_output(self):
+        """mori ConvertDispatchOutput: repack recv tokens into per-local-expert
+        buckets. Returns (packed_x, packed_count, packed_src); GEMM overwrites
+        packed_x in place."""
+        assert self.cfg.enable_std_moe, "op built without enable_std_moe"
+        self.packed_count.zero_()
+        self.slot_map.fill_(-1)
+        arena = self.arena
+        stream = fx.Stream(torch.cuda.current_stream())
+        self._convert_dispatch(
+            arena.local_ptr("disp_out"),
+            arena.local_ptr("out_idx"),
+            arena.local_ptr("recv_to_src_token"),
+            self.total_recv.data_ptr(),
+            self.packed_x.data_ptr(),
+            self.packed_count.data_ptr(),
+            self.packed_src.data_ptr(),
+            self.slot_map.data_ptr(),
+            stream,
+        )
+        experts_per_rank = self.cfg.num_experts_per_rank
+        max_tok_per_expert = self._max_tok_per_expert
+        hidden_dim = self.cfg.hidden_dim
+        packed_x_view = from_gpu_ptr(
+            self.packed_x.data_ptr(),
+            (experts_per_rank, max_tok_per_expert, hidden_dim),
+            self.cfg.dispatch_dtype,
+        )
+        return packed_x_view, self.packed_count, self.packed_src
+
+    def convert_combine_input(self, routing):
+        """mori ConvertCombineInput: weighted-reduce each recv token's local-expert
+        outputs from packed_x back into comb_stg. Run after GEMM, before combine."""
+        assert self.cfg.enable_std_moe, "op built without enable_std_moe"
+        arena = self.arena
+        stream = fx.Stream(torch.cuda.current_stream())
+        self._convert_combine(
+            arena.local_ptr("comb_stg"),
+            arena.local_ptr("out_wts"),
+            routing.total_recv_token_num.data_ptr(),
+            self.packed_x.data_ptr(),
+            self.slot_map.data_ptr(),
+            stream,
+        )
+
+    def recv_weights(self):
+        """Arena out_wts as [max_recv, topk] f32 (forwarded per-token weights)."""
+        return from_gpu_ptr(
+            self.arena.local_ptr("out_wts"),
+            (self._recv_cap, self.cfg.num_experts_per_token),
+            torch.float32,
+        )
+
+    def recv_indices(self):
+        """Arena out_idx as [max_recv, topk] i32 (forwarded expert indices)."""
+        return from_gpu_ptr(
+            self.arena.local_ptr("out_idx"),
+            (self._recv_cap, self.cfg.num_experts_per_token),
+            torch.int32,
+        )
+
+    def recv_scales(self):
+        """Forwarded per-token scales as opaque i32 dwords [max_recv, scale_num_i32],
+        or None if built without scales."""
+        if not self._enable_scales:
+            return None
+        return from_gpu_ptr(
+            self.arena.local_ptr("out_scales"),
+            (self._recv_cap, self._scale_num_i32),
+            torch.int32,
+        )
+
+    def _pick(self, num_tokens):
+        """((disp_block, disp_warp), (comb_block, comb_warp)) for a runtime token
+        count via the per-token schedule; falls back to the single-shot specs
+        otherwise. Returned specs are clamped to the precompiled variants."""
+        schedule = self.cfg.schedule
+        disp_spec = comb_spec = None
+        if schedule:
+            for bucket in schedule:
+                max_tok = bucket[0]
+                if max_tok is None or num_tokens <= max_tok:
+                    disp_spec, comb_spec = (bucket[1], bucket[2]), (
+                        bucket[3],
+                        bucket[4],
+                    )
+                    break
+            if disp_spec is None:
+                last = schedule[-1]
+                disp_spec, comb_spec = (last[1], last[2]), (last[3], last[4])
+        else:
+            disp_spec, comb_spec = self._dispatch_specs[0], self._combine_specs[0]
+        if disp_spec not in self._dispatch_variants:
+            disp_spec = self._dispatch_specs[-1]
+        if comb_spec not in self._combine_variants:
+            comb_spec = self._combine_specs[-1]
+        return disp_spec, comb_spec
+
+    def dispatch(
+        self, input, weights, scales, indices, *, routing=None, return_routing=False
+    ):
+        """mori-parity dispatch. input [n_tok,hidden], weights [n_tok,topk] f32,
+        scales [n_tok,scale_dim] (or None), indices [n_tok,topk] i32.
+
+        routing=: replay a prior handle (reuse cached dest-slot layout, skip
+        atomic routing). return_routing=: also return the handle. Mutually
+        exclusive. Returns (out, out_weights, out_scales, out_indices,
+        total_recv[, routing]); out == arena disp_out (safe to read without
+        .clone() — combine stages into a separate comb_stg buffer).
+        """
+        if routing is not None and return_routing:
+            raise ValueError(
+                "pass either routing= (replay) or return_routing=True, not both"
+            )
+        num_input_tokens = input.shape[0]
+        disp_spec, _ = self._pick(num_input_tokens)
+        if routing is None and self._push_group and not self._pg_initialized:
+            # One-time only: seed pg_running=0 before the very first push-group
+            # landing. Subsequent layers are zeroed race-free inside finalize
+            # (read-then-zero). Doing it per-dispatch would race with peers' P2P
+            # atomic_add into this counter.
+            self.reset_push_group()
+            self._pg_initialized = True
+        # total_recv is self-reset inside the dispatch kernel (warp 0, Phase 2).
+        scale_ptr = (
+            scales.data_ptr() if (scales is not None and self._enable_scales) else 0
+        )
+        stream = fx.Stream(torch.cuda.current_stream())
+        weight_ptr = weights.data_ptr() if weights is not None else 0
+        if routing is not None:
+            if self._dispatch_tdm_variants:
+                raise NotImplementedError(
+                    "replay is not ported to dispatch_transport='tdm': its slots "
+                    "come from a per-(block, peer) reservation, so a cached map is "
+                    "only replayable under the same grid AND the same block->token "
+                    "assignment"
+                )
+            kern = self._dispatch_replay_variants.get(disp_spec)
+            if kern is None:
+                kern = self._dispatch_replay_variants[disp_spec] = make_dispatch(
+                    replay=True,
+                    block_num=disp_spec[0],
+                    warp_num_per_block=disp_spec[1],
+                    **self._dispatch_kwargs,
+                )
+            dest_map_ptr = routing.disp_dest_tok_id_map.data_ptr()
+            kern(
+                self.arena.handle,
+                input.data_ptr(),
+                indices.data_ptr(),
+                weight_ptr,
+                dest_map_ptr,
+                self.dest_pe_counter.data_ptr(),
+                self.dispatch_barrier.data_ptr(),
+                self.total_recv.data_ptr(),
+                scale_ptr,
+                self.cfg.rank,
+                num_input_tokens,
+                stream,
+            )
+        else:
+            # return_routing hands the map to the caller, so give the kernel a
+            # fresh -1 map instead of the shared persistent one (which the handle
+            # would then have to clone to stay valid across calls).
+            dest_map = (
+                torch.full_like(self.token_dest_map, -1)
+                if return_routing
+                else self.token_dest_map
+            )
+            if self._dispatch_tdm_variants:
+                stg_idx, stg_wt, stg_src = self._tdm_stage
+                self._dispatch_tdm_variants[disp_spec](
+                    self.arena.handle,
+                    input.data_ptr(),
+                    indices.data_ptr(),
+                    weight_ptr,
+                    dest_map.data_ptr(),
+                    self.dest_pe_counter.data_ptr(),
+                    self.dispatch_barrier.data_ptr(),
+                    self.total_recv.data_ptr(),
+                    stg_idx.data_ptr(),
+                    stg_wt.data_ptr(),
+                    stg_src.data_ptr(),
+                    self.cfg.rank,
+                    num_input_tokens,
+                    stream,
+                )
+            else:
+                self._dispatch_variants[disp_spec](
+                    self.arena.handle,
+                    input.data_ptr(),
+                    indices.data_ptr(),
+                    weight_ptr,
+                    dest_map.data_ptr(),
+                    self.dest_pe_counter.data_ptr(),
+                    self.dispatch_barrier.data_ptr(),
+                    self.total_recv.data_ptr(),
+                    scale_ptr,
+                    self.cfg.rank,
+                    num_input_tokens,
+                    stream,
+                )
+
+        out = self.recv_tokens()
+        out_weights = self.recv_weights()
+        out_scales = self.recv_scales()
+        out_indices = self.recv_indices()
+        base = (out, out_weights, out_scales, out_indices, self.total_recv)
+        if not return_routing:
+            return base
+
+        recv_to_src_view = from_gpu_ptr(
+            self.arena.local_ptr("recv_to_src_token"),
+            (self._pg_recv_rows,),
+            torch.int32,
+        )
+        routing = EpDispatchRoutingHandle(
+            disp_dest_tok_id_map=dest_map,
+            inter_node_disp_dest_tok_id_map=self._empty_i32,
+            inter_node_disp_send_map=self._empty_i32,
+            total_recv_token_num=self.total_recv,
+            cur_rank_num_token=num_input_tokens,
+            reverse_src_view=recv_to_src_view,
+        )
+        return base + (routing,)
+
+    def combine(self, input, weights=None, indices=None, *, routing):
+        """mori-parity combine. input [<=max_recv,hidden] post-expert tokens
+        (copied into arena comb_stg if not already there). weights/indices are
+        accepted for API parity but unused (weights come from forwarded out_wts,
+        routing carries the mapping). Returns (out [ct,hidden], out_weights [ct,topk]).
+        """
+        if self.cfg.is_fused:
+            return self._combine_fused(routing)
+        comb_stg_ptr = self.arena.local_ptr("comb_stg")
+        if self.cfg.is_scatter:
+            # Scatter Stage 1 only LOCAL-reads its source, so read the post-expert
+            # tokens (GEMM output) directly and skip the copy into symmetric
+            # comb_stg. StdMoE already staged comb_stg, so use that.
+            src_tok_ptr = comb_stg_ptr if self.cfg.enable_std_moe else input.data_ptr()
+        else:
+            # Gather peers REMOTE-read comb_stg, so the post-expert tokens must be
+            # copied into symmetric memory first. StdMoE already staged comb_stg.
+            if not self.cfg.enable_std_moe and input.data_ptr() != comb_stg_ptr:
+                # copy in the combine-dtype layout (not recv_tokens()'s dispatch view)
+                dst = self.combine_in_view().view(-1)[: input.numel()]
+                dst.copy_(input.reshape(-1))
+        stream = fx.Stream(torch.cuda.current_stream())
+        _, comb_spec = self._pick(routing.cur_rank_num_token)
+        if self.cfg.is_scatter:
+            self._combine_variants[comb_spec](
+                self.arena.handle,
+                routing.disp_dest_tok_id_map.data_ptr(),
+                self.combine_barrier.data_ptr(),
+                self.cross_device_flag.data_ptr(),
+                routing.total_recv_token_num.data_ptr(),
+                self.combine_out.data_ptr(),
+                self.combine_out_weights.data_ptr(),
+                src_tok_ptr,
+                self.cfg.rank,
+                routing.cur_rank_num_token,
+                stream,
+            )
+        else:
+            self._combine_variants[comb_spec](
+                self.arena.handle,
+                routing.disp_dest_tok_id_map.data_ptr(),
+                self.combine_barrier.data_ptr(),
+                self.cross_device_flag.data_ptr(),
+                routing.total_recv_token_num.data_ptr(),
+                self.combine_out.data_ptr(),
+                self.combine_out_weights.data_ptr(),
+                self.cfg.rank,
+                routing.cur_rank_num_token,
+                stream,
+            )
+        count = routing.cur_rank_num_token
+        hidden_dim = self.cfg.hidden_dim
+        topk = self.cfg.num_experts_per_token
+        cdt = self.cfg.combine_dtype
+        cols = (
+            hidden_dim // 2 if cdt == torch.float4_e2m1fn_x2 else hidden_dim
+        )  # fp4 out is hidden/2 float4 elems
+        out = self.combine_out[: count * cols].view(cdt).view(count, cols)
+        return out, self.combine_out_weights[: count * topk].view(count, topk)
+
+    # ---- gemm2-fused scatter (combine_mode="scatter_fused") ---- #
+    def zero_fused_staging(self):
+        """Zero the per-(token,k) comb_inp before the gemm2 P2P writes of a layer.
+        Needed because gemm2 writes only the (token,k) slots whose expert survived
+        dispatch/capacity; dropped slots must read 0 in the combine topk sum."""
+        assert self.cfg.is_fused, "zero_fused_staging is scatter_fused-only"
+        self.arena.zero("comb_inp")
+
+    def ep_scatter_params(self):
+        """Handles the moe gemm2 epilogue needs to P2P-write its weighted per-(token,k)
+        results straight into peers' comb_inp (combine_mode='scatter_fused')."""
+        assert self.cfg.is_fused, "ep_scatter_params is scatter_fused-only"
+        return dict(
+            ep_arena_handle=self.arena.handle,
+            ep_comb_inp_off=self.arena.offset("comb_inp"),
+            ep_tis_off=self.arena.offset("recv_to_src_token"),
+            ep_wire_nbytes=self.cfg.comb_inp_slot_nbytes,
+            ep_rank=self.cfg.rank,
+            ep_max_tok=self.cfg.max_num_inp_token_per_rank,
+            ep_topk=self.cfg.num_experts_per_token,
+        )
+
+    def _combine_fused(self, routing):
+        """gemm2 already P2P-wrote weighted per-(token,k) results into comb_inp; just
+        barrier (wait for peers' writes) + sum the topk slots per origin token."""
+        stream = fx.Stream(torch.cuda.current_stream())
+        count = routing.cur_rank_num_token
+        # Token-adaptive geometry: few blocks (barrier-bound) at low token counts,
+        # more blocks (sum/BW-bound) at high token counts. Falls back to _pick when
+        # a single spec is compiled (e.g. SCATTER_COMB_BW pinned).
+        _tiers = getattr(self, "_fused_comb_tiers", None)
+        if _tiers is not None:
+            comb_spec = _tiers[-1][1]
+            for _ub, _spec in _tiers:
+                if _ub is not None and count <= _ub:
+                    comb_spec = _spec
+                    break
+        else:
+            _, comb_spec = self._pick(count)
+        # The kernel overwrites every element of each active token's hidden row.
+        # Unlike comb_inp, there are no dropped slots that require a zero sentinel.
+        self._combine_variants[comb_spec](
+            self.arena.handle,
+            self.arena.local_ptr("comb_inp"),
+            self.combine_barrier.data_ptr(),
+            self.cross_device_flag.data_ptr(),
+            self.combine_out.data_ptr(),
+            self.cfg.rank,
+            count,
+            stream,
+        )
+        hidden_dim = self.cfg.hidden_dim
+        topk = self.cfg.num_experts_per_token
+        cdt = self.cfg.combine_dtype
+        cols = hidden_dim // 2 if cdt == torch.float4_e2m1fn_x2 else hidden_dim
+        out = self.combine_out[: count * cols].view(cdt).view(count, cols)
+        return out, self.combine_out_weights[: count * topk].view(count, topk)
+
+    def local_expert_count(self):
+        """[num_experts_per_rank] i32: recv tokens per local expert. Call after
+        dispatch, before combine (gather resets total_recv)."""
+        self._local_expert_count_buf.zero_()
+        stream = fx.Stream(torch.cuda.current_stream())
+        self._local_expert_count(
+            self.arena.local_ptr("out_idx"),
+            self.total_recv.data_ptr(),
+            self._local_expert_count_buf.data_ptr(),
+            stream,
+        )
+        return self._local_expert_count_buf
+
+    def reset(self):
+        """Zero arena staging + per-rank counters/barriers (mori LaunchReset).
+        Kernels self-reset counters already; this forces a clean slate."""
+        self.arena.zero()
+        self.token_dest_map.fill_(-1)
+        self.dest_pe_counter.zero_()
+        self.dispatch_barrier.zero_()
+        self.total_recv.zero_()
+        self.combine_barrier.zero_()
+        self.cross_device_flag.fill_(1)
+
+    def reset_push_group(self):
+        """One-time init of the per-expert landing cursors (pg_running == 0) before
+        the FIRST push-group dispatch. NOT called per-layer: the finalize kernel
+        read-then-zeros pg_running each layer (race-free, between dispatch's end
+        barrier and the next layer's landing). A per-layer memset here would race
+        with peers' P2P atomic_add into the same counter -> lost increments ->
+        dropped rows -> intermittent wrong results.
+
+        pg_rowmap / recv_to_src_token need NO reset: with the finalize tile_valid
+        bound, the gemm2 scatter only reads a tile's valid rows (< mn_oob), which
+        dispatch overwrites every layer; padding rows are never read."""
+        if not self._push_group:
+            return
+        self.arena.zero("pg_running")
+
+    def push_group_ptrs(self):
+        """Fixed-slot layout descriptor for the GEMM1 contiguous A-load: local
+        pointers + per-expert CAP so the consumer indexes disp_out as
+        [num_local_experts, CAP] without a gather."""
+        if not self._push_group:
+            return None
+        return {
+            "cap": self._push_group_cap,
+            "num_local_experts": self.cfg.num_experts_per_rank,
+            "recv_rows": self._pg_recv_rows,
+            "disp_out_ptr": self.arena.local_ptr("disp_out"),
+            "pg_running_ptr": self.arena.local_ptr("pg_running"),
+            "pg_rowmap_ptr": self.arena.local_ptr("pg_rowmap"),
+            "recv_to_src_token_ptr": self.arena.local_ptr("recv_to_src_token"),
+            "out_idx_ptr": self.arena.local_ptr("out_idx"),
+            "out_wts_ptr": self.arena.local_ptr("out_wts"),
+        }
+
+    def push_group_overlap_ptrs(self):
+        """Arena offsets + local pointers the fused stage-1 mega kernel needs.
+
+        Offsets (not local pointers) for anything a peer writes: the producer
+        reaches a destination's copy via ``cco.Window(handle).lsa_ptr(pe, off)``.
+        """
+        if not self.cfg.push_group_overlap:
+            return None
+        cfg = self.cfg
+        arena = self.arena
+        return {
+            "rank": cfg.rank,
+            "world_size": cfg.world_size,
+            "experts_per_rank": cfg.num_experts_per_rank,
+            "experts_per_token": cfg.num_experts_per_token,
+            "max_tok_per_rank": cfg.max_num_inp_token_per_rank,
+            "arena_handle": arena.handle,
+            "off_count": arena.offset("pg_ov_count"),
+            "off_count_done": arena.offset("pg_ov_count_done"),
+            "off_tile_arrived": arena.offset("pg_ov_tile_arrived"),
+            "off_disp_out": arena.offset("disp_out"),
+            "off_out_scales": arena.offset("out_scales"),
+            "off_pg_rowmap": arena.offset("pg_rowmap"),
+            "off_tis": arena.offset("recv_to_src_token"),
+            "tile_expected_ptr": arena.local_ptr("pg_ov_tile_expected"),
+            "count_ptr": arena.local_ptr("pg_ov_count"),
+            "count_done_ptr": arena.local_ptr("pg_ov_count_done"),
+            "tile_arrived_ptr": arena.local_ptr("pg_ov_tile_arrived"),
+            "entry_ptr": arena.local_ptr("pg_ov_entry"),
+            "bar_ptr": arena.local_ptr("pg_ov_bar"),
+            "plan_ready_ptr": arena.local_ptr("pg_ov_plan_ready"),
+            "my_base_ptr": arena.local_ptr("pg_ov_my_base"),
+            "hist_ptr": arena.local_ptr("pg_ov_hist"),
+            "route_slot_ptr": arena.local_ptr("pg_ov_route_slot"),
+            "route_order_ptr": arena.local_ptr("pg_ov_route_order"),
+            "cap": self._push_group_cap,
+            "tile_m": cfg.push_group_overlap_tile_m,
+            "tiles_per_expert": cfg.push_group_overlap_tiles_per_expert,
+        }
+
+    def overlap_routing(self, num_tokens):
+        """Combine handle for the fused stage-1, which makes no dispatch call.
+
+        scatter_fused combine reads comb_inp and only needs the origin token
+        count; the forward dest-slot map exists solely for the gather/scatter
+        combines, which the fused stage-1 does not feed. Seeds the overlap
+        counters on first use, the same one-time deal as reset_push_group.
+        """
+        if not self.cfg.push_group_overlap:
+            raise ValueError("overlap_routing requires push_group_overlap")
+        if not self._pg_ov_initialized:
+            self.reset_push_group_overlap()
+            self._pg_ov_initialized = True
+        return EpDispatchRoutingHandle(
+            disp_dest_tok_id_map=self._empty_i32,
+            inter_node_disp_dest_tok_id_map=self._empty_i32,
+            inter_node_disp_send_map=self._empty_i32,
+            total_recv_token_num=self.total_recv,
+            cur_rank_num_token=num_tokens,
+        )
+
+    def push_group_overlap_debug(self):
+        """Torch views of the overlap protocol state, for diagnosing a stage-1 run.
+
+        Reading these tells you how far the handshake got: a zero ``plan_ready``
+        means the planner never finished, an all-zero ``count`` row means a peer
+        never published, and a ``tile_expected`` that disagrees with ``hist``
+        means the prefix sum is wrong.
+        """
+        if not self.cfg.push_group_overlap:
+            return None
+        cfg = self.cfg
+        e_total = cfg.world_size * cfg.num_experts_per_rank
+        tiles = cfg.num_experts_per_rank * cfg.push_group_overlap_tiles_per_expert
+
+        def _v(name, shape):
+            return from_gpu_ptr(self.arena.local_ptr(name), shape, torch.int32)
+
+        return dict(
+            entry=_v("pg_ov_entry", (1,)),
+            bar=_v("pg_ov_bar", (PG_OV_BAR_SLOTS,)),
+            plan_ready=_v("pg_ov_plan_ready", (1,)),
+            count_done=_v("pg_ov_count_done", (cfg.world_size,)),
+            count=_v("pg_ov_count", (2, cfg.world_size, e_total)),
+            hist=_v("pg_ov_hist", (e_total,)),
+            my_base=_v("pg_ov_my_base", (e_total,)),
+            tile_expected=_v("pg_ov_tile_expected", (tiles,)),
+            tile_arrived=_v("pg_ov_tile_arrived", (tiles,)),
+        )
+
+    def reset_push_group_overlap(self):
+        """One-time seeding of the overlap counters before the FIRST stage-1
+        launch. Like reset_push_group this is NOT per-layer: ``pg_ov_count_done``
+        and ``pg_ov_entry``/``pg_ov_bar`` are monotonic by construction, and
+        ``pg_ov_tile_arrived`` is zeroed inside the kernel at a point no peer can
+        be writing. A per-layer host memset here would race peers' P2P atomics."""
+        if not self.cfg.push_group_overlap:
+            return
+        for name in (
+            "pg_ov_count",
+            "pg_ov_count_done",
+            "pg_ov_tile_arrived",
+            "pg_ov_tile_expected",
+            "pg_ov_entry",
+            "pg_ov_bar",
+            "pg_ov_plan_ready",
+            "pg_ov_my_base",
+            "pg_ov_hist",
+            "pg_ov_route_slot",
+            "pg_ov_route_order",
+        ):
+            self.arena.zero(name)
+
+    def push_group_moe_inputs(self):
+        """Torch views of the fixed-slot recv grid + the dispatch-emitted combine
+        map, for the push-group MoE (grouped_a8w4_tdm_moe_push_scatter). ``disp_out``
+        is [num_local_experts*CAP, hidden] grouped bf16, ``pg_running`` the per-expert
+        landed counts, ``pg_rowmap`` the (rrows+1,2) {dst_packed, weight} map.
+
+        When the sender pre-quantized (``push_group_scale_wmma_rep > 0``), ``disp_out``
+        is the fp8 payload and ``disp_scale`` is the matching WMMA-preshuffled e8m0
+        scale, both already in the layout GEMM1 reads -- the caller runs no quant
+        pass at all."""
+        if not self._push_group:
+            return None
+        rrows = self._pg_recv_rows
+        cols = self.cfg.hidden_dim // 2 if self.cfg.is_fp4 else self.cfg.hidden_dim
+        wmma_rep = self.cfg.push_group_scale_wmma_rep
+        disp_scale = None
+        if wmma_rep > 0:
+            cap = self._push_group_cap
+            disp_scale = from_gpu_ptr(
+                self.arena.local_ptr("out_scales"),
+                (
+                    self.cfg.num_experts_per_rank,
+                    cap // wmma_rep,
+                    (self.cfg.hidden_dim // 32) * wmma_rep,
+                ),
+                torch.uint8,
+            )
+        return dict(
+            disp_out=from_gpu_ptr(
+                self.arena.local_ptr("disp_out"),
+                (rrows, cols),
+                self.cfg.dispatch_dtype,
+            ),
+            disp_scale=disp_scale,
+            pg_running=from_gpu_ptr(
+                self.arena.local_ptr("pg_running"),
+                (self.cfg.num_experts_per_rank,),
+                torch.int32,
+            ),
+            pg_rowmap=from_gpu_ptr(
+                self.arena.local_ptr("pg_rowmap"),
+                (rrows + 1, 2),
+                torch.int32,
+            ),
+            cap=self._push_group_cap,
+            num_local_experts=self.cfg.num_experts_per_rank,
+            slot_stride=self.cfg.max_num_inp_token_per_rank
+            * self.cfg.num_experts_per_token,
+        )

--- a/aiter/ops/flydsl/dispatch_combine_v2/flydsl_prims.py
+++ b/aiter/ops/flydsl/dispatch_combine_v2/flydsl_prims.py
@@ -1,0 +1,384 @@
+# Copyright © Advanced Micro Devices, Inc. All rights reserved.
+#
+# MIT License
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+"""FlyDSL device primitives for the cco-LSA dispatch/combine kernels: system-scope
+atomics, ordered stores, fences, uncached/non-temporal loads and volatile spin-waits,
+on top of cco peer pointers (cco.Window(h).lsa_ptr(pe, off)).
+
+The atomic / ordered-store / fence / volatile-load ops stay on
+flydsl._mlir.dialects.llvm: the high-level FlyDSL API exposes no memory ordering,
+sync-scope, volatile, or non-temporal control, which these primitives require.
+"""
+from flydsl._mlir import ir
+from flydsl._mlir.dialects import llvm as _llvm_d
+from flydsl._mlir.dialects import rocdl as _rocdl_d
+from flydsl._mlir.dialects import scf
+from flydsl.expr import arith
+from flydsl.expr.typing import T
+import os
+
+import flydsl.expr as fx
+
+
+def _gptr(addr_i64):
+    return _llvm_d.IntToPtrOp(
+        _llvm_d.PointerType.get(address_space=1), arith.unwrap(addr_i64)
+    ).result
+
+
+def _ptr_plus(base_i64, offset, elem_bytes):
+    """Global pointer for base + offset*elem_bytes (offset may be i32 or i64)."""
+    addr = fx.Int64(arith.unwrap(base_i64)) + fx.Int64(arith.unwrap(offset)) * elem_bytes
+    return _gptr(addr)
+
+
+def atomic_add_global(addr_i64, val):
+    """Monotonic remote global fetch-and-add at addr_i64; returns old value."""
+    return _llvm_d.AtomicRMWOp(
+        _llvm_d.AtomicBinOp.add,
+        _gptr(addr_i64),
+        arith.unwrap(val),
+        _llvm_d.AtomicOrdering.monotonic,
+    ).res
+
+
+def atomic_add_agent(addr_i64, val):
+    """Device-scope fetch-and-add at addr_i64; returns old value.
+
+    Same op as :func:`atomic_add_global` but scoped to this GPU, so it stays in
+    L2 instead of being routed as a potentially remote transaction. Only correct
+    for counters no peer ever touches -- the work-stealing heads, not the
+    arrival counters.
+    """
+    return _llvm_d.AtomicRMWOp(
+        _llvm_d.AtomicBinOp.add,
+        _gptr(addr_i64),
+        arith.unwrap(val),
+        _llvm_d.AtomicOrdering.monotonic,
+        syncscope="agent",
+    ).res
+
+
+def atomic_max_agent(addr_i64, val):
+    """Device-scope signed fetch-and-max at addr_i64; returns old value."""
+    return _llvm_d.AtomicRMWOp(
+        _llvm_d.AtomicBinOp.max,
+        _gptr(addr_i64),
+        arith.unwrap(val),
+        _llvm_d.AtomicOrdering.monotonic,
+        syncscope="agent",
+    ).res
+
+
+def _lds_ptr(addr_i64):
+    return _llvm_d.IntToPtrOp(
+        _llvm_d.PointerType.get(address_space=3), arith.unwrap(addr_i64)
+    ).result
+
+
+def atomic_add_lds(addr_i64, val):
+    """Workgroup-scope LDS fetch-and-add at addr_i64; returns old value.
+
+    ``addr_i64`` is a raw LDS byte address (``ptrtoint`` of a SharedAllocator
+    pointer), not a global one: the block-local counters this serves are hit by
+    every lane of every warp in the block, which in global memory would be a
+    device-scope atomic per route.
+    """
+    return _llvm_d.AtomicRMWOp(
+        _llvm_d.AtomicBinOp.add,
+        _lds_ptr(addr_i64),
+        arith.unwrap(val),
+        _llvm_d.AtomicOrdering.monotonic,
+        syncscope="workgroup",
+        alignment=4,
+    ).res
+
+
+def load_i32_lds(addr_i64):
+    """Plain i32 load from a raw LDS byte address."""
+    return _llvm_d.LoadOp(T.i32, _lds_ptr(addr_i64), alignment=4).res
+
+
+def store_i32_lds(addr_i64, val):
+    """Plain i32 store to a raw LDS byte address."""
+    _llvm_d.StoreOp(arith.unwrap(val), _lds_ptr(addr_i64), alignment=4)
+
+
+def store_i32_system(addr_i64, offset, val):
+    """System-release i32 store at addr + offset*4."""
+    _llvm_d.StoreOp(
+        arith.unwrap(val),
+        _ptr_plus(addr_i64, offset, 4),
+        alignment=4,
+        ordering=_llvm_d.AtomicOrdering.release,
+        syncscope="one-as",
+    )
+
+
+def store_i64_system(addr_i64, offset, val):
+    """System-release i64 store at addr + offset*8."""
+    _llvm_d.StoreOp(
+        arith.unwrap(val),
+        _ptr_plus(addr_i64, offset, 8),
+        alignment=8,
+        ordering=_llvm_d.AtomicOrdering.release,
+        syncscope="one-as",
+    )
+
+
+#: ``sendmsg(MSG_RTN_GET_REALTIME)``. gfx11 dropped ``s_memtime`` and gfx12 also
+#: dropped ``s_memrealtime``, so the constant-rate counter is only reachable
+#: through the return-message path.
+_MSG_RTN_GET_REALTIME = 0x83
+
+
+def read_realtime():
+    """The constant-rate 64-bit counter, for in-kernel phase timing.
+
+    Constant-rate rather than shader-clock, so a measurement is not distorted by
+    the clock throttling that makes this box's ranks drift apart. It is a scalar
+    read, so call it from one lane with the surrounding work already waited on --
+    it orders against nothing by itself.
+    """
+    return _llvm_d.CallIntrinsicOp(
+        T.i64,
+        ir.StringAttr.get("llvm.amdgcn.s.sendmsg.rtn.i64"),
+        [arith.unwrap(fx.Int32(_MSG_RTN_GET_REALTIME))],
+        [],
+        ir.DenseI32ArrayAttr.get([]),
+    ).results[0]
+
+
+def _is_gfx12():
+    try:
+        from mori.jit.config import detect_gpu_arch
+
+        return detect_gpu_arch().startswith("gfx12")
+    except Exception:
+        return False
+
+
+def waitcnt_stores():
+    """Drain outstanding global stores (no cache management, unlike a release
+    fence). gpu.barrier/s_barrier only syncs wavefronts and does NOT wait for
+    in-flight memory ops, so this must precede a grid barrier when the stores
+    before it need to be complete.
+
+    Store completion alone is what makes those writes visible to a peer released
+    by the barrier; in-flight loads need no wait here because their results are
+    already ordered by the register dependencies that consume them. gfx12/gfx1250
+    split the legacy s_waitcnt into per-kind counters, so there the wait narrows
+    to storecnt; gfx9's unified vmcnt tracks loads and stores together and cannot
+    be narrowed."""
+    if _is_gfx12():
+        _rocdl_d.s_wait_storecnt(0)
+    else:
+        _rocdl_d.s_waitcnt(0)
+
+
+def fence_system_acquire():
+    _llvm_d.FenceOp(_llvm_d.AtomicOrdering.acquire, syncscope="one-as")
+
+
+def fence_system_release():
+    _llvm_d.FenceOp(_llvm_d.AtomicOrdering.release, syncscope="one-as")
+
+
+def fence_acquire_all():
+    """System acquire over ALL address spaces: unlike the ``one-as`` variant this
+    is what invalidates the caches a peer's P2P payload was written behind."""
+    _llvm_d.FenceOp(_llvm_d.AtomicOrdering.acquire)
+
+
+def fence_release_all():
+    """System release over all address spaces (pairs with fence_acquire_all)."""
+    _llvm_d.FenceOp(_llvm_d.AtomicOrdering.release)
+
+
+def fence_agent_acquire():
+    """Device-scope acquire: invalidates the per-CU caches but not the L2, so it
+    is safe only for data already landed in this device's L2."""
+    _llvm_d.FenceOp(_llvm_d.AtomicOrdering.acquire, syncscope="agent-one-as")
+
+
+def fence_agent_release():
+    """Device-scope release: orders prior writes before a following device-scoped
+    flag, without the L2 writeback a system release pays for. Correct only when
+    the reader is another CTA on this GPU."""
+    _llvm_d.FenceOp(_llvm_d.AtomicOrdering.release, syncscope="agent-one-as")
+
+
+def _unwrap(v):
+    return v.ir_value() if hasattr(v, "ir_value") else v
+
+
+def load_i32_acquire(addr_i64):
+    """Volatile monotonic i32 load: volatile+ordering keeps the spin re-read from
+    being hoisted/CSE'd out of the wait loop (LICM would otherwise spin on a stale
+    value)."""
+    return _llvm_d.LoadOp(
+        T.i32,
+        _gptr(addr_i64),
+        alignment=4,
+        volatile_=True,
+        ordering=_llvm_d.AtomicOrdering.monotonic,
+        syncscope="one-as",
+    ).res
+
+
+def load_i32_agent(addr_i64):
+    """Volatile monotonic i32 load at DEVICE scope: unlike the system-scope load
+    this may be served by the L2, which matters for a flag hundreds of waves poll
+    at once. Only valid for flags written by this device."""
+    return _llvm_d.LoadOp(
+        T.i32,
+        _gptr(addr_i64),
+        alignment=4,
+        volatile_=True,
+        ordering=_llvm_d.AtomicOrdering.monotonic,
+        syncscope="agent-one-as",
+    ).res
+
+
+def load_i64_acquire(addr_i64):
+    """Volatile monotonic i64 load."""
+    return _llvm_d.LoadOp(
+        T.i64,
+        _gptr(addr_i64),
+        alignment=8,
+        volatile_=True,
+        ordering=_llvm_d.AtomicOrdering.monotonic,
+        syncscope="one-as",
+    ).res
+
+
+def load_i32_nt(base_i64, offset):
+    """Non-temporal global i32 load at base + offset*4. A raw global load (VGPR
+    address) avoids the per-expert buffer-descriptor waterfall; caller ensures the
+    address is in-bounds."""
+    return _llvm_d.LoadOp(
+        T.i32, _ptr_plus(base_i64, offset, 4), alignment=4, nontemporal=True
+    ).res
+
+
+def load_v4i32_nt(base_i64, offset):
+    """Non-temporal global vector<4xi32> load at base + offset*4 (global_load_dwordx4).
+    offset is in i32 units; alignment=4 since the per-warp offset is only 4B-aligned."""
+    return _llvm_d.LoadOp(
+        T.i32x4, _ptr_plus(base_i64, offset, 4), alignment=4, nontemporal=True
+    ).res
+
+
+def _backoff(cycles):
+    """s_sleep between polls. A wave re-reading a flag as fast as it can issue
+    starves the very traffic it is waiting for -- with a few hundred waves on the
+    same cache line the peer's atomic can take milliseconds to get through."""
+    if cycles:
+        _rocdl_d.s_sleep(cycles)
+
+
+def _spin(addr_i64, keep_waiting, *, width=32, backoff=0, agent=False):
+    """Spin on a volatile/atomic load at addr_i64 until keep_waiting(cur) is false;
+    returns the awaited value. Self-contained (mori's wait_until_* need ShmemStates
+    and cannot run on a cco-only stack)."""
+    if width == 64:
+        ty, load, wrap = T.i64, load_i64_acquire, fx.Int64
+    else:
+        ty, wrap = T.i32, fx.Int32
+        load = load_i32_agent if agent else load_i32_acquire
+    loop = scf.WhileOp([ty], [_unwrap(load(addr_i64))])
+    cond = ir.Block.create_at_start(loop.before, [ty])
+    body = ir.Block.create_at_start(loop.after, [ty])
+    with ir.InsertionPoint(cond):
+        scf.ConditionOp(
+            _unwrap(keep_waiting(wrap(cond.arguments[0]))), [cond.arguments[0]]
+        )
+    with ir.InsertionPoint(body):
+        _backoff(backoff)
+        scf.YieldOp([_unwrap(load(addr_i64))])
+    return wrap(loop.results[0])
+
+
+def spin_until_eq_i64(addr_i64, val):
+    """Spin until *addr (i64) == val."""
+    return _spin(addr_i64, lambda cur: cur != fx.Int64(val), width=64)
+
+
+def spin_until_ge_i64(addr_i64, val):
+    """Spin until *addr (i64) >= val (signed).
+
+    For a MONOTONIC cross-device flag this is deadlock-safe under lapping: if a
+    faster peer overwrites the slot with a higher call count before a slow rank
+    reads it, `>=` still passes (whereas `==` would spin forever). It only
+    releases early when the peer is *ahead* — the safe direction for a
+    wait-for-peer barrier."""
+    return _spin(addr_i64, lambda cur: cur < fx.Int64(val), width=64)
+
+
+def spin_until_eq_i32(addr_i64, val):
+    """Spin until *addr == val."""
+    return _spin(addr_i64, lambda cur: cur != fx.Int32(val))
+
+
+def spin_until_gt_i32(addr_i64, val):
+    """Spin until *addr > val (signed); returns the value seen."""
+    return _spin(addr_i64, lambda cur: cur <= fx.Int32(val))
+
+
+_SPIN_BACKOFF = int(os.environ.get("AITER_FLYDSL_SPIN_BACKOFF", "8"))
+
+
+def spin_until_ge_i32_backoff(addr_i64, val, cycles=_SPIN_BACKOFF, agent=False):
+    """spin_until_ge_i32 with an s_sleep between polls, for waits that many waves
+    perform at once on the same address. ``agent`` polls at device scope (L2), the
+    difference between a cache hit and a fabric round trip per poll."""
+    return _spin(
+        addr_i64, lambda cur: cur < fx.Int32(val), backoff=cycles, agent=agent
+    )
+
+
+def spin_until_ge_i32_bounded(addr_i64, val, max_iters):
+    """Spin until *addr >= val or `max_iters` re-reads elapse; returns the value
+    seen. Debug-only escape hatch: turns a stuck handshake into observable state
+    instead of a hang."""
+    loop = scf.WhileOp(
+        [T.i32, T.i32], [_unwrap(load_i32_acquire(addr_i64)), _unwrap(fx.Int32(0))]
+    )
+    cond = ir.Block.create_at_start(loop.before, [T.i32, T.i32])
+    body = ir.Block.create_at_start(loop.after, [T.i32, T.i32])
+    with ir.InsertionPoint(cond):
+        cur, it = fx.Int32(cond.arguments[0]), fx.Int32(cond.arguments[1])
+        keep = (cur < fx.Int32(val)) & (it < fx.Int32(max_iters))
+        scf.ConditionOp(_unwrap(keep), [cond.arguments[0], cond.arguments[1]])
+    with ir.InsertionPoint(body):
+        _backoff(8)
+        nxt = _unwrap(load_i32_acquire(addr_i64))
+        scf.YieldOp([nxt, _unwrap(fx.Int32(body.arguments[1]) + fx.Int32(1))])
+    return fx.Int32(loop.results[0])
+
+
+def spin_until_ge_i32(addr_i64, val):
+    """Spin until *addr >= val (signed); returns the value seen.
+
+    The i32 counterpart of :func:`spin_until_ge_i64`: use it on monotonic
+    counters (launch generations, arrival tallies) where a peer may already have
+    run ahead of the value being waited on -- `==` would spin forever there."""
+    return _spin(addr_i64, lambda cur: cur < fx.Int32(val))

--- a/aiter/ops/flydsl/dispatch_combine_v2/intranode_kernels.py
+++ b/aiter/ops/flydsl/dispatch_combine_v2/intranode_kernels.py
@@ -1,0 +1,2051 @@
+# Copyright © Advanced Micro Devices, Inc. All rights reserved.
+#
+# MIT License
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+"""FlyDSL intranode (single-node cco-LSA P2P) device kernels for the dispatch/combine
+op: dispatch (+scales/replay), combine (gather + scatter/quant), StdMoE convert and
+local expert count. Each is a compile-time-parameterised @flyc.jit factory; peer
+addressing goes through cco.Window(handle).lsa_ptr(pe, off).
+
+Conventions: `rsrc_*` = buffer resource descriptor; `safe_*` = real value on live
+lanes / in-bounds fallback (0 or self-rank) on dropped lanes; "sentinel" = tok_map
+dropped-slot marker (dest PE == npes); "tis" = recv-slot -> global source-token map;
+"xdb" = cross-device barrier (bumped i64 flag handshaked across all ranks).
+"""
+import flydsl.compiler as flyc
+import flydsl.expr as fx
+from flydsl.expr import arith, const_expr, range_constexpr
+from . import vector
+from aiter.ops.flydsl.kernels.buffer_ops import (
+    buffer_load,
+    buffer_store,
+    create_buffer_resource_from_addr,
+)
+from flydsl.expr.rocdl import (
+    ballot,
+    readlane,
+    ds_bpermute,
+    fmed3,
+    cvt_pk_f32_fp8,
+    cvt_pk_fp8_f32,
+    cvt_scalef32_pk_f32_fp4,
+    cvt_scalef32_pk_fp4_f32,
+    cvt_scale_pk8_f32_fp4,
+    cvt_scalef32_pk8_fp4_f32,
+)
+from flydsl.expr.typing import Int32, Int64, T
+
+import mori.cco.device.flydsl as cco
+from . import flydsl_prims as P
+
+# Wavefront size: gfx9 = 64, gfx12 (gfx1250) = 32. Override with MORI_WAVE_SIZE;
+# key off the arch string since get_warp_size(gfx1250) wrongly reports 64.
+import os as _os
+
+
+def _detect_wave_size():
+    v = _os.environ.get("MORI_WAVE_SIZE")
+    if v:
+        return int(v)
+    try:
+        from mori.jit.config import detect_gpu_arch
+
+        return 32 if detect_gpu_arch().startswith("gfx12") else 64
+    except Exception:
+        return 64
+
+
+WAVE = _detect_wave_size()
+LANE_MASK = WAVE - 1
+LOG2_WAVE = WAVE.bit_length() - 1
+def _BALLOT_INT():
+    # Deferred: T.i32/T.i64 build an ir.Type, which needs an active MLIR
+    # Context (flydsl>=0.3.0 no longer auto-establishes one at import).
+    return T.i64 if WAVE == 64 else T.i32
+_LANE_STRIDE_I32 = WAVE * 4  # one wave of lanes, vec4 (16B) each
+# dispatch scatter unroll: gfx12/gfx1250 (WAVE=32) benefits from 4 vec4 streams
+# for memory-level parallelism; gfx9 (WAVE=64) stays at 2.
+_DISP_NSTREAMS = 4 if WAVE == 32 else 2
+_MAIN_STRIDE_I32 = _DISP_NSTREAMS * _LANE_STRIDE_I32
+_BUTTERFLY_OFFSETS = tuple(WAVE >> i for i in range(1, LOG2_WAVE + 1))
+
+# NOTE: the cross-device xdb barrier is kept inlined per kernel (dispatch Phase 2,
+# combine gather/scatter/fused) rather than a shared helper: FlyDSL only AST-rewrites
+# dynamic `if` in the @flyc.kernel body, not in called helpers, so a helper's
+# `if <lane predicate>:` would raise "cannot evaluate dynamic Boolean" at trace time.
+
+
+# ── dispatch ──────────────────────────────────────────────────────────────
+
+
+def make_dispatch(
+    *,
+    rank,
+    npes,
+    experts_per_rank,
+    experts_per_token,
+    hidden_dim,
+    hidden_elem_size,
+    max_tok_per_rank,
+    max_recv,
+    block_num,
+    warp_num_per_block,
+    off_tok_off,
+    off_recv_num,
+    off_tis,
+    off_out_idx,
+    off_out_wts,
+    off_out_tok,
+    off_out_scales=0,
+    scale_dim=0,
+    scale_type_size=0,
+    enable_signal=True,
+    replay=False,
+    fp4=False,
+    push_group=False,
+    push_group_cap=0,
+    off_pg_running=0,
+    off_pg_rowmap=0,
+    push_group_scale_wmma_rep=0,
+):
+    # fp4 (e2m1) packs 2 values/byte -> token is hidden_dim/2 bytes; dispatch is a
+    # pure byte mover (no fp4 decode).
+    nbytes = hidden_dim // 2 if fp4 else hidden_dim * hidden_elem_size
+    n_i32 = nbytes // 4
+    # push-group: tokens land grouped as [num_local_experts, CAP]; the per-recv-row
+    # encoding base (tok_map / sentinel) grows from max_recv to num_local_experts*CAP.
+    row_stride = experts_per_rank * push_group_cap if push_group else max_recv
+    # sentinel: tok_map dropped-slot marker whose dest_pe (value // row_stride) == npes.
+    sentinel_val = npes * row_stride
+    # Optional per-token scales forwarded verbatim to the dest peer's out_scales.
+    scale_bytes = scale_dim * scale_type_size
+    scale_num_i32 = (scale_bytes + 3) // 4
+    enable_scales = scale_bytes > 0
+    # Hand each lane a contiguous run of scale dwords rather than one dword per
+    # lane-strided step. A 7168-wide row is 56 dwords, so a wave of 32 needed two
+    # steps whose loads sat on a dependency chain; two dwords per lane covers it
+    # in one. Take the narrowest width that still collapses the walk to a single
+    # step -- going wider idles lanes that would otherwise have loads in flight,
+    # which at bs=512 cost more (~7us) than the step it saves.
+    scale_vec = 1
+    _scale_steps = (scale_num_i32 + WAVE - 1) // WAVE
+    for _v in (2, 4, 8):
+        if _v >= _scale_steps and scale_num_i32 % _v == 0:
+            scale_vec = _v
+            break
+    # push-group MX scales: the sender quantizes, so the wire carries a linear
+    # [row, scale_dim] e8m0 scale, but the GEMM reads the WMMA-preshuffled layout
+    # whose position depends on the row's slot within its destination expert --
+    # known only here, after the capacity atomic. Apply the permutation on the
+    # store side so the receiver needs no repacking pass at all. All four bytes of
+    # a source dword share one mx_block group and land in one destination dword,
+    # so this stays a dword store, just at a permuted index.
+    preshuffle_scales = enable_scales and push_group and push_group_scale_wmma_rep > 0
+    if preshuffle_scales and push_group_cap % (push_group_scale_wmma_rep * 16):
+        raise ValueError(
+            f"push_group_cap={push_group_cap} must be a multiple of "
+            f"wmma_rep*16={push_group_scale_wmma_rep * 16} to preshuffle scales"
+        )
+
+    @flyc.kernel(known_block_size=[warp_num_per_block * WAVE, 1, 1])
+    def ep_dispatch(
+        arena: Int64,
+        addr_inp_tok: Int64,
+        addr_inp_idx: Int64,
+        addr_inp_wts: Int64,
+        addr_tok_map: Int64,
+        addr_dest_pe_ctr: Int64,
+        addr_disp_bar: Int64,
+        addr_total_recv: Int64,
+        addr_inp_scales: Int64,
+        my_lsa_rank: Int32,
+        inp_cur_tok: Int32,
+    ):
+        tid = fx.thread_idx.x
+        bid = fx.block_idx.x
+        lane = tid & LANE_MASK
+        warp = tid >> LOG2_WAVE
+        global_warp_id = bid * warp_num_per_block + warp
+        global_warp_num = block_num * warp_num_per_block
+        work_limit = inp_cur_tok * experts_per_token
+
+        window = cco.Window(arena)
+        rsrc_inp_idx = create_buffer_resource_from_addr(addr_inp_idx)
+        rsrc_inp_wts = create_buffer_resource_from_addr(addr_inp_wts)
+        rsrc_tok_map = create_buffer_resource_from_addr(addr_tok_map)
+        rsrc_dest_ctr = create_buffer_resource_from_addr(addr_dest_pe_ctr)
+        rsrc_disp_bar = create_buffer_resource_from_addr(addr_disp_bar)
+
+        # ── Phase 1: P2P-scatter each (src_tok, k_slot) to its dest PE ──
+        for work_idx in range(global_warp_id, work_limit, global_warp_num):
+            src_tok = work_idx // experts_per_token
+            k_slot = work_idx % experts_per_token
+            dest_expert = buffer_load(
+                rsrc_inp_idx, work_idx, vec_width=1, dtype=T.i32
+            )
+            # Dedup: a token routed to several experts on the SAME dest PE is sent
+            # once. If a lower lane (< k_slot) already targets our dest_pe, drop this
+            # (src_tok, k_slot); safe_lane keeps the probe in-bounds for lanes >= k_slot.
+            safe_lane = arith.select(lane < k_slot, lane, 0)
+            lane_expert = buffer_load(
+                rsrc_inp_idx,
+                src_tok * experts_per_token + safe_lane,
+                vec_width=1,
+                dtype=T.i32,
+            )
+            dest_pe = dest_expert // experts_per_rank
+            lane_dest_pe = lane_expert // experts_per_rank
+            dup_per_lane = arith.select(
+                lane_dest_pe == dest_pe, arith.select(lane < k_slot, lane, WAVE), WAVE
+            )
+            dup_ballot = ballot(_BALLOT_INT(), dup_per_lane < WAVE)
+            is_dup = dup_ballot != 0
+
+            if const_expr(replay):
+                # decode dest_tok_id from cached tok_map (skip atomic alloc)
+                cached = buffer_load(rsrc_tok_map, work_idx, vec_width=1, dtype=T.i32)
+                is_dup_or_overflow = cached >= sentinel_val
+                do_publish = cached < sentinel_val
+                dest_tok_id = cached - dest_pe * row_stride
+            elif const_expr(push_group):
+                # Fixed-slot landing: no per-PE dedup (a token routed to two experts
+                # on the same PE must appear in BOTH expert groups). Row =
+                # local_expert*CAP + atomic_add(pg_running[dest_pe][local_expert]).
+                local_expert = dest_expert - dest_pe * experts_per_rank
+                cur_lane0 = arith.constant(0)
+                if lane == 0:
+                    peer_run = fx.Int64(
+                        window.lsa_ptr(dest_pe, off_pg_running)
+                    ) + fx.Int64(local_expert) * fx.Int64(4)
+                    cur_lane0 = P.atomic_add_global(peer_run, fx.Int32(1))
+                cursor = readlane(T.i32, cur_lane0, 0)
+                grouped_row = local_expert * push_group_cap + cursor
+                overflow = cursor >= push_group_cap
+                dest_tok_id = grouped_row
+                is_dup_or_overflow = overflow
+                do_publish = cursor < push_group_cap
+                tok_map_entry = arith.select(
+                    is_dup_or_overflow, sentinel_val, dest_pe * row_stride + grouped_row
+                )
+                if lane == 0:
+                    buffer_store(tok_map_entry, rsrc_tok_map, work_idx)
+            else:
+                dest_tok_lane0 = arith.constant(0)
+                if lane == 0:
+                    if dup_ballot == 0:
+                        peer_tok_off = fx.Int64(window.lsa_ptr(dest_pe, off_tok_off))
+                        dest_tok_lane0 = P.atomic_add_global(peer_tok_off, fx.Int32(1))
+                dest_tok_id = readlane(T.i32, dest_tok_lane0, 0)
+                overflow = dest_tok_id >= max_recv
+                is_dup_or_overflow = arith.select(is_dup, is_dup, overflow)
+                no_dup = dup_ballot == 0
+                in_cap = dest_tok_id < max_recv
+                do_publish = arith.select(no_dup, in_cap, no_dup)
+                tok_map_entry = arith.select(
+                    is_dup_or_overflow, sentinel_val, dest_pe * max_recv + dest_tok_id
+                )
+                if lane == 0:
+                    buffer_store(tok_map_entry, rsrc_tok_map, work_idx)
+
+            if lane == 0:
+                if do_publish:
+                    # publish this recv slot's origin (global source token id) into
+                    # the dest peer's tis, for combine routing.
+                    src_tok_encoded = rank * max_tok_per_rank + src_tok
+                    peer_tis = fx.Int64(window.lsa_ptr(dest_pe, off_tis))
+                    buffer_store(
+                        src_tok_encoded,
+                        create_buffer_resource_from_addr(peer_tis),
+                        dest_tok_id,
+                    )
+                    if const_expr(push_group):
+                        # Emit the downstream combine map[final_slot] = {origin, weight}
+                        # straight into the dest peer's pg_rowmap at the fixed-slot row
+                        # this token just landed in (dest_tok_id == grouped_row). The
+                        # gemm2 TDM scatter epilogue reads pg_rowmap[grouped_row] and
+                        # writes the weighted result into comb_inp[origin_pe][
+                        # origin_lid*topk + k] -- no gather/remap needed.
+                        pg_slot_stride = max_tok_per_rank * experts_per_token
+                        dst_packed = (
+                            rank * pg_slot_stride + src_tok * experts_per_token + k_slot
+                        )
+                        pg_w = buffer_load(
+                            rsrc_inp_wts,
+                            src_tok * experts_per_token + k_slot,
+                            vec_width=1,
+                            dtype=T.f32,
+                        )
+                        peer_rowmap = create_buffer_resource_from_addr(
+                            fx.Int64(window.lsa_ptr(dest_pe, off_pg_rowmap))
+                        )
+                        # {origin, weight} occupy adjacent dwords at an 8B-aligned
+                        # slot, so emit one dwordx2 instead of two remote 4B
+                        # stores: each store is a partial-line write across the
+                        # fabric and the Phase-2 drain waits on all of them.
+                        buffer_store(
+                            vector.from_elements(
+                                T.vec(2, T.i32),
+                                [dst_packed, arith.bitcast(T.i32, pg_w)],
+                            ),
+                            peer_rowmap,
+                            dest_tok_id * 2,
+                        )
+                    dest_ctr_addr = fx.Int64(addr_dest_pe_ctr) + fx.Int64(
+                        dest_pe
+                    ) * fx.Int64(4)
+                    P.atomic_add_global(dest_ctr_addr, fx.Int32(1))
+
+            # Per-lane (weight, expert-idx) scatter (lanes < k).
+            if lane < experts_per_token:
+                if do_publish:
+                    weight_src_off = src_tok * experts_per_token + lane
+                    weight_val = buffer_load(
+                        rsrc_inp_wts, weight_src_off, vec_width=1, dtype=T.f32
+                    )
+                    idx_val = buffer_load(
+                        rsrc_inp_idx, weight_src_off, vec_width=1, dtype=T.i32
+                    )
+                    dest_slot = dest_tok_id * experts_per_token + lane
+                    peer_wts = fx.Int64(window.lsa_ptr(dest_pe, off_out_wts))
+                    buffer_store(
+                        arith.bitcast(T.i32, weight_val),
+                        create_buffer_resource_from_addr(peer_wts),
+                        dest_slot,
+                    )
+                    peer_idx = fx.Int64(window.lsa_ptr(dest_pe, off_out_idx))
+                    buffer_store(
+                        idx_val, create_buffer_resource_from_addr(peer_idx), dest_slot
+                    )
+
+            # Per-token scales scatter: forward the src token's scale_num_i32 dwords
+            # (scale_vec per lane) to the dest peer's out_scales[dest_tok_id].
+            if const_expr(enable_scales):
+                if do_publish:
+                    rsrc_inp_scales = create_buffer_resource_from_addr(addr_inp_scales)
+                    peer_scales = fx.Int64(window.lsa_ptr(dest_pe, off_out_scales))
+                    rsrc_peer_scales = create_buffer_resource_from_addr(peer_scales)
+                    if const_expr(preshuffle_scales):
+                        # dst_dword = e*(CAP*sdpr) + out_row*(sdpr*wmma_rep)
+                        #             + scale_dword*wmma_rep + wmma_row, with
+                        # out_row = (slot // rows_per_tile)*16 + slot % 16 and
+                        # wmma_row = (slot % rows_per_tile) // 16.
+                        rows_per_tile = arith.constant(
+                            push_group_scale_wmma_rep * 16
+                        )
+                        scale_tile = cursor // rows_per_tile
+                        row_in_tile = cursor - scale_tile * rows_per_tile
+                        wmma_row = row_in_tile // arith.constant(16)
+                        row_lane16 = row_in_tile - wmma_row * arith.constant(16)
+                        out_row = scale_tile * arith.constant(16) + row_lane16
+                        dst_base = (
+                            local_expert
+                            * arith.constant(push_group_cap * scale_num_i32)
+                            + out_row
+                            * arith.constant(
+                                scale_num_i32 * push_group_scale_wmma_rep
+                            )
+                            + wmma_row
+                        )
+                    for k_off in range(
+                        lane * scale_vec, scale_num_i32, WAVE * scale_vec
+                    ):
+                        scale_val = buffer_load(
+                            rsrc_inp_scales,
+                            src_tok * scale_num_i32 + k_off,
+                            vec_width=scale_vec,
+                            dtype=T.i32,
+                        )
+                        if const_expr(preshuffle_scales):
+                            # wmma_rep interleaves rep rows at dword granularity,
+                            # so the destination dwords stay rep apart however
+                            # wide the source read was.
+                            dst_off = dst_base + k_off * arith.constant(
+                                push_group_scale_wmma_rep
+                            )
+                            for j in range_constexpr(scale_vec):
+                                elem = (
+                                    vector.extract(scale_val, static_position=[j])
+                                    if const_expr(scale_vec > 1)
+                                    else scale_val
+                                )
+                                buffer_store(
+                                    elem,
+                                    rsrc_peer_scales,
+                                    dst_off
+                                    + arith.constant(
+                                        j * push_group_scale_wmma_rep
+                                    ),
+                                )
+                        else:
+                            buffer_store(
+                                scale_val,
+                                rsrc_peer_scales,
+                                dest_tok_id * scale_num_i32 + k_off,
+                            )
+
+            # Token-embedding scatter: each lane owns 4 i32 (16B). _DISP_NSTREAMS
+            # vec4 streams for memory-level parallelism, one-stream tail for the
+            # remainder; dropped slots set copy_end == lane_i32_off (no-op).
+            peer_tok_base = fx.Int64(window.lsa_ptr(dest_pe, off_out_tok))
+            remote_tok_addr = peer_tok_base + fx.Int64(dest_tok_id) * fx.Int64(nbytes)
+            local_tok_addr = fx.Int64(addr_inp_tok) + fx.Int64(src_tok) * fx.Int64(
+                nbytes
+            )
+            rsrc_src = create_buffer_resource_from_addr(local_tok_addr)
+            rsrc_dst = create_buffer_resource_from_addr(remote_tok_addr)
+            lane_i32_off = lane * 4
+            safe_end_i32 = (n_i32 // _MAIN_STRIDE_I32) * _MAIN_STRIDE_I32
+            if const_expr(n_i32 >= _MAIN_STRIDE_I32 and safe_end_i32 > 0):
+                copy_end_main = arith.select(
+                    is_dup_or_overflow, lane_i32_off, safe_end_i32
+                )
+                for chunk in range(lane_i32_off, copy_end_main, _MAIN_STRIDE_I32):
+                    vecs = [
+                        buffer_load(
+                            rsrc_src,
+                            chunk + k * _LANE_STRIDE_I32,
+                            vec_width=4,
+                            dtype=T.i32,
+                        )
+                        for k in range_constexpr(_DISP_NSTREAMS)
+                    ]
+                    for k in range_constexpr(_DISP_NSTREAMS):
+                        buffer_store(vecs[k], rsrc_dst, chunk + k * _LANE_STRIDE_I32)
+            if const_expr(safe_end_i32 < n_i32):
+                copy_end_tail = arith.select(is_dup_or_overflow, lane_i32_off, n_i32)
+                for chunk in range(
+                    lane_i32_off + safe_end_i32, copy_end_tail, _LANE_STRIDE_I32
+                ):
+                    vec_a = buffer_load(rsrc_src, chunk, vec_width=4, dtype=T.i32)
+                    buffer_store(vec_a, rsrc_dst, chunk)
+            elif const_expr(n_i32 < _MAIN_STRIDE_I32):
+                copy_end_small = arith.select(is_dup_or_overflow, lane_i32_off, n_i32)
+                for chunk in range(lane_i32_off, copy_end_small, _LANE_STRIDE_I32):
+                    vec_a = buffer_load(rsrc_src, chunk, vec_width=4, dtype=T.i32)
+                    buffer_store(vec_a, rsrc_dst, chunk)
+
+        if const_expr(enable_signal):
+            # Self-reset total_recv (replaces the host-side total_recv.zero_()):
+            # only global warp 0 touches it — lane 0 zeros it here, all lanes
+            # accumulate into it in Phase 3. The waitcnt_stores + grid barrier
+            # below drains this store before the Phase-3 adds; total_recv is
+            # local, so no release fence / L2 writeback is needed. CUDAGraph-safe.
+            if global_warp_id == 0:
+                if lane == 0:
+                    buffer_store(
+                        arith.constant(0),
+                        create_buffer_resource_from_addr(addr_total_recv),
+                        0,
+                    )
+
+            # ── Phase 2: grid barrier + per-peer count signal ──
+            # s_barrier only syncs wavefronts; drain the store counter first so the
+            # token/count stores above are complete before the grid barrier makes
+            # them visible to peers (unlike HIP __syncthreads, gpu.barrier has no
+            # implicit s_waitcnt).
+            P.waitcnt_stores()
+            fx.barrier()
+            if tid == 0:
+                P.atomic_add_global(fx.Int64(addr_disp_bar), arith.constant(1))
+
+            local_recv_num = fx.Int64(window.lsa_ptr(my_lsa_rank, off_recv_num))
+            for dest_pe in range(lane, npes, WAVE):
+                if global_warp_id == 0:
+                    P.spin_until_eq_i32(fx.Int64(addr_disp_bar), block_num)
+                    buffer_store(arith.constant(0), rsrc_disp_bar, 0)
+                    signal_value = (
+                        buffer_load(rsrc_dest_ctr, dest_pe, vec_width=1, dtype=T.i32)
+                        + 1
+                    )
+                    peer_recv_num = fx.Int64(window.lsa_ptr(dest_pe, off_recv_num))
+                    recv_num_remote_addr = peer_recv_num + fx.Int64(rank) * fx.Int64(4)
+                    P.spin_until_eq_i32(recv_num_remote_addr, 0)
+                    P.store_i32_system(
+                        recv_num_remote_addr, arith.constant(0), signal_value
+                    )
+
+            # ── Phase 3: collect per-source counts into total_recv ──
+            for src_pe in range(lane, npes, WAVE):
+                if global_warp_id == 0:
+                    recv_num_src_addr = local_recv_num + fx.Int64(src_pe) * fx.Int64(4)
+                    signal_value = P.spin_until_gt_i32(recv_num_src_addr, 0)
+                    peer_recv_count = signal_value - 1
+                    P.store_i32_system(
+                        recv_num_src_addr, arith.constant(0), arith.constant(0)
+                    )
+                    P.atomic_add_global(fx.Int64(addr_total_recv), peer_recv_count)
+                    buffer_store(arith.constant(0), rsrc_dest_ctr, src_pe)
+
+            if global_warp_id == 0:
+                if lane == 0:
+                    local_tok_off = fx.Int64(window.lsa_ptr(my_lsa_rank, off_tok_off))
+                    P.store_i32_system(
+                        local_tok_off, arith.constant(0), arith.constant(0)
+                    )
+
+    @flyc.jit
+    def run(
+        arena: Int64,
+        addr_inp_tok: Int64,
+        addr_inp_idx: Int64,
+        addr_inp_wts: Int64,
+        addr_tok_map: Int64,
+        addr_dest_pe_ctr: Int64,
+        addr_disp_bar: Int64,
+        addr_total_recv: Int64,
+        addr_inp_scales: Int64,
+        my_lsa_rank: Int32,
+        inp_cur_tok: Int32,
+        stream=fx.Stream(None),
+    ):
+        ep_dispatch(
+            arena,
+            addr_inp_tok,
+            addr_inp_idx,
+            addr_inp_wts,
+            addr_tok_map,
+            addr_dest_pe_ctr,
+            addr_disp_bar,
+            addr_total_recv,
+            addr_inp_scales,
+            my_lsa_rank,
+            inp_cur_tok,
+        ).launch(
+            grid=(block_num, 1, 1),
+            block=[warp_num_per_block * WAVE, 1, 1],
+            stream=stream,
+        )
+
+    return run
+
+
+# ── combine (gather + scatter/quant) ──────────────────────────────────────
+
+
+def _V2BF16():
+    return T.vec(2, T.bf16)
+
+
+def _V2F32():
+    return T.vec(2, T.f32)
+
+
+def _V4F32():
+    return T.vec(4, T.f32)
+
+
+def _V8F32():
+    return T.vec(8, T.f32)
+
+
+def _V1I32():
+    return T.vec(1, T.i32)
+
+
+def _accum_funcs(hidden_elem_size, fp8_direct_cast=False, fp4=False):
+    if fp4:  # fp4 e2m1: i32 = 8 packed fp4 -> v8f32
+        if WAVE == 32:
+            # gfx1250: one pack-8 instr converts all 8 fp4/i32 (the gfx950 pk-2
+            # variants don't exist here). Plain fp4 => scale 1.0, scale_sel 0.
+            def to_accum(i32_scalar):
+                # dequant uses the E8M0 block-scale; 1.0 == 2^(127-127) => 127.
+                return cvt_scale_pk8_f32_fp4(
+                    res=_V8F32(),
+                    src=i32_scalar,
+                    scale=arith.constant(127, type=T.i32),
+                    scale_sel=0,
+                )
+
+            def from_accum(acc):
+                return cvt_scalef32_pk8_fp4_f32(
+                    res=T.i32, src=acc, scale=arith.constant(1.0, type=T.f32)
+                )
+
+            def zero_accum():
+                return arith.constant_vector(0.0, _V8F32())
+
+            return to_accum, from_accum, zero_accum
+
+        # cvt_scalef32_pk_*_fp4 are gfx950-only (fail on gfx942); opt-in (fp4=True).
+        def to_accum(i32_scalar):
+            one = arith.constant(1.0, type=T.f32)
+            pairs = [
+                cvt_scalef32_pk_f32_fp4(
+                    res=_V2F32(), src=i32_scalar, scale=one, src_sel_index=s
+                )
+                for s in range(4)
+            ]
+            lo4 = vector.shuffle(pairs[0], pairs[1], [0, 1, 2, 3])
+            hi4 = vector.shuffle(pairs[2], pairs[3], [0, 1, 2, 3])
+            return vector.shuffle(lo4, hi4, [0, 1, 2, 3, 4, 5, 6, 7])
+
+        def from_accum(acc):
+            one = arith.constant(1.0, type=T.f32)
+            old = arith.constant(0, type=T.i32)
+            for s in range(4):
+                fa = vector.extract(acc, static_position=[s * 2])
+                fb = vector.extract(acc, static_position=[s * 2 + 1])
+                old = cvt_scalef32_pk_fp4_f32(
+                    res=T.i32,
+                    old_vdst=old,
+                    src0=fa,
+                    src1=fb,
+                    scale=one,
+                    dst_sel_index=s,
+                )
+            return old
+
+        def zero_accum():
+            return arith.constant_vector(0.0, _V8F32())
+
+        return to_accum, from_accum, zero_accum
+    return _accum_funcs_int(hidden_elem_size, fp8_direct_cast)
+
+
+def _accum_funcs_int(hidden_elem_size, fp8_direct_cast=False):
+    """Return (to_accum, from_accum, zero_accum) for one i32 'unit' of the
+    transport dtype, mirroring the FlyDSL reference's per-dtype branches.
+
+    Each i32 packs: 2 bf16 (v2f32), 1 f32 (scalar), or 4 fp8 (v4f32).
+    """
+    if hidden_elem_size == 2:  # bf16: i32 = 2 bf16
+
+        def to_accum(i32_scalar):
+            return vector.bitcast(
+                _V2BF16(), vector.from_elements(_V1I32(), [i32_scalar])
+            ).extf(_V2F32())
+
+        def from_accum(acc):
+            return vector.extract(
+                vector.bitcast(_V1I32(), acc.truncf(_V2BF16())), static_position=[0]
+            )
+
+        def zero_accum():
+            return to_accum(arith.constant(0))
+
+    elif hidden_elem_size == 4:  # f32: i32 = 1 f32
+
+        def to_accum(i32_scalar):
+            return fx.Float32(arith.bitcast(T.f32, arith.unwrap(i32_scalar)))
+
+        def from_accum(acc):
+            return fx.Int32(arith.bitcast(T.i32, arith.unwrap(acc)))
+
+        def zero_accum():
+            return fx.Float32(arith.constant(0.0, type=T.f32))
+
+    elif hidden_elem_size == 1:  # fp8 (OCP e4m3): i32 = 4 fp8
+
+        def to_accum(i32_scalar):
+            lo = cvt_pk_f32_fp8(res=_V2F32(), src=i32_scalar, word_sel=False)
+            hi = cvt_pk_f32_fp8(res=_V2F32(), src=i32_scalar, word_sel=True)
+            return vector.shuffle(lo, hi, [0, 1, 2, 3])
+
+        def from_accum(acc):
+            f0 = vector.extract(acc, static_position=[0])
+            f1 = vector.extract(acc, static_position=[1])
+            f2 = vector.extract(acc, static_position=[2])
+            f3 = vector.extract(acc, static_position=[3])
+            if fp8_direct_cast:  # wire fp8 -> external bf16: v4f32 -> v4bf16 -> 2 i32
+                v4bf16 = acc.truncf(T.vec(4, T.bf16))
+                return vector.bitcast(T.vec(2, T.i32), v4bf16)
+            zero = arith.constant(0, type=T.i32)
+            lo = cvt_pk_fp8_f32(
+                res=T.i32, src_a=f0, src_b=f1, old=zero, word_sel=False
+            )
+            return cvt_pk_fp8_f32(
+                res=T.i32, src_a=f2, src_b=f3, old=lo, word_sel=True
+            )
+
+        def zero_accum():
+            return arith.constant_vector(0.0, _V4F32())
+
+    else:
+        raise ValueError(f"unsupported hidden_elem_size {hidden_elem_size}")
+    return to_accum, from_accum, zero_accum
+
+
+# Fixed size of the per-block xdb flag counter array for the gather combine entry
+# barrier: one i64 per block. 256 == the CU count (the max combine block_num), so
+# block_num never exceeds it. Deliberately a hard-coded compile-time constant.
+xdb_flag_slots = 256
+
+
+def make_combine(
+    *,
+    rank,
+    npes,
+    experts_per_token,
+    hidden_dim,
+    hidden_elem_size,
+    max_tok_per_rank,
+    max_recv,
+    block_num,
+    warp_num_per_block,
+    off_out_tok,
+    off_xdb_mem,
+    off_out_wts=0,
+    enable_weights=True,
+    fp8_direct_cast=False,
+    fp4=False,
+    reset_total_recv=True,
+    _unroll=4,
+):
+    # Transport dtype = external dtype; fp8_direct_cast wires fp8 while the output
+    # stays bf16 (2 i32 per fp8 unit). fp4: i32 = 8 fp4.
+    _to_accum2, _from_accum2, _zero_accum = _accum_funcs(
+        hidden_elem_size, fp8_direct_cast, fp4
+    )
+    nbytes = hidden_dim // 2 if fp4 else hidden_dim * hidden_elem_size
+    n_i32 = hidden_dim // 8 if fp4 else nbytes // 4
+    out_n_i32 = (hidden_dim * 2) // 4 if fp8_direct_cast else n_i32
+    # vec4 gather: 4 i32 per load (global_load_dwordx4) when output is 1:1.
+    _use_vec4 = (n_i32 % 4 == 0) and not fp8_direct_cast
+    out_step_mult = 2 if fp8_direct_cast else 1
+
+    @flyc.kernel(known_block_size=[warp_num_per_block * WAVE, 1, 1])
+    def ep_combine(
+        arena: Int64,
+        addr_tok_map: Int64,
+        addr_comb_bar: Int64,
+        addr_xdb_flag: Int64,
+        addr_total_recv: Int64,
+        addr_out: Int64,
+        addr_out_wts: Int64,
+        my_lsa_rank: Int32,
+        cur_rank_num_token: Int32,
+    ):
+        tid = fx.thread_idx.x
+        bid = fx.block_idx.x
+        lane = tid & LANE_MASK
+        warp = tid >> LOG2_WAVE
+        global_warp_id = bid * warp_num_per_block + warp
+        global_warp_num = block_num * warp_num_per_block
+        grid_thread_id = bid * (warp_num_per_block * WAVE) + tid
+
+        window = cco.Window(arena)
+        rsrc_tok_map = create_buffer_resource_from_addr(addr_tok_map)
+        rsrc_total_recv = create_buffer_resource_from_addr(addr_total_recv)
+        rsrc_out = create_buffer_resource_from_addr(addr_out)
+        rsrc_xdb_flag = create_buffer_resource_from_addr(addr_xdb_flag)
+
+        # ── Stage 1: per-block cross-device entry barrier ──
+        # Each block owns a PRIVATE flag counter xdb_flag[bid]; all counters stay
+        # in lockstep (== combine call count) because every block bumps its own
+        # once per call (single writer -> no atomic, no cross-block race). Block 0
+        # pushes this call's flag to every peer's shared xdb slot (npes posted
+        # writes); then EVERY block independently polls the SAME local slots for
+        # its own flag. No shared comb_bar (no atomic contention / reset /
+        # cross-call race) and no block-0 funnel; the monotonic flag needs no
+        # reset. Polling is local (peer pushes into our slots), so the extra
+        # per-block spins add no remote traffic.
+        phase = fx.Int64(buffer_load(rsrc_xdb_flag, bid, vec_width=1, dtype=T.i64))
+        if grid_thread_id < npes:
+            xdb_remote = fx.Int64(
+                window.lsa_ptr(grid_thread_id, off_xdb_mem)
+            ) + fx.Int64(rank) * fx.Int64(8)
+            P.store_i64_system(xdb_remote, arith.constant(0), phase)
+        # advance this block's private counter for the next call (single writer)
+        if tid == 0:
+            buffer_store(phase + arith.constant(1, type=T.i64), rsrc_xdb_flag, bid)
+        # block 0 fills the unused tail counters [block_num, xdb_flag_slots) in
+        # parallel so a later call that picks a larger block_num still reads
+        # synced counters. Nobody reads these slots this call => no cross-block
+        # race. block 0 has warp_num_per_block*WAVE threads, which can be < the
+        # tail (e.g. WAVE=32, warp=4 => 128 threads < 256-block_num), so stride
+        # over the tail in a compile-time-fixed number of rounds (1-2 in practice).
+        if const_expr(xdb_flag_slots > block_num):
+            if bid == 0:
+                _tail = xdb_flag_slots - block_num
+                _nthr = warp_num_per_block * WAVE
+                for r in range_constexpr((_tail + _nthr - 1) // _nthr):
+                    idx = tid + r * _nthr
+                    if idx < _tail:
+                        buffer_store(
+                            phase + arith.constant(1, type=T.i64),
+                            rsrc_xdb_flag,
+                            block_num + idx,
+                        )
+        # every block independently polls the shared local slots (local reads).
+        # Use >= (not ==): every block — including late-scheduled ones — reads the
+        # slot, so a faster peer can lap us and overwrite its (monotonic) push with
+        # a higher call count before our late blocks read it. `>=` still releases
+        # (a peer being ahead is the safe direction); `==` would deadlock.
+        if tid < npes:
+            xdb_peer_slot = fx.Int64(
+                window.lsa_ptr(my_lsa_rank, off_xdb_mem)
+            ) + fx.Int64(tid) * fx.Int64(8)
+            P.spin_until_ge_i64(xdb_peer_slot, phase)
+        fx.barrier()
+        # No acquire fence needed here: the gather reads peer out_tok via
+        # non-temporal loads (cache-bypassing, always fresh from HBM), and the
+        # spin above is a control dependency ordering the gather after the flag.
+        # Peer's out_tok is written before its flag push (kernel boundary), so
+        # observing the flag implies the data is ready.
+        if const_expr(reset_total_recv):
+            if tid == 0:
+                buffer_store(arith.constant(0), rsrc_total_recv, 0)
+
+        rsrc_out_wts = create_buffer_resource_from_addr(addr_out_wts)
+
+        # ── Stage 2: warp-partitioned remote gather + f32 accumulate ──
+        # Register-light i32 reads + `_unroll`-way unroll (each lane keeps _unroll
+        # loads/accumulators in flight per k) hide xGMI latency with fewer warps;
+        # each token's hidden is split across warps_per_tok warps to fill the grid.
+        STEP = _unroll * WAVE
+        safe_tok = arith.select(
+            cur_rank_num_token == arith.constant(0),
+            arith.constant(1),
+            cur_rank_num_token,
+        )
+        warps_per_tok = (
+            arith.constant(global_warp_num) + safe_tok - arith.constant(1)
+        ) // safe_tok
+        units_per_warp = (
+            arith.constant(n_i32) + warps_per_tok - arith.constant(1)
+        ) // warps_per_tok
+        stage3_total = cur_rank_num_token * warps_per_tok
+        for stage3_idx in range(global_warp_id, stage3_total, global_warp_num):
+            tok_id = stage3_idx // warps_per_tok
+            part_id = stage3_idx % warps_per_tok
+            unit_base = part_id * units_per_warp
+            tok_map_base = tok_id * experts_per_token
+            expert_bases = []
+            expert_valids = []
+            expert_pes = []
+            expert_toks = []
+            # One coalesced tok_map load per lane, then broadcast each k_slot
+            # via readlane (replaces K per-k_slot buffer_loads).
+            encoded_my = buffer_load(
+                rsrc_tok_map, tok_map_base + lane, vec_width=1, dtype=T.i32
+            )
+            for k_slot in range_constexpr(experts_per_token):
+                encoded_k = readlane(T.i32, encoded_my, k_slot)
+                dest_pe_k = encoded_k // max_recv  # sentinel: dest_pe == npes
+                dest_tok_k = encoded_k % max_recv  # peer-local recv slot
+                valid_k = dest_pe_k < npes
+                safe_pe = arith.select(valid_k, dest_pe_k, arith.constant(rank))
+                safe_tok_k = arith.select(valid_k, dest_tok_k, arith.constant(0))
+                # Remote base peer[dest_pe].out_tok[dest_tok]; global-load gather
+                # (no per-expert descriptor) keeps all K loads in flight.
+                slot_addr = fx.Int64(window.lsa_ptr(safe_pe, off_out_tok)) + fx.Int64(
+                    safe_tok_k
+                ) * fx.Int64(nbytes)
+                expert_bases.append(slot_addr)
+                expert_valids.append(valid_k)
+                expert_pes.append(safe_pe)
+                expert_toks.append(safe_tok_k)
+
+            # Weights: once per token (part 0), reduce the K forwarded weights ->
+            # out_weights[tok][e]; overlaps with this warp's hidden gather.
+            if const_expr(enable_weights):
+                if part_id == arith.constant(0):
+                    if lane < experts_per_token:
+                        weight_acc = arith.constant(0.0, type=T.f32)
+                        for k_slot in range_constexpr(experts_per_token):
+                            weight_addr = fx.Int64(
+                                window.lsa_ptr(expert_pes[k_slot], off_out_wts)
+                            ) + (
+                                fx.Int64(expert_toks[k_slot])
+                                * fx.Int64(experts_per_token)
+                                + fx.Int64(lane)
+                            ) * fx.Int64(
+                                4
+                            )
+                            weight_val = buffer_load(
+                                create_buffer_resource_from_addr(weight_addr),
+                                0,
+                                vec_width=1,
+                                dtype=T.f32,
+                            )
+                            weight_acc = weight_acc + arith.select(
+                                expert_valids[k_slot],
+                                weight_val,
+                                arith.constant(0.0, type=T.f32),
+                            )
+                        buffer_store(weight_acc, rsrc_out_wts, tok_map_base + lane)
+            rem = arith.constant(n_i32) - unit_base
+            eff = arith.select(
+                rem < units_per_warp, rem, units_per_warp
+            )  # i32 units this warp
+            out_base = tok_id * out_n_i32
+
+            # Nested fn: closure over expert_bases/valids (lists can't be loop-carried).
+            def _one(off):  # reduce k contributions for one i32 unit
+                vals = []
+                for k_slot in range_constexpr(experts_per_token):
+                    v = P.load_i32_nt(expert_bases[k_slot], off)
+                    vals.append(
+                        arith.select(expert_valids[k_slot], v, arith.constant(0))
+                    )
+                acc = _zero_accum()
+                for k_slot in range_constexpr(experts_per_token):
+                    acc = acc + _to_accum2(vals[k_slot])
+                buffer_store(
+                    _from_accum2(acc), rsrc_out, out_base + off * out_step_mult
+                )
+
+            if const_expr(_use_vec4):
+                # Vec4 path: load 4 i32 (16B, global_load_dwordx4) per expert
+                # per iteration, reducing xGMI load count 4×.
+                VEC = 4
+                STEP_CHUNK = WAVE * VEC
+                STEP_V4 = _unroll * STEP_CHUNK
+
+                def _load_expert_vecs(off):
+                    vecs = []
+                    valids = []
+                    for k_slot in range_constexpr(experts_per_token):
+                        vecs.append(P.load_v4i32_nt(expert_bases[k_slot], off))
+                        valids.append(expert_valids[k_slot])
+                    return vecs, valids
+
+                def _accum_loop():
+                    main_end = (eff // STEP_V4) * STEP_V4
+                    for u in range(lane * VEC, main_end, STEP_V4):
+                        base = unit_base + u
+                        # Issue all remote loads first (both unroll rounds) so stores
+                        # in the j/r nest cannot block the next load batch.
+                        pre_vecs = []
+                        pre_valids = []
+                        for r in range_constexpr(_unroll):
+                            off_r = base + r * STEP_CHUNK
+                            vecs_r, valids_r = _load_expert_vecs(off_r)
+                            pre_vecs.append(vecs_r)
+                            pre_valids.append(valids_r)
+                        # Reduce+store: j outer, r inner (unroll innermost).
+                        for j in range_constexpr(VEC):
+                            for r in range_constexpr(_unroll):
+                                off = base + r * STEP_CHUNK
+                                acc = _zero_accum()
+                                for k_slot in range_constexpr(experts_per_token):
+                                    elem = vector.extract(
+                                        pre_vecs[r][k_slot], static_position=[j]
+                                    )
+                                    v = arith.select(
+                                        pre_valids[r][k_slot], elem, arith.constant(0)
+                                    )
+                                    acc = acc + _to_accum2(v)
+                                buffer_store(
+                                    _from_accum2(acc), rsrc_out, out_base + off + j
+                                )
+                    for u in range(main_end + lane, eff, WAVE):
+                        _one(unit_base + u)
+
+            else:
+
+                def _accum_loop():
+                    main_end = (eff // STEP) * STEP
+                    for u in range(lane, main_end, STEP):
+                        base = unit_base + u
+                        pre_vals = []
+                        for r in range_constexpr(_unroll):
+                            off_r = base + r * WAVE
+                            vals_r = []
+                            for k_slot in range_constexpr(experts_per_token):
+                                v = P.load_i32_nt(expert_bases[k_slot], off_r)
+                                vals_r.append(
+                                    arith.select(
+                                        expert_valids[k_slot], v, arith.constant(0)
+                                    )
+                                )
+                            pre_vals.append(vals_r)
+                        for r in range_constexpr(_unroll):
+                            off = base + r * WAVE
+                            acc = _zero_accum()
+                            for k_slot in range_constexpr(experts_per_token):
+                                acc = acc + _to_accum2(pre_vals[r][k_slot])
+                            buffer_store(
+                                _from_accum2(acc),
+                                rsrc_out,
+                                out_base + off * out_step_mult,
+                            )
+                    for u in range(main_end + lane, eff, WAVE):
+                        _one(unit_base + u)
+
+            _accum_loop()
+
+        # No exit barrier: the per-block monotonic flag needs no reset, and gather
+        # does no post-completion work, so kernel retirement (stream-ordered) is
+        # the only completion signal the host needs. This removes the former
+        # (block_num-1)-way contended atomic_add on comb_bar.
+
+    @flyc.jit
+    def run(
+        arena: Int64,
+        addr_tok_map: Int64,
+        addr_comb_bar: Int64,
+        addr_xdb_flag: Int64,
+        addr_total_recv: Int64,
+        addr_out: Int64,
+        addr_out_wts: Int64,
+        my_lsa_rank: Int32,
+        cur_rank_num_token: Int32,
+        stream=fx.Stream(None),
+    ):
+        ep_combine(
+            arena,
+            addr_tok_map,
+            addr_comb_bar,
+            addr_xdb_flag,
+            addr_total_recv,
+            addr_out,
+            addr_out_wts,
+            my_lsa_rank,
+            cur_rank_num_token,
+        ).launch(
+            grid=(block_num, 1, 1),
+            block=[warp_num_per_block * WAVE, 1, 1],
+            stream=stream,
+        )
+
+    return run
+
+
+_FP8_MAX = 240.0  # gfx942 native fp8 is e4m3fnuz: max finite 240 (NOT OCP 448);
+# clamping above 240 yields NaN from cvt_pk_fp8_f32 on this arch
+
+
+def _fabs(f):
+    return arith.maximumf(f, arith.negf(f))
+
+
+def _bf16x2(i32_scalar):  # i32 (2 bf16) -> v2f32
+    return vector.bitcast(_V2BF16(), vector.from_elements(_V1I32(), [i32_scalar])).extf(
+        _V2F32()
+    )
+
+
+def _warp_amax(lane, v):
+    """Max-reduce an f32 across the wavefront (butterfly via ds_bpermute, per-lane
+    gather index). Every lane returns the wavefront max; raw values in/out."""
+    for off in _BUTTERFLY_OFFSETS:
+        idx = arith.unwrap((lane ^ off) * 4)  # byte addr = lane*4
+        o = ds_bpermute(T.i32, idx, arith.bitcast(T.i32, arith.unwrap(v)))
+        v = arith.maximumf(v, arith.bitcast(T.f32, o))
+    return v
+
+
+def make_combine_scatter(
+    *,
+    rank,
+    npes,
+    experts_per_token,
+    hidden_dim,
+    hidden_elem_size,
+    max_tok_per_rank,
+    max_recv,
+    block_num,
+    warp_num_per_block,
+    off_out_tok,
+    off_comb_inp,
+    off_tis,
+    off_xdb_mem,
+    off_out_wts=0,
+    off_comb_wts=0,
+    off_comb_scales=0,
+    enable_weights=True,
+    fp8_direct_cast=False,
+    fp8_blockwise=False,
+    scale_dim=0,
+    reset_total_recv=True,
+    _s3_cache=2,
+    _unroll=2,
+):
+    """Scatter combine (mori _nop2p path): 2 passes vs gather, but compresses the
+    transport to fp8 (the natural home for fp8_direct_cast).
+
+    Stage 1  each computing rank P2P-WRITES post-expert tokens to the ORIGIN's
+             comb_inp[computing_rank*M + origin_lid] (bf16->fp8 if cast).
+    Stage 2  cross-device barrier.
+    Stage 3  origin LOCAL-reads comb_inp for its token's k expert PEs and reduces."""
+    if fp8_blockwise and WAVE != 64:
+        raise NotImplementedError(
+            "fp8_blockwise combine's coalesced path assumes wave64 (one wave == one "
+            "128-elem block); wave32 (gfx12) port is TODO"
+        )
+    _fp8_out = fp8_direct_cast or fp8_blockwise
+    wire_elem_size = 1 if _fp8_out else hidden_elem_size
+    to_acc, from_acc, zero_acc = _accum_funcs(wire_elem_size, _fp8_out)
+    inp_nbytes = hidden_dim * hidden_elem_size  # source out_tok (bf16/f32)
+    wire_nbytes = hidden_dim * wire_elem_size  # comb_inp transport
+    wire_n_i32 = wire_nbytes // 4
+    out_n_i32 = (hidden_dim * 2) // 4 if _fp8_out else wire_n_i32
+    out_step_mult = 2 if _fp8_out else 1
+    if fp8_blockwise:
+        block_elems = hidden_dim // scale_dim
+        assert (
+            hidden_dim % scale_dim == 0 and block_elems == 128
+        ), "blockwise (coalesced path): block_elems must be 128 (scale_dim = hidden/128)"
+        block_i32_fp8 = block_elems // 4  # fp8 i32 units per block (=32)
+
+    @flyc.kernel(known_block_size=[warp_num_per_block * WAVE, 1, 1])
+    def ep_combine_s(
+        arena: Int64,
+        addr_tok_map: Int64,
+        addr_comb_bar: Int64,
+        addr_xdb_flag: Int64,
+        addr_total_recv: Int64,
+        addr_out: Int64,
+        addr_out_wts: Int64,
+        addr_src_tok: Int64,
+        my_lsa_rank: Int32,
+        cur_rank_num_token: Int32,
+    ):
+        tid = fx.thread_idx.x
+        bid = fx.block_idx.x
+        lane = tid & LANE_MASK
+        warp = tid >> LOG2_WAVE
+        global_warp_id = bid * warp_num_per_block + warp
+        global_warp_num = block_num * warp_num_per_block
+        grid_thread_id = bid * (warp_num_per_block * WAVE) + tid
+
+        window = cco.Window(arena)
+        rsrc_tok_map = create_buffer_resource_from_addr(addr_tok_map)
+        rsrc_comb_bar = create_buffer_resource_from_addr(addr_comb_bar)
+        rsrc_total_recv = create_buffer_resource_from_addr(addr_total_recv)
+        rsrc_tis = create_buffer_resource_from_addr(
+            fx.Int64(window.lsa_ptr(my_lsa_rank, off_tis))
+        )
+        rsrc_out = create_buffer_resource_from_addr(addr_out)
+        rsrc_out_wts = create_buffer_resource_from_addr(addr_out_wts)
+        total_recv = buffer_load(rsrc_total_recv, 0, vec_width=1, dtype=T.i32)
+
+        # ── Stage 1: scatter post-expert tokens back to origin's comb_inp ──
+        # addr_src_tok is a raw LOCAL pointer to the post-expert tokens (the GEMM
+        # output). Scatter only ever LOCAL-reads its source, so the caller can pass
+        # the GEMM output directly and skip the copy into symmetric comb_stg that
+        # gather requires (gather peers remote-read it, so it must be symmetric).
+        src_tok_base = fx.Int64(addr_src_tok)
+        for recv_slot in range(global_warp_id, total_recv, global_warp_num):
+            # tis encodes origin = src_pe*max_tok_per_rank + local_id
+            encoded_origin = buffer_load(
+                rsrc_tis, recv_slot, vec_width=1, dtype=T.i32
+            )
+            origin_pe = encoded_origin // max_tok_per_rank
+            origin_lid = encoded_origin % max_tok_per_rank
+            dst = fx.Int64(window.lsa_ptr(origin_pe, off_comb_inp)) + (
+                fx.Int64(rank * max_tok_per_rank + origin_lid)
+            ) * fx.Int64(wire_nbytes)
+            src = src_tok_base + fx.Int64(recv_slot) * fx.Int64(inp_nbytes)
+            rsrc_src = create_buffer_resource_from_addr(src)
+            rsrc_dst = create_buffer_resource_from_addr(dst)
+            if const_expr(fp8_blockwise):
+                # Blockwise fp8 quant, coalesced + warp-reduce (block_elems==128, one
+                # i32/lane spans a block): ds_bpermute butterfly gives every lane the
+                # block amax; scale = (amax>MAX)? amax/MAX : 1, quant = clamp(v*MAX/amax);
+                # sign sentinel: if ANY block scaled, negate block-0 scale.
+                scale_dst = fx.Int64(
+                    window.lsa_ptr(origin_pe, off_comb_scales)
+                ) + fx.Int64(rank * max_tok_per_rank + origin_lid) * fx.Int64(
+                    scale_dim
+                ) * fx.Int64(
+                    4
+                )
+                rsrc_scales = create_buffer_resource_from_addr(scale_dst)
+                fp8max = arith.constant(_FP8_MAX, type=T.f32)
+                nlim = arith.constant(-_FP8_MAX, type=T.f32)
+                any_scaled = arith.constant(0) != arith.constant(0)  # False (uniform)
+                for scale_block in range_constexpr(scale_dim):
+                    v2 = _bf16x2(
+                        buffer_load(
+                            rsrc_src,
+                            scale_block * 64 + lane,
+                            vec_width=1,
+                            dtype=T.i32,
+                        )
+                    )
+                    e0 = vector.extract(v2, static_position=[0])
+                    e1 = vector.extract(v2, static_position=[1])
+                    amax = _warp_amax(lane, arith.maximumf(_fabs(e0), _fabs(e1)))
+                    scaled = amax > fp8max
+                    any_scaled = arith.select(scaled, scaled, any_scaled)
+                    scale = arith.select(
+                        scaled,
+                        arith.divf(amax, fp8max),
+                        arith.constant(1.0, type=T.f32),
+                    )
+                    inv = arith.select(
+                        scaled,
+                        arith.divf(fp8max, amax),
+                        arith.constant(1.0, type=T.f32),
+                    )
+                    if lane == 0:
+                        buffer_store(scale, rsrc_scales, scale_block)
+                    f0 = fmed3(T.f32, arith.mulf(e0, inv), fp8max, nlim)
+                    f1 = fmed3(T.f32, arith.mulf(e1, inv), fp8max, nlim)
+                    my_packed = cvt_pk_fp8_f32(
+                        res=T.i32,
+                        src_a=f0,
+                        src_b=f1,
+                        old=arith.constant(0, type=T.i32),
+                        word_sel=False,
+                    )
+                    # neighbour (lane^1)'s 2 fp8 (its low 16) via ds_bpermute.
+                    nbr_packed = ds_bpermute(
+                        T.i32,
+                        arith.unwrap((lane ^ arith.constant(1)) * arith.constant(4)),
+                        arith.unwrap(my_packed),
+                    )
+                    my_lo16 = my_packed & arith.constant(0xFFFF)
+                    packed_pair = my_lo16 | (
+                        (nbr_packed & arith.constant(0xFFFF)) << arith.constant(16)
+                    )
+                    if (lane & arith.constant(1)) == arith.constant(0):
+                        buffer_store(
+                            packed_pair,
+                            rsrc_dst,
+                            scale_block * block_i32_fp8 + (lane >> arith.constant(1)),
+                        )
+                if any_scaled:
+                    if lane == 0:
+                        s0 = buffer_load(rsrc_scales, 0, vec_width=1, dtype=T.f32)
+                        buffer_store(arith.negf(s0), rsrc_scales, 0)
+            elif const_expr(fp8_direct_cast):
+                # 2 bf16 i32 -> v4f32 -> cvt_pk_fp8 x2 -> 1 fp8 i32
+                for elem in range(lane, wire_n_i32, WAVE):
+                    bf = buffer_load(rsrc_src, elem * 2, vec_width=2, dtype=T.i32)
+                    v4 = vector.bitcast(T.vec(4, T.bf16), bf).extf(
+                        _V4F32()
+                    )
+                    f0 = vector.extract(v4, static_position=[0])
+                    f1 = vector.extract(v4, static_position=[1])
+                    f2 = vector.extract(v4, static_position=[2])
+                    f3 = vector.extract(v4, static_position=[3])
+                    z = arith.constant(0, type=T.i32)
+                    lo = cvt_pk_fp8_f32(
+                        res=T.i32, src_a=f0, src_b=f1, old=z, word_sel=False
+                    )
+                    fp8 = cvt_pk_fp8_f32(
+                        res=T.i32, src_a=f2, src_b=f3, old=lo, word_sel=True
+                    )
+                    buffer_store(fp8, rsrc_dst, elem)
+            else:
+                # bf16/f32 (no compression): plain local-read -> remote-write copy.
+                # vec4 (global_load/store_dwordx4, 16B) + _unroll-way prefetch to keep
+                # multiple remote stores in flight and hide xGMI write latency.
+                _v4n = wire_n_i32 // 4
+                _step = _unroll * WAVE
+                _main_end = (_v4n // _step) * _step
+                for _b in range(lane, _main_end, _step):
+                    _pre = []
+                    for _r in range_constexpr(_unroll):
+                        _pre.append(P.load_v4i32_nt(src, (_b + _r * WAVE) * 4))
+                    for _r in range_constexpr(_unroll):
+                        buffer_store(_pre[_r], rsrc_dst, (_b + _r * WAVE) * 4)
+                for _u in range(_main_end + lane, _v4n, WAVE):
+                    buffer_store(P.load_v4i32_nt(src, _u * 4), rsrc_dst, _u * 4)
+                for elem in range(_v4n * 4 + lane, wire_n_i32, WAVE):
+                    v = buffer_load(rsrc_src, elem, vec_width=1, dtype=T.i32)
+                    buffer_store(v, rsrc_dst, elem)
+            if const_expr(enable_weights):
+                # forward this recv slot's weights to the ORIGIN's
+                # comb_wts[computing_rank*M + lid] (dedicated region).
+                weight_src = fx.Int64(
+                    window.lsa_ptr(my_lsa_rank, off_out_wts)
+                ) + fx.Int64(recv_slot) * fx.Int64(experts_per_token) * fx.Int64(4)
+                weight_dst = fx.Int64(
+                    window.lsa_ptr(origin_pe, off_comb_wts)
+                ) + fx.Int64(rank * max_tok_per_rank + origin_lid) * fx.Int64(
+                    experts_per_token
+                ) * fx.Int64(
+                    4
+                )
+                if lane < experts_per_token:
+                    weight_val = buffer_load(
+                        create_buffer_resource_from_addr(weight_src),
+                        lane,
+                        vec_width=1,
+                        dtype=T.i32,
+                    )
+                    buffer_store(
+                        weight_val, create_buffer_resource_from_addr(weight_dst), lane
+                    )
+
+        xdb_cur_flag = P.load_i64_acquire(fx.Int64(addr_xdb_flag))
+
+        # ── Stage 2: cross-device barrier ──
+        # Grid sync ensures all blocks finished Stage-1 scatter writes.
+        # Block 0 then handles xdb and signals completion via comb_bar.
+        P.fence_system_release()
+        fx.barrier()
+        if tid == 0:
+            P.atomic_add_global(fx.Int64(addr_comb_bar), arith.constant(1))
+        if grid_thread_id < npes:
+            P.spin_until_eq_i32(fx.Int64(addr_comb_bar), block_num)
+            P.fence_system_acquire()
+            xdb_remote = fx.Int64(
+                window.lsa_ptr(grid_thread_id, off_xdb_mem)
+            ) + fx.Int64(rank) * fx.Int64(8)
+            P.store_i64_system(xdb_remote, arith.constant(0), xdb_cur_flag)
+        if grid_thread_id == 0:
+            P.atomic_add_global(
+                fx.Int64(addr_xdb_flag), arith.constant(1, type=T.i64)
+            )
+        if grid_thread_id < npes:
+            xdb_slot = fx.Int64(window.lsa_ptr(my_lsa_rank, off_xdb_mem)) + fx.Int64(
+                grid_thread_id
+            ) * fx.Int64(8)
+            P.spin_until_eq_i64(xdb_slot, xdb_cur_flag)
+        if bid == 0:
+            fx.barrier()
+            if tid == 0:
+                P.store_i32_system(
+                    fx.Int64(addr_comb_bar),
+                    arith.constant(0),
+                    arith.constant(block_num + 1),
+                )
+        if bid != 0:
+            if tid == 0:
+                P.spin_until_gt_i32(fx.Int64(addr_comb_bar), block_num)
+            fx.barrier()
+            if tid == 0:
+                P.atomic_add_global(fx.Int64(addr_comb_bar), arith.constant(1))
+        if const_expr(reset_total_recv):
+            if tid == 0:
+                buffer_store(arith.constant(0), rsrc_total_recv, 0)
+
+        # ── Stage 3: local read of comb_inp + reduce ──
+        comb_inp_base = fx.Int64(window.lsa_ptr(my_lsa_rank, off_comb_inp))
+        safe_tok = arith.select(
+            cur_rank_num_token == arith.constant(0),
+            arith.constant(1),
+            cur_rank_num_token,
+        )
+        warps_per_tok = (
+            arith.constant(global_warp_num) + safe_tok - arith.constant(1)
+        ) // safe_tok
+        units_per_warp = (
+            arith.constant(wire_n_i32) + warps_per_tok - arith.constant(1)
+        ) // warps_per_tok
+        stage3_total = cur_rank_num_token * warps_per_tok
+        for stage3_idx in range(global_warp_id, stage3_total, global_warp_num):
+            tok_id = stage3_idx // warps_per_tok
+            part_id = stage3_idx % warps_per_tok
+            unit_base = part_id * units_per_warp
+            tok_map_base = tok_id * experts_per_token
+            expert_rsrcs = []
+            expert_addrs = []
+            expert_valids = []
+            expert_pes = []
+            expert_scales = []
+            for k_slot in range_constexpr(experts_per_token):
+                encoded_k = buffer_load(
+                    rsrc_tok_map, tok_map_base + k_slot, vec_width=1, dtype=T.i32
+                )
+                dest_pe = encoded_k // max_recv
+                valid = dest_pe < npes
+                safe_pe = arith.select(valid, dest_pe, arith.constant(rank))
+                # LOCAL comb_inp[computing_pe*M + tok_id]
+                src_addr = comb_inp_base + (
+                    fx.Int64(safe_pe) * fx.Int64(max_tok_per_rank) + fx.Int64(tok_id)
+                ) * fx.Int64(wire_nbytes)
+                expert_rsrcs.append(create_buffer_resource_from_addr(src_addr))
+                expert_addrs.append(src_addr)
+                expert_valids.append(valid)
+                expert_pes.append(safe_pe)
+                if const_expr(fp8_blockwise):
+                    scale_addr = fx.Int64(
+                        window.lsa_ptr(my_lsa_rank, off_comb_scales)
+                    ) + (
+                        fx.Int64(safe_pe) * fx.Int64(max_tok_per_rank)
+                        + fx.Int64(tok_id)
+                    ) * fx.Int64(
+                        scale_dim
+                    ) * fx.Int64(
+                        4
+                    )
+                    expert_scales.append(create_buffer_resource_from_addr(scale_addr))
+            if const_expr(enable_weights):
+                if part_id == arith.constant(0):
+                    if lane < experts_per_token:
+                        weight_acc = arith.constant(0.0, type=T.f32)
+                        for k_slot in range_constexpr(experts_per_token):
+                            # LOCAL comb_wts[computing_pe*M + tok_id] (scattered in S1)
+                            weight_addr = (
+                                fx.Int64(window.lsa_ptr(my_lsa_rank, off_comb_wts))
+                                + (
+                                    fx.Int64(expert_pes[k_slot])
+                                    * fx.Int64(max_tok_per_rank)
+                                    + fx.Int64(tok_id)
+                                )
+                                * fx.Int64(experts_per_token)
+                                * fx.Int64(4)
+                                + fx.Int64(lane) * fx.Int64(4)
+                            )
+                            weight_val = buffer_load(
+                                create_buffer_resource_from_addr(weight_addr),
+                                0,
+                                vec_width=1,
+                                dtype=T.f32,
+                            )
+                            weight_acc = weight_acc + arith.select(
+                                expert_valids[k_slot],
+                                weight_val,
+                                arith.constant(0.0, type=T.f32),
+                            )
+                        buffer_store(weight_acc, rsrc_out_wts, tok_map_base + lane)
+            rem = arith.constant(wire_n_i32) - unit_base
+            eff = arith.select(rem < units_per_warp, rem, units_per_warp)
+            out_base = tok_id * out_n_i32
+
+            def _one(off):
+                acc = zero_acc()
+                # blockwise: 4 fp8 per i32 unit are 4 consecutive elements in the
+                # same block -> one scale per unit. scale_block = (off*4)//block_elems.
+                if const_expr(fp8_blockwise):
+                    scale_block = (off * arith.constant(4)) // arith.constant(
+                        block_elems
+                    )
+                    is_b0 = scale_block == arith.constant(0)
+                for k_slot in range_constexpr(experts_per_token):
+                    v = buffer_load(
+                        expert_rsrcs[k_slot],
+                        off,
+                        vec_width=1,
+                        dtype=T.i32,
+                        cache_modifier=_s3_cache,
+                    )
+                    v = arith.select(expert_valids[k_slot], v, arith.constant(0))
+                    if const_expr(fp8_blockwise):
+                        scale = buffer_load(
+                            expert_scales[k_slot],
+                            scale_block,
+                            vec_width=1,
+                            dtype=T.f32,
+                        )
+                        scale = arith.select(
+                            is_b0, _fabs(scale), scale
+                        )  # undo block-0 sign sentinel
+                        # invalid expert -> v already 0; force finite scale so a
+                        # stale/garbage comb_scales slot can't make 0*NaN = NaN.
+                        scale = arith.select(
+                            expert_valids[k_slot],
+                            scale,
+                            arith.constant(1.0, type=T.f32),
+                        )
+                        acc = acc + to_acc(v) * scale
+                    else:
+                        acc = acc + to_acc(v)
+                buffer_store(from_acc(acc), rsrc_out, out_base + off * out_step_mult)
+
+            def _loop():
+                if const_expr(not _fp8_out):
+                    # Non-quant (bf16/f32) fast path: vec4 local reads (4 i32/lane)
+                    # per expert + per-i32 reduce + vec4 store, WAVE-strided so the
+                    # wave stays coalesced. fp8 paths keep the scalar _one loop.
+                    _v4eff = eff // arith.constant(4)
+                    for _u in range(lane, _v4eff, WAVE):
+                        _off = unit_base + _u * arith.constant(4)
+                        _accs = [zero_acc(), zero_acc(), zero_acc(), zero_acc()]
+                        for k_slot in range_constexpr(experts_per_token):
+                            _vv = P.load_v4i32_nt(expert_addrs[k_slot], _off)
+                            for _j in range_constexpr(4):
+                                _e = vector.extract(_vv, static_position=[_j])
+                                _e = arith.select(
+                                    expert_valids[k_slot], _e, arith.constant(0)
+                                )
+                                _accs[_j] = _accs[_j] + to_acc(_e)
+                        _res = vector.from_elements(
+                            T.vec(4, T.i32),
+                            [
+                                from_acc(_accs[0]),
+                                from_acc(_accs[1]),
+                                from_acc(_accs[2]),
+                                from_acc(_accs[3]),
+                            ],
+                        )
+                        buffer_store(_res, rsrc_out, out_base + _off)
+                    for _u in range(_v4eff * arith.constant(4) + lane, eff, WAVE):
+                        _one(unit_base + _u)
+                else:
+                    for u in range(lane, eff, WAVE):
+                        _one(unit_base + u)
+
+            _loop()
+
+        # Epilogue: block 0 waits for every other block's Stage-3 completion
+        # (comb_bar reached 2*block_num), then resets comb_bar for the next call.
+        if global_warp_id == 0:
+            if lane == 0:
+                P.spin_until_gt_i32(fx.Int64(addr_comb_bar), 2 * block_num - 1)
+                buffer_store(arith.constant(0), rsrc_comb_bar, 0)
+
+    @flyc.jit
+    def run(
+        arena: Int64,
+        addr_tok_map: Int64,
+        addr_comb_bar: Int64,
+        addr_xdb_flag: Int64,
+        addr_total_recv: Int64,
+        addr_out: Int64,
+        addr_out_wts: Int64,
+        addr_src_tok: Int64,
+        my_lsa_rank: Int32,
+        cur_rank_num_token: Int32,
+        stream=fx.Stream(None),
+    ):
+        ep_combine_s(
+            arena,
+            addr_tok_map,
+            addr_comb_bar,
+            addr_xdb_flag,
+            addr_total_recv,
+            addr_out,
+            addr_out_wts,
+            addr_src_tok,
+            my_lsa_rank,
+            cur_rank_num_token,
+        ).launch(
+            grid=(block_num, 1, 1),
+            block=[warp_num_per_block * WAVE, 1, 1],
+            stream=stream,
+        )
+
+    return run
+
+
+def make_combine_fused_reduce(
+    *,
+    rank,
+    npes,
+    experts_per_token,
+    hidden_dim,
+    hidden_elem_size,
+    max_tok_per_rank,
+    block_num,
+    warp_num_per_block,
+    off_comb_inp,
+    off_xdb_mem,
+    slot_stride_nbytes=None,
+    _s3_cache=2,
+):
+    """Combine for the gemm2-fused scatter path (combine_mode='scatter_fused').
+
+    gemm2 has already P2P-written each token's WEIGHTED per-expert result into this
+    rank's comb_inp[origin_lid*topk + k] (one contiguous topk-block per token). So
+    combine only:
+      Stage A  cross-device barrier -- wait until every peer's gemm2 P2P writes are
+               globally visible before reading comb_inp.
+      Stage B  each origin token: out[t] = sum_{k<topk} comb_inp[t*topk + k]. Weights
+               were pre-applied in gemm2, so this is an unweighted sum. Dropped
+               (token,k) slots must read 0 (caller zeroes comb_inp before gemm2).
+
+    bf16/f32 non-quant only (the fused path carries a bf16 wire).
+    """
+    to_acc, from_acc, zero_acc = _accum_funcs(hidden_elem_size)
+    wire_nbytes = hidden_dim * hidden_elem_size  # valid bytes per slot (hidden row)
+    n_i32 = wire_nbytes // 4  # valid i32 units read per slot (unpadded)
+    # Per-slot stride: padded (pow2) for the TDM gather-store path so slot
+    # addresses divide the 4GB-aligned per-rank window; defaults to the natural
+    # hidden row size. Only the slot ADDRESS strides by this; the read count
+    # (n_i32) stays hidden-based so padding tail is never read.
+    slot_stride = slot_stride_nbytes if slot_stride_nbytes is not None else wire_nbytes
+    topk = experts_per_token
+
+    @flyc.kernel(known_block_size=[warp_num_per_block * WAVE, 1, 1])
+    def ep_combine_fused(
+        arena: Int64,
+        addr_comb_inp: Int64,
+        addr_comb_bar: Int64,
+        addr_xdb_flag: Int64,
+        addr_out: Int64,
+        my_lsa_rank: Int32,
+        cur_rank_num_token: Int32,
+    ):
+        tid = fx.thread_idx.x
+        bid = fx.block_idx.x
+        lane = tid & LANE_MASK
+        warp = tid >> LOG2_WAVE
+        global_warp_id = bid * warp_num_per_block + warp
+        global_warp_num = block_num * warp_num_per_block
+        grid_thread_id = bid * (warp_num_per_block * WAVE) + tid
+
+        window = cco.Window(arena)
+        rsrc_out = create_buffer_resource_from_addr(addr_out)
+        rsrc_xdb_flag = create_buffer_resource_from_addr(addr_xdb_flag)
+
+        # ── Stage A: cross-device barrier — wait until all peers' gemm2 P2P writes
+        # into our comb_inp are globally visible. Per-block private flag counters,
+        # same scheme as make_combine Stage 1: each block owns xdb_flag[bid] (single
+        # writer, no atomic), block 0 pushes this call's flag to every peer's shared
+        # xdb slot, then EVERY block independently polls the local slots for its own
+        # flag. No shared comb_bar => no atomic contention, no reset, no block-0
+        # funnel; the monotonic flag needs no reset. ──
+        phase = fx.Int64(buffer_load(rsrc_xdb_flag, bid, vec_width=1, dtype=T.i64))
+        if grid_thread_id < npes:
+            xdb_remote = fx.Int64(
+                window.lsa_ptr(grid_thread_id, off_xdb_mem)
+            ) + fx.Int64(rank) * fx.Int64(8)
+            P.store_i64_system(xdb_remote, arith.constant(0), phase)
+        # advance this block's private counter for the next call (single writer)
+        if tid == 0:
+            buffer_store(phase + arith.constant(1, type=T.i64), rsrc_xdb_flag, bid)
+        # block 0 fills the unused tail counters [block_num, xdb_flag_slots) so a
+        # later call that picks a larger block_num still reads synced counters.
+        if const_expr(xdb_flag_slots > block_num):
+            if bid == 0:
+                _tail = xdb_flag_slots - block_num
+                _nthr = warp_num_per_block * WAVE
+                for r in range_constexpr((_tail + _nthr - 1) // _nthr):
+                    idx = tid + r * _nthr
+                    if idx < _tail:
+                        buffer_store(
+                            phase + arith.constant(1, type=T.i64),
+                            rsrc_xdb_flag,
+                            block_num + idx,
+                        )
+        # every block independently polls the shared local slots (local reads).
+        # `>=` not `==`: a faster peer can lap us and overwrite its monotonic push
+        # with a higher call count before our late-scheduled blocks read it.
+        if tid < npes:
+            xdb_peer_slot = fx.Int64(
+                window.lsa_ptr(my_lsa_rank, off_xdb_mem)
+            ) + fx.Int64(tid) * fx.Int64(8)
+            P.spin_until_ge_i64(xdb_peer_slot, phase)
+        fx.barrier()
+
+        # ── Stage B: local read of comb_inp[tok*topk + k] + unweighted topk sum ──
+        comb_inp_base = fx.Int64(addr_comb_inp)
+        safe_tok = arith.select(
+            cur_rank_num_token == arith.constant(0),
+            arith.constant(1),
+            cur_rank_num_token,
+        )
+        warps_per_tok = (
+            arith.constant(global_warp_num) + safe_tok - arith.constant(1)
+        ) // safe_tok
+        units_per_warp = (
+            arith.constant(n_i32) + warps_per_tok - arith.constant(1)
+        ) // warps_per_tok
+        stageb_total = cur_rank_num_token * warps_per_tok
+        for stageb_idx in range(global_warp_id, stageb_total, global_warp_num):
+            tok_id = stageb_idx // warps_per_tok
+            part_id = stageb_idx % warps_per_tok
+            unit_base = part_id * units_per_warp
+            slot0 = fx.Int64(tok_id) * fx.Int64(topk)  # comb_inp[tok*topk + 0]
+            expert_addrs = []
+            for k_slot in range_constexpr(topk):
+                expert_addrs.append(
+                    comb_inp_base
+                    + (slot0 + fx.Int64(k_slot)) * fx.Int64(slot_stride)
+                )
+            rem = arith.constant(n_i32) - unit_base
+            eff = arith.select(rem < units_per_warp, rem, units_per_warp)
+            out_base = tok_id * n_i32
+
+            def _one(off):
+                acc = zero_acc()
+                for k_slot in range_constexpr(topk):
+                    v = P.load_i32_nt(expert_addrs[k_slot], off)
+                    acc = acc + to_acc(v)
+                buffer_store(from_acc(acc), rsrc_out, out_base + off)
+
+            # Inner-unrolled vec4: issue _UNROLL x topk v4 loads FIRST (load-first,
+            # high MLP to hide the 6 strided comb_inp streams), then reduce + vec4
+            # store. Mirrors make_combine's load-first scheduling (#484). Tail units
+            # (< STEP_V4) fall back to the scalar _one path.
+            # _UNROLL=1 keeps VGPR low so the grid can fill all CUs (occupancy),
+            # which matters far more than per-wave MLP here: the reduce is HBM-BW
+            # bound, and a big grid (block_num ~= #CUs) is what saturates HBM. A
+            # deep unroll (4) blew VGPR to ~200 and capped occupancy, throttling
+            # load issue (s_clause). Overridable via SCATTER_COMB_UNROLL for tuning.
+            _UNROLL = int(_os.environ.get("SCATTER_COMB_UNROLL", "1"))
+            VEC = 4
+            STEP_CHUNK = WAVE * VEC  # 128 i32 elems/round across the wave
+            STEP_V4 = _UNROLL * STEP_CHUNK  # _UNROLL * 128
+            main_end = (eff // arith.constant(STEP_V4)) * arith.constant(STEP_V4)
+            for u in range(lane * VEC, main_end, STEP_V4):
+                base = unit_base + u
+                _pre = []
+                for _r in range_constexpr(_UNROLL):
+                    _off_r = base + _r * STEP_CHUNK
+                    _pre.append(
+                        [
+                            P.load_v4i32_nt(expert_addrs[k_slot], _off_r)
+                            for k_slot in range_constexpr(topk)
+                        ]
+                    )
+                for _r in range_constexpr(_UNROLL):
+                    _off = base + _r * STEP_CHUNK
+                    if const_expr(hidden_elem_size == 2):
+                        # Preserve all eight packed bf16 values as one vector through
+                        # conversion and accumulation. This avoids scalar extract /
+                        # rebuild moves while retaining f32 accumulation.
+                        _v8bf = T.vec(8, T.bf16)
+                        _v8f = T.vec(8, T.f32)
+                        _vacc = arith.constant_vector(0.0, _v8f)
+                        for k_slot in range_constexpr(topk):
+                            _vacc = _vacc + vector.bitcast(
+                                _v8bf, _pre[_r][k_slot]
+                            ).extf(_v8f)
+                        _res = vector.bitcast(
+                            T.vec(4, T.i32), _vacc.truncf(_v8bf)
+                        )
+                    else:
+                        _accs = [zero_acc(), zero_acc(), zero_acc(), zero_acc()]
+                        for k_slot in range_constexpr(topk):
+                            for _j in range_constexpr(VEC):
+                                _accs[_j] = _accs[_j] + to_acc(
+                                    vector.extract(
+                                        _pre[_r][k_slot], static_position=[_j]
+                                    )
+                                )
+                        _res = vector.from_elements(
+                            T.vec(4, T.i32),
+                            [
+                                from_acc(_accs[0]),
+                                from_acc(_accs[1]),
+                                from_acc(_accs[2]),
+                                from_acc(_accs[3]),
+                            ],
+                        )
+                    buffer_store(_res, rsrc_out, out_base + _off)
+            for u in range(main_end + lane, eff, WAVE):
+                _one(unit_base + u)
+
+        # No exit barrier: the per-block monotonic flag needs no reset, and the
+        # reduce does no post-completion work, so kernel retirement (stream-ordered)
+        # is the only completion signal the host needs. This removes both the former
+        # comb_bar reset (#494) and its (block_num-1)-way contended atomic_add.
+
+    @flyc.jit
+    def run(
+        arena: Int64,
+        addr_comb_inp: Int64,
+        addr_comb_bar: Int64,
+        addr_xdb_flag: Int64,
+        addr_out: Int64,
+        my_lsa_rank: Int32,
+        cur_rank_num_token: Int32,
+        stream=fx.Stream(None),
+    ):
+        ep_combine_fused(
+            arena,
+            addr_comb_inp,
+            addr_comb_bar,
+            addr_xdb_flag,
+            addr_out,
+            my_lsa_rank,
+            cur_rank_num_token,
+        ).launch(
+            grid=(block_num, 1, 1),
+            block=[warp_num_per_block * WAVE, 1, 1],
+            stream=stream,
+        )
+
+    return run
+
+
+# ── StdMoE convert ────────────────────────────────────────────────────────
+
+
+def _to_accum2(i32_scalar):  # i32 (2 bf16) -> v2f32
+    return vector.bitcast(_V2BF16(), vector.from_elements(_V1I32(), [i32_scalar])).extf(
+        _V2F32()
+    )
+
+
+def _from_accum2(v2f32):  # v2f32 -> i32 (2 bf16)
+    return vector.extract(
+        vector.bitcast(_V1I32(), v2f32.truncf(_V2BF16())), static_position=[0]
+    )
+
+
+def _splat2(f32_scalar):  # f32 -> v2f32 (broadcast)
+    return vector.from_elements(_V2F32(), [f32_scalar, f32_scalar])
+
+
+def make_convert_dispatch_output(
+    *,
+    rank,
+    experts_per_rank,
+    experts_per_token,
+    hidden_dim,
+    hidden_elem_size,
+    max_tok_per_expert,
+    block_num,
+    warp_num_per_block,
+):
+    """Per-expert packing of dispatched tokens. One warp per (recv_tok, k_slot):
+    lane0 bumps packed_cnt[localExpert] to claim a slot, warp copies the token
+    embedding into packed_x[slot]."""
+    assert hidden_elem_size == 2, "stdmoe convert is bf16-only"
+    nbytes = hidden_dim * hidden_elem_size
+    n_i32 = nbytes // 4
+
+    @flyc.kernel(known_block_size=[warp_num_per_block * WAVE, 1, 1])
+    def convert_disp(
+        addr_out_tok: Int64,
+        addr_out_idx: Int64,
+        addr_tis: Int64,
+        addr_total_recv: Int64,
+        addr_packed_x: Int64,
+        addr_packed_cnt: Int64,
+        addr_packed_src: Int64,
+        addr_slot_map: Int64,
+    ):
+        tid = fx.thread_idx.x
+        bid = fx.block_idx.x
+        lane = tid & LANE_MASK
+        warp = tid >> LOG2_WAVE
+        global_warp_id = bid * warp_num_per_block + warp
+        global_warp_num = block_num * warp_num_per_block
+
+        rsrc_out_idx = create_buffer_resource_from_addr(addr_out_idx)
+        rsrc_tis = create_buffer_resource_from_addr(addr_tis)
+        rsrc_total_recv = create_buffer_resource_from_addr(addr_total_recv)
+        rsrc_packed_src = create_buffer_resource_from_addr(addr_packed_src)
+
+        total_recv = buffer_load(rsrc_total_recv, 0, vec_width=1, dtype=T.i32)
+        work_limit = total_recv * experts_per_token
+        for i in range(global_warp_id, work_limit, global_warp_num):
+            recv_tok = i // experts_per_token
+            expert = buffer_load(rsrc_out_idx, i, vec_width=1, dtype=T.i32)
+            local_expert = expert - arith.constant(rank * experts_per_rank)
+            # MUST be unsigned ult: signed slt would treat negative local_expert
+            # (non-local experts) as in-range and trigger an OOB copy.
+            is_local = arith.cmpi(
+                arith.CmpIPredicate.ult, local_expert, arith.constant(experts_per_rank)
+            )
+            slot_lane0 = arith.constant(0)
+            if lane == 0:
+                if is_local:
+                    cnt_addr = fx.Int64(addr_packed_cnt) + fx.Int64(
+                        local_expert
+                    ) * fx.Int64(4)
+                    slot_lane0 = P.atomic_add_global(cnt_addr, fx.Int32(1))
+            slot = readlane(T.i32, slot_lane0, 0)
+            safe_local_expert = arith.select(is_local, local_expert, arith.constant(0))
+            packed_lin_idx = (
+                safe_local_expert * arith.constant(max_tok_per_expert) + slot
+            )
+            slot_val = arith.select(
+                is_local, fx.Int64(packed_lin_idx), arith.constant(-1, type=T.i64)
+            )
+            if lane == 0:
+                P.store_i64_system(
+                    fx.Int64(addr_slot_map) + fx.Int64(i) * fx.Int64(8),
+                    arith.constant(0),
+                    slot_val,
+                )
+                if is_local:
+                    src = buffer_load(rsrc_tis, recv_tok, vec_width=1, dtype=T.i32)
+                    buffer_store(src, rsrc_packed_src, packed_lin_idx)
+            if is_local:
+                dst = fx.Int64(addr_packed_x) + fx.Int64(packed_lin_idx) * fx.Int64(
+                    nbytes
+                )
+                src_t = fx.Int64(addr_out_tok) + fx.Int64(recv_tok) * fx.Int64(nbytes)
+                rsrc_dst = create_buffer_resource_from_addr(dst)
+                rsrc_src = create_buffer_resource_from_addr(src_t)
+                for chunk in range(lane * 4, n_i32, _LANE_STRIDE_I32):
+                    v = buffer_load(rsrc_src, chunk, vec_width=4, dtype=T.i32)
+                    buffer_store(v, rsrc_dst, chunk)
+
+    @flyc.jit
+    def run(
+        addr_out_tok: Int64,
+        addr_out_idx: Int64,
+        addr_tis: Int64,
+        addr_total_recv: Int64,
+        addr_packed_x: Int64,
+        addr_packed_cnt: Int64,
+        addr_packed_src: Int64,
+        addr_slot_map: Int64,
+        stream=fx.Stream(None),
+    ):
+        convert_disp(
+            addr_out_tok,
+            addr_out_idx,
+            addr_tis,
+            addr_total_recv,
+            addr_packed_x,
+            addr_packed_cnt,
+            addr_packed_src,
+            addr_slot_map,
+        ).launch(
+            grid=(block_num, 1, 1),
+            block=[warp_num_per_block * WAVE, 1, 1],
+            stream=stream,
+        )
+
+    return run
+
+
+def make_convert_combine_input(
+    *,
+    rank,
+    experts_per_rank,
+    experts_per_token,
+    hidden_dim,
+    hidden_elem_size,
+    max_tok_per_expert,
+    block_num,
+    warp_num_per_block,
+):
+    """Inverse: weighted-reduce each recv token's local-expert outputs back into
+    out_tok. out_tok[recv_t][e] = sum_{k: slot_k valid} wts[k]*packed_x[slot_k][e]."""
+    assert hidden_elem_size == 2, "stdmoe convert is bf16-only"
+    nbytes = hidden_dim * hidden_elem_size
+    n_i32 = nbytes // 4
+
+    @flyc.kernel(known_block_size=[warp_num_per_block * WAVE, 1, 1])
+    def convert_comb(
+        addr_out_tok: Int64,
+        addr_out_wts: Int64,
+        addr_total_recv: Int64,
+        addr_packed_x: Int64,
+        addr_slot_map: Int64,
+    ):
+        tid = fx.thread_idx.x
+        bid = fx.block_idx.x
+        lane = tid & LANE_MASK
+        warp = tid >> LOG2_WAVE
+        global_warp_id = bid * warp_num_per_block + warp
+        global_warp_num = block_num * warp_num_per_block
+
+        rsrc_out_wts = create_buffer_resource_from_addr(addr_out_wts)
+        rsrc_total_recv = create_buffer_resource_from_addr(addr_total_recv)
+
+        total_recv = buffer_load(rsrc_total_recv, 0, vec_width=1, dtype=T.i32)
+        safe_recv = arith.select(
+            total_recv == arith.constant(0), arith.constant(1), total_recv
+        )
+        warps_per_tok = (
+            arith.constant(global_warp_num) + safe_recv - arith.constant(1)
+        ) // safe_recv
+        units_per_warp = (
+            arith.constant(n_i32) + warps_per_tok - arith.constant(1)
+        ) // warps_per_tok
+        stage_total = total_recv * warps_per_tok
+        for stage_idx in range(global_warp_id, stage_total, global_warp_num):
+            recv_tok = stage_idx // warps_per_tok
+            part_id = stage_idx % warps_per_tok
+            unit_base = part_id * units_per_warp
+            slot_map_base = recv_tok * experts_per_token
+            expert_rsrcs = []
+            expert_valids = []
+            expert_weights = []
+            for k_slot in range_constexpr(experts_per_token):
+                slot = P.load_i64_acquire(
+                    fx.Int64(addr_slot_map)
+                    + fx.Int64(slot_map_base + k_slot) * fx.Int64(8)
+                )
+                valid = slot != arith.constant(-1, type=T.i64)
+                safe_slot = arith.select(valid, slot, arith.constant(0, type=T.i64))
+                x_addr = fx.Int64(addr_packed_x) + safe_slot * fx.Int64(nbytes)
+                expert_rsrcs.append(create_buffer_resource_from_addr(x_addr))
+                expert_valids.append(valid)
+                expert_weights.append(
+                    buffer_load(
+                        rsrc_out_wts, slot_map_base + k_slot, vec_width=1, dtype=T.f32
+                    )
+                )
+            rsrc_out = create_buffer_resource_from_addr(
+                fx.Int64(addr_out_tok) + fx.Int64(recv_tok) * fx.Int64(nbytes)
+            )
+            rem = arith.constant(n_i32) - unit_base
+            eff = arith.select(rem < units_per_warp, rem, units_per_warp)
+
+            def _one(off):
+                acc = _to_accum2(arith.constant(0))
+                for k_slot in range_constexpr(experts_per_token):
+                    v = buffer_load(
+                        expert_rsrcs[k_slot], off, vec_width=1, dtype=T.i32
+                    )
+                    weight_val = arith.select(
+                        expert_valids[k_slot],
+                        expert_weights[k_slot],
+                        arith.constant(0.0, type=T.f32),
+                    )
+                    acc = acc + _to_accum2(v) * weight_val  # v2f32 * f32 broadcast
+                buffer_store(_from_accum2(acc), rsrc_out, off)
+
+            def _loop():
+                for u in range(lane, eff, WAVE):
+                    _one(unit_base + u)
+
+            _loop()
+
+    @flyc.jit
+    def run(
+        addr_out_tok: Int64,
+        addr_out_wts: Int64,
+        addr_total_recv: Int64,
+        addr_packed_x: Int64,
+        addr_slot_map: Int64,
+        stream=fx.Stream(None),
+    ):
+        convert_comb(
+            addr_out_tok, addr_out_wts, addr_total_recv, addr_packed_x, addr_slot_map
+        ).launch(
+            grid=(block_num, 1, 1),
+            block=[warp_num_per_block * WAVE, 1, 1],
+            stream=stream,
+        )
+
+    return run
+
+
+# ── local expert count ────────────────────────────────────────────────────
+
+
+def make_local_expert_count(
+    *, rank, experts_per_rank, experts_per_token, block_num, warp_num_per_block
+):
+    expert_base = rank * experts_per_rank
+    block_size = warp_num_per_block * WAVE
+
+    @flyc.kernel(known_block_size=[block_size, 1, 1])
+    def local_expert_count_kernel(
+        addr_out_idx: Int64, addr_total_recv: Int64, addr_count: Int64
+    ):
+        global_thread_id = fx.block_idx.x * block_size + fx.thread_idx.x
+        global_thread_num = block_num * block_size
+        rsrc_out_idx = create_buffer_resource_from_addr(addr_out_idx)
+        rsrc_total_recv = create_buffer_resource_from_addr(addr_total_recv)
+        limit = (
+            buffer_load(rsrc_total_recv, 0, vec_width=1, dtype=T.i32)
+            * experts_per_token
+        )
+        for i in range(global_thread_id, limit, global_thread_num):
+            local_expert = (
+                buffer_load(rsrc_out_idx, i, vec_width=1, dtype=T.i32) - expert_base
+            )
+            if local_expert >= 0:
+                if local_expert < experts_per_rank:
+                    P.atomic_add_global(
+                        fx.Int64(addr_count) + fx.Int64(local_expert) * fx.Int64(4),
+                        fx.Int32(1),
+                    )
+
+    @flyc.jit
+    def run(
+        addr_out_idx: Int64,
+        addr_total_recv: Int64,
+        addr_count: Int64,
+        stream=fx.Stream(None),
+    ):
+        local_expert_count_kernel(addr_out_idx, addr_total_recv, addr_count).launch(
+            grid=(block_num, 1, 1), block=[block_size, 1, 1], stream=stream
+        )
+
+    return run

--- a/aiter/ops/flydsl/dispatch_combine_v2/intranode_kernels_tdm.py
+++ b/aiter/ops/flydsl/dispatch_combine_v2/intranode_kernels_tdm.py
@@ -1,0 +1,709 @@
+# Copyright © Advanced Micro Devices, Inc. All rights reserved.
+#
+# MIT License
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+"""TDM-transported intranode EP dispatch (gfx1250), a FlyDSL port of mori's
+``src/ops/dispatch_combine_v2/ep_intranode_1250x.hpp``.
+
+The sibling ``intranode_kernels.make_dispatch`` gives one whole wave to one
+(token, expert-slot) route: the wave takes a remote atomic for the recv slot,
+then copies the token with 16-byte per-lane stores. That shape is what a machine
+without a DMA engine wants. It is the wrong shape for gfx1250, where the Tensor
+Data Mover moves a whole row on one descriptor: the copy stops needing lanes at
+all, so the per-route remote atomic and the scattered 4-byte metadata stores --
+previously hidden under the payload copy -- become the cost.
+
+So this kernel keeps mori's restructuring rather than bolting TDM onto the
+existing one. Three things change, and they only pay off together:
+
+  * a route is one LANE, not one wave (``WAVE / topk`` tokens per wave), so a
+    wave sees all of a token's routes at once and can dedup same-peer routes
+    against each other with a permute instead of a ballot per route;
+  * the recv slots for a whole BLOCK are reserved with one remote atomic per
+    (block, peer) instead of one per route, off an LDS histogram;
+  * idx / weights / srcmap are gathered into a block-local, destination-ordered
+    staging array first, so the cross-GPU metadata write is a handful of bulk
+    TDM runs instead of thousands of scattered dwords.
+
+Everything downstream (``tok_map`` encoding, the grid barrier, the per-peer
+count signal, the self-resetting counters) is bit-compatible with
+``make_dispatch``, so combine, replay and the op layer are unchanged.
+
+Not ported: scales, fp4, push-group and replay. They are orthogonal to the
+transport and each one needs its own staging region; ``make_dispatch`` still
+owns those paths.
+"""
+import flydsl.compiler as flyc
+import flydsl.expr as fx
+from flydsl.expr import arith, const_expr, range_constexpr
+from aiter.ops.flydsl.kernels.buffer_ops import (
+    buffer_load,
+    buffer_store,
+    create_buffer_resource_from_addr,
+)
+from flydsl.expr.rocdl import ballot, ds_bpermute, readfirstlane, readlane
+from flydsl.expr.typing import Int32, Int64, T
+
+import mori.cco.device.flydsl as cco
+from . import flydsl_prims as P
+from . import tdm_prims as TDM
+from .intranode_kernels import LANE_MASK, LOG2_WAVE, WAVE, _BALLOT_INT
+
+#: gfx1250 LDS per workgroup. The payload tiles are the whole budget.
+_LDS_BUDGET = 327680
+
+
+def _align(v, a):
+    return (v + a - 1) // a * a
+
+
+def tdm_tokens_per_wave(experts_per_token):
+    """Tokens one wave covers per iteration: enough lanes for a token's routes.
+
+    ``WAVE / topk`` when the routes tile the wave exactly, so COUNT reads
+    ``topk`` consecutive indices per token with every lane busy. Otherwise one
+    token per wave with the tail lanes idle -- correct, just wider.
+    """
+    topk = experts_per_token
+    return WAVE // topk if (0 < topk <= WAVE and WAVE % topk == 0) else 1
+
+
+def tdm_stage_capacity(
+    *, npes, experts_per_token, max_tok_per_rank, block_num, warp_num_per_block
+):
+    """(per-(block,peer) slot capacity, total staging slots).
+
+    A block's routes to one peer cannot outnumber the tokens the block itself
+    walked, and the token loop is grid-strided, so the bound is the number of
+    whole rounds the block takes times what it covers in a round. Staging is
+    indexed ``((block * npes) + peer) * cap + j`` -- contiguous per (block, peer)
+    is what lets the metadata leave as bulk runs.
+
+    Still an upper bound under the kernel's runtime quota ``etpi <= tpi``: the
+    quota only drops below ``tpi`` when ``warps_total * etpi`` already covers the
+    token count, which is one round of ``warp_num_per_block * etpi`` per block,
+    and ``rounds`` is floored at 1 so ``cap`` is never under
+    ``warp_num_per_block * tpi``.
+    """
+    tpi = tdm_tokens_per_wave(experts_per_token)
+    per_round_grid = block_num * warp_num_per_block * tpi
+    rounds = (max_tok_per_rank + per_round_grid - 1) // per_round_grid
+    cap = warp_num_per_block * tpi * max(rounds, 1)
+    return cap, block_num * npes * cap
+
+
+def tdm_lds_bytes(*, hidden_dim, hidden_elem_size, warp_num_per_block, npes):
+    """LDS the kernel asks for: one payload tile per warp, plus the counters."""
+    tile = _align(hidden_dim * hidden_elem_size, 128)
+    return warp_num_per_block * tile + _align(3 * npes * 4, 128)
+
+
+def tdm_max_warps(*, hidden_dim, hidden_elem_size, npes):
+    """Widest power-of-two warp count whose payload tiles fit the LDS budget.
+
+    The vector transport holds no per-warp LDS, so a geometry tuned against it
+    can name a warp count this one cannot honour: a 7168-wide bf16 tile is 14 KB
+    and 32 of them want 448 KB against a 320 KB budget. A caller clamping to this
+    keeps the tuned block count -- which is what paces the grid barrier -- and
+    gives up only the warp width.
+    """
+    tile = _align(hidden_dim * hidden_elem_size, 128)
+    room = (_LDS_BUDGET - _align(3 * npes * 4, 128)) // tile
+    if room < 1:
+        raise ValueError(
+            f"a single {tile}B payload tile (hidden_dim={hidden_dim}, "
+            f"{hidden_elem_size}B elements) does not fit the {_LDS_BUDGET}B LDS "
+            f"budget; dispatch_transport='tdm' cannot serve this hidden size"
+        )
+    warps = 1
+    while warps * 2 <= room:
+        warps *= 2
+    return warps
+
+
+def make_dispatch_tdm(
+    *,
+    rank,
+    npes,
+    experts_per_rank,
+    experts_per_token,
+    hidden_dim,
+    hidden_elem_size,
+    max_tok_per_rank,
+    max_recv,
+    block_num,
+    warp_num_per_block,
+    off_tok_off,
+    off_recv_num,
+    off_tis,
+    off_out_idx,
+    off_out_wts,
+    off_out_tok,
+    enable_signal=True,
+    meta_tdm=True,
+):
+    """Build the TDM dispatch kernel. Returns a ``@flyc.jit`` launcher.
+
+    Arguments mirror :func:`intranode_kernels.make_dispatch` so the op layer can
+    forward the same kwargs, minus the scales / fp4 / push-group / replay knobs
+    this transport does not implement. ``meta_tdm=False`` routes the metadata
+    through per-lane stores instead of the TDM engine -- same result, and the
+    A/B that says whether the bulk path is worth its LDS.
+    """
+    if WAVE != 32:
+        raise ValueError(
+            f"TDM dispatch is gfx1250-only (wave32); wave size resolved to {WAVE}"
+        )
+    topk = experts_per_token
+    nbytes = hidden_dim * hidden_elem_size
+    if nbytes % 4:
+        raise ValueError(f"token payload must be a whole number of dwords, got {nbytes}B")
+    if topk > WAVE:
+        raise ValueError(f"topk={topk} exceeds the wave size; a token's routes must fit one wave")
+
+    tpi = tdm_tokens_per_wave(topk)
+    warps_total = block_num * warp_num_per_block
+    block_threads = warp_num_per_block * WAVE
+    cap_blk, _stage_slots = tdm_stage_capacity(
+        npes=npes,
+        experts_per_token=topk,
+        max_tok_per_rank=max_tok_per_rank,
+        block_num=block_num,
+        warp_num_per_block=warp_num_per_block,
+    )
+    sentinel_val = npes * max_recv
+
+    tile_bytes = _align(nbytes, 128)
+    ctl_bytes = _align(3 * npes * 4, 128)
+    lds_bytes = warp_num_per_block * tile_bytes + ctl_bytes
+    if lds_bytes > _LDS_BUDGET:
+        raise ValueError(
+            f"TDM dispatch needs {lds_bytes}B of LDS ({warp_num_per_block} warps x "
+            f"{tile_bytes}B payload tile) over the {_LDS_BUDGET}B budget; lower "
+            f"warp_num_per_block"
+        )
+
+    # A metadata batch reuses the warp's payload tile: idx, weights and srcmap
+    # for `meta_chunk` destination-ordered tokens, each region 128B-aligned so
+    # every TDM row is a full 128 bytes. Chunks are a whole number of rows, so
+    # the shapes are compile-time; the ragged remainder falls back to stores.
+    # A chunk needs a legal tile for BOTH its `chunk*topk` index/weight run and
+    # its much shorter `chunk` srcmap run, and the srcmap is what binds: it needs
+    # chunk >= 64 before any dim1 >= 2 leaves a 32-element row. Chunks that only
+    # the srcmap rejects would otherwise silently take a 1xN descriptor.
+    meta_per_tok = topk * 4 * 2 + 4
+    meta_cap = (tile_bytes - 3 * 128) // meta_per_tok
+    meta_chunk = 0
+    meta_idx_shape = meta_src_shape = None
+    for cand in (128, 64):
+        if cand > meta_cap:
+            continue
+        idx_shape = TDM.tdm_run_shape(cand * topk)
+        src_shape = TDM.tdm_run_shape(cand)
+        if idx_shape and src_shape:
+            meta_chunk, meta_idx_shape, meta_src_shape = cand, idx_shape, src_shape
+            break
+    use_meta_tdm = bool(meta_tdm) and meta_chunk > 0
+    m_idx_off = 0
+    m_wt_off = _align(meta_chunk * topk * 4, 128)
+    m_src_off = m_wt_off + _align(meta_chunk * topk * 4, 128)
+
+    # One warp per peer would leave every warp past the world size idle, so the
+    # peers are split across the warps that exist. mori measured the split to be
+    # a loss at small batches (the sub-runs get shorter than a TDM row), where
+    # the metadata is short enough for one warp per peer to hide anyway.
+    peer_split = max(1, warp_num_per_block // npes) if npes else 1
+    meta_runs = npes * peer_split
+
+    @flyc.kernel(known_block_size=[block_threads, 1, 1])
+    def ep_dispatch_tdm(
+        arena: Int64,
+        addr_inp_tok: Int64,
+        addr_inp_idx: Int64,
+        addr_inp_wts: Int64,
+        addr_tok_map: Int64,
+        addr_dest_pe_ctr: Int64,
+        addr_disp_bar: Int64,
+        addr_total_recv: Int64,
+        addr_stg_idx: Int64,
+        addr_stg_wt: Int64,
+        addr_stg_src: Int64,
+        my_lsa_rank: Int32,
+        inp_cur_tok: Int32,
+    ):
+        tid = fx.thread_idx.x
+        bid = fx.block_idx.x
+        lane = tid & LANE_MASK
+        warp = tid >> LOG2_WAVE
+        global_warp_id = bid * warp_num_per_block + warp
+        window = cco.Window(arena)
+
+        rsrc_inp_idx = create_buffer_resource_from_addr(addr_inp_idx)
+        rsrc_inp_wts = create_buffer_resource_from_addr(addr_inp_wts)
+        rsrc_tok_map = create_buffer_resource_from_addr(addr_tok_map)
+        rsrc_dest_ctr = create_buffer_resource_from_addr(addr_dest_pe_ctr)
+        rsrc_disp_bar = create_buffer_resource_from_addr(addr_disp_bar)
+        rsrc_stg_idx = create_buffer_resource_from_addr(addr_stg_idx)
+        rsrc_stg_wt = create_buffer_resource_from_addr(addr_stg_wt)
+        rsrc_stg_src = create_buffer_resource_from_addr(addr_stg_src)
+
+        # LDS: `warp_num_per_block` payload tiles, then the three per-peer
+        # counters (committed count / reserved remote base / handout cursor).
+        smem = fx.SharedAllocator(static=False)
+        tile_ptr = smem.allocate(warp_num_per_block * tile_bytes, 128)._ptr
+        ctl_ptr = smem.allocate(ctl_bytes, 128)._ptr
+        tile_base_i32 = arith.index_cast(T.i32, fx.index_cast(T.index, fx.ptrtoint(tile_ptr)))
+        my_tile = arith.addi(
+            tile_base_i32,
+            arith.muli(
+                readfirstlane(T.i32, warp), arith.constant(tile_bytes, type=T.i32)
+            ),
+        )
+        ctl = fx.Int64(fx.ptrtoint(ctl_ptr))
+
+        def s_n(p):
+            return ctl + fx.Int64(p) * fx.Int64(4)
+
+        def s_base(p):
+            return ctl + (fx.Int64(p) + fx.Int64(npes)) * fx.Int64(4)
+
+        def s_run(p):
+            return ctl + (fx.Int64(p) + fx.Int64(2 * npes)) * fx.Int64(4)
+
+        # Tokens a warp takes per iteration. A fixed quota of `tpi` only fills the
+        # grid once there are `warps_total * tpi` tokens to go round: below that
+        # every token lands on a low warp id, which is block-major, so most of the
+        # grid sends no payload at all and the kernel costs the same at 8 tokens
+        # as at 512. Capping the quota at what it takes to cover the grid spreads
+        # them. COUNT gives up its full-warp index burst when the cap bites, which
+        # is the cheaper half of that trade.
+        #
+        # The clamp to 1 is load-bearing: `ceil(n / warps_total)` is 0 for n == 0,
+        # and a token loop stepping by `warps_total * 0` never advances -- a hang
+        # no correctness check can report, because the check hangs with it.
+        if const_expr(tpi > 1):
+            q_tok = (inp_cur_tok + (warps_total - 1)) // warps_total
+            etpi = arith.select(
+                q_tok < 1,
+                fx.Int32(1),
+                arith.select(q_tok < tpi, q_tok, fx.Int32(tpi)),
+            )
+        else:
+            etpi = fx.Int32(1)
+
+        # Lane -> (which of the wave's tokens, which of that token's routes). The
+        # grouping follows `etpi`, not `tpi`: left on `tpi` the surplus lanes
+        # would keep routing tokens the loops below hand to another warp.
+        if const_expr(tpi > 1):
+            s_lane = lane // topk
+            e_lane = lane - s_lane * topk
+        else:
+            s_lane = fx.Int32(0)
+            e_lane = lane
+        lane_act = (s_lane < etpi) & (e_lane < topk)
+
+        if tid < npes:
+            P.store_i32_lds(s_n(tid), arith.constant(0))
+            P.store_i32_lds(s_run(tid), arith.constant(0))
+        fx.barrier()
+
+        # Route resolution, shared by COUNT and FINALIZE. No dynamic `if`: it
+        # runs under both phases' loops and selects rather than branches, so
+        # inactive lanes stay in bounds instead of being masked off.
+        def resolve(tok_base):
+            tok = tok_base + s_lane
+            act = lane_act & (tok < inp_cur_tok)
+            tok_s = arith.select(tok < inp_cur_tok, tok, inp_cur_tok - 1)
+            e_s = arith.select(lane_act, e_lane, 0)
+            slot_off = tok_s * topk + e_s
+            expert = buffer_load(rsrc_inp_idx, slot_off, vec_width=1, dtype=T.i32)
+            dest_pe = expert // experts_per_rank
+            valid = act & (expert >= 0) & (dest_pe < npes)
+            # Dedup: a token routed to several experts on one peer is sent once.
+            # The token's routes are `topk` adjacent lanes of this wave, so the
+            # duplicate test is a permute per route slot -- lane (s_lane, e)'s
+            # dest PE against mine -- and the lowest such lane wins.
+            valid_i = arith.select(valid, fx.Int32(1), fx.Int32(0))
+            keep = valid
+            for e in range_constexpr(topk):
+                probe = (s_lane * topk + e) * 4
+                other_pe = ds_bpermute(T.i32, probe, dest_pe)
+                other_ok = ds_bpermute(T.i32, probe, valid_i)
+                dup = (e < e_lane) & (other_ok != 0) & (other_pe == dest_pe)
+                keep = keep & ~dup
+            # slot_off rather than the weight itself: COUNT has no use for the
+            # weight, and the op permits a null weight pointer as long as nothing
+            # is published, so the load belongs in FINALIZE.
+            return tok, act, expert, slot_off, dest_pe, keep
+
+        # ── COUNT: block-local histogram of routes per destination peer ──
+        for tok_base in range(global_warp_id * etpi, inp_cur_tok, warps_total * etpi):
+            _tok, _act, _expert, _off, dest_pe, keep = resolve(tok_base)
+            if keep:
+                P.atomic_add_lds(s_n(dest_pe), arith.constant(1))
+        fx.barrier()
+
+        # ── RESERVE: one remote atomic per (block, peer), not per route ──
+        if tid < npes:
+            n = P.load_i32_lds(s_n(tid))
+            base = arith.constant(0)
+            if n > 0:
+                base = P.atomic_add_global(
+                    fx.Int64(window.lsa_ptr(tid, off_tok_off)), n
+                )
+                P.atomic_add_global(
+                    fx.Int64(addr_dest_pe_ctr) + fx.Int64(tid) * fx.Int64(4), n
+                )
+            P.store_i32_lds(s_base(tid), base)
+        fx.barrier()
+
+        # ── FINALIZE: hand out the reserved slots and gather the metadata ──
+        # The slot order within a block's run is whatever the LDS cursor hands
+        # out; only its contiguity matters, since the metadata is staged in that
+        # same order and shipped as one run.
+        for tok_base in range(global_warp_id * etpi, inp_cur_tok, warps_total * etpi):
+            tok, act, expert, slot_off, dest_pe, keep = resolve(tok_base)
+            wt = buffer_load(rsrc_inp_wts, slot_off, vec_width=1, dtype=T.f32)
+            j = arith.constant(0)
+            if keep:
+                j = P.atomic_add_lds(s_run(dest_pe), arith.constant(1))
+            base = arith.constant(0)
+            if keep:
+                base = P.load_i32_lds(s_base(dest_pe))
+            dest_tok = base + j
+            # `j >= cap_blk` cannot happen for a block that walked at most
+            # cap_blk tokens; `dest_tok >= max_recv` can, when the peer is over
+            # its configured recv cap. Both drop the route rather than write out
+            # of bounds, matching make_dispatch's overflow behaviour.
+            pub = keep & (j < cap_blk) & (dest_tok < max_recv)
+            if act:
+                buffer_store(
+                    arith.select(pub, dest_pe * max_recv + dest_tok, sentinel_val),
+                    rsrc_tok_map,
+                    tok * topk + e_lane,
+                )
+            slot = (bid * npes + dest_pe) * cap_blk + j
+            src_encoded = rank * max_tok_per_rank + tok
+            # Stage the metadata destination-ordered. Every lane of the token's
+            # group writes element `e_lane` of the published lane's slot, so a
+            # route's `topk` indices leave as one contiguous 32-byte run and a
+            # token routed to several peers is staged once per peer.
+            pub_i = arith.select(pub, fx.Int32(1), fx.Int32(0))
+            for e in range_constexpr(topk):
+                probe = (s_lane * topk + e) * 4
+                pub_e = ds_bpermute(T.i32, probe, pub_i)
+                slot_e = ds_bpermute(T.i32, probe, slot)
+                if lane_act & (pub_e != 0):
+                    buffer_store(expert, rsrc_stg_idx, slot_e * topk + e_lane)
+                    buffer_store(
+                        arith.bitcast(T.i32, wt), rsrc_stg_wt, slot_e * topk + e_lane
+                    )
+                    if e_lane == 0:
+                        buffer_store(src_encoded, rsrc_stg_src, slot_e)
+
+        # tok_map is written here and re-read by the payload phase, and the
+        # staging arrays are written here and read by the metadata phase; both
+        # go through global memory, so the stores have to land before either.
+        P.waitcnt_stores()
+        fx.barrier()
+
+        # ── META: the staged runs leave as bulk cross-GPU writes ──
+        for run_id in range(warp, meta_runs, warp_num_per_block):
+            peer = run_id // peer_split
+            part = run_id - peer * peer_split
+            cnt_all = P.load_i32_lds(s_n(peer))
+            base_all = P.load_i32_lds(s_base(peer))
+            # Split the peer's run across `peer_split` warps, remainder to the
+            # low parts so the sub-runs differ by at most one token.
+            q = cnt_all // peer_split
+            rem = cnt_all - q * peer_split
+            my_beg = part * q + arith.select(part < rem, part, rem)
+            my_cnt = q + arith.select(part < rem, fx.Int32(1), fx.Int32(0))
+            peer_idx = create_buffer_resource_from_addr(
+                fx.Int64(window.lsa_ptr(peer, off_out_idx))
+            )
+            peer_wts = create_buffer_resource_from_addr(
+                fx.Int64(window.lsa_ptr(peer, off_out_wts))
+            )
+            peer_tis = create_buffer_resource_from_addr(
+                fx.Int64(window.lsa_ptr(peer, off_tis))
+            )
+            stg_beg = (bid * npes + peer) * cap_blk + my_beg
+            step = meta_chunk if use_meta_tdm else 1
+            for cs in range(0, my_cnt, step):
+                left = my_cnt - cs
+                dst = base_all + my_beg + cs
+                src = stg_beg + cs
+                if const_expr(use_meta_tdm):
+                    if left >= meta_chunk:
+                        g_idx = TDM.tdm_group1(*meta_idx_shape, 4)
+                        g_src = TDM.tdm_group1(*meta_src_shape, 4)
+                        l_idx = arith.addi(my_tile, arith.constant(m_idx_off, type=T.i32))
+                        l_wt = arith.addi(my_tile, arith.constant(m_wt_off, type=T.i32))
+                        l_src = arith.addi(my_tile, arith.constant(m_src_off, type=T.i32))
+                        TDM.tdm_load(
+                            TDM.tdm_group0(
+                                l_idx,
+                                fx.Int64(addr_stg_idx)
+                                + fx.Int64(src) * fx.Int64(topk * 4),
+                            ),
+                            g_idx,
+                        )
+                        TDM.tdm_load(
+                            TDM.tdm_group0(
+                                l_wt,
+                                fx.Int64(addr_stg_wt)
+                                + fx.Int64(src) * fx.Int64(topk * 4),
+                            ),
+                            g_idx,
+                        )
+                        TDM.tdm_load(
+                            TDM.tdm_group0(
+                                l_src,
+                                fx.Int64(addr_stg_src) + fx.Int64(src) * fx.Int64(4),
+                            ),
+                            g_src,
+                        )
+                        TDM.tdm_wait(0)
+                        TDM.tdm_store(
+                            TDM.tdm_group0(
+                                l_idx,
+                                fx.Int64(window.lsa_ptr(peer, off_out_idx))
+                                + fx.Int64(dst) * fx.Int64(topk * 4),
+                            ),
+                            g_idx,
+                        )
+                        TDM.tdm_store(
+                            TDM.tdm_group0(
+                                l_wt,
+                                fx.Int64(window.lsa_ptr(peer, off_out_wts))
+                                + fx.Int64(dst) * fx.Int64(topk * 4),
+                            ),
+                            g_idx,
+                        )
+                        TDM.tdm_store(
+                            TDM.tdm_group0(
+                                l_src,
+                                fx.Int64(window.lsa_ptr(peer, off_tis))
+                                + fx.Int64(dst) * fx.Int64(4),
+                            ),
+                            g_src,
+                        )
+                        TDM.tdm_wait(0)
+                    else:
+                        # Ragged tail: fewer tokens than a whole TDM tile.
+                        for i in range(lane, left * topk, WAVE):
+                            buffer_store(
+                                buffer_load(
+                                    rsrc_stg_idx, src * topk + i, vec_width=1, dtype=T.i32
+                                ),
+                                peer_idx,
+                                dst * topk + i,
+                            )
+                            buffer_store(
+                                buffer_load(
+                                    rsrc_stg_wt, src * topk + i, vec_width=1, dtype=T.i32
+                                ),
+                                peer_wts,
+                                dst * topk + i,
+                            )
+                        for i in range(lane, left, WAVE):
+                            buffer_store(
+                                buffer_load(
+                                    rsrc_stg_src, src + i, vec_width=1, dtype=T.i32
+                                ),
+                                peer_tis,
+                                dst + i,
+                            )
+                else:
+                    for i in range(lane, topk, WAVE):
+                        buffer_store(
+                            buffer_load(
+                                rsrc_stg_idx, src * topk + i, vec_width=1, dtype=T.i32
+                            ),
+                            peer_idx,
+                            dst * topk + i,
+                        )
+                        buffer_store(
+                            buffer_load(
+                                rsrc_stg_wt, src * topk + i, vec_width=1, dtype=T.i32
+                            ),
+                            peer_wts,
+                            dst * topk + i,
+                        )
+                    if lane == 0:
+                        buffer_store(
+                            buffer_load(rsrc_stg_src, src, vec_width=1, dtype=T.i32),
+                            peer_tis,
+                            dst,
+                        )
+
+        # ── PAYLOAD: one TDM load per token, one TDM store per surviving route ──
+        # No barrier before this. The tile a warp is about to overwrite is the
+        # one it just drained itself; the cross-warp state (staging, s_base) was
+        # published by the barrier after FINALIZE.
+        #
+        # The token partition has to be FINALIZE's, walked one token at a time.
+        # tok_map goes through global memory but the only barrier between the two
+        # phases is a workgroup one, so a warp may read back nothing but the
+        # entries it wrote itself. A grid-strided `range(global_warp_id, ...)`
+        # reads slots other BLOCKS own: at 512 tokens on a 64x8 grid it is warps
+        # 0..127 (blocks 0..15) that route, and every one of the remaining 48
+        # blocks would send payload off entries still holding the host's -1 fill.
+        # -1 passes a `< sentinel` liveness test and decodes to dest_pe 0,
+        # dest_tok -1, i.e. a TDM store one whole token BEFORE a peer's recv
+        # buffer -- an out-of-bounds fabric write, which is what wedges the
+        # engine rather than merely corrupting the result.
+        #
+        # `sub` is a runtime loop and not `range_constexpr` on purpose: the route
+        # loop below already unrolls `topk` descriptor sites, and unrolling this
+        # one too would multiply them by `tpi`.
+        g_payload = TDM.tdm_group1(hidden_dim, 1, hidden_elem_size)
+        probe_off = arith.select(lane < topk, lane, 0)
+        for tok_base in range(global_warp_id * etpi, inp_cur_tok, warps_total * etpi):
+            for sub in range(0, etpi):
+                tok = tok_base + sub
+                if tok < inp_cur_tok:
+                    flat = buffer_load(
+                        rsrc_tok_map, tok * topk + probe_off, vec_width=1, dtype=T.i32
+                    )
+                    # `flat >= 0` rejects the host's -1 fill as well as the
+                    # sentinel, so a slot FINALIZE never published can never name
+                    # a route.
+                    live = (lane < topk) & (flat >= 0) & (flat < sentinel_val)
+                    if ballot(_BALLOT_INT(), live) != 0:
+                        TDM.tdm_load(
+                            TDM.tdm_group0(
+                                my_tile,
+                                fx.Int64(addr_inp_tok)
+                                + fx.Int64(tok) * fx.Int64(nbytes),
+                            ),
+                            g_payload,
+                        )
+                        TDM.tdm_wait(0)
+                        live_i = arith.select(live, fx.Int32(1), fx.Int32(0))
+                        for l in range_constexpr(topk):
+                            live_l = readlane(T.i32, live_i, l)
+                            flat_l = readlane(T.i32, flat, l)
+                            if live_l != 0:
+                                dest_pe = flat_l // max_recv
+                                dest_tok = flat_l - dest_pe * max_recv
+                                TDM.tdm_store(
+                                    TDM.tdm_group0(
+                                        my_tile,
+                                        fx.Int64(window.lsa_ptr(dest_pe, off_out_tok))
+                                        + fx.Int64(dest_tok) * fx.Int64(nbytes),
+                                    ),
+                                    g_payload,
+                                )
+                        # The next token reloads into this same tile.
+                        TDM.tdm_wait(0)
+
+        if const_expr(enable_signal):
+            # Identical to make_dispatch's completion, so the two kernels are
+            # interchangeable from combine's point of view.
+            if global_warp_id == 0:
+                if lane == 0:
+                    buffer_store(
+                        arith.constant(0),
+                        create_buffer_resource_from_addr(addr_total_recv),
+                        0,
+                    )
+
+            # TDM stores retire on the tensor counter, which storecnt does not
+            # track, so the grid barrier needs both drains to cover the payload
+            # and the plain stores.
+            TDM.tdm_wait(0)
+            P.waitcnt_stores()
+            fx.barrier()
+            if tid == 0:
+                P.atomic_add_global(fx.Int64(addr_disp_bar), arith.constant(1))
+
+            local_recv_num = fx.Int64(window.lsa_ptr(my_lsa_rank, off_recv_num))
+            for dest_pe in range(lane, npes, WAVE):
+                if global_warp_id == 0:
+                    P.spin_until_eq_i32(fx.Int64(addr_disp_bar), block_num)
+                    buffer_store(arith.constant(0), rsrc_disp_bar, 0)
+                    signal_value = (
+                        buffer_load(rsrc_dest_ctr, dest_pe, vec_width=1, dtype=T.i32) + 1
+                    )
+                    peer_recv_num = fx.Int64(window.lsa_ptr(dest_pe, off_recv_num))
+                    recv_num_remote_addr = peer_recv_num + fx.Int64(rank) * fx.Int64(4)
+                    P.spin_until_eq_i32(recv_num_remote_addr, 0)
+                    P.store_i32_system(
+                        recv_num_remote_addr, arith.constant(0), signal_value
+                    )
+
+            for src_pe in range(lane, npes, WAVE):
+                if global_warp_id == 0:
+                    recv_num_src_addr = local_recv_num + fx.Int64(src_pe) * fx.Int64(4)
+                    signal_value = P.spin_until_gt_i32(recv_num_src_addr, 0)
+                    peer_recv_count = signal_value - 1
+                    P.store_i32_system(
+                        recv_num_src_addr, arith.constant(0), arith.constant(0)
+                    )
+                    P.atomic_add_global(fx.Int64(addr_total_recv), peer_recv_count)
+                    buffer_store(arith.constant(0), rsrc_dest_ctr, src_pe)
+
+            if global_warp_id == 0:
+                if lane == 0:
+                    local_tok_off = fx.Int64(window.lsa_ptr(my_lsa_rank, off_tok_off))
+                    P.store_i32_system(
+                        local_tok_off, arith.constant(0), arith.constant(0)
+                    )
+
+    @flyc.jit
+    def run(
+        arena: Int64,
+        addr_inp_tok: Int64,
+        addr_inp_idx: Int64,
+        addr_inp_wts: Int64,
+        addr_tok_map: Int64,
+        addr_dest_pe_ctr: Int64,
+        addr_disp_bar: Int64,
+        addr_total_recv: Int64,
+        addr_stg_idx: Int64,
+        addr_stg_wt: Int64,
+        addr_stg_src: Int64,
+        my_lsa_rank: Int32,
+        inp_cur_tok: Int32,
+        stream=fx.Stream(None),
+    ):
+        ep_dispatch_tdm(
+            arena,
+            addr_inp_tok,
+            addr_inp_idx,
+            addr_inp_wts,
+            addr_tok_map,
+            addr_dest_pe_ctr,
+            addr_disp_bar,
+            addr_total_recv,
+            addr_stg_idx,
+            addr_stg_wt,
+            addr_stg_src,
+            my_lsa_rank,
+            inp_cur_tok,
+        ).launch(
+            grid=(block_num, 1, 1),
+            block=[block_threads, 1, 1],
+            stream=stream,
+        )
+
+    return run

--- a/aiter/ops/flydsl/dispatch_combine_v2/tdm_prims.py
+++ b/aiter/ops/flydsl/dispatch_combine_v2/tdm_prims.py
@@ -1,0 +1,186 @@
+# Copyright © Advanced Micro Devices, Inc. All rights reserved.
+#
+# MIT License
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+"""gfx1250 TDM (Tensor Data Mover) descriptors over RAW 64-bit addresses.
+
+``flydsl.expr.rocdl.tdm_ops.make_tensor_descriptor_2d`` derives the descriptor's
+global base from a fly memref/tensor. The EP dispatch path cannot use it: the
+destination of a payload move is a *peer's* copy of a symmetric region, i.e. the
+integer ``cco.Window(h).lsa_ptr(pe, off)``, which is a runtime value and not a
+kernel tensor argument. So GROUP0 is packed here by hand from an i64 address and
+an LDS byte address, and GROUP1 from the compile-time tile geometry.
+
+The bit layout is copied from ``make_tensor_descriptor_2d`` and must track it:
+
+  GROUP0 (vector<4xi32>)   lane0 pred | lane1 lds byte addr | lane2/3 global lo/hi
+                           (lane3 bit31 = descriptor type field)
+  GROUP1 (vector<8xi32>)   s0 data_size[17:16] and the pad/mcast bits we leave 0
+                           s1 tensor_dim0[15:0] << 16
+                           s2 tensor_dim0[31:16] | tensor_dim1[15:0] << 16
+                           s3 tensor_dim1[31:16] | tile_dim0 << 16
+                           s4 tile_dim1[15:0]
+                           s5 tensor_dim0_stride[31:0]
+                           s6 tensor_dim0_stride[47:32] | tensor_dim1_stride[15:0] << 16
+                           s7 tensor_dim1_stride[31:16]
+
+dim0 is the innermost (contiguous) extent and dim1 the number of rows, matching
+the ISA convention -- note ``s5`` is called ``tensor_dim0_stride`` in the ISA but
+is the stride *between rows*, i.e. flydsl's ``outer_stride``.
+
+``tensor_dim1_stride`` is set to ``dim1``, which is what every one of mori's
+three descriptor builders does (``TdmShape`` 1 for its 1 x hiddenDim payload,
+``TdmShape2D`` dim1, ``TdmShapeGather`` nRows). flydsl's
+``make_tensor_descriptor_2d`` instead leaves s6/s7 zero as "no higher-dim
+strides"; that holds for its own tiles, which are always dim1 >= 2, but a
+``dim1 == 1`` descriptor with a zero dim1 stride hangs the TDM engine. mori's
+own note on the subject is that "gfx1250 has no 1xN wedge, while the payload has
+always sent 1 x hiddenDim" -- the reconciliation is this field.
+
+Setting tensor_dim == tile_dim is flydsl's "OOB checking off" encoding: the
+caller guarantees the run is in bounds. This module never enables padding, the
+atomic barrier, or multicast; all three change the transfer protocol and none
+are wanted for a point-to-point copy.
+"""
+import math
+
+from flydsl._mlir import ir
+from flydsl.expr import arith
+from . import vector
+from flydsl.expr.rocdl import readfirstlane, tdm_ops
+from flydsl.expr.typing import T
+
+#: Widest ISA dim/tile field. Both extents and the row stride are 16-bit in the
+#: parts of GROUP1 a 2D descriptor actually uses.
+TDM_MAX_DIM = 0xFFFF
+
+#: A TDM row narrower than this moves at a fraction of peak: the engine issues
+#: one descriptor-driven burst per row, so short rows pay the per-row overhead
+#: on every one of them. It is a bandwidth floor, not a legality bound -- a
+#: 1-row / sub-128B transfer is well-formed and lands correctly.
+TDM_ROW_FLOOR_BYTES = 128
+
+
+def _i32(v):
+    """i32 constant from a bit pattern that may set bit 31 (arith wants signed)."""
+    v &= 0xFFFFFFFF
+    if v >= 1 << 31:
+        v -= 1 << 32
+    return arith.constant(v, type=T.i32)
+
+
+def tdm_group1(dim0, dim1, elem_bytes, stride=None):
+    """GROUP1 for a ``dim1`` x ``dim0`` tile of ``elem_bytes`` elements.
+
+    ``dim0`` is the contiguous extent of one row and ``stride`` (default
+    ``dim0``, i.e. a dense run) the element distance between rows. All three are
+    compile-time, so the whole descriptor folds to eight SGPR constants.
+    """
+    if elem_bytes not in (1, 2, 4, 8):
+        raise ValueError(f"TDM data_size encodes 1/2/4/8-byte elements, got {elem_bytes}")
+    if not (1 <= dim0 <= TDM_MAX_DIM and 1 <= dim1 <= TDM_MAX_DIM):
+        raise ValueError(f"TDM tile dims must be in [1, {TDM_MAX_DIM}], got {dim1}x{dim0}")
+    if stride is None:
+        stride = dim0
+    ds = int(math.log2(elem_bytes))
+    return vector.from_elements(
+        T.vec(8, T.i32),
+        [
+            _i32(ds << 16),
+            _i32((dim0 & 0xFFFF) << 16),
+            _i32(((dim0 >> 16) & 0xFFFF) | ((dim1 & 0xFFFF) << 16)),
+            _i32(((dim1 >> 16) & 0xFFFF) | ((dim0 & 0xFFFF) << 16)),
+            _i32(dim1 & 0xFFFF),
+            _i32(stride & 0xFFFFFFFF),
+            _i32(((stride >> 32) & 0xFFFF) | ((dim1 & 0xFFFF) << 16)),
+            _i32((dim1 >> 16) & 0xFFFFFFFF),
+        ],
+    )
+
+
+#: 128B / 4B: the row floor in elements for the 4-byte metadata runs.
+_TDM_ROW_ELEMS_4B = TDM_ROW_FLOOR_BYTES // 4
+
+
+def tdm_run_shape(n_elems):
+    """``(dim0, dim1)`` covering a contiguous run of ``n_elems``, or None.
+
+    mori's ``TdmCheapDim1`` closed form: the largest ``dim1`` in 8/4/2 that
+    divides the run and still leaves a row of at least 32 elements (the 128B
+    floor at 4 bytes). ``dim0 * dim1 == n_elems`` exactly, so the descriptor
+    footprint is the run and cannot spill past it.
+
+    Returns None when no such split exists. The caller must then move the run
+    some other way rather than falling back to ``dim1 == 1``: a 1xN tile is not
+    a shape the engine accepts here (see the module docstring).
+    """
+    for d1 in (8, 4, 2):
+        if n_elems % d1 == 0 and n_elems // d1 >= _TDM_ROW_ELEMS_4B:
+            return n_elems // d1, d1
+    return None
+
+
+def tdm_group0(lds_addr_i32, global_addr_i64):
+    """GROUP0 binding a descriptor to one (LDS byte address, global address) pair.
+
+    Both operands must be wave-uniform -- the intrinsic reads them out of SGPRs.
+    They are put through ``readfirstlane`` here rather than left to the compiler's
+    uniformity analysis: the addresses this kernel feeds in are uniform by
+    construction (a warp-strided token id, a ``readlane``-broadcast peer slot) but
+    are computed from ``thread_idx``, and a descriptor lane that silently lands in
+    a VGPR moves the wrong bytes instead of failing to compile. Every caller is in
+    a wave-uniform branch, so lane 0 is always active.
+    """
+    i32 = ir.IntegerType.get_signless(32)
+    addr = arith.unwrap(global_addr_i64)
+    lo = arith.trunci(i32, addr)
+    hi = arith.ori(
+        arith.trunci(i32, arith.shrui(addr, arith.constant(32, type=T.i64))),
+        _i32(1 << 31),  # descriptor type field
+    )
+    return vector.from_elements(
+        T.vec(4, T.i32),
+        [
+            _i32(1),
+            readfirstlane(T.i32, arith.unwrap(lds_addr_i32)),
+            readfirstlane(T.i32, lo),
+            readfirstlane(T.i32, hi),
+        ],
+    )
+
+
+def tdm_load(group0, group1, cache_policy=0):
+    """Async global -> LDS. Completion is observed with :func:`tdm_wait`."""
+    tdm_ops.tensor_load_2d(tdm_ops.TDMDescriptor2D(group0, group1), cache_policy)
+
+
+def tdm_store(group0, group1, cache_policy=0):
+    """Async LDS -> global. Completion is observed with :func:`tdm_wait`."""
+    tdm_ops.tensor_store_2d(tdm_ops.TDMDescriptor2D(group0, group1), cache_policy)
+
+
+def tdm_wait(count=0):
+    """Wait until at most ``count`` TDM transfers are still in flight.
+
+    Loads and stores share the one tensor counter and retire in issue order, so
+    a partial wait releases the oldest transfers -- there is no way to wait on
+    just the loads.
+    """
+    tdm_ops.tensor_wait(count)

--- a/aiter/ops/flydsl/dispatch_combine_v2/tuning_configs.py
+++ b/aiter/ops/flydsl/dispatch_combine_v2/tuning_configs.py
@@ -1,0 +1,261 @@
+# Copyright © Advanced Micro Devices, Inc. All rights reserved.
+#
+# MIT License
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+"""Per-device, per-shape block/warp tuning for the cco-LSA dispatch/combine kernels.
+
+Geometry is picked per device, then by (world_size, hidden_dim, topk). Devices are
+told apart by PCI device id (gfx942 family) or arch (gfx950/gfx1250) from KFD sysfs
+(no torch/HIP dep). block_num must stay <= CU count; re-tune per GPU. A SCHEDULE is a
+tuple of (max_tok_inclusive | None, disp_block, disp_warp, comb_block, comb_warp)
+buckets; the op precompiles the distinct (block, warp) variants and picks by token count.
+"""
+
+import functools
+import glob
+
+
+# ── MI308X (gfx942, 80 CU) — measured 2026-07-08, EP8, block x warp sweep.
+_MI308X_SCHEDULE = (
+    (256, 64, 8, 64, 4),
+    (2048, 64, 16, 64, 4),
+    (None, 64, 16, 80, 4),
+)
+# Single-shot fallback (schedule ignored) = peak-optimal.
+_MI308X_DEFAULT = dict(
+    dispatch_block_num=64,
+    combine_block_num=80,
+    dispatch_warp_num_per_block=16,
+    combine_warp_num_per_block=4,
+    schedule=_MI308X_SCHEDULE,
+)
+# Per-shape -> per-dtype schedules (tuned fp8-dispatch + bf16-combine, under "fp8").
+# hidden 4096 / 2048 reuse the 7168 schedule until separately tuned.
+_MI308X_TABLE = {
+    (8, 7168, 8): {"fp8": _MI308X_SCHEDULE},
+    (8, 4096, 8): {"fp8": _MI308X_SCHEDULE},
+    (8, 2048, 8): {"fp8": _MI308X_SCHEDULE},
+}
+
+# ── MI325X (gfx942, 304 CU, DID 0x74a5) — measured 2026-07-08, EP8, 2D block x warp
+# sweep by min latency. Dispatch wants warp 8 (block grows with tok); combine is
+# latency-bound at small/mid tok (small block 64 + warp 4 wins), bandwidth-bound only
+# at large tok (>1024: block ~0.5*CU + warp 2).
+_MI325X_SCHEDULE = (
+    (8, 64, 8, 64, 2),  # <=8 tok: tiny, combine warp 2
+    (64, 64, 8, 64, 4),  # <=64:   small block both
+    (1024, 152, 8, 64, 4),  # <=1024: disp 0.5*CU, comb small-block/warp4 (latency)
+    (4096, 228, 8, 152, 2),  # <=4096: comb 0.5*CU/warp2 (bandwidth)
+    (None, 304, 8, 152, 2),  # >4096 (peak)
+)
+_MI325X_DEFAULT = dict(
+    dispatch_block_num=304,
+    combine_block_num=152,
+    dispatch_warp_num_per_block=8,
+    combine_warp_num_per_block=2,
+    schedule=_MI325X_SCHEDULE,
+)
+# hidden 4096 / 2048 reuse the 7168 schedule until separately tuned.
+_MI325X_TABLE = {
+    (8, 7168, 8): {"fp8": _MI325X_SCHEDULE},
+    (8, 4096, 8): {"fp8": _MI325X_SCHEDULE},
+    (8, 2048, 8): {"fp8": _MI325X_SCHEDULE},
+}
+
+# ── MI300X (gfx942, 304 CU) — TODO: re-tune. Falls back to CU-scaled default. ──
+_MI300X_DEFAULT = None  # None => derive from CU count (see _cu_scaled_default)
+_MI300X_TABLE = {}
+
+# ── MI355X (gfx950, wave64) — re-tuned 2026-07-13 (vec4 combine gather), EP8 single-node
+# xGMI. vec4 combine wants a small block (32-48) + warp up to 16, dispatch block 96->160
+# (wave64 => warp <= 16). Geometry is topk-independent.
+# bf16 dispatch + bf16 combine:
+_MI355X_SCHED_BF16 = (
+    (128, 128, 8, 32, 8),
+    (256, 96, 8, 64, 8),
+    (1024, 96, 8, 32, 16),
+    (4096, 160, 8, 32, 16),
+    (None, 128, 16, 48, 16),
+)
+# fp8 dispatch + bf16 combine (combine geometry shared with bf16):
+_MI355X_SCHED_FP8 = (
+    (128, 128, 8, 32, 8),
+    (256, 160, 8, 64, 8),
+    (1024, 128, 8, 32, 16),
+    (4096, 160, 8, 32, 16),
+    (None, 128, 16, 48, 16),
+)
+# fp4 dispatch + fp4 combine (0.5 B/elem):
+_MI355X_SCHED_FP4 = (
+    (256, 128, 4, 32, 8),
+    (2048, 144, 4, 64, 16),
+    (None, 128, 8, 64, 16),
+)
+_MI355X_DEFAULT = dict(
+    dispatch_block_num=128,
+    combine_block_num=48,
+    dispatch_warp_num_per_block=16,
+    combine_warp_num_per_block=16,
+    schedule=_MI355X_SCHED_BF16,
+)
+_MI355X_TABLE = {
+    (8, 7168, 8): {
+        "bf16": _MI355X_SCHED_BF16,
+        "fp8": _MI355X_SCHED_FP8,
+        "fp4": _MI355X_SCHED_FP4,
+    },
+    (8, 7168, 6): {
+        "bf16": _MI355X_SCHED_BF16,
+        "fp8": _MI355X_SCHED_FP8,
+        "fp4": _MI355X_SCHED_FP4,
+    },
+}
+
+# ── gfx1250 (256 CU, wave32) — RE-TUNED 2026-07-15 EP4, bf16, vec4 combine + inner-unroll
+# scheduling, 2-pass block x warp sweep (tok 16..16384). Dispatch warp 32 / block 192;
+# combine is warp-sensitive at small tok (warp 2 <=128, warp 4 mid, warp 8 large; block
+# 64->96->128). GUARDRAIL: block_num < CU (256); 192 ceiling (Phase-2 grid barrier).
+# The <=128 tier keeps disp warp at 8: work is one warp per (token, k_slot), so fewer
+# warps per block spreads the same routes over more CUs (8 warps => 6 blocks at bs=8,
+# 16 warps => 3), which shortens the Phase-1 tail the grid barrier waits on.
+_GFX1250_SCHED_BF16 = (
+    (128, 128, 8, 64, 2),  # <=128:  latency-bound; combine warp 2 (fewest warps win)
+    (512, 192, 32, 64, 4),  # <=512:  disp peak; comb 64/4
+    (1536, 192, 32, 96, 4),  # <=1536: comb block 96
+    (4096, 192, 32, 128, 8),  # <=4096: comb block 128, warp 8 (#500)
+    (None, 192, 32, 192, 8),  # >4096:  comb 192/8 (#500; 242/273 GB/s @8192/16384)
+)
+_GFX1250_DEFAULT = dict(
+    dispatch_block_num=192,
+    combine_block_num=192,
+    dispatch_warp_num_per_block=32,
+    combine_warp_num_per_block=16,
+    schedule=_GFX1250_SCHED_BF16,
+)
+# DeepSeek-V4-Pro (hidden 7168, topk 6): geometry is topk-independent, reuse topk=8.
+_GFX1250_SCHED_BF16_T6 = _GFX1250_SCHED_BF16
+# EP8 RE-TUNED 2026-07-13 cross-node (UALink fabric). Dispatch block 128 (warp 16->32);
+# combine block 64 uniformly best (warp 4->8->16). Fabric caps disp ~200 GB/s;
+# world_size-independent so this also serves single-node EP8.
+_GFX1250_SCHED_BF16_EP8 = (
+    (256, 128, 16, 64, 4),  # <=256:  disp warp 16, comb 64/4 (latency-bound)
+    (1024, 128, 32, 64, 8),  # <=1024: disp warp 32, comb 64/8
+    (None, 128, 32, 64, 16),  # >1024 (peak)
+)
+# bf16-tuned (EP4 + EP8). fp8/fp4 fall back to the bf16 schedule until separately tuned.
+_GFX1250_TABLE = {
+    (4, 7168, 8): {"bf16": _GFX1250_SCHED_BF16},
+    (4, 7168, 6): {"bf16": _GFX1250_SCHED_BF16_T6},  # DeepSeek-V4-Pro
+    (8, 7168, 8): {"bf16": _GFX1250_SCHED_BF16_EP8},  # cross-node / single-node EP8
+    (8, 7168, 6): {"bf16": _GFX1250_SCHED_BF16_EP8},  # topk-independent, reuse topk=8
+}
+
+_DEVICES = {
+    "mi308x": (_MI308X_DEFAULT, _MI308X_TABLE),
+    "mi325x": (_MI325X_DEFAULT, _MI325X_TABLE),
+    "mi300x": (_MI300X_DEFAULT, _MI300X_TABLE),
+    "mi355x": (_MI355X_DEFAULT, _MI355X_TABLE),
+    "gfx1250": (_GFX1250_DEFAULT, _GFX1250_TABLE),
+}
+
+
+# PCI device IDs (KFD `device_id`) → device table key. gfx942 family only; the
+# gfx950 parts (MI350/MI355X) are matched by arch below since their DIDs vary.
+_DID_TO_KEY = {
+    0x74A1: "mi300x",  # MI300X
+    0x74A5: "mi325x",  # MI325X (304-CU gfx942; tuned 2026-07-08)
+    0x74A2: "mi308x",  # MI308X (80 CU)
+}
+
+
+@functools.lru_cache(maxsize=1)
+def _topology():
+    """(cu_count, gfx_target_version, device_id) of the first GPU node from KFD sysfs
+    (torch/HIP-free, homogeneous host). Returns (0, 0, 0) if sysfs is unavailable."""
+    for props in sorted(glob.glob("/sys/class/kfd/kfd/topology/nodes/*/properties")):
+        try:
+            vals = {}
+            with open(props) as f:
+                for line in f:
+                    parts = line.split()
+                    if len(parts) == 2:
+                        vals[parts[0]] = int(parts[1])
+            simd = vals.get("simd_count", 0)
+            if simd <= 0:  # CPU / non-GPU node
+                continue
+            spc = vals.get("simd_per_cu", 0) or 1
+            return (
+                simd // spc,
+                vals.get("gfx_target_version", 0),
+                vals.get("device_id", 0),
+            )
+        except Exception:
+            continue
+    return 0, 0, 0
+
+
+def _cu_count():
+    return _topology()[0]
+
+
+def _device_key():
+    """Map the current GPU to a device table key: exact PCI DID first, then arch
+    for gfx950. Returns None if unknown (caller uses a CU-scaled default)."""
+    _, gfx, did = _topology()
+    key = _DID_TO_KEY.get(did)
+    if key is not None:
+        return key
+    if gfx == 90500:  # gfx950 (MI350 / MI355X), DID varies
+        return "mi355x"
+    if gfx == 120500:  # gfx1250 (256 CU, wave32), DID varies
+        return "gfx1250"
+    return None
+
+
+def _cu_scaled_default():
+    """Untuned fallback (~1 block/CU, single-shot) for devices without a measured table."""
+    cu = _cu_count() or 80
+    return dict(
+        dispatch_block_num=cu,
+        combine_block_num=cu,
+        dispatch_warp_num_per_block=16,
+        combine_warp_num_per_block=4,
+        schedule=None,
+    )
+
+
+def lookup(world_size, hidden_dim, topk, dtype="fp8"):
+    """Return {dispatch_block_num, combine_block_num, dispatch_warp_num_per_block,
+    combine_warp_num_per_block, schedule} for the current GPU, shape, and dtype.
+
+    `dtype` ("bf16" | "fp8" | "fp4") selects the per-dtype schedule (dtype sets the
+    communication volume and thus the best geometry); falls back to "fp8" then the
+    device default. `schedule` (or None) is the per-token launch plan; the block/warp
+    fields are the single-shot fallback used when schedule is None."""
+    key = _device_key()
+    if key is None or key not in _DEVICES:
+        return _cu_scaled_default()
+    dev_default, dev_table = _DEVICES[key]
+    base = dict(dev_default) if dev_default is not None else _cu_scaled_default()
+    base.setdefault("schedule", None)
+    entry = dev_table.get((world_size, hidden_dim, topk))
+    if entry:
+        base["schedule"] = entry.get(dtype) or entry.get("fp8") or base["schedule"]
+    return base

--- a/aiter/ops/flydsl/dispatch_combine_v2/vector.py
+++ b/aiter/ops/flydsl/dispatch_combine_v2/vector.py
@@ -1,0 +1,144 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2025 FlyDSL Project Contributors
+# Modifications Copyright (C) 2026 Advanced Micro Devices, Inc.
+
+"""Vector dialect wrappers, vendored next to dispatch_combine_v2.
+
+main dropped ``aiter.ops.flydsl.kernels.vector`` in #5303 (callers moved to
+``fx.Vector``). The vector-transport sibling kernel in this package still
+uses the dialect helpers, so the file lives here instead of restoring that
+global module.
+
+flydsl deleted ``flydsl.expr.vector``; callers are now expected to use the raw
+``flydsl._mlir.dialects.vector`` and wrap every operand in ``as_ir_value``.
+The auto-unwrapping layer is kept here — a missing ``as_ir_value`` or
+``kDynamic`` sentinel only surfaces at trace time.
+
+Re-exports the whole raw dialect (``broadcast``, ``shuffle``, ``insert``,
+``extract_strided_slice``, ``reduction``, ...) and rebuilds the five wrappers
+that unwrap DSL values: ``from_elements``, ``store``, ``extract``,
+``load_op``, ``bitcast``. ``extract`` also supplies the ``kDynamic`` sentinel
+for dynamic positions. Only published flydsl APIs are used.
+
+Upstream: FlyDSL ``python/flydsl/expr/vector.py``, deleted before
+ROCm/FlyDSL#880; the wrappers use FlyDSL's canonical ``as_ir_value``
+converter.
+"""
+
+from __future__ import annotations
+
+from flydsl._mlir import ir
+from flydsl._mlir.dialects import vector as _vector
+
+# Re-export the raw dialect so vector.broadcast / vector.shuffle work directly
+from flydsl._mlir.dialects.vector import *
+from flydsl.expr.meta import dsl_loc_tracing
+
+# Vector and related types, which flydsl.expr.vector also re-exported
+from flydsl.expr.typing import (  # noqa: F401
+    ReductionOp,
+    Vector,
+    as_ir_value,
+    empty_like,
+    full,
+    full_like,
+    ones_like,
+    zeros_like,
+)
+
+# ═══════════════════════════════════════════════════════════════════════
+# Dialect helper wrappers (legacy, will be deprecated)
+# Prefer using Vector methods or _mlir.dialects.vector directly.
+# ═══════════════════════════════════════════════════════════════════════
+
+
+def _as_index_ir_value(value):
+    if isinstance(value, int):
+        from flydsl.expr import arith as _arith_ext
+
+        return _arith_ext.constant(value, index=True)
+    v = as_ir_value(value)
+    # vector/memref indices must be index-typed; cast integer offsets
+    # (e.g. fx.Int64/i32) so callers can pass explicit-width offsets.
+    if isinstance(v.type, ir.IntegerType):
+        from flydsl._mlir.dialects import arith as _std_arith
+
+        v = _std_arith.IndexCastOp(ir.IndexType.get(), v).result
+    return v
+
+
+@dsl_loc_tracing
+def from_elements(*args, **kwargs):
+    """Construct a vector from scalar elements, auto-unwrapping ArithValue wrappers."""
+    if len(args) >= 2:
+        args = list(args)
+        elems = args[1]
+        if isinstance(elems, (list, tuple)):
+            args[1] = [as_ir_value(v) for v in elems]
+        return _vector.from_elements(*args, **kwargs)
+
+    return _vector.from_elements(*args, **kwargs)
+
+
+@dsl_loc_tracing
+def store(value, memref, indices, **kwargs):
+    """Vector store wrapper that accepts ArithValue/wrappers for value/indices."""
+    return _vector.store(
+        as_ir_value(value),
+        as_ir_value(memref),
+        [_as_index_ir_value(i) for i in indices],
+        **kwargs,
+    )
+
+
+# -----------------------------------------------------------------------------
+# Thin wrappers for common op classes that otherwise require `.result` access.
+# -----------------------------------------------------------------------------
+
+
+@dsl_loc_tracing
+def extract(vector, static_position=None, dynamic_position=None):
+    """Wrapper around `vector.ExtractOp(...).result`.
+
+    When only ``dynamic_position`` is supplied (without explicit
+    ``static_position``), each dynamic index needs a corresponding
+    ``kDynamic`` sentinel in the static attribute so the ODS builder
+    pairs them correctly.  This wrapper fills in the sentinels
+    automatically.
+    """
+    if static_position is None:
+        static_position = []
+    if dynamic_position is None:
+        dynamic_position = []
+    dynamic_position = [_as_index_ir_value(i) for i in dynamic_position]
+
+    n_static = len(static_position)
+    n_dynamic = len(dynamic_position)
+    if n_dynamic > 0 and n_static < n_dynamic:
+        kDynamic = ir.ShapedType.get_dynamic_size()
+        static_position = list(static_position) + [kDynamic] * (n_dynamic - n_static)
+
+    return _vector.ExtractOp(
+        as_ir_value(vector),
+        static_position=static_position,
+        dynamic_position=dynamic_position,
+    ).result
+
+
+@dsl_loc_tracing
+def load_op(result_type, memref, indices):
+    """Wrapper around `vector.LoadOp(...).result`."""
+    return _vector.LoadOp(
+        result_type,
+        as_ir_value(memref),
+        [_as_index_ir_value(i) for i in indices],
+    ).result
+
+
+@dsl_loc_tracing
+def bitcast(result_type, source):
+    """Wrapper around `vector.BitCastOp(...).result`."""
+    return _vector.BitCastOp(
+        result_type,
+        as_ir_value(source),
+    ).result

--- a/op_tests/flydsl_tests/compile_dispatch_tdm.py
+++ b/op_tests/flydsl_tests/compile_dispatch_tdm.py
@@ -1,0 +1,87 @@
+# SPDX-License-Identifier: MIT
+"""Compile-only check for the TDM dispatch kernel -- no GPU needed.
+
+``COMPILE_ONLY=1`` makes FlyDSL trace, lower and codegen the kernel and then
+return instead of launching, so this exercises every DSL construct in
+``make_dispatch_tdm`` (and every compile-time shape assert) without touching a
+device. It cannot say whether the kernel is *correct*, only whether it is
+well-formed.
+
+    COMPILE_ONLY=1 FLYDSL_GPU_ARCH=gfx1250 python compile_dispatch_tdm.py
+"""
+import os
+import sys
+import time
+
+os.environ.setdefault("COMPILE_ONLY", "1")
+os.environ.setdefault("FLYDSL_GPU_ARCH", "gfx1250")
+
+from aiter.ops.flydsl.dispatch_combine_v2.intranode_kernels_tdm import (  # noqa: E402
+    make_dispatch_tdm,
+    tdm_stage_capacity,
+)
+
+# (npes, topk, hidden, elem, block, warp): the shapes that pick different
+# compile-time paths -- meta TDM on/off, one warp per peer vs a peer split,
+# and the tokens-per-wave fallback when topk does not divide the wave.
+CASES = [
+    (4, 8, 7168, 2, 64, 8),
+    (4, 8, 2048, 2, 64, 16),
+    (1, 8, 2048, 2, 64, 8),
+    (4, 6, 4096, 2, 64, 8),
+    (8, 8, 512, 2, 64, 8),  # tile too small for a meta batch -> scalar metadata
+]
+
+
+def main():
+    bad = 0
+    for npes, topk, hidden, elem, block, warp in CASES:
+        max_tok = 512
+        cap, slots = tdm_stage_capacity(
+            npes=npes,
+            experts_per_token=topk,
+            max_tok_per_rank=max_tok,
+            block_num=block,
+            warp_num_per_block=warp,
+        )
+        tag = f"npes={npes} topk={topk} hidden={hidden} elem={elem} {block}x{warp}"
+        t0 = time.time()
+        try:
+            run = make_dispatch_tdm(
+                rank=0,
+                npes=npes,
+                experts_per_rank=8,
+                experts_per_token=topk,
+                hidden_dim=hidden,
+                hidden_elem_size=elem,
+                max_tok_per_rank=max_tok,
+                max_recv=npes * max_tok,
+                block_num=block,
+                warp_num_per_block=warp,
+                off_tok_off=0,
+                off_recv_num=256,
+                off_tis=512,
+                off_out_idx=4096,
+                off_out_wts=8192,
+                off_out_tok=16384,
+            )
+            run(*([0] * 11), 0, 8)
+        except Exception as exc:  # noqa: BLE001 - report every case, not just the first
+            bad += 1
+            print(f"FAIL {tag}\n  {type(exc).__name__}: {exc}", flush=True)
+            if os.environ.get("TB"):
+                import traceback
+
+                traceback.print_exc()
+                return 1
+        else:
+            print(
+                f"ok   {tag}  cap/blk={cap} slots={slots}  ({time.time() - t0:.1f}s)",
+                flush=True,
+            )
+    print(f"\n{len(CASES) - bad}/{len(CASES)} configs compiled")
+    return 1 if bad else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/op_tests/flydsl_tests/test_dispatch_tdm.py
+++ b/op_tests/flydsl_tests/test_dispatch_tdm.py
@@ -1,0 +1,278 @@
+# Copyright © Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Correctness + A/B for the TDM dispatch transport (gfx1250).
+
+Runs the same routing through ``dispatch_transport='vector'`` and
+``'tdm'`` and checks both against a CPU model of what every rank should
+receive. The two transports assign recv slots in different orders -- vector
+takes one remote atomic per route, TDM reserves a contiguous run per (block,
+peer) -- so the check is order-independent: it keys each received row by the
+``(src_pe, src_tok)`` its srcmap names and compares the row's payload, indices
+and weights against that source token.
+
+    torchrun --standalone --nproc_per_node=4 test_dispatch_tdm.py
+    HIDDEN=7168 TOPK=8 EPR=32 SWEEP=8,128,512 BENCH=1 torchrun ...
+"""
+import os
+import sys
+
+import torch
+import torch.distributed as dist
+
+from aiter.ops.flydsl.dispatch_combine_v2 import (
+    EpDispatchCombineConfig,
+    EpDispatchCombineOp,
+)
+from mori.cco import Communicator
+
+HIDDEN = int(os.environ.get("HIDDEN", 2048))
+TOPK = int(os.environ.get("TOPK", 8))
+EPR = int(os.environ.get("EPR", 8))
+SWEEP = [int(x) for x in os.environ.get("SWEEP", "8,64,512").split(",")]
+BENCH = os.environ.get("BENCH") == "1"
+BALANCED = os.environ.get("BALANCED") == "1"
+ITERS = int(os.environ.get("ITERS", 50))
+WARMUP = int(os.environ.get("WARMUP", 10))
+DTYPE = torch.bfloat16
+
+
+def _balanced_idx(pe, n_tok, n_experts, world, epr, topk):
+    """Every expert draws the same number of tokens, by construction.
+
+    randperm routing is only balanced on average, so a sweep measures the tail
+    of a multinomial as much as it measures the transport. Here route j of token
+    t lands on rank ``j % world``, which spreads a token over the ranks as evenly
+    as topk allows, and walks the destination rank's local experts on a stride
+    that rotates with the token id (and with the sending rank, so the ranks do
+    not march in lockstep). Each expert then takes exactly ``n_tok * topk /
+    n_experts`` routes from each sender.
+
+    Note this is also the heaviest traffic pattern available: with topk >= world
+    every token reaches every rank, so each rank receives ``world * n_tok`` rows
+    where random routing leaves a few percent of the pairs unrouted.
+    """
+    per_rank = -(-topk // world)  # ceil: how many of a token's routes share a rank
+    t = torch.arange(n_tok).unsqueeze(1)
+    j = torch.arange(topk).unsqueeze(0)
+    dest = j % world
+    local = (t * per_rank + j // world + pe) % epr
+    return (dest * epr + local).int()
+
+
+def _bootstrap():
+    """torchrun + gloo, used only to carry the cco unique id and pass/fail counts."""
+    rank = int(os.environ["RANK"])
+    world = int(os.environ["WORLD_SIZE"])
+    local = int(os.environ.get("LOCAL_RANK", rank))
+    torch.cuda.set_device(local)
+    dist.init_process_group("gloo", rank=rank, world_size=world)
+    uid = [Communicator.get_unique_id() if rank == 0 else None]
+    dist.broadcast_object_list(uid, src=0)
+    return rank, world, local, uid[0]
+
+
+def _allreduce_sum(v):
+    t = torch.tensor([v], dtype=torch.int64)
+    dist.all_reduce(t)
+    return int(t[0])
+
+
+def _expected_rows(all_idx, all_tok, rank, world, epr, topk, n_tok):
+    """{(src_pe, src_tok): sorted expert ids} for every token routed to `rank`.
+
+    A token routed to several of this rank's experts arrives once (the sender
+    dedups per destination PE), and it carries its whole topk index/weight row,
+    not just the experts that live here.
+    """
+    want = {}
+    for pe in range(world):
+        idx = all_idx[pe]
+        for t in range(n_tok):
+            row = [int(e) for e in idx[t]]
+            if any(e // epr == rank for e in row if e >= 0):
+                want[(pe, t)] = row
+    return want
+
+
+def _check(op, cfg, comm, rank, world, all_idx, all_wts, all_tok, n_tok, tag):
+    out, out_w, _out_s, out_i, total_recv, routing = op.dispatch(
+        all_tok[rank][:n_tok],
+        all_wts[rank][:n_tok],
+        None,
+        all_idx[rank][:n_tok],
+        return_routing=True,
+    )
+    torch.cuda.synchronize()
+    comm.barrier()
+
+    recv = int(total_recv.item())
+    src = routing.disp_tok_id_to_src_tok_id_local[:recv].cpu()
+    got_tok = out[:recv].float().cpu()
+    got_idx = out_i[:recv].cpu()
+    got_wts = out_w[:recv].cpu()
+
+    want = _expected_rows(all_idx, all_tok, rank, world, cfg.num_experts_per_rank, TOPK, n_tok)
+    errs = []
+    if recv != len(want):
+        errs.append(f"recv={recv} expected={len(want)}")
+    seen = set()
+    max_tok = cfg.max_num_inp_token_per_rank
+    for r in range(recv):
+        enc = int(src[r])
+        key = (enc // max_tok, enc % max_tok)
+        if key not in want:
+            errs.append(f"row {r}: unexpected source {key}")
+            break
+        if key in seen:
+            errs.append(f"row {r}: duplicate source {key}")
+            break
+        seen.add(key)
+        pe, t = key
+        if not torch.equal(got_idx[r], all_idx[pe][t].cpu()):
+            errs.append(f"row {r} src={key}: indices mismatch")
+            break
+        if not torch.allclose(got_wts[r], all_wts[pe][t].cpu(), atol=0, rtol=0):
+            errs.append(f"row {r} src={key}: weights mismatch")
+            break
+        if not torch.equal(got_tok[r], all_tok[pe][t].float().cpu()):
+            errs.append(f"row {r} src={key}: payload mismatch")
+            break
+    ok = not errs
+    bad = _allreduce_sum(0 if ok else 1)
+    if rank == 0:
+        print(
+            f"# {tag} ct={n_tok}: {'PASS' if bad == 0 else 'FAIL'} (recv={recv})",
+            flush=True,
+        )
+    if errs and rank == 0:
+        print(f"    rank{rank}: {errs[0]}", flush=True)
+    return bad == 0
+
+
+def _time(op, comm, all_idx, all_wts, all_tok, rank, n_tok):
+    """(us per dispatch, tokens landed in this rank's recv buffer)."""
+    inp, w, i = all_tok[rank][:n_tok], all_wts[rank][:n_tok], all_idx[rank][:n_tok]
+    for _ in range(WARMUP):
+        op.dispatch(inp, w, None, i)
+    torch.cuda.synchronize()
+    comm.barrier()
+    # One quiesced dispatch for the row count. Reading it out of the timed loop
+    # undercounts: that loop runs back-to-back with no barrier between ranks, so
+    # a peer is still landing rows from iteration N when this rank resets its
+    # counter for N + 1.
+    _out, _w, _s, _i, total_recv = op.dispatch(inp, w, None, i)
+    torch.cuda.synchronize()
+    comm.barrier()
+    recv = int(total_recv.item())
+    s = torch.cuda.Event(enable_timing=True)
+    e = torch.cuda.Event(enable_timing=True)
+    s.record()
+    for _ in range(ITERS):
+        op.dispatch(inp, w, None, i)
+    e.record()
+    torch.cuda.synchronize()
+    comm.barrier()
+    return s.elapsed_time(e) / ITERS * 1000.0, recv
+
+
+def main():
+    rank, world, local, uid = _bootstrap()
+    max_tok = max(SWEEP)
+    n_experts = EPR * world
+    torch.manual_seed(1234)
+
+    # Same routing on every rank's view: each rank generates its own tokens but
+    # all of them are needed to model what any one rank receives, so they are
+    # generated from a per-rank seed the whole world can reproduce.
+    all_idx, all_wts, all_tok = [], [], []
+    for pe in range(world):
+        g = torch.Generator().manual_seed(1000 + pe)
+        if BALANCED:
+            idx = _balanced_idx(pe, max_tok, n_experts, world, EPR, TOPK)
+        else:
+            idx = torch.stack(
+                [torch.randperm(n_experts, generator=g)[:TOPK] for _ in range(max_tok)]
+            ).int()
+        wts = torch.rand(max_tok, TOPK, generator=g)
+        tok = torch.randn(max_tok, HIDDEN, generator=g).to(DTYPE)
+        dev = f"cuda:{local}"
+        all_idx.append(idx.to(dev))
+        all_wts.append(wts.to(dev))
+        all_tok.append(tok.to(dev))
+
+    if rank == 0:
+        load = torch.zeros(n_experts, dtype=torch.int64)
+        for pe in range(world):
+            load += torch.bincount(
+                all_idx[pe][: max(SWEEP)].reshape(-1).cpu(), minlength=n_experts
+            )
+        dup = sum(
+            int((torch.unique(all_idx[pe][: max(SWEEP)], dim=1).shape[1] != TOPK))
+            for pe in range(world)
+        )
+        print(
+            f"# routing={'balanced' if BALANCED else 'random'} "
+            f"experts={n_experts} load min/max={int(load.min())}/{int(load.max())} "
+            f"dup_rows={dup}",
+            flush=True,
+        )
+
+    comm = Communicator.init(world, rank, uid)
+
+    failures = 0
+    timings = {}
+    for transport in ("vector", "tdm"):
+        cfg = EpDispatchCombineConfig(
+            rank=rank,
+            world_size=world,
+            hidden_dim=HIDDEN,
+            max_num_inp_token_per_rank=max_tok,
+            num_experts_per_rank=EPR,
+            num_experts_per_token=TOPK,
+            data_type=DTYPE,
+            dispatch_transport=transport,
+        )
+        op = EpDispatchCombineOp(cfg, comm)
+        try:
+            for ct in SWEEP:
+                if not _check(
+                    op, cfg, comm, rank, world, all_idx, all_wts, all_tok, ct, transport
+                ):
+                    failures += 1
+            if BENCH:
+                timings[transport] = {
+                    ct: _time(op, comm, all_idx, all_wts, all_tok, rank, ct)
+                    for ct in SWEEP
+                }
+        finally:
+            op.close()
+
+    if BENCH and rank == 0:
+        # Payload landed per rank: recv tokens of a hidden row each. Counts the
+        # rank's own tokens too -- those never cross the fabric, so at world=4
+        # roughly a quarter of this is local traffic. Same for both transports,
+        # so the ratio is unaffected; the absolute number is not a link figure.
+        row_b = HIDDEN * DTYPE.itemsize
+        print(f"\n# dispatch (hidden={HIDDEN} topk={TOPK} world={world})")
+        print(f"# GB/s = recv tokens x {row_b}B per rank / time")
+        print(
+            f"{'tokens':>8} {'recv':>8} {'vector':>9} {'tdm':>9} {'speedup':>8}"
+            f" {'vec GB/s':>9} {'tdm GB/s':>9}"
+        )
+        for ct in SWEEP:
+            (v, recv), (t, _) = timings["vector"][ct], timings["tdm"][ct]
+            gb = recv * row_b / 1e9
+            print(
+                f"{ct:>8} {recv:>8} {v:>9.1f} {t:>9.1f} {v / t:>7.2f}x"
+                f" {gb / (v * 1e-6):>9.1f} {gb / (t * 1e-6):>9.1f}"
+            )
+
+    dist.barrier()
+    dist.destroy_process_group()
+    if rank == 0:
+        print(f"\n{'ALL PASS' if failures == 0 else f'{failures} FAILURES'}")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Retarget #4821 onto current main: land dispatch_combine_v2 with the TDM transport without the fused-gemm2 stack that PR originally stacked on.

Selected with dispatch_transport='tdm'; 'auto' still resolves to vector. Vendor kernels.vector inside the package because #5303 removed it from aiter.ops.flydsl.kernels.

Compile-only check: COMPILE_ONLY=1 FLYDSL_GPU_ARCH=gfx1250 python op_tests/flydsl_tests/compile_dispatch_tdm.py (5/5).

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/TheRock/blob/main/GOVERNANCE.md#pull-requests.
