### PR TITLE
[Triton/Gluon] make W4A16 backend warning print it only once instead of on every call

### DIFF
--- a/aiter/ops/triton/moe/moe_op_gemm_a16w4.py
+++ b/aiter/ops/triton/moe/moe_op_gemm_a16w4.py
@@ -2,6 +2,7 @@
 # original code https://github.com/triton-lang/triton/blob/main/python/triton_kernels/triton_kernels/matmul_details/_matmul.py
 
 import itertools
+from functools import lru_cache
 
 import torch
 import triton
@@ -20,6 +21,14 @@ from aiter.ops.triton.utils.logger import AiterTritonLogger
 _LOGGER = AiterTritonLogger()
 
 _GLUON_SUPPORTED_ARCHS = ("gfx1250",)
+
+
+@lru_cache(maxsize=1)
+def _warn_gluon_fallback_once():
+    _LOGGER.warning(
+        "Gluon was explicitly requested for moe_gemm_a16w4 but is not supported "
+        "on this GPU; using Triton."
+    )
 
 
 def _is_gluon_available():
@@ -252,7 +261,8 @@ def moe_gemm_a16w4(
         if _is_gluon_available():
             backend = "gluon"
         else:
-            _LOGGER.warning("GLUON backend not available. Using TRITON backend!!!")
+            if backend == "gluon":
+                _warn_gluon_fallback_once()
             backend = "triton"
 
     backend = backend.lower()


### PR DESCRIPTION
## Purpose

Keep automatic backend selection quiet in `moe_gemm_a16w4`. Warn once per process when a caller explicitly requests unsupported Gluon and falls back to Triton.

The current selector treats `backend=None` like an explicit `"gluon"` request. Its Gluon implementation supports only `gfx1250`, so automatic selection on `gfx950` logs on every GEMM invocation. The vLLM W4A16 MoE wrapper calls this operator twice per layer and TP worker.

The original MI355X TP4 DeepSeek-V4.1-Flash run contains 56,264 occurrences of `GLUON backend not available. Using TRITON backend!!!`: 10,184 before server readiness and 46,080 afterward.

- [Original job](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/34651830283/job/103436309734)
- [Complete server-log artifact](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/34651830283/artifacts/10285837503)
- [Introducing AITER change](https://github.com/ROCm/aiter/pull/4446)

This draft contains only the quiet-auto-selection patch. It does not change vLLM, kernel selection, kernel code, scales, or the logging level. The `lru_cache` decorates only the warning helper, not architecture detection or backend selection. Keep this PR draft / DNM until GPU validation and maintainer review.

## Validation

The [combined InferenceX sweep](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/34661567802) passed: all six MI355X TP4 benchmark points at concurrency 1/2/4/8/16/32 and GSM8K eval succeeded. Both patch hashes matched in all seven jobs. The seven complete server logs contain 44,516 lines and **zero original fallback warnings**, with server readiness and actual inference confirmed. [InferenceX #3031](https://github.com/SemiAnalysisAI/InferenceX/pull/3031) lists every artifact and per-run count.

[GSM8K](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/34661567802/artifacts/10287709551): 1,319 questions, strict-match 0.9734647460 and flexible-extract 0.9727065959, both above the configured 0.9 gate. Concurrency 32 recorded one client request-body write error among 2,004 profiling requests (0.05%) and still passed; duration-limit cancellation messages also occur. This result does not isolate either patch or establish baseline-equivalent accuracy/performance.

- Local source-extracted CPU checks: 9 passed, 20 parametrized subtests passed. These checks do not import or execute GPU kernels.
- 10,000 automatic gfx950 selections: 10,000 warnings before, zero after.
- 10,000 explicit unsupported `"gluon"` selections: one warning after.
- Auto selection followed by an explicit unsupported request still warns.
- Backend results remain unchanged across gfx942, gfx950, gfx1250, a gfx1250 feature-suffixed target, and an unknown target.
- `ruff check aiter/ops/triton/moe/moe_op_gemm_a16w4.py`: passed.
- `black --check aiter/ops/triton/moe/moe_op_gemm_a16w4.py`: passed.
- `git diff --check`: passed.
- Patch application checked against `v0.1.21.post1`.

[InferenceX #3031](https://github.com/SemiAnalysisAI/InferenceX/pull/3031) tested this patch together with the explicit-Triton vLLM workaround in [vLLM #56543](https://github.com/vllm-project/vllm/pull/56543), at the requester's direction. The earlier AITER-only sweep was cancelled when that scope changed. Both runtime transformations produce bytes identical to the upstream drafts, and 56 InferenceX runner tests passed locally. Warning log levels remain unchanged. The combined run cannot isolate each patch's contribution. No speedup or original cancellation-cause claim is made.

Open-PR searches for the exact warning and related backend changes found no duplicate fix.

AI assistance was used to investigate, implement, and run the local checks. Human review is required before merging.
