### PR TITLE
[MSA] Instantiate sparse score kernels for 4, 8, and 16 index heads

### DIFF
--- a/csrc/kernels/sparse_attn/msa/pa_sparse_block_select.hpp
+++ b/csrc/kernels/sparse_attn/msa/pa_sparse_block_select.hpp
@@ -168,10 +168,20 @@ void launch_topk(SPARSE_TOPK_PARAMS)
 // scoring & topk kernel instantiation configuration tables
 // ---------------------------------------------------------------------------
 // (index heads, waves)
-#define SPARSE_DECODE_TABLE(F) F(1, 1) F(1, 2) F(1, 4) F(2, 1) F(2, 2) F(2, 4)
+#define SPARSE_DECODE_TABLE(F)              \
+    F(1, 1) F(1, 2) F(1, 4)                \
+    F(2, 1) F(2, 2) F(2, 4)                \
+    F(4, 1) F(4, 2) F(4, 4)                \
+    F(8, 1) F(8, 2) F(8, 4)                \
+    F(16, 1) F(16, 2) F(16, 4)
 
 // (index heads, query tiles)
-#define SPARSE_PREFILL_TABLE(F) F(1, 1) F(1, 2) F(1, 4) F(2, 1) F(2, 2) F(2, 4)
+#define SPARSE_PREFILL_TABLE(F)             \
+    F(1, 1) F(1, 2) F(1, 4)                \
+    F(2, 1) F(2, 2) F(2, 4)                \
+    F(4, 1) F(4, 2) F(4, 4)                \
+    F(8, 1) F(8, 2) F(8, 4)                \
+    F(16, 1) F(16, 2) F(16, 4)
 
 // (slots, waves)
 // clang-format off

--- a/op_tests/test_msa_block_select.py
+++ b/op_tests/test_msa_block_select.py
@@ -235,7 +235,7 @@ def test_topk(num_idx_heads: int, batch: int, ctx: int, query_len: int):
     return {"pass": "topk", "us": avg_us}
 
 
-l_num_idx_heads = [1, 2]
+l_num_idx_heads = [1, 2, 4, 8, 16]
 l_batch = [4, 8, 16, 32, 64, 128]
 l_ctx = [4096, 8192, 16384, 32768, 65536, 128000]
 l_query_len = [1, 4]
@@ -250,7 +250,7 @@ parser.add_argument(
     type=int,
     nargs="*",
     default=None,
-    help="Index heads per rank. Only 1 and 2 are built. e.g. -H 1 2",
+    help="Index heads per rank. Supported values: 1, 2, 4, 8, and 16",
 )
 parser.add_argument(
     "-b", "--batch", type=int, nargs="*", default=None, help="Requests per launch"


### PR DESCRIPTION
## Motivation

MiniMax-M3 cannot run with an fp8 indexer cache. It has 4 index heads, but the MSA score kernels are only instantiated for 1 and 2, so it dispatches to a kernel that does not exist and aborts at the first score call:


pa_sparse_block_score_decode: no build for num_idx_heads=4 num_waves=4


The index heads are replicated rather than sharded, so this affects every tensor-parallel layout, not just one. It is a hard failure at model load — on TP4 every worker dies during load_model.

The vLLM side already assumes these kernels exist: its selection gate admits any head count up to the 16 MFMA columns. Only the C++ instantiation list lagged.

## Technical Details

The kernels are already templated on head count (launch_score_decode<H, W>, launch_score_prefill<H, QTiles>). The only thing missing was listing the values in the two tables in pa_sparse_block_select.hpp. Those tables drive the declarations, definitions, and dispatch switch via macro expansion, so adding entries is sufficient — no kernel or dispatch changes.

Added 4, 8, and 16 to both tables. 4 is what MiniMax-M3 needs; 8 and 16 complete the range the score tile can serve.

Two notes for review:

The upper bound is already enforced. Both config structs assert kHeads > 0 && kHeads <= kN with kN = 16 (MFMA columns), so H=16 sits exactly at the bound and nothing beyond the instruction's capability can be requested.

The second macro argument differs between the tables. In SPARSE_DECODE_TABLE it is waves; in SPARSE_PREFILL_TABLE it is query tiles, since launch_score_prefill passes the fixed SPARSE_PREFILL_WAVES constant as the wave count. This matters because scoring_prefill_cfg asserts kWaves > 1, which appears to rule out F(H, 1) for prefill — it does not, because that argument never reaches WAVES. The prefill q_tiles=1 variants are required.

Instantiation count goes from 6 to 15 per table.

## Test Plan

Extended the existing sweep in op_tests/test_msa_block_select.py from l_num_idx_heads = [1, 2] to [1, 2, 4, 8, 16] so the new configs are exercised, not just compiled. Updated the -H help text to match.

Coverage: decode, prefill, and top-k; query lengths 1-64 (all prefill query-tile variants); contexts 4K and 128K. Hardware: gfx950 (MI355X).