### PR TITLE
[FlyDSL] [fix] fp8_mqa_logits: zero-extend the FN->FNUZ halves on gfx942

### DIFF
--- a/aiter/ops/flydsl/kernels/mqa_logits/fp8_mqa_logits.py
+++ b/aiter/ops/flydsl/kernels/mqa_logits/fp8_mqa_logits.py
@@ -212,8 +212,8 @@ def _build_kernel_mfma_r_w(
                     result = result | (cleaned << shift)
                 return result
 
-            lo_64 = fx.Int64(_fix_i32(lo_i32))
-            hi_64 = fx.Int64(_fix_i32(hi_i32)) << 32
+            lo_64 = fx.Int64(fx.Uint32(_fix_i32(lo_i32)))
+            hi_64 = fx.Int64(fx.Uint32(_fix_i32(hi_i32))) << 32
             return (lo_64 | hi_64).ir_value()
 
         # Preload window bounds, Q frags, and weights for all RPB rows.


### PR DESCRIPTION
## Summary

`_fn_to_fnuz_i64` splits an 8-byte fp8 pack into two 32-bit halves, patches FN
`-0` (`0x80`) to `+0` in each, then recombines them. #4606 rewrote the recombine
from an explicit `arith.ExtUIOp` to a plain `fx.Int64(...)`, which sign-extends.

Every fp8 byte `>= 0x80` is a negative value, so the top byte of a half
routinely sets bit 31. The sign extension then floods the upper word with ones
and the `OR` corrupts the pack.

`fx.Int64(fx.Uint32(x))` is already the zero-extend idiom used elsewhere in this
same file — the stride / base-pointer path added by the same PR, where the
comment explicitly notes that a sign-extended value would be wrong. It just
wasn't applied in this helper.

```diff
-            lo_64 = fx.Int64(_fix_i32(lo_i32))
-            hi_64 = fx.Int64(_fix_i32(hi_i32)) << 32
+            lo_64 = fx.Int64(fx.Uint32(_fix_i32(lo_i32)))
+            hi_64 = fx.Int64(fx.Uint32(_fix_i32(hi_i32))) << 32
```

## Impact

Only reachable on gfx942, where `convert_q_fn` / `convert_kv_fn` are set, and
only for `e4m3fn` operands — which is what vLLM's sparse-MLA indexer feeds this
kernel. `e4m3fnuz` never traces the path and makes a clean control.

The failure is silent. Compute volume is unchanged, so throughput, latency and
memory all look normal; what degrades is the indexer's top-k selection, and
therefore long-context quality.

## Prerequisite for reproducing these numbers

#4606 also left `_fn_to_fnuz_i64` calling `shrui` with a Python `int`, which
aborts at trace time on stock flydsl. That crash fires *before* the wrong
numerics, so on current `main` the reproducer below raises
`AttributeError: 'int' object has no attribute '_CAPIPtr'` instead of printing
the "before" row.

A companion PR fixes the lowering: <!-- link the shrui PR here -->https://github.com/ROCm/aiter/pull/5453

The measurements below were taken with that lowering fix applied, on stock
flydsl 0.3.2 with no local flydsl patches. Please land both; either order works.

## Test plan

Standalone repro — aiter + torch, one gfx942 GPU, ~30s:

```python
import torch
from aiter.ops.flydsl import flydsl_fp8_mqa_logits

M, H, D, N = 64, 32, 128, 512
dev = "cuda"


def reference(q, k, scale, w):
    score = torch.einsum("mhd,nd->hmn", q.to(torch.bfloat16),
                         k.to(torch.bfloat16)).float() * scale.reshape(-1)
    return (score.relu() * w.unsqueeze(-1).transpose(0, 1)).sum(dim=0)


for dtype in (torch.float8_e4m3fnuz, torch.float8_e4m3fn):
    torch.manual_seed(0)
    q = torch.randn(M, H, D, device=dev, dtype=torch.bfloat16).to(dtype)
    k = torch.randn(N, D, device=dev, dtype=torch.bfloat16).to(dtype)
    scale = torch.rand(N, device=dev, dtype=torch.float32) + 0.5
    w = torch.rand(M, H, device=dev, dtype=torch.float32)
    ks = torch.zeros(M, device=dev, dtype=torch.int32)
    ke = torch.full((M,), N, device=dev, dtype=torch.int32)

    ref = reference(q, k, scale, w)
    out = flydsl_fp8_mqa_logits(q, k, scale, w, ks, ke).float()
    torch.cuda.synchronize()
    rel = (out - ref).abs().max().item() / ref.abs().max().item()
    print(f"{dtype}: ref_max={ref.max():.2f} out_max={out.max():.2f} max_rel={rel:.6g}")
```

## Test result

MI325X (gfx942), ROCm 7.2.3, flydsl 0.3.2.

Before:

```
torch.float8_e4m3fnuz: ref_max=267.46 out_max=267.30        max_rel=0.000992
torch.float8_e4m3fn  : ref_max=267.46 out_max=175833504.00  max_rel=657427
```

After:

```
torch.float8_e4m3fnuz: ref_max=267.46 out_max=267.30 max_rel=0.000992
torch.float8_e4m3fn  : ref_max=267.46 out_max=267.30 max_rel=0.000946
```

Because the logits only drive a top-k selection, the more meaningful metric is
index overlap against the reference (M=256, N=4096, k=2048; 50% is random):

| build | top-k overlap |
| ----- | ------------- |
| v0.1.19 (pre-#4606) | 99.95% |
| current `main` | **71.15%** |
| this PR | 99.95% |

## The other defect from #4606, and why the order matters

The same rewrite turned

```python
hi_i64 = arith.ShRUIOp(raw_i64, arith.constant(32, type=T.i64)).result
```

into `raw.shrui(32)`, passing a Python `int`. `ArithValue.shrui` calls `_to_raw`,
which only accepts an `ir.Value` or an object exposing `.ir_value()`, so the
kernel aborts at trace time:

```
File ".../flydsl/expr/utils/arith.py", line 579, in _to_raw
    return ir.Value._CAPICreate(v._CAPIPtr)
AttributeError: 'int' object has no attribute '_CAPIPtr'
```

That is fixed in the companion PR rather than here, so each change stays
reviewable on its own. The interaction is the part worth flagging: the crash
fires *before* the bad numerics, so it has masked them since August. Fixing only
the `shrui` lowering — the obvious local fix — converts a loud abort into silent
long-context quality loss.

Measured on stock flydsl 0.3.2 with `e4m3fn` operands:

| build | result |
| ----- | ------ |
| current `main` | `AttributeError ... '_CAPIPtr'` |
| shrui fix only | runs, `max_rel = 6.6e+5` |
| shrui fix + this PR | runs, `max_rel = 9.5e-4` |

## Suggested follow-up

The existing `fp8_mqa_logits` op test appears not to exercise
`convert_q_fn` / `convert_kv_fn`. An `e4m3fn` case on gfx942 would have caught
this at review time.
