### PR TITLE
[FlyDSL] [gfx1250] Drop the row-major a1 scale layout

### DIFF
--- a/aiter/ops/flydsl/grouped_gemm_mxfp4.py
+++ b/aiter/ops/flydsl/grouped_gemm_mxfp4.py
@@ -96,7 +96,6 @@ def flydsl_grouped_gemm_a8w4_masked(
     ep_row_map=None,
     situ_beta=1.0,
     situ_linear_beta=1.0,
-    row_major_ascale=0,
 ):
     """Launches a contiguous-M grouped a8w4 GEMM on the TDM kernel."""
     from .kernels.mxfp4_preshuffle_gfx1250_tdm import launch_gemm_a8w4_tdm
@@ -165,6 +164,5 @@ def flydsl_grouped_gemm_a8w4_masked(
         arg_ep_row_map=ep_row_map_tensor,
         f32_situ_beta=float(situ_beta),
         f32_situ_linear_beta=float(situ_linear_beta),
-        row_major_ascale=int(row_major_ascale),
     )
     return out

--- a/aiter/ops/flydsl/grouped_moe_gfx1250.py
+++ b/aiter/ops/flydsl/grouped_moe_gfx1250.py
@@ -633,16 +633,6 @@ def _grouped_a8w4_tdm_moe(
             f"row at model_dim {model_dim}, got {_src_width}"
         )
 
