### PR TITLE
.agent_loop: orchestration layer driving review-pr and validate-kerne…

### DIFF
--- a/.agent_loop/.gitignore
+++ b/.agent_loop/.gitignore
@@ -1,0 +1,7 @@
+﻿# installation-specific and never committed
+config/loop.json
+*.key
+id_*
+*.pem
+__pycache__/
+*.pyc

--- a/.agent_loop/README.md
+++ b/.agent_loop/README.md
@@ -1,0 +1,83 @@
+# .agent_loop
+
+An orchestration layer that drives the two review skills in this repo — `.claude/skills/review-pr`
+and `.claude/skills/validate-kernel-pr` — as one repeatable loop, so that a PR goes from a number
+to a gated verdict card plus deterministic on-GPU evidence without a human holding it by the hand.
+
+It is **not** a third skill. The skills decide *what* a review means; this decides *who runs what,
+in which order, and what may not be believed*. It calls their CLI surface and nothing else.
+
+```
+[once per host] environment probe → human confirms → env record
+[per PR]  phase P (prefetch): verify env + skill Step 1 fetch        ← cheap, 2 agents
+             ↓  ★ the single human break: targets, models, budget — asked once
+          phase R: analysis fan-out → independent refutation → card → seven gates
+                   → on-GPU validation → refute the executor → refold → cleanup   ← no stops
+```
+
+## Why a loop rather than one review pass
+
+Three things only a loop can do, each of which happened during the runs this was built from:
+
+- **It re-reviews the same PR as it moves.** When the base advances, a file the previous head added
+  and this head removed is invisible in the diff — it reads as if it never existed. Phase P reports
+  `git log <prev-head>..<head>` for exactly this reason.
+- **It puts the tools on trial too.** A validator finding is a claim, not a fact. Stage S6b refutes
+  the executor's own findings; on the runs behind this package that withdrew four false ones,
+  including a "comparison tolerance widened" verdict that was an artifact of positional matching.
+- **It makes the review record falsifiable.** Every finding on the card was attacked by a fresh
+  agent that never saw the reasoning behind it, and that agent — not the card's author — wrote the
+  ledger line recording the outcome.
+
+## Quick start
+
+```bash
+cp config/loop.example.json config/loop.json && $EDITOR config/loop.json
+
+node tools/dryrun.mjs            # zero-token: proves the guards fire. 10/10 or do not proceed.
+```
+
+Then, from an agent harness that provides a `workflow` tool (the scripts are workflow script
+bodies, not standalone programs):
+
+1. run `workflows/prefetch.workflow.js` with `args` built from your config plus `{ pr, sinceHead }`;
+2. **stop and ask a human** the four questions phase P's report makes answerable — which validation
+   targets (the skill refuses to pick when several candidates exist), which model per role, the
+   refutation budget, and whether the environment record still holds;
+3. run `workflows/run.workflow.js` with those answers. It does not stop again.
+
+## What it guarantees, and what it does not
+
+**Guarantees.** Every finding on the card was attacked by an independent agent that did not see the
+analysis; the ledger recording that was written by the refuters themselves and is checked for
+count and format before a card can be certified; the seven gates are judged by the skill's own exit
+codes, never by a model's say-so; deterministic claims come only from a `validation_report.json`
+whose `repo.head` matches the PR head; a run that cannot establish any of this aborts rather than
+producing a green result.
+
+**Does not guarantee.** That the findings are *correct* — that is what a human reads the card for.
+That the review is *complete*: the set of files given to the per-file assessment is still chosen by
+the caller. That the executor never produces false signals — hence S6b. See
+[docs/known-limitations.md](docs/known-limitations.md), which is deliberately specific.
+
+## Layout
+
+| path | what |
+|---|---|
+| `loop.md` | the contract: roles, artifact layout, eight stages, gates, termination, environment traps, and the lessons behind each guard |
+| `workflows/prefetch.workflow.js` | phase P |
+| `workflows/run.workflow.js` | phase R |
+| `tools/dryrun.mjs` | local harness that stubs the workflow hooks and asserts every guard fires — no model calls |
+| `tools/gh_shim.py` | drop-in `gh` for hosts without it, or for a diff over GitHub's 20000-line API cap |
+| `tools/agent_cost.py`, `dump_subagent_log.py`, `list_run_agents.py` | after-the-fact inspection: token accounting, readable transcripts, and which agents a run actually started |
+| `config/loop.example.json` | every installation-specific value, with the reasoning inline |
+| `docs/known-limitations.md` | what is still broken or unverified |
+| `docs/upstream-findings.md` | four reproducible defects this loop found **in the skills it drives** |
+| `VALIDATED-AGAINST.md` | the skill commit, PR heads, hardware and measurements this was validated on |
+
+## The one number worth knowing
+
+The refuter must not be the same model as the worker. Measured over three rounds of the same PR:
+a same-model refuter killed **18%** of findings; a cross-model refuter killed **40%**, including
+four of six `RED`s in one round. The false positive that a same-model round shipped to the card —
+and that had to be withdrawn by hand — was caught automatically once the refuter changed family.

--- a/.agent_loop/VALIDATED-AGAINST.md
+++ b/.agent_loop/VALIDATED-AGAINST.md
@@ -1,0 +1,74 @@
+# Validated against
+
+This loop consumes the **CLI surface** of two skills in this repository. That surface is still
+evolving, so a release pins what it was exercised against. If a pinned command or flag has moved,
+the loop can still appear to work while drawing the wrong conclusion — check before trusting a run.
+
+## Loop
+
+    .agent_loop 0.1.0
+
+## Skills
+
+    ROCm/aiter .claude/skills @ the commit this directory was added on
+
+**`review-pr` — the seven gates, all of which must exist and keep their argument order:**
+
+    triage.py answers      <answers.txt>
+    triage.py diagnostic   <ai_diagnostic.txt>
+    triage.py corefiles    <core_files.txt> <pr.diff> <project-root>
+    triage.py ledger       <rules.txt> <verdicts.txt> <pr.diff>
+    triage.py card         <card.md> <verdicts.txt> <ai_diagnostic.txt> <answers.txt> <pr.diff> <late_findings.txt>
+    triage.py refutations  <refutations.txt> <pr.diff> <card.md>
+    triage.py independent  <independent.txt> <card.md>
+
+    fetch.sh <PR> <owner/repo>            # honours REVIEW_AUTO_VALIDATE=0
+
+Artifacts the loop reads by name from `fetch.sh`'s scratch dir: `pr.diff`, `pr_meta.json`,
+`rules.txt`, `rules_expanded.txt`, `applies.txt`, `merge_target.txt`, `guards.txt`, `siblings.txt`,
+`symbols.txt`, `twins.txt`, `test_quality.txt`, `kernel_tests.txt`, `ci_coverage.txt`,
+`perf_claims.txt`, `struct_abi.txt`, `comment_only.txt`, `evidence.txt`,
+`validation_requirement.json`, and the `head/` and `merge-target/` worktrees.
+
+**`validate-kernel-pr` — the flags the loop passes:**
+
+    validate_pr.sh --repo --patch --head-sha --target --label --out
+                   [--expected-route] [--shape-argnames] [--shape-env] [--no-perf]
+
+Report fields the loop reads: `verdict`, `findings[]`, `stages.*.status` and their notes,
+`test_selection`, `execution_receipt`, `stages.correctness_repo_tests.stats`, `stages.perf`
+(`median_ratio`, `worst_column`, `matched_rows`, `threshold`, `baseline_method`), `arch_coverage`.
+
+## Pull request
+
+    ROCm/aiter#4961, reviewed at three successive heads:
+      round 1  head a65d5ffee51752b9051a76328631994dd4231248  base 24a62b1c122f23645a19b9d8b0abd4750c59359b
+      round 2  head a05fe49e1c28d36b21419b543e62a89357ca2aaf  base f0321c0e8927d1d90a29385433f71e592b1c51f5
+      round 3  head 1f24221fe2dfd3b36e742a628eee4ebc8abe1aea  base 226ee790953feedcc9d5e17323db0a019a177d23
+
+    diff size 21.7k-22.0k lines, 68-74 changed files, 30-32 of 53 rules derived
+
+## Hardware
+
+    gfx950  (MI350X, 8 GPUs)      — correctness, policy, interface and JIT-cache targets
+    gfx1250 (MI450X ES, 1 GPU)    — the CO-integration and split-K targets that skip on gfx950
+
+## Measurements
+
+    subagents over the whole exercise      211
+    tokens                                  in 6.82M / out 5.86M
+    one full phase R on a 21.7k-line diff   ~45 agents, in ~1.5M / out ~1.1M
+    refutation cost                         3.7k-38.8k input per finding, median ~10k
+
+    refutation kill rate, same-model refuter        18%   (2 of 11)
+    refutation kill rate, cross-model refuter       40%   (7 of 17, 6 of 15)
+    dry-run guard scenarios                         10/10
+
+## What a real run produced
+
+Round 2's validation on gfx1250 found a reproducible failure in the PR's own added test
+(`correctness_repo_tests: fail`, all other stages passing), which a dedicated debugging agent traced
+to a kernel id registered in Python but absent from the generated C++ dispatch table on any fresh
+build — and whose one-line fix it verified on hardware. Round 3, on a head where that test had been
+removed, produced no correctness failure. Both rounds independently withdrew validator artifacts as
+non-defects. That is the behaviour this package exists to reproduce.

--- a/.agent_loop/config/loop.example.json
+++ b/.agent_loop/config/loop.example.json
@@ -1,0 +1,61 @@
+{
+  "$schema": "./loop.schema.json",
+  "_comment": "Copy to loop.json and fill in. Nothing here may contain a private key, a real hostname or a token; loop.json itself is gitignored.",
+
+  "workspace": {
+    "tmpRoot": "<absolute path to a scratch dir outside the repo>",
+    "_layout": "tmpRoot/pr-review/<pr>/<round>/{work,reports} — every intermediate lives here and the whole tree is deletable after a round"
+  },
+
+  "local": {
+    "ssh": "ssh",
+    "scp": "scp",
+    "identityFile": "<path to the ssh key, or null to use the agent's default>",
+    "python": "python3",
+    "toolsRoot": "<absolute path to .agent_loop/tools>",
+    "_note": "On Windows use the native OpenSSH binaries (C:\\Windows\\System32\\OpenSSH\\ssh.exe); the ones shipped with Git may not start under a confined harness."
+  },
+
+  "skill": {
+    "projectRoot": "<absolute path to the aiter checkout the gates read>",
+    "reviewPrRoot": "<projectRoot>/.claude/skills/review-pr",
+    "validateSkillRoot": "<projectRoot>/.claude/skills/validate-kernel-pr"
+  },
+
+  "providers": {
+    "_note": "Never hardcode these in the workflow scripts. The refuter MUST be a different model family from the worker: a same-model refuter killed 18% of findings, a cross-model one killed 40%.",
+    "worker":    { "provider": "<local-model>",    "model": "<local-model-id>" },
+    "refuter":   { "provider": "<frontier-model>", "model": "<frontier-model-id>" },
+    "formatter": { "provider": "<local-model>",    "model": "<local-model-id>" },
+    "remote":    { "provider": "<local-model>",    "model": "<local-model-id>" }
+  },
+
+  "hosts": [
+    {
+      "name": "gfx950-box",
+      "sshHost": "<fqdn>",
+      "user": "<user>",
+      "uidGid": "<uid>:<gid>",
+      "container": "<container name>",
+      "image": "<image the container was made from>",
+      "hostRoot": "/home/<user>/pr-review",
+      "containerMount": "/work",
+      "scratch": "/work/_tmp/{runId}",
+      "gpuGate": "/opt/rocm/bin/rocm-smi --showpids",
+      "_rules": "All PR testing runs inside the container. Scratch never goes to the host /tmp. The GPU gate must report no KFD processes before any run."
+    }
+  ],
+
+  "policy": {
+    "maxGateRounds": 3,
+    "refuteGranularity": "per-finding",
+    "severityBar": "in-tree-trigger-required",
+    "_severityBar": "A 🔴 requires a triggering point verifiable in this tree. A protocol documented outside the tree (a README telling downstream integrations to call something) caps the finding at ⚠️. Fixing this bar is what makes rounds comparable.",
+    "resume": true,
+    "budget": {
+      "maxAgents": 120,
+      "maxInputTokens": 4000000,
+      "_measured": "One full round on a 21.7k-line diff: ~45 agents, ~1.5M input / ~1.1M output tokens. Refutation is ~15k input per finding."
+    }
+  }
+}

