### PR TITLE
[FlyDSL] [fix] fp8_mqa_logits: pass typed shift amounts to shrui

### DIFF
--- a/aiter/ops/flydsl/kernels/mqa_logits/fp8_mqa_logits.py
+++ b/aiter/ops/flydsl/kernels/mqa_logits/fp8_mqa_logits.py
@@ -200,13 +200,13 @@ def _build_kernel_mfma_r_w(
             # Map FN byte 0x80 (neg-zero, = FNUZ NaN) -> 0x00 in 8 packed fp8 bytes.
             raw = fx.Int64(raw_i64)
             lo_i32 = fx.Int32(raw)
-            hi_i32 = fx.Int32(raw.shrui(32))
+            hi_i32 = fx.Int32(raw.shrui(fx.Int64(32)))
 
             def _fix_i32(src):
                 result = fx.Int32(0)
                 for byte_idx in range_constexpr(4):
                     shift = byte_idx * 8
-                    byte_val = src.shrui(shift) & 0xFF
+                    byte_val = src.shrui(fx.Int32(shift)) & 0xFF
                     is_0x80 = byte_val == 0x80
                     cleaned = is_0x80.select(fx.Int32(0), byte_val)
                     result = result | (cleaned << shift)


### PR DESCRIPTION
## Summary

#4606 rewrote the shift in `_fn_to_fnuz_i64` from

```python
hi_i64 = arith.ShRUIOp(raw_i64, arith.constant(32, type=T.i64)).result
```

to `raw.shrui(32)`, and the byte loop in `_fix_i32` likewise to
`src.shrui(shift)` with a Python `int`.

`ArithValue.shrui` forwards the amount to `_to_raw`, which only accepts an
`ir.Value` or an object exposing `.ir_value()`, so the kernel aborts while
tracing:

```
File ".../flydsl/expr/utils/arith.py", line 579, in _to_raw
    return ir.Value._CAPICreate(v._CAPIPtr)
AttributeError: 'int' object has no attribute '_CAPIPtr'
```

This materializes each shift at the operand's own width — which is also what
`ShRUIOp` requires of its two operands.

```diff
-            hi_i32 = fx.Int32(raw.shrui(32))
+            hi_i32 = fx.Int32(raw.shrui(fx.Int64(32)))
...
-                    byte_val = src.shrui(shift) & 0xFF
+                    byte_val = src.shrui(fx.Int32(shift)) & 0xFF
```

## Impact

Only reachable on gfx942, where `convert_q_fn` / `convert_kv_fn` are set. Every
`e4m3fn` call into this kernel — which is what vLLM's sparse-MLA indexer does —
has aborted since #4606. `e4m3fnuz` never traces the path and is unaffected.

## Important: this fix alone is not sufficient

#4606 introduced a second, independent defect in the same helper: the two
fixed-up 32-bit halves are recombined with a sign-extend where the original used
`arith.ExtUIOp`. **This crash was masking that one.** Landing only this PR turns
a loud abort into silently wrong logits, which is the worse failure mode — the
indexer's top-k selection degrades with no change to throughput, latency or
memory, so nothing in a perf sweep will catch it.

The companion PR fixes the zero-extend: <!-- link the zero-extend PR here --> https://github.com/ROCm/aiter/pull/5452

Please land both, in either order.

## Test plan

Standalone repro — aiter + torch, one gfx942 GPU, **stock flydsl 0.3.2**
(no local flydsl patches), ~30s:

```python
import torch
from aiter.ops.flydsl import flydsl_fp8_mqa_logits

M, H, D, N = 64, 32, 128, 512
dev = "cuda"


def reference(q, k, scale, w):
    score = torch.einsum("mhd,nd->hmn", q.to(torch.bfloat16),
                         k.to(torch.bfloat16)).float() * scale.reshape(-1)
    return (score.relu() * w.unsqueeze(-1).transpose(0, 1)).sum(dim=0)


for dtype in (torch.float8_e4m3fnuz, torch.float8_e4m3fn):
    torch.manual_seed(0)
    q = torch.randn(M, H, D, device=dev, dtype=torch.bfloat16).to(dtype)
    k = torch.randn(N, D, device=dev, dtype=torch.bfloat16).to(dtype)
    scale = torch.rand(N, device=dev, dtype=torch.float32) + 0.5
    w = torch.rand(M, H, device=dev, dtype=torch.float32)
    ks = torch.zeros(M, device=dev, dtype=torch.int32)
    ke = torch.full((M,), N, device=dev, dtype=torch.int32)

    ref = reference(q, k, scale, w)
    out = flydsl_fp8_mqa_logits(q, k, scale, w, ks, ke).float()
    torch.cuda.synchronize()
    rel = (out - ref).abs().max().item() / ref.abs().max().item()
    print(f"{dtype}: ref_max={ref.max():.2f} out_max={out.max():.2f} max_rel={rel:.6g}")
```

## Test result

MI325X (gfx942), ROCm 7.2.3, stock flydsl 0.3.2, `e4m3fn` operands:

| build | result |
| ----- | ------ |
| current `main` | `AttributeError: 'int' object has no attribute '_CAPIPtr'` |
| **this PR** | runs, `max_rel = 6.6e+5` (crash fixed, numerics still wrong) |
| this PR + zero-extend PR | runs, `max_rel = 9.5e-4` (correct) |

`e4m3fnuz` reports `max_rel = 9.9e-4` in all three, confirming the control path
is untouched.

## Suggested follow-up

The existing `fp8_mqa_logits` op test appears not to exercise
`convert_q_fn` / `convert_kv_fn` on gfx942. A single `e4m3fn` case would have
caught both this abort and the numerics defect at review time.