-    # The 16-row-interleaved a1 scale makes the quant pass write 4 B per cache
-    # line; the row-major form moves that interleave into gemm1's LDS read,
-    # which is free (~12 us off quant at 16k tokens, gemm1 unchanged). Only the
-    # topk=6 multidest quant path implements it.
-    _row_major_ascale = (
-        not _prequantized
-        and int(topk) == 6
-        and os.environ.get("AITER_FLYDSL_ROWMAJOR_ASCALE", "1") in ("1", "true", "True")
-    )
-
     a1_payload, a1_scale = flydsl_moe_fused_quant_preshuffle(
         hidden_states.reshape(1, token_num, _src_width),
         1,
@@ -654,7 +644,6 @@ def _grouped_a8w4_tdm_moe(
         source_topk=topk,
         num_valid_routes=_ep_nvr,
         prequantized_scale=src_a1_scale if _prequantized else None,
-        row_major_scale=_row_major_ascale,
     )
 
     # Fuse gemm1 activation + MX quantization + scale preshuffle into the
@@ -708,7 +697,6 @@ def _grouped_a8w4_tdm_moe(
             cluster_n=cluster_n,
             waves_per_tensor_tdm=waves_per_tensor_tdm,
             next_stage_prefetch=next_stage_prefetch,
-            row_major_ascale=int(_row_major_ascale),
             **_situ_kw,
         )
     else:
@@ -739,7 +727,6 @@ def _grouped_a8w4_tdm_moe(
             cluster_n=cluster_n,
             waves_per_tensor_tdm=waves_per_tensor_tdm,
             next_stage_prefetch=next_stage_prefetch,
-            row_major_ascale=int(_row_major_ascale),
             **_situ_kw,
         )
         a2_payload, a2_scale = flydsl_moe_fused_quant_preshuffle(

--- a/aiter/ops/flydsl/kernels/moe_fused_route_quant_scatter.py
+++ b/aiter/ops/flydsl/kernels/moe_fused_route_quant_scatter.py
@@ -530,18 +530,6 @@ def _emit_quant_block_loop(c: SimpleNamespace) -> None:
 
         quant_results.append((mx_block, payload_val, e8m0_scale))
 
-    if const_expr(getattr(c, "scale_vec4", False)):
-        # Payload per block as usual, but the row's e8m0 goes out 16 B at a
-        # time: the store pass has every block's result live, so two adjacent
-        # blocks' dwords pair into one dwordx4.
-        for mx_block, payload_val, _e8m0 in quant_results:
-            _emit_payload_stores(c, dst_payload, payload_val, mx_block)
-        for i in range_constexpr(0, len(quant_results), 2):
-            _emit_row_major_scale_vec4(
-                c, quant_results[i][0], quant_results[i][2], quant_results[i + 1][2]
-            )
-        return
-
     # Stores are a separate pass so the quant pass above stays one basic block and
     # its loads can cluster. That only works while the quant pass is branch-free:
     # a value defined inside a guarded region does not dominate this loop, so
@@ -565,29 +553,16 @@ def _emit_quant_result_stores(c, dst_payload, mx_block, payload_val, e8m0_scale)
     e8m0_byte = arith.trunci(T.i8, e8m0_scale)
     _emit_payload_stores(c, dst_payload, payload_val, mx_block)
 
-    row_major_scale = getattr(c, "row_major_scale", False)
-    if const_expr(row_major_scale and getattr(c, "scale_pack_dwords", False)):
-        _emit_row_major_scale_dwords(c, mx_block, scale_dword, e8m0_scale)
-        return
-
     # one e8m0 byte per block, written by the block's lead lane. This plain
     # helper is not AST-rewritten, so the runtime guard goes through a local
     # @flyc.jit dispatch (a bare Python ``if`` would eval the dynamic Boolean
     # as a host bool).
     def _store_lead_scale():
         for dst in c.dests:
-            if const_expr(row_major_scale):
-                # (row, feat_dim//32) bytes: each row's scales contiguous, so a
-                # warp's six destination writes stay within six rows instead of
-                # touching a fresh cache line per MX block.
-                dst_scale_byte = (
-                    dst.payload_row_i32 * c.c_scale_bytes_per_row + mx_block
-                )
-            else:
-                dst_scale_dword = (
-                    dst.scale_row_dword_base + scale_dword * c.c_wmma_rep * 16
-                )
-                dst_scale_byte = dst_scale_dword * c.c4_i32 + byte_in_dword
+            dst_scale_dword = (
+                dst.scale_row_dword_base + scale_dword * c.c_wmma_rep * 16
+            )
+            dst_scale_byte = dst_scale_dword * c.c4_i32 + byte_in_dword
             c.scale_t[dst_scale_byte] = e8m0_byte
 
     @flyc.jit
@@ -618,93 +593,6 @@ def _emit_payload_stores(c, dst_payload, payload_val, mx_block):
             cache_modifier=payload_cache,
             offset_is_bytes=True,
         )
-
-
-def _pack_block_group_dword(c, e8m0_scale):
-    """The dword of e8m0 bytes for the 4 MX blocks around this lane's block.
-
-    Only the lane holding block 4k ends up with them in the right order; the
-    caller predicates on that.
-    """
-    i32 = c.i32
-    v = ArithValue(arith.andi(e8m0_scale, arith.constant(0xFF, type=i32)))
-    p1 = ArithValue(v.shuffle_xor(c.c4_i32, c.c_wave))
-    half = v | (p1 << arith.constant(8, type=i32))
-    p2 = ArithValue(half.shuffle_xor(arith.constant(8, type=i32), c.c_wave))
-    return half | (p2 << arith.constant(16, type=i32))
-
-
-def _emit_row_major_scale_vec4(c, mx_block_lo, e8m0_lo, e8m0_hi):
-    """Two blocks' worth of row-major e8m0 (16 B) in one dwordx4 store.
-
-    ``mx_block_lo`` is the low iteration's block for this lane. Lane 4k*4 holds
-    the low dword of each pair and picks up its partner's upper dword with one
-    more xor-shuffle, so a single lane writes all 16 bytes.
-
-    Like the payload, the packed scale stays on the width-agnostic buffer_ops V#:
-    ``c.scale_t`` is a byte view, and this store is a dword-indexed dwordx4.
-    """
-    i32 = c.i32
-    lo = _pack_block_group_dword(c, e8m0_lo)
-    hi = _pack_block_group_dword(c, e8m0_hi)
-    lo_peer = ArithValue(lo).shuffle_xor(arith.constant(16, type=i32), c.c_wave)
-    hi_peer = ArithValue(hi).shuffle_xor(arith.constant(16, type=i32), c.c_wave)
-    quad = fx.Vector.from_elements(
-        [lo, lo_peer, hi, hi_peer], fx.Numeric.from_ir_type(i32)
-    )
-    scale_dword = fx.Uint32(mx_block_lo) // fx.Uint32(c.c4_i32)
-
-    def _store_quad():
-        for dst in c.dests:
-            buffer_ops.buffer_store(
-                quad,
-                c.scale_rsrc,
-                dst.payload_row_i32 * c.c_scale_dwords_per_row + scale_dword,
-            )
-
-    # Only lane 0 of the wave stores: it holds blocks 4k..4k+3 of both halves.
-    is_wave_lead = arith.andi(
-        fx.Int32(c.block_in_wave) == c.c0_i32,
-        c.is_block_lead,
-    )
-
-    @flyc.jit
-    def _dispatch_quad():
-        if is_wave_lead:
-            _store_quad()
-
-    _dispatch_quad()
-
-
-def _emit_row_major_scale_dwords(c, mx_block, scale_dword, e8m0_scale):
-    """Row-major e8m0 as one dword per 4 MX blocks instead of 4 byte stores.
-
-    Only the lane holding block 4k ends up with the bytes in the right order,
-    hence the ``block_in_wave % 4 == 0`` predicate.
-    """
-    i32 = c.i32
-    packed = _pack_block_group_dword(c, e8m0_scale)
-
-    def _store_packed():
-        for dst in c.dests:
-            # buffer_store scales the offset by the stored type, so index dwords.
-            buffer_ops.buffer_store(
-                packed,
-                c.scale_rsrc,
-                dst.payload_row_i32 * c.c_scale_dwords_per_row + scale_dword,
-            )
-
-    group_lead = arith.andi(
-        arith.andi(fx.Int32(c.block_in_wave), arith.constant(3, type=i32)) == c.c0_i32,
-        c.is_block_lead,
-    )
-
-    @flyc.jit
-    def _dispatch_packed():
-        if group_lead:
-            _store_packed()
-
-    _dispatch_packed()
 
 
 def _emit_quant_one_k_group(c: SimpleNamespace, mx_group) -> None:
@@ -1872,7 +1760,6 @@ def build_moe_token_multidest_quant_module(
     wmma_rep: int,
     topk: int,
     quant_mode: str = "fp4",
-    row_major_scale: bool = False,
     tdm_hidden_chunks: int = _TOKEN_MULTIDEST_TDM_CHUNKS,
     ksplit: int = 1,
 ):
@@ -1923,17 +1810,9 @@ def build_moe_token_multidest_quant_module(
             f"{block_iters} and leave a 16 B-aligned chunk of {feat_dim * 2} B"
         )
     hidden_chunk_bytes = feat_dim * 2 // tdm_hidden_chunks if tdm_hidden_chunks else 0
-    # Row-major e8m0 goes out packed: a dword per 4 MX blocks, widened to a
-    # dwordx4 per 8 when the block count pairs up. Both need the pk8 geometry
-    # (4 lanes per MX block) to assemble the bytes with xor-shuffles.
-    scale_pack_dwords = row_major_scale and lanes_per_mx_block == 4
-    scale_vec4 = scale_pack_dwords and block_iters % 2 == 0
     module_name = (
         f"moe_token_multidest_quant_k{topk}_fd{feat_dim}_r{wmma_rep}"
         f"_{quant_mode}_{L.native_tag}"
-        f"{'_rmscale' if row_major_scale else ''}"
-        f"{'_scpk' if scale_pack_dwords else ''}"
-        f"{'_scv4' if scale_vec4 else ''}"
         f"{f'_hidtdm{tdm_hidden_chunks}' if tdm_hidden_chunks else ''}"
         f"{f'_ks{ksplit}' if ksplit > 1 else ''}"
     )
@@ -1965,8 +1844,6 @@ def build_moe_token_multidest_quant_module(
         c_rows_per_tile = arith.constant(rows_per_tile, type=i32)
         c_lanes_per_block = arith.constant(lanes_per_mx_block, type=i32)
         c_elems_per_lane = arith.constant(elems_per_lane, type=i32)
-        c_scale_bytes_per_row = arith.constant(mx_blocks_per_row, type=i32)
-        c_scale_dwords_per_row = arith.constant(mx_blocks_per_row // 4, type=i32)
 
         tid = fx.Uint32(fx.thread_idx.x)
         bid = fx.Uint32(fx.block_idx.x)
@@ -2110,27 +1987,17 @@ def build_moe_token_multidest_quant_module(
                     SimpleNamespace(payload_row_i32=row, scale_row_dword_base=sc)
                     for row, sc in zip(rows, scales)
                 ],
-                # Byte view for the unpacked e8m0 store; the packed dword /
-                # dwordx4 row-major stores need a width-agnostic V# instead.
-                # Both carry the same zero-on-invalid bound.
+                # Zero-on-invalid bound: a dead token takes a zero-length
+                # descriptor rather than a branch.
                 scale_t=ptr_buf_tensor(
                     grouped_scale, fx.Int8, num_records_bytes=scale_records
                 ),
-                scale_rsrc=buffer_ops.create_buffer_resource_from_addr(
-                    fx.Int64(ptrtoint(grouped_scale)),
-                    num_records_bytes=scale_records,
-                ),
-                row_major_scale=row_major_scale,
-                c_scale_bytes_per_row=c_scale_bytes_per_row,
-                c_scale_dwords_per_row=c_scale_dwords_per_row,
                 hidden_chunks=max(1, tdm_hidden_chunks),
                 chunk_prefetch=chunk_prefetch,
                 hidden_lds_load=hidden_lds_load,
                 hidden_lds_idx=hidden_lds_idx,
                 hidden_lds_row_off=hidden_lds_row_off,
                 hidden_slot_bytes=hslot,
-                scale_pack_dwords=scale_pack_dwords,
-                scale_vec4=scale_vec4,
                 mx_group_base=(
                     fx.Uint32(fx.block_idx.y) * arith.constant(block_iters, type=i32)
                     if const_expr(ksplit > 1)

--- a/aiter/ops/flydsl/kernels/mxfp4_preshuffle_gfx1250_tdm.py
+++ b/aiter/ops/flydsl/kernels/mxfp4_preshuffle_gfx1250_tdm.py
@@ -82,7 +82,6 @@ def launch_gemm_a8w4_tdm(
     arg_ep_row_map: fx.Tensor = None,
     f32_situ_beta: fx.Float32 = 1.0,
     f32_situ_linear_beta: fx.Float32 = 1.0,
-    row_major_ascale: Constexpr[int] = 0,
 ):
     """Launch the grouped contiguous-M a8w4 MoE GEMM for gfx1250.
 
@@ -146,7 +145,6 @@ def launch_gemm_a8w4_tdm(
         ep_slot_stride_bytes,
         ep_destination_stride,
         ep_world_size,
-        row_major_ascale,
     )
     _ = cache_tag
     if enable_ep_scatter:
@@ -184,17 +182,7 @@ def launch_gemm_a8w4_tdm(
     # (k128, wm, lane16) layout gives each WMMA scale operand a contiguous
     # 16-dword block -- which is why the global buffer has to arrive already
     # interleaved across 16 M rows.
-    #
-    # row_major_ascale instead takes a plain (row, k128) global buffer, so a
-    # producer writes each row's scales contiguously, and moves the 16-row
-    # interleave into the per-lane ds_read below (lane == M row, stride
-    # SA_KDW dwords -> a 2-way bank conflict on one b32 read per operand).
-    SA_KDW = AS_KSTEPS  # scale dwords per row per k-tile (tile_k // 128)
-    STAGE_SA = (
-        ((tile_m * SA_KDW * 4 + 15) // 16) * 16
-        if row_major_ascale
-        else ((AS_SUPERS * AS_INNER * 4 + 15) // 16) * 16
-    )
+    STAGE_SA = ((AS_SUPERS * AS_INNER * 4 + 15) // 16) * 16
     STAGE_SB = ((SB_SUPERS * SC_INNER * 4 + 15) // 16) * 16
     SA_OFF = STAGE_A + STAGE_B
     SB_OFF = STAGE_A + STAGE_B + STAGE_SA
@@ -324,7 +312,6 @@ def launch_gemm_a8w4_tdm(
         B_BATCH_ROWS = n64 // 16
         N_SUPERS = (n64 + 31) // 32
         AS_ROW = (K // 128) * wmma_m_rep * 16
-        SA_GROW = K // 128  # row-major: scale dwords per M row
 
         c_outer_off, c_inner_off, c_stride = blk_m64, blk_n64, i32_n
         SB_OUTER_STRIDE = K4
@@ -504,35 +491,20 @@ def launch_gemm_a8w4_tdm(
             k_adv=PACK_TK * 16,
             wv=waves[1],
         )
-        if const_expr(row_major_ascale):
-            add_tdm_loads(
-                gSA_base,
-                blk_m64 * SA_GROW,
-                SA_GROW,
-                None,
-                SA_KDW,
-                tile_m,
-                on_i32=True,
-                lds_off=SA_OFF // 4,
-                lds_row=SA_KDW,
-                k_adv=SA_KDW * 4,
-                wv=waves[2],
-            )
-        else:
-            add_tdm_loads(
-                gSA_base,
-                (blk_m64 // (wmma_m_rep * 16)) * AS_ROW,
-                AS_ROW,
-                None,
-                AS_INNER,
-                AS_SUPERS,
-                on_i32=True,
-                lds_off=SA_OFF // 4,
-                lds_row=AS_INNER,
-                k_adv=AS_INNER * 4,
-                wv=waves[2],
-                split_inner=AS_SUPERS < len(waves[2]),
-            )
+        add_tdm_loads(
+            gSA_base,
+            (blk_m64 // (wmma_m_rep * 16)) * AS_ROW,
+            AS_ROW,
+            None,
+            AS_INNER,
+            AS_SUPERS,
+            on_i32=True,
+            lds_off=SA_OFF // 4,
+            lds_row=AS_INNER,
+            k_adv=AS_INNER * 4,
+            wv=waves[2],
+            split_inner=AS_SUPERS < len(waves[2]),
+        )
         add_tdm_loads(
             gSB_base,
             sb_off0,
@@ -596,12 +568,7 @@ def launch_gemm_a8w4_tdm(
         lds_b_lane_off = STAGE_A + (wnb // 16) * B_LDS_ROW + kgrp * 256 + lane16 * 16
         assert wmma_m_rep == 1 or wmma_m_rep % 2 == 0
         sa_lane = lane16 if wmma_m_rep == 1 else lane
-        SA_ROWS_PER_LOAD = 16 if wmma_m_rep == 1 else 32
-        lds_sa_lane_off = (
-            SA_OFF + (wave_m * warp_tile_m + sa_lane) * SA_KDW * 4
-            if row_major_ascale
-            else SA_OFF + wave_m * (AS_INNER * 4) + sa_lane * 4
-        )
+        lds_sa_lane_off = SA_OFF + wave_m * (AS_INNER * 4) + sa_lane * 4
         # One full-wave load covers both 16-column halves of an N32 scale
         # super-row. WMMA opsel_a selects lane 0:15 or 16:31 for each wn.
         assert warp_tile_n % 32 == 0, "load_sb split requires a 32-aligned wnb"
@@ -659,11 +626,7 @@ def launch_gemm_a8w4_tdm(
             return load_half(wn)
 
         def load_sa(buf, sm, ksl):
-            off = (
-                (sm * SA_ROWS_PER_LOAD * SA_KDW + ksl) * 4
-                if row_major_ascale
-                else (ksl * wmma_m_rep + sm * 2) * 16 * 4
-            )
+            off = (ksl * wmma_m_rep + sm * 2) * 16 * 4
             return lds_load_b32(lds_sa_base(buf), fx.Int32(off))[0]
 
         def load_sb(buf, sn, ksl):

--- a/aiter/ops/flydsl/moe_kernels.py
+++ b/aiter/ops/flydsl/moe_kernels.py
@@ -3003,7 +3003,6 @@ def _get_compiled_token_multidest_quant(
     wmma_rep: int,
     topk: int,
     quant_mode: str,
-    row_major_scale: bool = False,
     tdm_hidden_chunks: int = 4,
     ksplit: int = 1,
 ):
@@ -3016,7 +3015,6 @@ def _get_compiled_token_multidest_quant(
         wmma_rep=wmma_rep,
         topk=topk,
         quant_mode=quant_mode,
-        row_major_scale=row_major_scale,
         tdm_hidden_chunks=tdm_hidden_chunks,
         ksplit=ksplit,
     )
@@ -3069,10 +3067,6 @@ def flydsl_moe_fused_quant_preshuffle(
     # ``quant_mode``: the sender already quantized, so the kernel only scatters
     # + preshuffles.
     prequantized_scale: torch.Tensor | None = None,
-    # When True, write the e8m0 scale as (row, feat_dim//32) instead of the
-    # 16-row-interleaved WMMA form. The consuming GEMM must be built with
-    # row_major_ascale so it does the interleave on its LDS->register read.
-    row_major_scale: bool = False,
 ):
     """Fused grouped quant + e8m0 scale-preshuffle in one kernel pass.
 
@@ -3175,11 +3169,6 @@ def flydsl_moe_fused_quant_preshuffle(
             and os.environ.get("AITER_FLYDSL_TOKEN_MULTIDEST_QUANT", "1")
             in ("1", "true", "True")
         )
-        if row_major_scale and not use_token_multidest:
-            raise ValueError(
-                "row_major_scale is only implemented on the token-multidest "
-                "quant path"
-            )
         if use_token_multidest:
             from aiter.ops.flydsl.kernels.moe_fused_route_quant_scatter import (
                 token_multidest_ksplit,
@@ -3194,7 +3183,6 @@ def flydsl_moe_fused_quant_preshuffle(
                 wmma_rep=wmma_rep,
                 topk=int(source_topk),
                 quant_mode=quant_mode,
-                row_major_scale=bool(row_major_scale),
                 tdm_hidden_chunks=token_multidest_tdm_chunks(
                     feat_dim, wmma_rep, quant_mode, md_ksplit
                 ),


### PR DESCRIPTION
## Summary

[#5313](https://github.com/ROCm/aiter/pull/5313) added a second e8m0 layout for the grouped MoE A operand: the token-multidest quant could write a plain `(row, K/32)` buffer instead of the 16-row interleaved WMMA form, and gemm1 moved the interleave into its LDS→register read. This PR removes it and keeps the interleaved layout only.

Two layouts is one too many. The producer and the consumer have to agree, but they derived the choice independently — the GEMM caller re-stated the quant dispatcher's topk / token-count / EP gates rather than being told which layout had actually been written. They disagree for EP: MegaMoE passes `num_valid_routes`, which sends the quant to the route-ksplit path (interleaved), while the caller still asked for row-major on `topk == 6`. A plain a8w4 run raises:

```
ValueError: row_major_scale is only implemented on the token-multidest quant path
```

repro (4x gfx1250):

```bash
torchrun --nproc_per_node=4 op_tests/multigpu_tests/test_mega_moe_gfx1250.py \
    -q a8w4_mxfp4 -tpr 512 --layers 1 --combine fused \
    --dispatch_wire bf16 --acc_verify 1
```

What goes: the row-major store and its dword/dwordx4 packing, the `row_major_ascale` LDS read that undid it in `launch_gemm_a8w4_tdm`, and the flag threaded from `_grouped_a8w4_tdm_moe` through `flydsl_moe_fused_quant_preshuffle` to both kernels. Net −197 lines.

The row-major write did buy a contiguous scale write, which the interleaved form cannot match — its contiguous axis is M (16 rows of a WMMA group), and a quant wave owns one row. If that write is worth reclaiming later it should come back as one layout, chosen by the producer and reported to the consumer, not re-derived on both sides.

## Test plan

- [x] `token-multidest` and `route-ksplit` produce bit-identical payload and scale on the same input: fp8/fp4 × topk 2/6/8 × 64/512/2048 tokens, 18/18. This is the load-bearing check — MegaMoE is EP, so it never reaches the token-multidest kernel, which is the one whose layout changed.
- [x] MegaMoE fused, 4 ranks, 512 tokens/rank, 1 layer: a8w4 `logits_diff` 0.001083 (tol 0.002142), a4w4 0.021552 (tol 0.032735) — unchanged from before #5313, and a8w4 no longer raises.
- [ ] CI

No perf claim: on a shared node a single MegaMoE e2e run varied 409–802 us, and the scale store is a low single-digit percentage of the layer, so e2e cannot resolve this either way.

Made with [Cursor](https://cursor.com)