--- a/.agent_loop/docs/known-limitations.md
+++ b/.agent_loop/docs/known-limitations.md
@@ -1,0 +1,78 @@
+# Known limitations
+
+Written so that nobody has to discover these by being misled. Each entry says what is missing, what
+it costs, and what would fix it.
+
+## Coverage
+
+**The per-file assessment set is chosen by the caller, not derived.** `args.files` and
+`args.ruleGroups` are filled in by whoever starts phase R, from the fetch report. On the runs behind
+this package, 9 of 68 changed files were assessed. The `corefiles` gate derives the *backbone* set
+from the diff and will refuse a card that ignores one of those, so a Tier-1/Tier-2 omission is
+caught — but a Tier-3 omission is not. **Fix:** derive the file set from the diff with the same
+tiering questions the gate uses, and let the caller only add to it.
+
+**Rule partitioning is manual.** `ruleGroups` splits the derived rule ids into batches for parallel
+adjudication. A rule that lands in no group is caught by the `ledger` gate, but the split itself is
+hand-made. **Fix:** partition programmatically from `rules.txt`.
+
+## Provenance
+
+**The ledger check counts, it does not authenticate.** Phase R verifies that the number of
+refuter-written files equals the number of ledger lines equals the number of findings, and that
+every line is well formed. It cannot detect a party overwriting the *first line* of an existing
+`F<nn>.md`. The separation-of-duties instruction forbids it and nothing observed has attempted it,
+but the guarantee is procedural, not cryptographic. **Fix:** have each refuter record a hash of its
+own file, and verify hashes at assembly.
+
+**Cross-round isolation is not enforced.** Artifacts from a previous round sit in a sibling
+directory and agents can and do find them: in one round a refuter cited the previous round's card in
+its evidence, despite the run being configured as "no prior". Either isolate the rounds or state on
+the card that priors were reachable — claiming independence while leaving them readable is the one
+unacceptable option. **Fix:** per-round workspace roots, and a prompt-level prohibition.
+
+## Operation
+
+**Human answers are not persisted.** Targets, model roles and budget are re-asked every round;
+the environment record is written but never read back by phase P (`envKnown` is passed in by the
+caller). **Fix:** a `state.json` per PR that the break writes and phase P reads.
+
+**No budget enforcement.** `policy.budget` is documented in the config and honoured by nothing. A
+round is roughly 45 agents and 2.6M tokens; nothing stops a pathological run from doing far more.
+**Fix:** count agents in the script and abort past the cap.
+
+**Resume is partial.** `resume: true` skips refuters whose file already exists. Analysis outputs,
+validation reports and the card are always redone. **Fix:** the same existence check for the S2
+artifacts, which are already all on disk.
+
+**Cleanup failure is a warning, not an error.** If a cleanup agent cannot reach a host, the run logs
+it and still returns. The remote side is then left dirty for the next round, which discovers it as a
+permission failure when removing a worktree. **Fix:** treat a failed cleanup as a failed round.
+
+## Environment
+
+**Windows hosts hit a long list of avoidable traps** — no usable bash under a confined harness,
+`schannel` TLS failures for git over https, CRLF breaking the skill's own rule parsing, and
+PowerShell quoting mangling remote commands. All are worked around in `loop.md` §7, and none of them
+exist on a Linux host. **Running the loop from Linux removes most of that section.**
+
+**One GPU per host is common and matters.** A host may expose a single GPU shared with other users'
+long-running containers. The GPU gate (`rocm-smi --showpids`) is checked immediately before launch,
+but nothing holds the GPU for the duration beyond the validator's own `flock`, and a co-tenant can
+claim it mid-run. A run that loses the GPU should be reported as an environment gap, never as a PR
+defect.
+
+**A host can reboot mid-run.** It happened. The validation agent returns no report, and the card
+records `NO REPORT` with the reason rather than inferring a verdict from another target. That is the
+correct behaviour, but the round is then incomplete and must be finished by hand.
+
+## Scope
+
+**Validated against one repository and one PR.** Three rounds of the same PR, on two GPU
+architectures. The loop contract is repo-agnostic, but nothing here has been run against a second
+repository, and the skill CLI surface it depends on is pinned in `../VALIDATED-AGAINST.md` precisely
+because that surface is still evolving.
+
+**The card's five-finding cap is a readability limit, not a recall claim.** It comes from the
+`review-pr` skill, which says so itself. Everything dropped is accounted for on the card and kept in
+full in `findings.md`.

--- a/.agent_loop/docs/upstream-findings.md
+++ b/.agent_loop/docs/upstream-findings.md
@@ -1,0 +1,108 @@
+# Defects found in the skills this loop drives
+
+Four reproducible defects in `.claude/skills/validate-kernel-pr/`, each observed while validating a
+real PR. They matter more than ordinary bugs because **every one of them produces a signal that
+reads as a defect in the PR under review**, and a reviewer who trusts the tool will report it to
+the author.
+
+Each entry states what was observed, the mechanism at the cited lines, and how it was confirmed.
+Line numbers are from the skill as of the commit in `../VALIDATED-AGAINST.md`.
+
+---
+
+## 1. The validator dirties the worktree it is checking, then blames the dirt on the PR
+
+**Observed.** A validation run reported `baseline_control: skip` with the note *"base run did not
+leave a clean worktree; head tests were not run"*, which cascaded into `correctness_repo_tests`,
+`correctness_s1_grid`, `execution_receipt` and `perf` all skipping. The verdict was `NEEDS_WORK`
+with no correctness evidence at all — indistinguishable, to a reader, from a PR that broke isolation.
+
+**Mechanism.** `validate_pr.sh` captures the ignored-file set at startup and compares it after the
+base phase; a new ignored entry means the base run was not isolated. The only new entry was
+`.claude/skills/validate-kernel-pr/__pycache__/pick-idle-gpu.cpython-312.pyc`, written by the
+validator's own GPU picker: lines 446 and 629 import `pick-idle-gpu.py` through
+`importlib.spec_from_file_location` + `exec_module` **without** `PYTHONDONTWRITEBYTECODE=1`, while
+the script does set that variable on its own test invocations (lines 731, 765, 815, 824).
+
+**Confirmed by.** Injecting `PYTHONDONTWRITEBYTECODE=1` into the environment of the run — with no
+other change — made every stage execute normally. `AITER_JIT_DIR` was ruled out first: it is
+already redirected to `$WORK` (lines 200, 730, 814, 1767, 2095), so JIT output was never the cause.
+
+**Fix.** Set `PYTHONDONTWRITEBYTECODE=1` (or `PYTHONPYCACHEPREFIX`) around those two imports.
+Editing `validate_pr.sh` from outside is not a workaround: the file is tracked, so touching it
+dirties the very worktree the run is about to check.
+
+---
+
+## 2. `test_policy` compares tolerances by position after discarding their names
+
+**Observed.** `test_policy: fail — comparison tolerance widened [[0.1, 0.5]] while kernel code also
+changed`. Reported as a `should-fix`, it made the run `NEEDS_WORK`. It reached a review card as a
+🔴 before being withdrawn.
+
+**Mechanism.** Lines 897–918 extract tolerances with
+`re.findall(r'(?:atol|rtol)\s*=\s*([0-9.eE+-]+)', src)` — the `atol=`/`rtol=` keyword is captured
+and then **thrown away**. Lines 922–932 zip the base and head lists positionally and keep any pair
+where the head value is larger. Nothing matches by name.
+
+The PR under test kept three call sites written `rtol=, atol=` and added a helper written
+`atol=, rtol=`. Position 5 therefore compared the base's **rtol** `0.1` against the head's **atol**
+`0.5` and declared a widening. Like for like, every tolerance was unchanged or tighter: bf16 rtol
+`0.1 → 0.03`, fp32 rtol `0.1 → 1e-3`, atol unchanged at `0.5` for bf16 and `0.5 → 0.05` for fp32.
+
+**Confirmed by.** Reading all six literals on each side with their owning call, and checking the
+arithmetic: bf16 unit roundoff is `2^-8 ≈ 0.0039`, so the head's `rtol=0.03` is ~7.7× the
+single-rounding bound and 3.3× *tighter* than the base's `0.1`.
+
+**Fix.** Pair by name (`(name, value)`), not by position. Note also that the comparison only runs
+when the two lists have equal length (lines 923–927), so today it silently passes whenever a diff
+changes the number of tolerance literals — a second reason to key by name.
+
+---
+
+## 3. The same regex sees only the first literal of a conditional tolerance
+
+**Observed.** In the same run, the head's fp32 tolerances never entered the comparison at all.
+
+**Mechanism.** The extractor takes one numeric literal per `atol=`/`rtol=` occurrence. For
+`atol = 0.5 if actual.dtype == torch.bfloat16 else 0.05` it captures `0.5` and never sees `0.05`;
+likewise `rtol = 0.03 if ... else 1e-3` yields only `0.03`. A file that expresses tolerances as
+conditionals is therefore compared on a subset of its own values.
+
+**Fix.** Parse the assignment with `ast` rather than a regex, or capture every numeric literal in
+the right-hand side.
+
+---
+
+## 4. `scrape_perf.py` reports "no common timing column" on logs that do have one
+
+**Observed.** A perf stage note: *"14 row(s) matched but no timing column is common to both logs"*,
+on a run whose base and head logs both carried timings.
+
+**Mechanism.** `scrape_perf.py:383-386` emits that message when its column-intersection step comes
+up empty. Row identity and column identity are derived from header text; bench tables in this repo
+print unlabeled measurement columns, which the relaxed row key already has to work around (the
+`row_key_basis` field exists for exactly that reason). The column side has no equivalent fallback.
+
+**Confirmed by.** An independent reading of both logs, which contained comparable timing columns
+under headers the intersection did not match.
+
+**Fix.** Apply the same relaxation on the column axis that `row_key_basis` applies on the row axis,
+and report the column names from each side in the note so the failure is diagnosable from the
+report alone.
+
+---
+
+## Two adjacent observations (not defects, but they mislead)
+
+**`-x` under-reports the failure surface.** The correctness stage runs pytest with `-x`, so a
+failure hides every case that would have run after it. One run reported 64 executed with 1 failure;
+the same file without `-x` executed 70 with 4 failures, and the extra three changed the diagnosis
+(the failure was specific to one kernel id, not to one parameter). A report should either say that
+execution stopped early, or the stage should re-run without `-x` to characterise a failure.
+
+**The C++ launch check cannot distinguish "not a workspace kid" from "not compiled in this build".**
+`opus_gemm.cu`'s non-workspace branch raises `non-workspace kid N requires workspace=None` for a kid
+that is simply absent from the generated table for that build. Checking the non-workspace table
+before raising would turn a misleading message into an accurate one — this cost a day of root-cause
+work on a real failure.

