### PR TITLE
[FlyDSL] Store fp8 MoE stage2 output through 64-bit pointers

### DIFF
--- a/aiter/ops/flydsl/kernels/mxmoe_gemm_v2.py
+++ b/aiter/ops/flydsl/kernels/mxmoe_gemm_v2.py
@@ -4,6 +4,7 @@
 
 import flydsl.compiler as flyc
 import flydsl.expr as fx
+from flydsl._mlir.dialects import llvm
 from flydsl.expr import arith as _arith
 from flydsl.expr import const_expr, gpu, range_constexpr, rocdl
 from flydsl.expr.typing import (
@@ -21,6 +22,8 @@ from flydsl.expr.typing import as_ir_value as _raw
 
 from .mxfp4_gemm_common import _fabs_f32 as fabs_f32
 from .mxfp4_gemm_common import (
+    _gep1,
+    _global_base_ptr1,
     _inline_dpp_pair_amax,
     _inline_dpp_quad_amax,
     _udiv,
@@ -35,8 +38,6 @@ from .mxfp4_gemm_common import (
     lds_vec_load,
 )
 from .mxfp4_gemm_common import _lds_swizzle_mask as lds_swizzle_mask
-
-STORE_CACHE_MODIFIER = 2
 
 _FP8_E8M0_SHIFT = 7
 
@@ -921,7 +922,7 @@ def atomic_bf16_epilog(
         bias_f32 = flat_buffer(arg_bias, T.f32, 4)
     out_bf16 = flat_buffer(arg_out, T.bf16, 4)
     out_bf16_ptr = global_typed_ptr(arg_out, T.bf16, align=2)
-    out_i8 = flat_buffer(arg_out, T.i8, 4)
+    out_i8_ptr = _global_base_ptr1(arg_out)
 
     load_i32 = fx.make_copy_atom(fx.rocdl.BufferCopy32b(), Int32)
     load_f32 = fx.make_copy_atom(fx.rocdl.BufferCopy32b(), Float32)
@@ -933,8 +934,6 @@ def atomic_bf16_epilog(
         if reduce_store_cache_modifier is not None
         else None
     )
-    store_i32 = fx.make_copy_atom(fx.rocdl.BufferCopy32b(STORE_CACHE_MODIFIER), Int32)
-    store_i8 = fx.make_copy_atom(fx.rocdl.BufferCopy8b(STORE_CACHE_MODIFIER), Int8)
 
     def load_scalar(atom, src, index, elem_ty):
         frag = fx.make_rmem_tensor(1, elem_ty)
@@ -1140,22 +1139,24 @@ def atomic_bf16_epilog(
 
                 def emit_stores(output_col, words, e8m0, rg=rg):
                     row_val_off = row_base_addr + fx.Int64(output_col)
-                    packed_frag = fx.make_rmem_tensor(1, Int32)
                     for d in range_constexpr(len(words)):
-                        packed_frag.store(Vec(words[d]).bitcast(Int32))
-                        fx.copy(
-                            store_i32,
-                            packed_frag,
-                            out_i8[None, row_val_off + fx.Int64(4 * d)],
+                        llvm.StoreOp(
+                            _raw(Vec(words[d]).bitcast(Int32)[0]),
+                            _gep1(out_i8_ptr, row_val_off + fx.Int64(4 * d)),
+                            alignment=4,
+                            nontemporal=True,
                         )
                     scale_off = (
                         row_base_addr
                         + fx.Int64(output_width)
                         + fx.Int64(_udiv(output_col, fx.Int32(g2_scale_blk)))
                     )
-                    scale_frag = fx.make_rmem_tensor(1, Int8)
-                    scale_frag.store(Vec.from_elements([e8m0.to(Int8)], Int8))
-                    fx.copy(store_i8, scale_frag, out_i8[None, scale_off])
+                    llvm.StoreOp(
+                        _raw(e8m0.to(Int8)),
+                        _gep1(out_i8_ptr, scale_off),
+                        alignment=1,
+                        nontemporal=True,
+                    )
 
                 @flyc.jit
                 def store_route_group_if_valid(col_lane8):


### PR DESCRIPTION
## Motivation

The fp8 route-out buffer in the v2 MoE stage2 epilogue is indexed by `token * topk`, which at token=131072 / model_dim=3584 is 7.25 GiB. The epilogue was storing into it through a buffer descriptor, and a buffer descriptor's `num_records` field is 32-bit, so anything past 4 GiB was not written. This is the fp8-output counterpart of the addressing work in #4906.

## Test Result

Kimi K3 MoE TP8, token=131072, best flydsl stage2 candidate:

| | kernel | time |
| --- | --- | --- |
| before | `flydsl_moe2_afp8_wfp4_bf16_t64x256x256_reduce_bnt2_xcd4` | 6847 us |
| after | `flydsl_moe2_layout_afp8_wfp4_bf16_t64x256x128_reduce_sbm64` | 5545 us |

About 19% faster. The winning layout kernel was previously rejected by the tuner with 100% error, which was exactly the out-of-range stores fixed here.

> **Note:** these numbers were collected with `AITER_FLYDSL_STAGE2_FP8=1` and a locally modified tuner, because flydsl v2 stage2 does not currently honour that flag.