### PR TITLE
[Triton/Gluon] Fix test_mha_v3 AssertionError on Mismatched elements

### DIFF
--- a/aiter/ops/triton/_triton_kernels/flash_attn_triton_amd/bwd.py
+++ b/aiter/ops/triton/_triton_kernels/flash_attn_triton_amd/bwd.py
@@ -2969,19 +2969,19 @@ def _bwd_dkdv_inner(
                     # cap, if any, is applied separately via MASK above)
                     window_mask = offs_n[:, None] >= 0
                 elif WINDOW_SIZE_LEFT < 0:
-                    window_mask = offs_n[:, None] <= (
-                        offs_m[None, :] + causal_offset + WINDOW_SIZE_RIGHT
-                    )
+                    rel = offs_n[:, None] - offs_m[None, :] - causal_offset
+                    window_mask = rel <= WINDOW_SIZE_RIGHT
                 elif WINDOW_SIZE_RIGHT < 0:
                     # unbounded right, finite left (mirror of infinite-left)
-                    window_mask = offs_n[:, None] >= (
-                        offs_m[None, :] + causal_offset - WINDOW_SIZE_LEFT
-                    )
+                    rel = offs_n[:, None] - offs_m[None, :] - causal_offset
+                    window_mask = rel >= -WINDOW_SIZE_LEFT
                 else:
-                    left_bound = offs_m[None, :] + causal_offset - WINDOW_SIZE_LEFT
-                    right_bound = offs_m[None, :] + causal_offset + WINDOW_SIZE_RIGHT
-                    window_mask = (offs_n[:, None] >= left_bound) & (
-                        offs_n[:, None] <= right_bound
+                    # Keep the relative-distance form:
+                    # broadcasting explicit left/right bound tiles potentially makes the
+                    # gfx950 backend spill the buffer descriptors and return silently wrong dK/dV.
+                    rel = offs_n[:, None] - offs_m[None, :] - causal_offset
+                    window_mask = (rel >= -WINDOW_SIZE_LEFT) & (
+                        rel <= WINDOW_SIZE_RIGHT
                     )
                 mask = window_mask & mask
             if DEBUG_TRITON_DETAIL and start_n == 256:


### PR DESCRIPTION
This change aims to fix the CI failure: 
`FAILED test_mha_v3.py::test_mha_v3_sliding_window_bwd[fp32-False-WINDOW_SIZE1-128-256-8-8-True]`

When the autotuner pick config `BLOCK_M1=BLOCK_N1=BLOCK_M2=BLOCK_N2=64, BLK_SLICE_FACTOR=2, waves_per_eu=1, num_warps=4, num_stages=1`, it brings high sgpr pressure, which needs eviction from sgpr to vgpr and reload with `v_readlane`.

On the other hand, buffer ops need 4 sgprs for SOFFSET, which should stay live in the loop section. While above eviction potentially could evict SOFFSET sgprs and have to reload with `v_readlane` in loop.

The fix - window_mask rewrite is algebraically identical, but it reduces the sgpr pressure largely, specifically it reduce the SOFFSET sgpr reload from 19 to 0 for this case. So the backend bug is never reached.

Detailed changes:

* BEFORE_FIX (buggy) — loop .LBB0_8, lines 965..3320

| SRD       | buffer_load in loop | descriptor v_writelane | descriptor v_readlane | loads whose SRD reaching-def is v_readlane |
|-----------|---------------------|------------------------|-----------------------|--------------------------------------------|
| s[0:3]    | 4                   | 4                      | 4                     | 4 / 4                                      |
| s[4:7]    | 32                  | 2                      | 2                     | 32 / 32                                    |
| s[20:23]  | 32                  | 2                      | 2                     | 32 / 32                                    |
| s[56:59]  | 4                   | 0                      | 0                     | 0 / 4                                      |

* AFTER_FIX (correct) — loop .LBB0_8, lines 754..2405

| SRD       | buffer_load in loop | descriptor v_writelane | descriptor v_readlane | loads whose SRD reaching-def is v_readlane |
|-----------|---------------------|------------------------|-----------------------|--------------------------------------------|
| s[76:79]  | 4                   | 0                      | 0                     | 0 / 4                                      |
| s[84:87]  | 4                   | 0                      | 0                     | 0 / 4                                      |
| s[92:95]  | 32                  | 0                      | 0                     | 0 / 32                                     |
| s[96:99]  | 32                  | 0                      | 0                     | 0 / 32                                     |

cc: @Dewei-Wang-sh 