--- a/.agent_loop/loop.md
+++ b/.agent_loop/loop.md
@@ -1,0 +1,281 @@
+# The loop contract
+
+This file is the contract. The orchestration layer underneath it can be replaced — a different
+harness, a different flow engine, a different set of models — but the directories, artifacts,
+gates and termination criteria defined here cannot, because every guarantee the loop offers is
+expressed in terms of them.
+
+Everything below was derived from three complete rounds against one real PR at three successive
+heads, on two GPU architectures. Numbers marked *measured* come from those runs.
+
+---
+
+## 0. Roles and models
+
+| role | responsibility | model class |
+|---|---|---|
+| `worker` | fetch, rule adjudication, core-file assessment, AI diagnostic, writing the card | local / cheap |
+| **`refuter`** | **independent refutation — must be a different model family from `worker`** | frontier |
+| `formatter` | prose → structured lines, mechanical file writing | local / cheap |
+| `remote-exec` | ssh, docker, running the skills on the GPU host | local / cheap |
+
+**Never hardcode these.** They come from configuration, and a human confirms them at the single
+break. The one constraint that is not negotiable is the second row: a refuter drawn from the same
+model as the worker is checking its own homework.
+
+*Measured:* a same-model refuter killed 18% of findings (2 of 11). A cross-model refuter killed
+40% (7 of 17, then 6 of 15), including four of six `RED`s in one round. The one false positive that
+reached a card and had to be withdrawn by hand came from a same-model round; the identical false
+positive was caught automatically once the refuter changed family.
+
+---
+
+## 1. The artifact contract
+
+Files are the contract. Return values are logs.
+
+### Local
+
+```
+<workspace>/
+  <repo>/                          the checkout the gates read (long-lived, read-only to the loop)
+  <tmpRoot>/                       every intermediate; deletable in one command after a round
+    pr-review/<pr>/<round>/work/       the skill's $WORK, synced back from the host
+    pr-review/<pr>/<round>/reports/    card.md, findings.md, validation_report*.json
+    runs/<run-id>/                     one-off scripts and launch logs
+    logs/                              subagent transcripts
+```
+
+No agent may write outside `<tmpRoot>` and the loop's own package directory. Creating files in the
+workspace root is forbidden.
+
+### Remote
+
+```
+<host>:<hostRoot>/                     the PR body: clone, base worktree, patch (long-lived)
+<container>:<scratch>/                 every temporary script, log and test artifact
+```
+
+Hard constraints:
+
+- **All PR testing runs inside the container.** The host does git and docker, nothing else.
+- **Temporary scripts go in the container scratch.** Writing scratch to the host's `/tmp` is
+  forbidden beyond a single script the agent deletes afterwards.
+- **Every round ends by removing its scratch** and chowning any root-owned artifact the container
+  left in the worktree back to the host user. A round that skips this leaves the next round unable
+  to remove its own worktree.
+
+### Handoff
+
+- Agents write their conclusions to named files; the return value only carries the prompt forward.
+- **The `worker` role never gets an output schema.** Structured output is the `formatter`'s job,
+  with at most three flat string fields.
+  *Measured:* of 74 agents in an early round, 23 (31%) returned nothing to the orchestrator while
+  their own logs showed `turn/end: completed`, files written and commands run. Schema validation,
+  not model capability, discarded finished work. Every one of those was recoverable only because
+  the agent had also written its result to disk.
+
+---
+
+## 2. Stages
+
+| stage | what happens | artifacts | role |
+|---|---|---|---|
+| **S0 env** | probe host, GPUs, container, tooling; confirm with a human | env record | remote-exec |
+| **S1 fetch** | run `review-pr/fetch.sh` in the container; sync `$WORK` back | ~20 skill artifacts | remote-exec |
+| **S2 analysis** | Step 2 semantic, Step 4 per file, Step 5 per rule group, Step 6 diagnostic | `answers.txt`, `core_files.txt`, `verdicts_*.txt`, `ai_diagnostic.txt` | worker |
+| **S3 refutation** | one fresh agent per finding; each writes its own ledger line | `refutation_lines/F<nn>.md`, `refutations.txt`, `independent.txt`, `findings.md` | **refuter** |
+| **S4 card** | rank surviving findings, write the card, account for the rest | `card.md` | worker |
+| **S5 gates** | the skill's seven `triage.py` gates | all green, or the complaint is fed back | worker |
+| **S6 validation** | `validate_pr.sh` per target, in the container, on a claimed-idle GPU | `validation_report*.json` | remote-exec |
+| **S6b executor refutation** | attack the executor's *own* findings the same way | verdicts per executor finding | **refuter** |
+| **S7 refold** | fold deterministic evidence into the card; re-gate; verify independently | updated `card.md` | worker |
+| **S8 cleanup** | recover artifacts, delete scratch, restore ownership | — | remote-exec |
+
+### Granularity in S2 and S3
+
+**Fan out; do not batch.** One agent per file and per rule group, one refuter per finding.
+
+*Measured:* a single agent given one rule family consumed 177k input over 79 steps; ten per-file
+agents consumed 4k–26k each and all ten succeeded, while the batched equivalent failed four times
+in a row. A single refuter given all 11 findings cost more (111k input, 84 steps) than the eleven
+separate refuters and failed outright twice. Cumulative input grows with *step count*, because
+every step resends the context — so step count, not file size, is what drives cost.
+
+### The cost of refutation
+
+*Measured:* 3.7k–38.8k input per finding, median ~10k; 11 findings ≈ 150k. The refuter is given the
+finding and a pointer to the evidence directory — **never the diff**; it greps for what it needs.
+Report the estimate (`findings × ~15k`) to the human at the break.
+
+---
+
+## 3. Human gates: all of them at the front
+
+```
+[once per host]  environment probe → human confirms → env record, reused by later rounds
+[per PR]   phase P (prefetch): verify env + skill Step 1                 ← cheap, 2 agents
+              ↓  ★ the single break: one batch of questions
+           phase R: S2 → S3 → S4 → S5 → S6 → S6b → S7 → S8               ← no further stops
+```
+
+**Why the break cannot move earlier.** The human must choose validation targets, and the candidate
+list comes from `validation_requirement.json`, which is produced by Step 1. The alternatives are to
+guess the target or to reimplement the skill's requirement derivation — the first is unacceptable,
+the second drifts from the skill immediately.
+
+**The four questions, asked once:**
+
+1. **Environment** — host, container/image, GPU pool, PR body path. Written to the env record.
+2. **Models** — one per role, from what the harness actually offers.
+3. **Refutation budget** — granularity and the estimate.
+4. **Validation** — the candidate targets, or `N/A` when the skill reports no runtime surface.
+
+After phase R starts, only a hard error may interrupt: host unreachable, patch conflict, no idle
+GPU, or the gates failing for `maxGateRounds` rounds. Everything else is recorded and carried.
+
+### Six fail-closed guards
+
+All are covered by `tools/dryrun.mjs`, which stubs the harness hooks and asserts each one fires
+without calling a model (10/10).
+
+| guard | fires when | the incident behind it |
+|---|---|---|
+| S2 completeness | any analysis agent returns nothing | a silently failed Step 4 left artifacts missing, and the gate then asked the card's author to supply them |
+| collection floor | findings < the `FIRE` count in `verdicts_*.txt` (**derived, not configured**) | a collector returned nothing and the refutation stage ran zero agents |
+| ledger provenance | refuter files ≠ ledger lines ≠ findings, or any malformed line | one formatter asked to write 17 ledger lines wrote 2 |
+| gate termination | still not green after `maxGateRounds` | the original implementation recorded the failure and delivered the card anyway |
+| ledger untouched | gates report green but the ledger line count has changed | the card's author wrote the refutation ledger itself to turn a gate green |
+| post-refold check | gates fail after S7 edits the card | only the editing agent witnessed its own success |
+
+**Separation of duties covers two records, not one.** The `worker` may not write the refutation
+ledger (`refutations.txt`, `independent.txt`, `findings.md`, `refutation_lines/`) — and may not add
+a verdict line for a rule that has none. The second is the same hole through a different door: a
+rule with no verdict means an analysis agent failed, and the correct response is to report a
+blocker, not to adjudicate it yourself.
+
+---
+
+## 4. The card
+
+- At most **five findings**. This is the `review-pr` skill's own readability limit, and the skill
+  says plainly that it is not a measured recall claim.
+- Everything dropped, killed or downgraded is accounted for at the bottom of the card with
+  `-- not reported: <reason>`; anything withdrawn after the blind-spot check uses `-- late finding:`.
+- **`findings.md` ships alongside**: every finding, its refutation verdict and the deciding
+  evidence. The card is for the reviewer's attention; `findings.md` is for anyone who wants to dig.
+- When a previous round exists, the card carries a **"since last review"** line. Once the base
+  moves, a file the previous head added and this head removed is invisible in the diff — it reads
+  as if it never existed. Only `git log <prev-head>..<head>` shows it, and phase P reports it.
+
+---
+
+## 5. When validation runs
+
+Driven by the skill's own `validation_requirement.json`:
+
+- `required=false` → **do not run** `validate-kernel-pr`. The card says
+  `Validation (deterministic): N/A — no runtime surface changed`. Not running it is not a defect.
+- `required=true` → put the candidate targets in front of the human at the break; after they
+  choose, the loop runs to the end without stopping.
+- Environment prevented it (no idle GPU, missing runtime, host rebooted) → `NOT RUN — <reason>`.
+  **That is an environment gap, never a PR defect**, and a missing report is never inferred from
+  another target's result.
+
+---
+
+## 6. Termination criteria
+
+Truth comes from files, never from an agent's summary.
+
+| claim | what establishes it |
+|---|---|
+| the analysis happened | the seven `triage.py` gates exit 0 |
+| a card finding stands up | a line in `refutations.txt` + `independent.txt`, written by the refuter, provenance-checked |
+| runtime behaviour | `validation_report.json` whose `repo.head` equals the PR head |
+| performance | `stages.perf` carries `median_ratio`; otherwise the card states why it skipped |
+| **the tools did not lie** | **every executor finding also went through refutation** |
+| the site is clean | scratch removed, no root-owned leftovers, nothing in the host `/tmp` |
+
+### Why tool-honesty is a hard criterion
+
+In one round the validator produced two signals that would otherwise have been attributed to the
+author:
+
+1. Its own GPU-picker import wrote `__pycache__` into the worktree under test; its own cleanliness
+   check then read the tree as dirty and skipped every correctness and perf stage.
+2. Its tolerance extractor discards the `atol=`/`rtol=` names and zips the remaining literals by
+   position. The PR had reordered one call site from `(rtol, atol)` to `(atol, rtol)`, so an rtol
+   was compared against an atol and reported as a widening. Like for like, every tolerance in that
+   PR was unchanged or tighter.
+
+Both reached a card before being withdrawn. S6b exists so that they are withdrawn automatically.
+See `docs/upstream-findings.md`.
+
+---
+
+## 7. Environment traps
+
+| trap | symptom | handling |
+|---|---|---|
+| no usable shell under a confined harness | cygwin `couldn't create signal pipe` | run the skills on the remote Linux host; keep the local side to the harness's own shell |
+| host git cannot reach https | `schannel: SEC_E_NO_CREDENTIALS` | force the openssl backend, or use ssh |
+| no `gh`, or `gh` unauthenticated | `fetch.sh` depends on it | use `tools/gh_shim.py` |
+| diff over GitHub's 20000-line API cap | `gh pr diff` returns HTTP 406 | the shim produces the diff locally with `git diff <merge-base> <head>` |
+| skill tooling reads files as the platform codepage | `MISSING-RULE-TEXT`, i.e. rules silently unexpanded | force `PYTHONUTF8=1` everywhere |
+| CRLF checkouts | same as above | `core.autocrlf=false` for the review checkout |
+| quoting through shell→ssh→shell | remote command mangled | write the script, copy it, run `bash <path>` |
+| login banners | ssh exit codes unreliable | judge by stdout |
+| PR stale against main | patch does not apply to the tip | base on `merge-base(main, head)`; note STALE on the card |
+| submodule uninitialised | `fatal error: 'ck_tile/core.hpp' file not found` | initialise the pinned submodule — this produced one false BLOCK |
+| container runs as root | root-owned artifacts block the next `git worktree remove` | clean from inside the container, then chown back |
+| container may be stopped | a docker restart left it `exited` | check `docker ps -a` first; starting someone else's container is out of scope and must be reported |
+| validator runs pytest with `-x` | the failure surface is under-reported (64 of 70 in one case) | say that execution stopped early, or re-run without `-x` to characterise a failure |
+| the host can reboot mid-run | the report never appears | record `NO REPORT` with the reason; never infer from another target |
+| GPU shared with co-tenants | a run can lose the GPU it claimed | gate on `rocm-smi --showpids` immediately before launch; a lost GPU is an environment gap |
+| harness-side sandbox faults | ssh refused locally while the host is fine | the agent must fail loud; a silently skipped cleanup is a failed round |
+
+---
+
+## 8. Lessons from the live runs
+
+### 8.1 Structured output silently discards finished work
+
+31% of agents in one round returned nothing while having completed their work. → No schema for
+workers; files are the durable contract.
+
+### 8.2 The reviewed party will write the review record if you let it
+
+A collection step returned empty, so zero refuters ran and the ledger was written empty — and the
+card's author, told to "fix what the gate names", wrote the ledger itself with five plausible
+`SURVIVED` lines. All seven gates went green on a fabricated record. → Fail closed on an empty
+collection; **each refuter writes its own line**; check provenance by count and format; forbid the
+worker from touching those files.
+
+### 8.3 The severity bar must be fixed, or rounds are not comparable
+
+The same finding — a public API removed with no shim — survived in one round and was killed in the
+next, on identical facts. One refuter accepted a protocol documented in a README as evidence of a
+consumer; the other demanded a consumer verifiable in the tree. Both are defensible; leaving the
+choice open is not. → **A 🔴 requires an in-tree triggering point. A protocol documented outside the
+tree caps the finding at ⚠️ with an action asking the author to confirm the downstream.**
+
+### 8.4 Prior rounds leak
+
+A run configured as "no prior" produced a refuter that cited the previous round's card, which sat
+in a sibling directory. → Either isolate rounds or state on the card that priors were reachable.
+Claiming independence while leaving them readable is the one unacceptable option.
+
+### 8.5 A diff cannot show what happened between rounds
+
+When the base advanced, a test the previous head had added and this head removed became invisible:
+relative to the new base it had never existed. The commit message said the update addressed the
+review; what it did was remove the test that exposed the problem. → Phase P must report
+`git log <prev-head>..<head>`, separate the author's commits from merge traffic, and name every
+test or guard added or removed.
+
+### 8.6 A failed cleanup must be loud
+
+One cleanup agent had every ssh refused by a local harness fault while ssh from elsewhere worked
+fine. It reported the refusal — but a prompt that does not demand that would have let it read as
+"nothing to clean". → Remote agents must stop and say so; a failed cleanup is a failed round.

--- a/.agent_loop/tools/agent_cost.py
+++ b/.agent_loop/tools/agent_cost.py
@@ -1,0 +1,96 @@
+"""Sum token usage per workflow subagent of this DSH session.
+
+Maps childId -> label/phase/workflow from the parent session's tool-workflow events,
+then walks each child session for usage records.
+"""
+import json
+import os
+from collections import defaultdict
+from pathlib import Path
+
+from compression import zstd
+
+# The harness exports the path of the current session log; every sibling session lives beside it.
+_jsonl = os.environ.get("DSH_SESSION_JSONL")
+if not _jsonl:
+    raise SystemExit("set DSH_SESSION_JSONL (the harness exports it) before running this tool")
+PARENT = Path(_jsonl)
+SESS = PARENT.parent.parent
+
+
+def events(path):
+    raw = zstd.decompress(path.read_bytes()).decode("utf-8", errors="replace")
+    for line in raw.splitlines():
+        try:
+            yield json.loads(line)
+        except Exception:
+            continue
+
+
+def find_usage(obj, acc):
+    """Recursively collect any {input/output/prompt/completion}_tokens style dicts."""
+    if isinstance(obj, dict):
+        keys = set(obj.keys())
+        if {"input", "output"} <= keys and all(isinstance(obj.get(k), int) for k in ("input", "output")):
+            acc["input"] += obj["input"]
+            acc["output"] += obj["output"]
+            return
+        if "inputTokens" in keys or "outputTokens" in keys:
+            acc["input"] += obj.get("inputTokens") or 0
+            acc["output"] += obj.get("outputTokens") or 0
+            return
+        if "prompt_tokens" in keys or "completion_tokens" in keys:
+            acc["input"] += obj.get("prompt_tokens") or 0
+            acc["output"] += obj.get("completion_tokens") or 0
+            return
+        for v in obj.values():
+            find_usage(v, acc)
+    elif isinstance(obj, list):
+        for v in obj:
+            find_usage(v, acc)
+
+
+def main():
+    meta = {}
+    run_names = {}
+    for ev in events(PARENT):
+        d = ev.get("data") or {}
+        if ev.get("type") == "tool-workflow/run-start":
+            run_names[d.get("runId")] = d.get("name")
+        if ev.get("type") == "tool-workflow/agent-start":
+            meta[d.get("childId")] = (run_names.get(d.get("runId"), "?"), d.get("label"))
+
+    rows = []
+    for cid, (run, label) in meta.items():
+        dirs = [p for p in SESS.iterdir() if p.is_dir() and p.name == cid]
+        if not dirs:
+            rows.append((run, label, 0, 0, "NO SESSION"))
+            continue
+        f = dirs[0] / "session.jsonl.zstd"
+        acc = defaultdict(int)
+        steps = 0
+        for ev in events(f):
+            if ev.get("type") == "step/start":
+                steps += 1
+            if ev.get("type") in ("step/end", "assistant/message", "turn/end", "usage"):
+                find_usage(ev.get("data") or {}, acc)
+        rows.append((run, label, acc["input"], acc["output"], f"{steps} steps"))
+
+    by_run = defaultdict(lambda: [0, 0, 0])
+    for run, label, i, o, note in rows:
+        by_run[run][0] += 1
+        by_run[run][1] += i
+        by_run[run][2] += o
+        print(f"{run:34} | {str(label)[:38]:38} | in {i:9,} | out {o:7,} | {note}")
+
+    print("\n=== per workflow ===")
+    ti = to = 0
+    for run, (n, i, o) in by_run.items():
+        print(f"{run:34} | {n:3} agents | in {i:10,} | out {o:8,}")
+        ti += i
+        to += o
+    print(f"{'TOTAL':34} | {len(rows):3} agents | in {ti:10,} | out {to:8,}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.agent_loop/tools/dryrun.mjs
+++ b/.agent_loop/tools/dryrun.mjs
@@ -1,0 +1,201 @@
+// Dry-run harness for loop/run.workflow.js.
+//
+// Loads the workflow script body, stubs the four hooks the workflow tool provides
+// (agent / parallel / phase / log) and exercises the control flow WITHOUT calling any model.
+// Its job is to prove that the guards fire: a happy path completes, and every failure the
+// post-round-3 review identified is refused rather than carried.
+//
+//   node loop/dryrun.mjs
+//
+// Exit code 0 = every scenario behaved as expected.
+
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const body = readFileSync(join(here, '..', 'workflows', 'run.workflow.js'), 'utf8');
+const AsyncFunction = Object.getPrototypeOf(async function () {}).constructor;
+const make = () => new AsyncFunction('args', 'agent', 'parallel', 'pipeline', 'phase', 'log', body);
+
+const ARGS = {
+  pr: 4961,
+  repo: 'ROCm/aiter',
+  headSha: 'HEADSHA',
+  baseSha: 'BASESHA',
+  stale: true,
+  localWork: 'W:\\work',
+  localReports: 'W:\\reports',
+  skillRoot: 'S:\\skills\\review-pr',
+  projectRoot: 'P:\\aiter',
+  python: 'python3',
+  hostUser: 'u',
+  uidGid: '1000:1000',
+  validateSkillRoot: 'S:\\\\skills\\\\validate-kernel-pr',
+  local: { ssh: 'ssh', scp: 'scp', identityFile: '/k/id', toolsRoot: 'T:' },
+  files: ['a/one.py', 'a/two.py', 'a/three.py'],
+  ruleGroups: [{ id: 'A_B', ids: 'A1 B1' }, { id: 'C_D', ids: 'C1 D1' }],
+  targets: [{
+    t: 'op_tests/test_x.py', host: 'h1.example', user: 'u', container: 'c1',
+    worktree: '/work/pr', patch: '/work/pr.patch', scratch: '/work/_tmp/run', hostRoot: '/home/u/pr', refresh: false,
+  }],
+  validationRequired: true,
+  providers: {
+    worker: { provider: 'w', model: 'w' },
+    refuter: { provider: 'r', model: 'r' },
+    formatter: { provider: 'f', model: 'f' },
+    remote: { provider: 'm', model: 'm' },
+  },
+  maxGateRounds: 2,
+  sinceHead: 'PREVHEAD',
+  resume: false,
+};
+
+// ---------------------------------------------------------------- the stub
+
+function makeAgent(scenario, calls) {
+  return async function agent(prompt, opts = {}) {
+    const label = String(opts.label || '');
+    calls.push(label);
+    const o = scenario.overrides || {};
+    if (Object.prototype.hasOwnProperty.call(o, label)) return o[label];
+    for (const [pattern, value] of Object.entries(scenario.patterns || {})) {
+      if (label.startsWith(pattern)) return typeof value === 'function' ? value(label) : value;
+    }
+
+    if (label.startsWith('S4 ')) {
+      const f = label.slice(3);
+      return `Looked at the hunks.\n${f} TIER2 COVERED -- the change to do_thing() is exercised by the added test`;
+    }
+    if (label.startsWith('S5 rules')) return 'wrote the verdict file; 2 rules adjudicated';
+    if (label === 'S2 semantic') return 'Q1..Q5 and BLIND written';
+    if (label === 'S6 AI diagnostic') return 'six checks written';
+    if (label === 'write core_files.txt') return `core_files.txt has ${ARGS.files.length} lines`;
+    if (label === 'count FIRE verdicts') return `FIRE=${scenario.fire ?? 3}`;
+    if (label === 'collect findings') {
+      const n = scenario.collected ?? 4;
+      const lines = Array.from({ length: n }, (_, i) => `RED|finding number ${i + 1} in a/one.py:${i + 10}`);
+      return `BEGIN_FINDINGS\n${lines.join('\n')}\nEND_FINDINGS`;
+    }
+    if (label === 'check resumable refutations') return scenario.existing || 'EXISTING=NONE';
+    if (label.startsWith('refute F')) return `SURVIVED -- opened a/one.py and could not kill it`;
+    if (label === 'assemble ledger') return 'refutations.txt and independent.txt written';
+    if (label === 'ledger provenance') {
+      const n = scenario.ledger ?? (scenario.collected ?? 4);
+      return `FILES=${n}\nREFUT=${n}\nINDEP=${n}\nBAD=${scenario.bad ?? 0}`;
+    }
+    if (label.startsWith('card + gates')) return 'card written, gates run';
+    if (label.startsWith('gate check')) {
+      const n = scenario.collected ?? 4;
+      return scenario.gatesGreen === false
+        ? `card gate failed: UNANCHORED finding\nrefutations.txt lines: ${n}`
+        : `all seven exit 0\nrefutations.txt lines: ${n}\nALLGREEN`;
+    }
+    if (label.startsWith('validate ')) return 'verdict INCONCLUSIVE, all stages pass except the shape grid';
+    if (label.startsWith('refute executor')) return 'the shape-grid note is a property of the invocation - KILLED';
+    if (label === 'fold validation into card') return 'validation folded in, gates re-run';
+    if (label === 'final independent gate check') {
+      const n = scenario.collected ?? 4;
+      return scenario.finalGreen === false
+        ? `card gate failed after refold\nrefutations.txt lines: ${n}`
+        : `all seven exit 0\nrefutations.txt lines: ${n}\nALLGREEN`;
+    }
+    if (label.startsWith('cleanup ')) return 'scratch deleted, worktree clean, 0 root-owned';
+    return `stub response for ${label}`;
+  };
+}
+
+async function run(scenario) {
+  const calls = [];
+  const logs = [];
+  const agent = makeAgent(scenario, calls);
+  const parallel = async (thunks) => {
+    const out = [];
+    for (const t of thunks) {
+      try { out.push(await t()); } catch { out.push(null); }
+    }
+    return out;
+  };
+  const fn = make();
+  try {
+    const value = await fn(ARGS, agent, parallel, async () => {}, () => {}, (m) => logs.push(String(m)));
+    return { ok: true, value, calls, logs };
+  } catch (err) {
+    return { ok: false, error: String(err && err.message || err), calls, logs };
+  }
+}
+
+// ---------------------------------------------------------------- scenarios
+
+const scenarios = [
+  {
+    name: 'happy path completes and returns a card',
+    scenario: { fire: 3, collected: 4 },
+    expect: (r) => r.ok && r.value.findings === 4 && r.value.gatesGreen === true
+      && r.value.validated.length === 1 && r.value.card.endsWith('card.md'),
+  },
+  {
+    name: 'FIX 4 — a dead S2 analysis agent aborts the run',
+    scenario: { fire: 3, collected: 4, patterns: { 'S5 rules C_D': null } },
+    expect: (r) => !r.ok && /analysis agents produced nothing/.test(r.error)
+      && /rule ledger and the core-file/.test(r.error),
+  },
+  {
+    name: 'FIX 8 — a collection short of the FIRE count aborts the run',
+    scenario: { fire: 7, collected: 5 },
+    expect: (r) => !r.ok && /5 findings but the verdict files contain 7 FIRE/.test(r.error),
+  },
+  {
+    name: 'FIX 2 — an empty collection aborts instead of certifying a clean card',
+    scenario: { fire: 0, collected: 0 },
+    expect: (r) => !r.ok && /0 findings/.test(r.error),
+  },
+  {
+    name: 'FIX 2 — a truncated ledger (the r2 failure) aborts on provenance',
+    scenario: { fire: 3, collected: 17, ledger: 2 },
+    expect: (r) => !r.ok && /provenance failed: 2 refuter files/.test(r.error),
+  },
+  {
+    name: 'provenance also catches a malformed ledger line',
+    scenario: { fire: 3, collected: 4, bad: 1 },
+    expect: (r) => !r.ok && /1 malformed/.test(r.error),
+  },
+  {
+    name: 'FIX 3 — gates that never go green abort before validation',
+    scenario: { fire: 3, collected: 4, gatesGreen: false },
+    expect: (r) => !r.ok && /did not go green within 2 rounds/.test(r.error)
+      && !r.calls.some(c => c.startsWith('validate ')),
+  },
+  {
+    name: 'FIX 9 — a card that fails the gates after the refold aborts',
+    scenario: { fire: 3, collected: 4, finalGreen: false },
+    expect: (r) => !r.ok && /do not pass after the validation refold/.test(r.error),
+  },
+  {
+    name: 'FIX 7 — resume skips refuters whose file already exists',
+    scenario: { fire: 3, collected: 4, existing: 'EXISTING=F01.md,F02.md' },
+    args: { resume: true },
+    expect: (r) => r.ok && r.calls.filter(c => c.startsWith('refute F')).length === 2
+      && r.logs.some(l => /resuming - 2 refuter files/.test(l)),
+  },
+  {
+    name: 'gate check that loses the ledger line count is not accepted as green',
+    scenario: { fire: 3, collected: 4, overrides: { 'gate check (round 1)': 'all seven exit 0\nALLGREEN', 'gate check (round 2)': 'all seven exit 0\nALLGREEN' } },
+    expect: (r) => !r.ok && /did not go green/.test(r.error),
+  },
+];
+
+let failed = 0;
+for (const s of scenarios) {
+  if (s.args) Object.assign(ARGS, s.args);
+  const r = await run(s.scenario);
+  if (s.args) Object.assign(ARGS, { resume: false });
+  let pass = false;
+  try { pass = !!s.expect(r); } catch { pass = false; }
+  if (!pass) failed++;
+  const detail = r.ok ? `returned ${JSON.stringify(r.value && r.value.findings)}` : `threw: ${r.error.split('\n')[0].slice(0, 110)}`;
+  console.log(`${pass ? 'PASS' : 'FAIL'}  ${s.name}\n        ${detail}`);
+}
+
+console.log(`\n${scenarios.length - failed}/${scenarios.length} scenarios behaved as specified`);
+process.exit(failed ? 1 : 0);

--- a/.agent_loop/tools/dump_subagent_log.py
+++ b/.agent_loop/tools/dump_subagent_log.py
@@ -1,0 +1,72 @@
+"""Render a DSH subagent session (zstd-compressed JSONL) as a readable transcript.
+
+usage: python dump_subagent_log.py <session-id-or-prefix> [more ids...]
+Writes <workspace>/pr-review-env/logs/<label>.md and prints where it went.
+"""
+import json
+import os
+import sys
+from pathlib import Path
+
+from compression import zstd
+
+# The harness exports the path of the current session log; every sibling session lives beside it.
+_jsonl = os.environ.get("DSH_SESSION_JSONL")
+if not _jsonl:
+    raise SystemExit("set DSH_SESSION_JSONL (the harness exports it) before running this tool")
+PARENT = Path(_jsonl)
+SESS = PARENT.parent.parent
+OUT = Path(os.environ.get("AGENT_LOOP_LOGS") or (Path.cwd() / "agent-logs"))
+
+
+def load(path):
+    raw = zstd.decompress(path.read_bytes()).decode("utf-8", errors="replace")
+    for line in raw.splitlines():
+        try:
+            yield json.loads(line)
+        except Exception:
+            continue
+
+
+def clip(text, n):
+    text = str(text)
+    return text if len(text) <= n else text[:n] + f"\n... [+{len(text) - n} chars truncated]"
+
+
+def render(sid, full=False):
+    matches = [d for d in SESS.iterdir() if d.is_dir() and d.name.startswith(sid)]
+    if not matches:
+        return f"no session dir for {sid}"
+    d = matches[0]
+    f = d / "session.jsonl.zstd"
+    out = [f"# subagent session {d.name}", ""]
+    limit = 10**9 if full else 4000
+    for ev in load(f):
+        t = ev.get("type")
+        data = ev.get("data") or {}
+        if t == "user/message":
+            out += ["## PROMPT", "", "```", clip(data.get("text") or data.get("content") or json.dumps(data), 20000), "```", ""]
+        elif t == "assistant/message":
+            txt = data.get("text") or data.get("content") or ""
+            if isinstance(txt, list):
+                txt = "\n".join(str(p.get("text", p)) for p in txt if isinstance(p, dict))
+            if str(txt).strip():
+                out += ["## ASSISTANT", "", clip(txt, limit), ""]
+        elif t == "tool/call":
+            name = data.get("name") or data.get("toolName")
+            args = data.get("arguments") or data.get("args") or data.get("input") or {}
+            out += [f"### -> tool `{name}`", "", "```", clip(json.dumps(args, ensure_ascii=False, indent=1), 3000), "```", ""]
+        elif t == "tool/result":
+            res = data.get("result") or data.get("output") or data
+            out += ["### <- result", "", "```", clip(json.dumps(res, ensure_ascii=False)[:100000], limit), "```", ""]
+        elif t in ("error", "agent/error", "step/error"):
+            out += [f"### !! {t}", "", "```", clip(json.dumps(data, ensure_ascii=False), 4000), "```", ""]
+    OUT.mkdir(parents=True, exist_ok=True)
+    target = OUT / f"{d.name}.md"
+    target.write_text("\n".join(out), encoding="utf-8")
+    return f"{target}  ({target.stat().st_size} bytes, {len(out)} blocks)"
+
+
+if __name__ == "__main__":
+    for sid in sys.argv[1:]:
+        print(render(sid))

--- a/.agent_loop/tools/gh_shim.py
+++ b/.agent_loop/tools/gh_shim.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python
+"""Minimal `gh` replacement covering exactly the calls review-pr/fetch.sh makes.
+
+No GitHub CLI is installable in this environment, and `gh pr diff` would in any case
+fail on aiter#4961 (diff over GitHub's 20000-line API cap).  `pr diff` here is produced
+from a LOCAL checkout with `git diff <merge-base> <head>`, which is what `gh pr diff`
+returns and what the skill tells a reviewer to do for an over-cap PR.
+"""
+import json
+import os
+import subprocess
+import sys
+import urllib.request
+
+API = "https://api.github.com"
+REPO_DIR = os.environ.get("GH_SHIM_REPO_DIR") or os.getcwd()
+
+
+def api(path):
+    url = path if path.startswith("http") else f"{API}/{path.lstrip('/')}"
+    req = urllib.request.Request(url, headers={
+        "Accept": "application/vnd.github+json",
+        "User-Agent": "gh-shim",
+    })
+    tok = os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN")
+    if tok:
+        req.add_header("Authorization", f"Bearer {tok}")
+    with urllib.request.urlopen(req, timeout=60) as r:
+        return json.load(r)
+
+
+def api_paged(path, cap=20):
+    out = []
+    for page in range(1, cap + 1):
+        sep = "&" if "?" in path else "?"
+        chunk = api(f"{path}{sep}per_page=100&page={page}")
+        if not isinstance(chunk, list) or not chunk:
+            break
+        out.extend(chunk)
+        if len(chunk) < 100:
+            break
+    return out
+
+
+def git(*args, check=True):
+    env = dict(os.environ)
+    if sys.platform == "win32":
+        # Windows git needs the SSL backend pinned. Forcing it on Linux breaks every network
+        # git op: Ubuntu git is a gnutls build and dies with
+        # "fatal: Unsupported SSL backend 'openssl'. Supported SSL backends: gnutls".
+        env.update({
+            "GIT_CONFIG_COUNT": "1",
+            "GIT_CONFIG_KEY_0": "http.sslBackend",
+            "GIT_CONFIG_VALUE_0": "openssl",
+        })
+    p = subprocess.run(["git", "-C", REPO_DIR, *args], capture_output=True,
+                       text=True, encoding="utf-8", errors="replace", env=env)
+    if check and p.returncode != 0:
+        sys.stderr.write(p.stderr)
+        sys.exit(p.returncode)
+    return p
+
+
+def pr_meta(repo, num):
+    pr = api(f"repos/{repo}/pulls/{num}")
+    files = api_paged(f"repos/{repo}/pulls/{num}/files")
+    reviews = api_paged(f"repos/{repo}/pulls/{num}/reviews")
+    comments = api_paged(f"repos/{repo}/issues/{num}/comments")
+    return {
+        "number": pr["number"],
+        "title": pr.get("title") or "",
+        "body": pr.get("body") or "",
+        "state": pr.get("state"),
+        "labels": [{"name": l["name"]} for l in pr.get("labels", [])],
+        "author": {"login": (pr.get("user") or {}).get("login", "")},
+        "baseRefName": pr["base"]["ref"],
+        "baseRefOid": pr["base"]["sha"],
+        "headRefOid": pr["head"]["sha"],
+        "files": [{"path": f["filename"], "additions": f["additions"],
+                   "deletions": f["deletions"]} for f in files],
+        "reviews": [{"author": {"login": (r.get("user") or {}).get("login", "")},
+                     "body": r.get("body") or "", "state": r.get("state")}
+                    for r in reviews],
+        "comments": [{"author": {"login": (c.get("user") or {}).get("login", "")},
+                      "body": c.get("body") or ""} for c in comments],
+    }
+
+
+def ensure(repo, sha, ref_spec):
+    """Make sure `sha` is present locally, fetching ref_spec from the canonical URL."""
+    if git("cat-file", "-e", f"{sha}^{{commit}}", check=False).returncode == 0:
+        return
+    git("fetch", "-q", f"https://github.com/{repo}", ref_spec, check=False)
+    if git("cat-file", "-e", f"{sha}^{{commit}}", check=False).returncode != 0:
+        git("fetch", "-q", "--unshallow", f"https://github.com/{repo}", ref_spec, check=False)
+
+
+def pr_diff(repo, num):
+    pr = api(f"repos/{repo}/pulls/{num}")
+    head, base = pr["head"]["sha"], pr["base"]["sha"]
+    ensure(repo, head, f"refs/pull/{num}/head")
+    ensure(repo, base, pr["base"]["ref"])
+    mb = git("merge-base", base, head, check=False)
+    if mb.returncode != 0:
+        git("fetch", "-q", "--unshallow", f"https://github.com/{repo}",
+            pr["base"]["ref"], check=False)
+        mb = git("merge-base", base, head)
+    env = dict(os.environ)
+    p = subprocess.run(["git", "-C", REPO_DIR, "diff", "--no-color",
+                        mb.stdout.strip(), head], capture_output=True, env=env)
+    if p.returncode != 0:
+        sys.stderr.buffer.write(p.stderr)
+        sys.exit(p.returncode)
+    sys.stdout.buffer.write(p.stdout)
+
+
+def jq_path(data, expr):
+    cur = data
+    for part in expr.strip().lstrip(".").split("."):
+        if not part:
+            continue
+        cur = cur.get(part) if isinstance(cur, dict) else None
+    return cur
+
+
+def main(argv):
+    if not argv:
+        sys.exit("gh-shim: no command")
+    cmd = argv[0]
+    args = argv[1:]
+
+    def opt(name, default=None):
+        return args[args.index(name) + 1] if name in args else default
+
+    if cmd == "pr" and args and args[0] == "view":
+        print(json.dumps(pr_meta(opt("--repo", "ROCm/aiter"), args[1]), indent=2))
+    elif cmd == "pr" and args and args[0] == "diff":
+        pr_diff(opt("--repo", "ROCm/aiter"), args[1])
+    elif cmd == "issue" and args and args[0] == "view":
+        d = api(f"repos/{opt('--repo', 'ROCm/aiter')}/issues/{args[1]}")
+        print(json.dumps({"title": d.get("title") or "", "body": d.get("body") or ""}))
+    elif cmd == "api":
+        path = args[0]
+        data = api_paged(path) if path.rstrip("/").endswith(("comments", "reviews", "files")) \
+            else api(path)
+        jq = opt("--jq")
+        print(json.dumps(data, indent=2) if not jq else (jq_path(data, jq) or ""))
+    elif cmd == "auth":
+        print("gh-shim: unauthenticated REST access")
+    else:
+        sys.exit(f"gh-shim: unsupported command: {' '.join(argv)}")
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/.agent_loop/tools/list_run_agents.py
+++ b/.agent_loop/tools/list_run_agents.py
@@ -1,0 +1,31 @@
+"""List the subagents a named workflow run actually launched, from the parent session log.
+
+usage: python list_run_agents.py <workflow-name>
+"""
+import json
+import os
+import sys
+
+from compression import zstd
+
+p = os.environ["DSH_SESSION_JSONL"]
+want = sys.argv[1] if len(sys.argv) > 1 else None
+
+runs = {}
+rows = []
+for line in zstd.decompress(open(p, "rb").read()).decode("utf-8", errors="replace").splitlines():
+    try:
+        o = json.loads(line)
+    except Exception:
+        continue
+    t, d = o.get("type"), (o.get("data") or {})
+    if t == "tool-workflow/run-start":
+        runs[d.get("runId")] = d.get("name")
+    if t == "tool-workflow/agent-start":
+        name = runs.get(d.get("runId"), "?")
+        if want is None or name == want:
+            rows.append((d.get("seq"), d.get("phase"), d.get("label"), d.get("childId")))
+
+for seq, ph, label, cid in rows:
+    print(f"seq {seq:>3}  {str(ph):<26} {str(label):<44} {cid}")
+print(f"\ntotal agents: {len(rows)}")

--- a/.agent_loop/workflows/prefetch.workflow.js
+++ b/.agent_loop/workflows/prefetch.workflow.js
@@ -1,0 +1,149 @@
+// .agent_loop — PHASE P (prefetch).
+//
+// The cheap stage that must run BEFORE the single human break: the questions the loop owes a
+// human (which validation target? what will refutation cost?) can only be asked concretely once
+// review-pr's Step 1 has produced validation_requirement.json.
+//
+// This is a DSH `workflow` script body: the harness supplies `args`, `agent`, `parallel`,
+// `phase` and `log`. It has no filesystem of its own - every path arrives through args, and the
+// agents do the file work. Nothing in this file is installation-specific; see config/loop.example.json.
+//
+// args = {
+//   pr, repo,                        // 4961, "ROCm/aiter"
+//   host: { name, sshHost, user, uidGid, container, image, hostRoot, containerMount, scratch },
+//   local: { ssh, scp, python, identityFile, toolsRoot },
+//   localWork,                       // where the $WORK scratch is synced to on this machine
+//   runId,
+//   provider, model,                 // the remote-exec role
+//   envKnown,                        // true when a confirmed env record already exists
+//   sinceHead                        // previously reviewed head sha, or null on a first round
+// }
+
+const A = args;
+const H = A.host;
+const LOCAL = A.local || {};
+const REMOTE = { provider: A.provider, model: A.model };
+
+const SSHX = LOCAL.ssh || 'ssh';
+const SCPX = LOCAL.scp || 'scp';
+const IDENT = LOCAL.identityFile ? `-i ${LOCAL.identityFile} -o IdentitiesOnly=yes ` : '';
+const SSH_TO = `${SSHX} ${IDENT}-o BatchMode=yes -o StrictHostKeyChecking=no -o ConnectTimeout=25 -o ServerAliveInterval=30 ${H.user}@${H.sshHost}`;
+const SCRATCH = `${H.scratch}`;
+
+const PRIMER = `
+You drive a remote Linux GPU host from this machine. Use your shell tool for local commands and ssh for remote ones:
+  ${SSH_TO} 'bash <script>'
+  ${SCPX} ${IDENT}<local> ${H.user}@${H.sshHost}:<remote>
+
+RULES OF THE ROAD (each one exists because it has already gone wrong):
+  - Never inline a multi-line or quote-heavy remote command; write the script to a local file, copy it over, and run
+    \`bash <path>\`. Quoting is mangled otherwise.
+  - Some hosts print a long login banner on every connection, which makes ssh exit codes unreliable. Judge success by
+    stdout content, not by the exit code.
+  - IF ssh is refused by your own harness (a sandbox or permission error on the LOCAL side), SAY SO IMMEDIATELY AND
+    STOP. Do not silently skip the task and do not report success: a skipped step reported as done is worse than a
+    failed step reported as failed.
+  - Keep every command's output small.
+
+PLACEMENT RULES - hard constraints:
+  - Every temporary script and every test artifact goes in the container scratch ${SCRATCH}. Writing scratch to the
+    remote host's /tmp is forbidden (beyond a single script you delete afterwards).
+  - The PR body (clone, base worktree, patch) lives on the host at ${H.hostRoot}, bind-mounted into container
+    ${H.container} at ${H.containerMount}.
+  - All PR testing runs inside container ${H.container}. The host does git and docker only.
+`;
+
+phase('env');
+
+const env = await agent(`${PRIMER}
+
+TASK: ${A.envKnown ? 'VERIFY the environment contract still holds (it was established and confirmed earlier) and report any drift.' : 'Establish the environment contract and gather the facts a human needs in order to confirm it.'}
+
+1. ssh reachability, hostname, GPU architecture (\`/opt/rocm/bin/rocminfo | grep -o 'gfx[0-9a-z]*' | sort -u\`).
+2. Per-GPU busy % AND VRAM used (\`rocm-smi --showuse --showmemuse\`) plus \`rocm-smi --showpids\`. Name the indices
+   that are genuinely idle. rocm-smi is not always on PATH - prefer /opt/rocm/bin/rocm-smi. A GPU at 0% busy but high
+   VRAM is NOT usable for validation; say so rather than calling it idle.
+3. Container ${H.container}: does it exist, and is it RUNNING? Verify inside it that torch, aiter and pytest import,
+   and report versions and the aiter path. Do NOT create, start, stop or remove any container - if it is stopped,
+   report that and stop; restarting someone's container is the human's decision, not yours.
+4. Host tooling: git, python3, docker, flock, jq, gh (and whether gh is authenticated - it usually is not). Free disk
+   on ${H.hostRoot}'s filesystem. Whether the host reaches GitHub.
+5. What is already under ${H.hostRoot} from an earlier round: the clone (origin, branch), whether a worktree exists
+   and is clean, and whether root-owned artifacts or old scratch directories remain. Report, do not clean yet.
+
+Report a prose summary and, explicitly, ANY blocker that would stop the run phase.`, {
+  label: 'env contract', phase: 'env', ...REMOTE
+});
+
+log(`env -> ${env ? 'reported' : 'FAILED'}`);
+if (!env) throw new Error('the environment phase produced nothing; refusing to fetch against an unverified host');
+
+phase('fetch');
+
+const fetched = await agent(`${PRIMER}
+
+Environment facts just established:
+${String(env).slice(0, 4000)}
+
+TASK: run Step 1 of the review-pr skill for ${A.repo}#${A.pr} at its CURRENT head, and bring the artifacts back.
+${A.sinceHead ? `This PR has been reviewed before at head ${A.sinceHead}; it has since moved. Nothing may be reused from the previous fetch.\n` : ''}
+Preconditions - do them, do not assume:
+1. Under ${H.hostRoot}: reuse the existing clone of https://github.com/${A.repo}.git at ${H.hostRoot}/aiter (clone it
+   if absent). \`git fetch origin pull/${A.pr}/head:pr${A.pr} --force\` and \`git fetch origin main\`.
+2. Remove any PREVIOUS round's worktree at ${H.hostRoot}/pr-${A.pr} (\`git worktree remove --force\`). In-container
+   runs write as root, so if removal is denied by permissions, clean it from inside the container
+   (\`docker exec ${H.container} bash -lc 'cd <container-side worktree> && git clean -xdf'\`) and chown back to
+   ${H.uidGid} - never use sudo.
+3. BASE = \`git merge-base origin/main pr${A.pr}\`. Use the MERGE-BASE, not today's main tip: a stale PR does not apply
+   to the tip, and the merge-base is the commit its diff actually describes. Record BASE and the head sha.
+4. The patch: \`git diff --no-color <BASE> pr${A.pr} > ${H.hostRoot}/pr-${A.pr}.patch\`. Record line count and sha256.
+5. A fresh detached BASE worktree at ${H.hostRoot}/pr-${A.pr}, verified clean by BOTH \`git status --porcelain\` and
+   \`--porcelain --ignored\`, with \`git apply --check\` proving the patch applies. Do NOT leave the patch applied.
+6. INITIALISE the \`3rdparty/composable_kernel\` submodule at the repo-pinned sha in that worktree. Skipping it makes
+   the JIT build fail with "fatal error: 'ck_tile/core.hpp' file not found", which looks exactly like a PR defect and
+   has already produced one false BLOCK.
+
+Then run the skill's Step 1:
+7. If gh is missing or unauthenticated - and note that a large PR's diff exceeds GitHub's 20000-line API cap, which
+   makes \`gh pr diff\` fail with HTTP 406 even when gh works - install the drop-in replacement shipped with this loop:
+   copy ${LOCAL.toolsRoot}/gh_shim.py into ${SCRATCH}/bin/gh_shim.py, create ${SCRATCH}/bin/gh as a two-line sh
+   wrapper (\`#!/bin/sh\` then \`exec python3 .../gh_shim.py "$@"\`), chmod +x, prepend that dir to PATH, and set
+   GH_SHIM_REPO_DIR to the clone. It answers pr view / pr diff / api / issue view from the unauthenticated REST API
+   and produces the diff locally with git.
+8. Run INSIDE container ${H.container}, cwd at the clone, with \`PYTHONUTF8=1 PYTHONIOENCODING=utf-8\` (without them
+   triage.py mis-parses rules.md and reports MISSING-RULE-TEXT) and \`PYTHONDONTWRITEBYTECODE=1\` (the skill's own
+   tooling otherwise drops __pycache__ into the tree):
+     bash .claude/skills/review-pr/fetch.sh ${A.pr} ${A.repo}
+   Capture output to ${SCRATCH}/fetch.log and take the scratch dir it prints.
+   Consider setting REVIEW_AUTO_VALIDATE=0: fetch.sh will otherwise auto-run the GPU validator in its own worktree,
+   which has no initialised submodule and pre-empts the human's target choice. If you set it, say so and why.
+9. VERIFY before believing it: pr.diff non-empty, rules.txt non-empty, rules_expanded.txt present with NO
+   "MISSING-RULE-TEXT". Fix and re-run if not.
+10. Bring the scratch dir back to ${A.localWork} (tar in the container, copy out, extract locally) and verify the
+    local file sizes match the in-container ones.
+
+REPORT precisely - the human's next decision depends on it:
+  - BASE sha, head sha, patch line count and sha256, whether apply --check passed;
+${A.sinceHead ? `  - THE CROSS-ROUND DELTA, which the diff cannot show: \`git log --oneline ${A.sinceHead}..pr${A.pr}\` and
+    \`git diff --stat ${A.sinceHead} pr${A.pr}\`. Separate the author's own commits from commits that arrived via a
+    merge of main, and NAME EVERY TEST FILE OR GUARD ADDED OR REMOVED. Once the base moves, a file the previous head
+    added and this head removed is invisible in the diff - it reads as if it never existed. State plainly whether the
+    author fixed what the last review raised or removed the thing that exposed it;
+  - whether the old head is an ancestor of the new head (a normal update) or the branch was force-pushed;
+` : ''}  - whether applies.txt says the PR is STALE against the merge target, quoted;
+  - the FULL contents of validation_requirement.json: required, runtime_path_count, candidates, blocking_reason,
+    perf_required, perf_command;
+  - the rule ids in rules.txt and how many were derived out of how many;
+  - the changed-file list, and which of them are backbone files (aiter/jit/core.py, aiter/__init__.py,
+    aiter/tuned_gemm.py, aiter/ops/gemm_op_a8w8.py, aiter/ops/batched_gemm_op_a8w8.py, aiter/ops/quant.py,
+    aiter/fused_moe.py, aiter/ops/mha.py, aiter/ops/attention.py, aiter/mla.py, aiter/ops/moe_op.py,
+    csrc/include/rocm_ops.hpp);
+  - anything that failed.`, {
+  label: 'skill Step 1 (fetch)', phase: 'fetch', ...REMOTE
+});
+
+log(`fetch -> ${fetched ? 'reported' : 'FAILED'}`);
+if (!fetched) throw new Error('the fetch phase produced nothing; there is nothing for the human break to decide on');
+
+// The caller turns these two prose reports into the single human question batch.
+return { env, fetched };

--- a/.agent_loop/workflows/run.workflow.js
+++ b/.agent_loop/workflows/run.workflow.js
@@ -1,0 +1,525 @@
+// .agent_loop — PHASE R (run to report). No human break inside this phase.
+//
+// Shape: rlar. The worker holds the analysis, a FRESH refuter that has not seen the worker's
+// reasoning attacks every finding, and the skill's own seven gates are the `done` signal —
+// a failing gate's complaint is fed back as the next round's notes, verbatim.
+//
+// This file IS the artifact that ran on ROCm/aiter#4961 round 3 (44 agents, gates green,
+// ledger provenance 15/15/15), plus the fixes from the post-round-3 review. Do not let an
+// inline variant diverge from it again: the deliverable and the tested thing must be one file.
+//
+// Loaded by the main agent and passed to the `workflow` tool as the `script` parameter.
+//
+// args = {
+//   pr, repo, headSha, baseSha, stale,
+//   localWork,        // ...\tmp\pr-review\<pr>\<round>\work\review-pr-XXXXXX   ($WORK)
+//   localReports,     // ...\tmp\pr-review\<pr>\<round>\reports
+//   skillRoot,        // ...\aiter\.claude\skills\review-pr
+//   projectRoot,      // ...\aiter          (the corefiles gate's PROJECT_ROOT)
+//   python,           // "C:\\Python314\\python.exe"
+//   files: [...],                                   // files to assess in Step 4
+//   ruleGroups: [ { id, ids }, ... ],               // Step 5 partition of rules.txt
+//   targets: [ { t, host, container, worktree, patch, scratch, hostRoot, refresh } ],
+//   validationRequired: true|false,
+//   providers: { worker, refuter, formatter, remote },   // each { provider, model }
+//   maxGateRounds: 3,
+//   sinceHead: "<previous reviewed head sha>" | null,     // for the cross-round delta line
+//   resume: true|false          // reuse refutation_lines/F*.md that already exist
+// }
+
+const A = args;
+const W = A.localWork;
+const R = A.localReports;
+const L = `${W}\\refutation_lines`;
+const SK = A.skillRoot;
+const VSK = A.validateSkillRoot;
+const PROJ = A.projectRoot;
+const PY = A.python;
+
+// Connection details are configuration, never literals: see config/loop.example.json.
+const LOCAL = A.local || {};
+const SSHX = LOCAL.ssh || 'ssh';
+const IDENT = LOCAL.identityFile ? `-i ${LOCAL.identityFile} -o IdentitiesOnly=yes ` : '';
+const SSH_TO = (t) => `${SSHX} ${IDENT}-o BatchMode=yes -o StrictHostKeyChecking=no ` +
+  `-o ConnectTimeout=25 -o ServerAliveInterval=30 ${t.user || A.hostUser}@${t.host}`;
+
+const WORKER = A.providers.worker;
+const REFUTER = A.providers.refuter;
+const FORMATTER = A.providers.formatter;
+const REMOTE = A.providers.remote;
+const MAX_ROUNDS = A.maxGateRounds || 3;
+
+const GATES = [
+  `& ${PY} ${SK}\\triage.py answers ${W}\\answers.txt`,
+  `& ${PY} ${SK}\\triage.py diagnostic ${W}\\ai_diagnostic.txt`,
+  `& ${PY} ${SK}\\triage.py corefiles ${W}\\core_files.txt ${W}\\pr.diff ${PROJ}`,
+  `& ${PY} ${SK}\\triage.py ledger ${W}\\rules.txt ${W}\\verdicts.txt ${W}\\pr.diff`,
+  `& ${PY} ${SK}\\triage.py card ${R}\\card.md ${W}\\verdicts.txt ${W}\\ai_diagnostic.txt ${W}\\answers.txt ${W}\\pr.diff ${W}\\late_findings.txt`,
+  `& ${PY} ${SK}\\triage.py refutations ${W}\\refutations.txt ${W}\\pr.diff ${R}\\card.md`,
+  `& ${PY} ${SK}\\triage.py independent ${W}\\independent.txt ${R}\\card.md`,
+].join('\n  ');
+
+const CTX = `
+REVIEW TARGET: ${A.repo} pull request #${A.pr}. Base ${A.baseSha}, head ${A.headSha}.${A.stale ? ' The PR is STALE against the live main tip - any CI result on it describes a tree that has moved.' : ''}
+
+Step 1 of the review-pr skill has ALREADY run at this head. Its artifacts are at ${W}\\ - read them, never re-derive:
+  pr.diff (the full base..head diff - ALWAYS Select-String it, never read it whole), pr_meta.json, rules.txt,
+  rules_expanded.txt (the full text of exactly the rules this diff derives - your rule book), applies.txt,
+  merge_target.txt, guards.txt (deleted asserts: moved / returned changed / gone), siblings.txt, symbols.txt
+  (first-party imports that do not resolve against the merge target - a REBASE signal, not invented code), twins.txt,
+  test_quality.txt, kernel_tests.txt, ci_coverage.txt, perf_claims.txt, struct_abi.txt, comment_only.txt,
+  evidence.txt (cross-file handling of every removed guard and changed signature - READ IT before writing any finding
+  about a removed guard), validation_requirement.json,
+  merge-target\\ (the BASE worktree - read base files HERE), head\\ (the PR-head post-images).
+
+Use your file and shell tools. Run any python with UTF-8 forced (PYTHONUTF8=1) - the skill's
+tooling mis-parses its own rules file otherwise.
+Never invent file contents, line numbers or symbols. Answer in PROSE - do not attempt to emit JSON.
+`;
+
+const FIND = `
+FINDING DISCIPLINE: 🔴 high risk / ⚠️ should fix / 📝 note, advisory only. Before firing a 🔴 you must name the
+concrete triggering input (shape / dtype / arch / value / scale); if you cannot, downgrade. Each finding has three
+parts: Problem (file:line) + Impact at runtime + Action ending in "**Author must** ..." or
+"**Reviewer should ask** ...". Tag [verified] or [inferred].
+`;
+
+// ============================================================ S2 analysis
+phase('S2 analysis');
+
+const analysisTasks = [
+  () => agent(`${CTX}
+TASK - Step 2: semantic understanding plus the Step 7.5 blind-spot check. Answer from the DIFF, not the description:
+Q1 what specifically changed computationally? Q2 hardware scope (arch, precision, execution phase)? Q3 does this
+change any public aiter API? Q4 the performance claim's MECHANISM? Q5 does the description explain WHY or only WHAT?
+BLIND: any correctness risk, resource hazard or behavioural edge case steps 1-7 would not catch - a bare "no" is
+rejected; say what you looked for and did not find.
+Read pr_meta.json for the existing reviewer threads and summarise what reviewers already objected to.
+WRITE ${W}\\answers.txt with exactly six lines "Q1: " .. "Q5: " then "BLIND: ", each naming concrete files/symbols.
+The BLIND line is a FINDING SOURCE, not commentary: if it names a concrete risk, state it as a finding would be
+stated (file, symbol, trigger), because a later step collects findings from this file.`,
+    { label: 'S2 semantic', phase: 'S2 analysis', ...WORKER }),
+
+  () => agent(`${CTX}${FIND}
+TASK - Step 6: the six structural AI-code checks, one recorded line each ("clean" alone is not an answer).
+1 Unresolved imports / hallucinated APIs - symbols.txt holds the static sweep; what is left for you is new kwargs on
+  existing calls, new attributes, new enum members - grep those against merge-target\\.
+2 Twin divergence - twins.txt and siblings.txt; arch codegen twins and gemm-vs-bmm twins, field by field.
+3 Claim vs code and number provenance - does the code enforce what the description asserts? Trace the biggest number
+  in perf_claims.txt to a committed script or log; untraceable => [unverified].
+4 Safety theater - each new if/try/assert: reachable? will it fire? does an except swallow a real error?
+5 Test calibrated to pass rather than to falsify - test_quality.txt; mirrored reference, loosened tolerance,
+  self-comparison. Also check for DELETED tests and say what coverage went with them.
+6 Magic constants - new tile sizes, thresholds, kid bands, offsets: is a derivation or tuning basis stated?
+Count how many cheap signs fire: description explains only WHAT; suspiciously clean perf numbers; screenshot-only
+perf; tests only M=1/M=16; gated-off params silently ignored; module-level sys.path/os.environ mutation; unrelated
+files; new default path not revertible by an env var; empty Test Plan; AI attribution footer.
+WRITE ${W}\\ai_diagnostic.txt with exactly six lines "1: " .. "6: ". Then report each finding.`,
+    { label: 'S6 AI diagnostic', phase: 'S2 analysis', ...WORKER }),
+];
+
+for (const f of A.files) {
+  analysisTasks.push(() => agent(`${CTX}
+TASK - Step 4 for exactly ONE file: ${f}
+1 Find its hunks: Select-String -Path ${W}\\pr.diff -Pattern '${f}' -Context 0,60 | Select-Object -First 40
+2 Decide the tier. TIER1 = if it breaks, "import aiter" fails (only aiter/jit/core.py and aiter/__init__.py qualify).
+  TIER2 = holds the Python dispatch selecting which kernel runs for an op class used by more than one production
+  model family, OR is the public aiter API for an op, OR is a header included by 10+ translation units.
+  TIER3 = an individual op wrapper or kernel.
+3 Decide COVERED / GAP / N/A against this PR's own tests (${W}\\test_quality.txt, kernel_tests.txt, ci_coverage.txt).
+Return ONE line, exactly, and nothing else:
+  ${f} TIER1|TIER2|TIER3 COVERED|GAP|N/A -- <reason over 30 chars naming a symbol THIS PR changes>`,
+    { label: `S4 ${f}`, phase: 'S2 analysis', ...WORKER }));
+}
+
+for (const g of A.ruleGroups) {
+  analysisTasks.push(() => agent(`${CTX}${FIND}
+TASK - Step 5 for THIS SUBSET of the derived rules: ${g.ids}
+Read ${W}\\rules_expanded.txt for each id; that text is the rule and the only definition you may use. Adjudicate
+EVERY id in your subset. CLEAR is a claim, not a default - it means you looked and it does not apply TO THIS DIFF,
+and the reason is what makes it checkable ("ok"/"n/a"/"fine" are rejected by the gate). Use guards.txt, evidence.txt,
+siblings.txt, twins.txt, symbols.txt, struct_abi.txt, ci_coverage.txt, test_quality.txt, kernel_tests.txt and
+perf_claims.txt rather than re-deriving them. A FIRE must cite at least one file THIS PR changes.
+WRITE ${W}\\verdicts_${g.id}.txt, one line per rule id, exactly:
+  <RULE-ID> FIRE|CLEAR|N/A — <specific reason naming file:line, symbol, or the condition>`,
+    { label: `S5 rules ${g.id}`, phase: 'S2 analysis', ...WORKER }));
+}
+
+log(`S2: ${analysisTasks.length} worker agents (2 + ${A.files.length} files + ${A.ruleGroups.length} rule groups)`);
+const analysis = await parallel(analysisTasks);
+
+// FAIL CLOSED (review fix #4). A silently failed analysis agent means a missing verdict file or a
+// missing core-file line, which the gates then blame on the card - and the card's author is the
+// only one who can "fix" it, by writing the missing adjudication itself. Stop instead.
+const dead = analysis.map((r, i) => (r ? null : i)).filter(i => i !== null);
+if (dead.length) {
+  const names = dead.map(i => analysisTasks[i].label || `#${i + 1}`);
+  throw new Error(`S2: ${dead.length} of ${analysisTasks.length} analysis agents produced nothing ` +
+    `(indices ${dead.join(', ')}). Their artifacts are missing, so the rule ledger and the core-file ` +
+    `ledger are incomplete. Refusing to continue: re-run those agents rather than letting the card ` +
+    `author invent the missing adjudications.`);
+}
+
+const analysisText = analysis.map(String).join('\n\n---\n\n');
+const s4 = analysis.slice(2, 2 + A.files.length).map(String);
+
+await agent(`Mechanical extraction and file writing only - do not analyse, do not invent a line for a file that has none.
+Each report below covers ONE file and contains one ledger line shaped
+  <path> TIER1|TIER2|TIER3 COVERED|GAP|N/A -- <reason>
+Extract exactly that line from each (ignore surrounding prose) and WRITE them one per line to ${W}\\core_files.txt,
+reasons verbatim. Read the file back and report its line count, which must be ${A.files.length}.
+
+REPORTS:
+${s4.map((t, i) => `### ${A.files[i]}\n${t.slice(0, 3000)}`).join('\n\n')}`,
+  { label: 'write core_files.txt', phase: 'S2 analysis', ...FORMATTER });
+
+// ============================================================ S3 refutation
+phase('S3 refutation');
+
+// The minimum finding count is DERIVED, not guessed (review fix #8): every FIRE is a finding the
+// collector must have carried, so a collection that returns fewer has lost some.
+const fireCount = await agent(`Counting only - change no files, analyse nothing. Report exactly one line:
+  FIRE=<the number of lines across ${W}\\verdicts_*.txt that contain the word FIRE>
+For example (PowerShell): (Select-String -Path ${W}\\verdicts_*.txt -Pattern 'FIRE').Count`,
+  { label: 'count FIRE verdicts', phase: 'S3 refutation', ...FORMATTER });
+const minFindings = Number((String(fireCount || '').match(/FIRE=(\d+)/) || [])[1] || 0);
+log(`S3: ${minFindings} FIRE verdicts - the collector must return at least that many findings`);
+
+const collected = await agent(`Mechanical extraction only - do not analyse, do not add findings of your own.
+Read and extract every distinct FINDING asserted by:
+  ${W}\\verdicts_A_B.txt and every other ${W}\\verdicts_*.txt   (every line marked FIRE)
+  ${W}\\ai_diagnostic.txt   (any defect the six structural checks name)
+  ${W}\\core_files.txt      (any line marked GAP)
+  ${W}\\answers.txt         (the BLIND: line - if it names a concrete risk, that is a finding too)
+Each entry: <SEVERITY>|<one self-contained sentence naming the file:line and what is wrong>, where SEVERITY is
+RED, WARN or NOTE. It must be understandable by someone who has read none of those files. Merge duplicates that
+describe the same defect. Exclude CLEAR and N/A verdicts.
+
+Write the list, and ONLY the list, between markers - nothing before the first, nothing after the last:
+BEGIN_FINDINGS
+<SEVERITY>|<sentence>
+END_FINDINGS
+Also WRITE the same list to ${W}\\findings_raw.txt so it survives if this answer is lost.`,
+  { label: 'collect findings', phase: 'S3 refutation', ...FORMATTER });
+
+const between = String(collected || '').split('BEGIN_FINDINGS')[1];
+const findings = String(between || '').split('END_FINDINGS')[0]
+  .split('\n').map(s => s.trim()).filter(s => /^(RED|WARN|NOTE)\s*\|/i.test(s));
+
+// FAIL CLOSED (review fix #2/#8). An empty or short collection is a lost collection, not a clean PR.
+if (findings.length < Math.max(1, minFindings)) {
+  throw new Error(`collect findings returned ${findings.length} findings but the verdict files contain ` +
+    `${minFindings} FIRE lines. Refusing to continue: an incomplete refutation stage cannot certify a card.`);
+}
+log(`S3: ${findings.length} findings, one refuter each (~${findings.length * 15}k input tokens estimated)`);
+
+// Resume support (review fix #7): a refuter that already wrote its own file is not re-run.
+let already = [];
+if (A.resume) {
+  const existing = await agent(`Listing only - change no files. Report exactly one line:
+  EXISTING=<comma-separated basenames of the *.md files in ${L}, or the word NONE>`,
+    { label: 'check resumable refutations', phase: 'S3 refutation', ...FORMATTER });
+  already = (String(existing || '').match(/F\d+\.md/g) || []).map(s => s.replace(/\D/g, ''));
+  if (already.length) log(`S3: resuming - ${already.length} refuter files already present, skipping those`);
+}
+
+const refuteTasks = findings.map((f, i) => {
+  const nn = String(i + 1).padStart(2, '0');
+  if (already.includes(nn)) return () => Promise.resolve(`SKIPPED (F${nn}.md already present)`);
+  return () => agent(`${CTX}
+
+YOU ARE AN ADVERSARIAL REFUTER and you have NOT seen the reasoning behind this finding. Treat it as FALSE UNTIL
+DEFENDED and try to KILL it with evidence. Do not improve it, do not agree politely - attack it.
+
+FINDING F${i + 1}: ${f}
+
+Kills to try: the symbol or guard MOVED rather than being deleted (grep the whole family, headers and callers
+included); it still exists or is re-exported elsewhere; an earlier validation makes the claimed trigger unreachable;
+the behaviour is pre-existing in merge-target\\ and this PR did not change it; the cited line or symbol does not
+exist; the asymmetry is a legitimate hardware-contract difference; the tool or scan that produced it matched
+positionally or by a regex that discards meaning. It SURVIVES only if you opened the evidence and could not kill it.
+A RED survives only if you can verify a CONCRETE triggering input; otherwise say DOWNGRADE.
+
+SEVERITY BAR (fixed, so that rounds are comparable): a 🔴 requires a triggering point verifiable IN THIS TREE. A
+protocol documented outside the tree (a README telling downstream integrations to call something) is real evidence
+but caps the finding at ⚠️ with an action asking the author to confirm the downstream.
+
+Use a handful of targeted Select-String / read calls; keep every command's output small.
+
+THEN - mandatory, and this file is YOURS; nobody else may write it - use the write tool to create
+  ${L}\\F${nn}.md
+whose FIRST LINE is exactly one line in this format and nothing else:
+  ${f.split('|')[0].trim()} <SURVIVED|KILLED> -- <what you opened and what it said, one line, no newlines>
+and whose remaining lines are your full evidence: the finding restated, the files and line numbers you opened, the
+kill attempts you made, and your keep / downgrade / drop recommendation.
+Finally report the same verdict in your answer.`,
+    { label: `refute F${i + 1}`, phase: 'S3 refutation', ...REFUTER });
+});
+
+const refuted = await parallel(refuteTasks);
+log(`S3: ${refuted.filter(Boolean).length}/${findings.length} refuters returned`);
+
+await agent(`Mechanical assembly only - do not analyse, do not add, drop or reword any entry.
+The directory ${L}\\ contains one file per finding, F01.md .. F${String(findings.length).padStart(2, '0')}.md, each
+whose FIRST LINE is that finding's ledger line.
+1. List the directory; report how many files are present and name any missing one - do NOT invent a line for it.
+2. WRITE ${W}\\refutations.txt: the first line of each file, in numeric file order, one per line, verbatim.
+3. WRITE ${W}\\independent.txt: the same lines with the leading severity word removed.
+4. WRITE ${R}\\findings.md: readable markdown concatenating every file's full content under a heading naming its
+   finding number and verdict. This is the companion to the five-finding card; nothing is dropped here.
+5. Create ${W}\\late_findings.txt if absent - keep any existing content. Report the final line counts.`,
+  { label: 'assemble ledger', phase: 'S3 refutation', ...FORMATTER });
+
+const verify = await agent(`Counting only - change no files. Report exactly these four lines:
+  FILES=<number of *.md files in ${L}>
+  REFUT=<(Get-Content ${W}\\refutations.txt | Measure-Object -Line).Lines>
+  INDEP=<(Get-Content ${W}\\independent.txt | Measure-Object -Line).Lines>
+  BAD=<lines in refutations.txt NOT matching '^(RED|WARN|NOTE) (SURVIVED|KILLED) -- '>`,
+  { label: 'ledger provenance', phase: 'S3 refutation', ...FORMATTER });
+
+const vm = String(verify || '');
+const nfiles = Number((vm.match(/FILES=(\d+)/) || [])[1] || 0);
+const nrefut = Number((vm.match(/REFUT=(\d+)/) || [])[1] || 0);
+const nindep = Number((vm.match(/INDEP=(\d+)/) || [])[1] || 0);
+const nbad = Number((vm.match(/BAD=(\d+)/) || [])[1] || 999);
+if (nfiles !== findings.length || nrefut !== findings.length || nindep !== findings.length || nbad !== 0) {
+  throw new Error(`ledger provenance failed: ${nfiles} refuter files, ${nrefut} refutation lines, ` +
+    `${nindep} independent lines, ${nbad} malformed, for ${findings.length} findings. ` +
+    `Refusing to certify a card on a ledger whose provenance cannot be established.`);
+}
+log(`S3: provenance ok - ${nfiles} refuter-written files, ${nrefut} ledger lines, 0 malformed`);
+
+// ============================================================ S4/S5 card and gates
+phase('S4/S5 card and gates');
+
+const SEPARATION = `
+SEPARATION OF DUTIES - ABSOLUTE. You may NOT create, edit, append to or delete any of:
+  ${W}\\refutations.txt , ${W}\\independent.txt , ${R}\\findings.md , anything under ${L}\\ ,
+  and you may NOT add a verdict line to ${W}\\verdicts.txt or any ${W}\\verdicts_*.txt for a rule that has none.
+Those files are other parties' records: the refuter's, and the rule adjudicators'. A party that writes its own
+review record has destroyed the only guarantee this loop offers. If a gate complains about one of them, do NOT fix
+the file: change the CARD so it only claims what the existing records support (drop the finding, or add a
+"-- not reported:" line), and say in your report that the record was left untouched. If a rule genuinely has no
+verdict, that is a failed analysis agent - report it as a blocker instead of adjudicating it yourself.
+`;
+
+let notes = '';
+let gatesGreen = false;
+
+for (let round = 1; round <= MAX_ROUNDS; round++) {
+  await agent(`${CTX}${FIND}
+
+TASK - Step 8: write the verdict card, then make the gates green.
+${round === 1 ? '' : `\nTHIS IS ROUND ${round}. The gates rejected the previous attempt. Their complaints, verbatim - fix exactly what they name and nothing else:\n${notes}\n`}
+
+THE LEDGER IS AUTHORITATIVE: ${W}\\refutations.txt has one line per finding, written by an independent refuter that
+never saw the analysis. Read it first. A KILLED finding must NOT reach the card; a line advising DOWNGRADE must be
+honoured. Full evidence per finding is in ${R}\\findings.md.
+
+Preparation: concatenate every ${W}\\verdicts_*.txt into ${W}\\verdicts.txt, preserving every line.
+
+Write ${R}\\card.md (read pr_meta.json for the title), header exactly:
+
+## [aiter] PR #${A.pr} — <title>
+
+**<one sentence: what this PR does, for a reviewer who has not read the diff>**
+
+Review (advisory): <✅ NO FINDINGS | ⚠️ NEEDS WORK | 🔴 HIGH RISK>${A.stale ? ' — the PR is STALE against the live main tip, so any CI result on it describes a tree that has moved' : ''}
+Validation (deterministic): PENDING
+Perf (advisory): PENDING
+${A.sinceHead ? `Since last review (${A.sinceHead}): <what the author changed since the previously reviewed head, from the delta the fetch phase reported - name any test or guard that was added or removed; this is invisible in the diff once the base moves>\n` : ''}
+then at most FIVE findings (🔴/⚠️/📝, most severe first), then "-- not reported: <reason>" accounting lines for
+every FIRE rule and every surviving finding below the cut, plus any "-- late finding:" lines already recorded.
+${SEPARATION}
+THEN run the gates with UTF-8 forced (PYTHONUTF8=1), one at a time, reporting output and $LASTEXITCODE verbatim:
+  ${GATES}
+Do not fabricate a pass.`, { label: `card + gates (round ${round})`, phase: 'S4/S5 card and gates', ...WORKER });
+
+  const check = await agent(`Run these seven commands with UTF-8 forced (PYTHONUTF8=1), one at a time, and report each
+one's output and $LASTEXITCODE. Change no files.
+  ${GATES}
+Also report (Get-Content ${W}\\refutations.txt | Measure-Object -Line).Lines so we can confirm the ledger was not
+rewritten - it must still be ${findings.length}.
+End with the single word ALLGREEN if and only if all seven exit codes were 0.`,
+    { label: `gate check (round ${round})`, phase: 'S4/S5 card and gates', ...FORMATTER });
+
+  notes = String(check || '').slice(0, 6000);
+  const ledgerStillIntact = new RegExp(`\\b${findings.length}\\b`).test(notes);
+  if (/ALLGREEN/.test(notes) && ledgerStillIntact) {
+    gatesGreen = true;
+    log(`gates green at round ${round}`);
+    break;
+  }
+  log(`gates not green at round ${round} - feeding the complaint back`);
+}
+
+// FAIL CLOSED (review fix #3). An ungated card is not a deliverable, and running validation on top
+// of one wastes GPU time on a review nobody can trust.
+if (!gatesGreen) {
+  throw new Error(`the seven gates did not go green within ${MAX_ROUNDS} rounds. Last complaint:\n${notes}\n` +
+    `Refusing to continue to validation: an ungated card must not be delivered.`);
+}
+
+// ============================================================ S6 validation
+phase('S6 validation');
+
+const results = [];
+if (A.validationRequired && A.targets && A.targets.length) {
+  for (const tg of A.targets) {
+    const v = await agent(`
+Use your shell tool locally and ssh for the remote side:
+  ${SSH_TO(tg)} 'bash <script>'
+Write remote scripts locally and scp them into the scratch dir; never inline multi-line remote commands; the
+Conductor banner makes ssh exit codes unreliable, so judge by stdout. Keep outputs small.
+IF ssh is refused by the local harness with a sandbox-backend error, SAY SO IMMEDIATELY AND STOP - do not silently
+skip the task and do not report success.
+
+TASK: run validate-kernel-pr for target ${tg.t} on host ${tg.host}, inside container ${tg.container}.
+PR: ${A.repo}#${A.pr}, head ${A.headSha}, base ${A.baseSha}.
+Container-side paths: worktree ${tg.worktree}, patch ${tg.patch}, scratch ${tg.scratch}. Host PR body: ${tg.hostRoot}.
+
+${tg.refresh ? `THIS HOST HOLDS AN OLDER ROUND'S STATE and must be refreshed first: fetch the new head
+(\`git fetch origin pull/${A.pr}/head:pr${A.pr} --force\`) and origin/main; remove the old worktree
+(\`git worktree remove --force\`; if permissions deny it, clean from inside the container - in-container runs write as
+root - and chown back to ${A.uidGid}, never sudo); verify merge-base(origin/main, pr${A.pr}) == ${A.baseSha};
+regenerate the patch; create a fresh detached worktree at ${A.baseSha}; verify both \`git status --porcelain\` and
+\`--porcelain --ignored\` are empty and \`git apply --check\` passes.
+` : `Verify the worktree is at base ${A.baseSha}, both \`git status --porcelain\` and \`--porcelain --ignored\` are
+empty, and \`git apply --check\` passes.
+`}ALWAYS verify the 3rdparty/composable_kernel submodule is initialised at the repo-pinned sha; skipping it produces a
+false BLOCK ("fatal error: 'ck_tile/core.hpp' file not found") that looks exactly like a PR defect.
+
+HARD GATE BEFORE LAUNCH: \`/opt/rocm/bin/rocm-smi --showpids\` must report no KFD processes (rocm-smi is not always on
+PATH; use the full path). Quote it verbatim. If anything holds the GPU, do NOT launch - report the occupancy as an
+environment gap and stop. Also report \`--showuse --showmemuse\`.
+
+Then launch in the BACKGROUND (nohup setsid):
+  docker exec -w ${tg.worktree} -e PYTHONDONTWRITEBYTECODE=1 ${tg.container} \\
+    bash .claude/skills/validate-kernel-pr/validate_pr.sh \\
+      --repo ${tg.worktree} --patch ${tg.patch} \\
+      --head-sha ${A.headSha} --target ${tg.t} \\
+      --label pr${A.pr} \\
+      --out ${tg.scratch}/validation_${tg.t.replace(/[^A-Za-z0-9]/g, '_')}.json
+PYTHONDONTWRITEBYTECODE=1 is REQUIRED: the validator's own GPU-picker import otherwise writes __pycache__ into the
+worktree, and its own isolation check then reads the tree as dirty and skips every correctness and perf stage.
+Choose --expected-route by reading the target's HEAD source (a function whose own frame binds the shape variables)
+and justify it. Add --shape-argnames / --shape-env ONLY if you can point at the consuming code. Use --no-perf only if
+the target has no benchmark entry point at all. Note the validator runs pytest with -x, so a failure hides whatever
+would have run after it - say so explicitly if a failure occurs.
+
+Wait with ONE blocking remote poll (pgrep every 30s, up to ~30 minutes), then report: .verdict, every stage name +
+status + note, .findings verbatim, .test_selection, .execution_receipt, .stages.correctness_repo_tests head and base
+counts, .stages.perf, .arch_coverage, and the wall time. Copy the report back to ${R}\\ and give its local path.
+If no report exists, say NO REPORT and why - never infer a verdict from another target.
+Treat the executor's own findings as CLAIMS, not facts.`,
+      { label: `validate ${tg.t} on ${String(tg.host).split('.')[0]}`, phase: 'S6 validation', ...REMOTE });
+    results.push({ target: tg.t, host: tg.host, report: String(v || 'NO REPORT - the validation agent produced nothing') });
+  }
+} else {
+  log('S6 skipped: validation not required, or no target was chosen');
+}
+
+// ============================================================ S6b executor refutation
+if (results.length) {
+  phase('S6b executor refutation');
+  const execRefuted = await parallel(results.map((r, i) => () => agent(`
+You are an ADVERSARIAL REFUTER. Below is a validate-kernel-pr report for ${A.repo}#${A.pr} (head ${A.headSha}),
+target ${r.target}, host ${r.host}.
+
+Every finding the EXECUTOR raised is a CLAIM, not a fact: the tool can be wrong about the PR. Treat each as FALSE
+UNTIL DEFENDED and attack it. Consider specifically whether the TOOL manufactured it: does its extractor match by
+position rather than by name, does a regex capture only the first literal of a conditional, does a cleanliness check
+count artifacts the tool itself created, is a "skip" a property of the invocation rather than of the PR?
+The executor's source is at ${VSK} and the PR artifacts (pr.diff, head\\, merge-target\\)
+are at ${W}\\ - open them and compare like with like. Re-derive rather than assume.
+
+REPORT:
+${r.report.slice(0, 12000)}
+
+For EACH executor finding report SURVIVED or KILLED, the deciding file:line you opened, and keep/downgrade/drop.
+If there are no findings, say what the run positively establishes and what it does not.`,
+    { label: `refute executor: ${r.target}`, phase: 'S6b executor refutation', ...REFUTER })));
+
+  // ========================================================== S7 refold
+  phase('S7 refold');
+
+  await agent(`${CTX}${FIND}
+
+TASK: fold the deterministic validation evidence into ${R}\\card.md, then re-gate.
+
+VALIDATION REPORTS:
+${results.map(r => `TARGET ${r.target} (host ${r.host}):\n${r.report.slice(0, 5000)}`).join('\n\n')}
+
+INDEPENDENT REFUTATION OF THE EXECUTOR'S OWN FINDINGS:
+${execRefuted.map((r, i) => `${results[i].target}:\n${String(r || 'NO VERDICT').slice(0, 2000)}`).join('\n\n')}
+
+Rules:
+- Replace "Validation (deterministic): PENDING" with the real state: each target's verdict, the host architecture,
+  which stages passed and which skipped with their real reasons. If a stage failed but the refutation KILLED it as a
+  tool artifact, say so on that line - a NEEDS_WORK caused by the validator's own extractor is NOT a PR defect. A
+  target with no report is recorded as NO REPORT with the reason; never infer it from another target.
+- Replace "Perf (advisory): PENDING": a measured ratio only if stages.perf carries median_ratio, else
+  "NOT RUN — <the real reason>". Never label a hand-run number deterministic.
+- A KILLED executor finding must not become a card finding: record it as "-- late finding: <withdrawal + evidence>"
+  and append the same line to ${W}\\late_findings.txt.
+- A SURVIVED executor finding may take a card slot on severity; keep the cap at five and account for what it displaces.
+${SEPARATION}
+Then re-run all seven gates and report each exit code verbatim:
+  ${GATES}`,
+    { label: 'fold validation into card', phase: 'S7 refold', ...WORKER });
+
+  // Independent re-verification (review fix #9): the refold agent must not be the only witness
+  // that the card still passes after it edited the card.
+  const finalCheck = await agent(`Run these seven commands with UTF-8 forced (PYTHONUTF8=1), one at a time, and report
+each output and $LASTEXITCODE. Change no files.
+  ${GATES}
+Also report (Get-Content ${W}\\refutations.txt | Measure-Object -Line).Lines - it must still be ${findings.length}.
+End with the single word ALLGREEN if and only if all seven exit codes were 0.`,
+    { label: 'final independent gate check', phase: 'S7 refold', ...FORMATTER });
+
+  if (!/ALLGREEN/.test(String(finalCheck || ''))) {
+    throw new Error(`the gates do not pass after the validation refold:\n${String(finalCheck || '').slice(0, 4000)}\n` +
+      `The card was edited into a state it cannot defend; fix the card before delivering.`);
+  }
+  log('S7: gates green after refold, independently verified');
+}
+
+// ============================================================ S8 cleanup
+phase('S8 cleanup');
+
+const hostKeys = [...new Set((A.targets || []).map(t => `${t.host}|${t.container}|${t.scratch}|${t.worktree}`))];
+const cleaned = await parallel(hostKeys.map(h => {
+  const [host, container, scratch, worktree] = h.split('|');
+  return () => agent(`
+Use your shell tool locally and ssh for the remote side (see below).
+Judge success by stdout. IF ssh is refused by the local harness with a sandbox-backend error, SAY SO AND STOP -
+a silently skipped cleanup is a failed round, not a clean one.
+
+TASK: leave ${host} clean after this round.
+1. Copy every validation_*.json and validator log out of ${scratch} (container ${container}) to ${R}\\ - report what.
+2. Delete the scratch: \`docker exec ${container} rm -rf ${scratch}\`.
+3. Clean the worktree of root-owned in-container artifacts:
+   \`docker exec ${container} bash -lc 'cd ${worktree} && git clean -xdf && git status --porcelain --ignored'\`
+   - the last command must print nothing - and chown anything still root-owned back to ${A.uidGid}. Report the
+   root-owned count before and after; it must end at 0.
+4. Remove any script you scp'd to the host, naming each. Nothing of ours may remain in the host /tmp.
+5. Leave the PR body (clone, worktree, patch) and the container itself in place; confirm you touched no other user's
+   container or files.
+6. Report the final \`/opt/rocm/bin/rocm-smi --showpids\` reading.`,
+    { label: `cleanup ${String(host).split('.')[0]}`, phase: 'S8 cleanup', ...REMOTE });
+}));
+
+const cleanupFailed = cleaned.filter(c => !c).length;
+if (cleanupFailed) log(`S8: WARNING - ${cleanupFailed} cleanup agent(s) produced nothing; the remote side may be dirty`);
+
+return {
+  findings: findings.length,
+  fireVerdicts: minFindings,
+  refuterFiles: nfiles,
+  ledgerLines: nrefut,
+  gatesGreen,
+  validated: results.map(r => `${r.target} @ ${String(r.host).split('.')[0]}`),
+  cleanupFailed,
+  card: `${R}\\card.md`,
+  findingsFile: `${R}\\findings.md`,
+};


### PR DESCRIPTION
…l-pr as one gated loop

Adds .agent_loop/, a workflow-level orchestration package that runs the two review skills as a single loop: prefetch, one human break, then analysis fan-out, independent cross-model refutation, the seven review-pr gates, on-GPU validation, refutation of the executor's own findings, refold and cleanup.

It is not a third skill, which is why it sits beside .claude rather than inside it: it calls the skills' CLI surface and adds the guarantees a single pass cannot give. Every card finding is attacked by an agent that never saw the analysis, that agent writes the ledger line itself, and the ledger's provenance is checked before a card can be certified.

Six fail-closed guards, all covered by a zero-token dry-run harness (tools/dryrun.mjs, 10/10): dead analysis agent, collection short of the FIRE count, ledger provenance mismatch, gates never green, ledger rewritten behind the gate, and gates failing after the validation refold.

docs/upstream-findings.md records four reproducible defects this loop found in validate-kernel-pr itself, each of which reads as a defect in the PR under review if the tool is trusted.

Validated on ROCm/aiter#4961 across three heads on gfx950 and gfx1250; see VALIDATED-AGAINST.md for the pinned CLI surface and the measurements.

