### PR TITLE
[Triton/Gluon] Keep automatic W4A16 backend selection quiet

### DIFF
--- a/aiter/ops/triton/moe/moe_op_gemm_a16w4.py
+++ b/aiter/ops/triton/moe/moe_op_gemm_a16w4.py
@@ -30,6 +30,27 @@ def _is_gluon_available():
         return False
 
 
+def _resolve_backend(backend: str | None) -> str:
+    """Resolve automatic selection without warning on the expected fallback."""
+    if backend is None:
+        return "gluon" if _is_gluon_available() else "triton"
+
+    backend = backend.lower()
+    assert backend in (
+        "triton",
+        "gluon",
+    ), f"Unknown backend '{backend}', must be 'triton' or 'gluon'"
+
+    if backend == "gluon" and not _is_gluon_available():
+        _LOGGER.warning(
+            "Gluon backend was explicitly requested but is not available; "
+            "using Triton."
+        )
+        return "triton"
+
+    return backend
+
+
 def can_overflow_int32(tensor: torch.Tensor):
     max_int32 = (1 << 31) - 1
     offset = 0
@@ -248,18 +269,7 @@ def moe_gemm_a16w4(
         torch.Tensor: Output with shape as x(num_tokens, K/hidden_dim/emb_dim)
     """
 
-    if backend in (None, "gluon"):
-        if _is_gluon_available():
-            backend = "gluon"
-        else:
-            _LOGGER.warning("GLUON backend not available. Using TRITON backend!!!")
-            backend = "triton"
-
-    backend = backend.lower()
-    assert backend in (
-        "triton",
-        "gluon",
-    ), f"Unknown backend '{backend}', must be 'triton' or 'gluon'"
+    backend = _resolve_backend(backend)
 
     _LOGGER.info(
         f"MOE_GEMM_A16W4: x={x.shape} w={w.shape} w_scales={w_scales.shape} swizzle_mx_scale={swizzle_mx_scale} backend={backend}"

--- a/op_tests/triton_tests/moe/test_moe_gemm_a16w4.py
+++ b/op_tests/triton_tests/moe/test_moe_gemm_a16w4.py
@@ -7,6 +7,8 @@ from dataclasses import dataclass, fields
 import pytest
 import torch
 
+import aiter.ops.triton.moe.moe_op_gemm_a16w4 as moe_gemm_a16w4_module
+
 # matmul utilities
 from aiter.ops.triton.moe.moe_op_gemm_a16w4 import (
     moe_gemm_a16w4,
@@ -155,6 +157,41 @@ def assert_close(ref, tri, maxtol=None, rmstol=None, description="--", verbose=T
 # ---------------
 # unit tests
 # ---------------
+
+
+@pytest.mark.parametrize(
+    "backend, gluon_available, expected, expected_warnings",
+    [
+        (None, False, "triton", []),
+        (None, True, "gluon", []),
+        ("triton", False, "triton", []),
+        ("gluon", True, "gluon", []),
+        (
+            "gluon",
+            False,
+            "triton",
+            [
+                (
+                    "Gluon backend was explicitly requested but is not available; "
+                    "using Triton."
+                )
+            ],
+        ),
+    ],
+)
+def test_resolve_backend(
+    monkeypatch, backend, gluon_available, expected, expected_warnings
+):
+    warnings = []
+    monkeypatch.setattr(
+        moe_gemm_a16w4_module,
+        "_is_gluon_available",
+        lambda: gluon_available,
+    )
+    monkeypatch.setattr(moe_gemm_a16w4_module._LOGGER, "warning", warnings.append)
+
+    assert moe_gemm_a16w4_module._resolve_backend(backend) == expected
+    assert warnings == expected_warnings
 
 
 @dataclass


### PR DESCRIPTION
## Summary

- keep `backend=None` as silent architecture-based auto-selection;
- preserve the existing warning and Triton fallback when `backend="gluon"`
  is explicitly requested on an unsupported architecture; and
- add focused regression coverage for automatic and explicit selection.

The A16W4 MoE Gluon implementation currently supports gfx1250. On gfx942 and
gfx950, automatic selection is therefore expected to choose Triton. The old
selector treated `None` like an explicit Gluon request and emitted a warning
for every GEMM invocation, which produces substantial log noise in vLLM's
DeepSeek-V4.1-Flash path.

This addresses the AITER-side cause of vllm-project/vllm#56540 without changing
kernel selection or kernel code.

ROCm/aiter#5471 appeared while this patch was being prepared and overlaps this
change. This version centralizes backend resolution, avoids process-global
warning state, and includes committed regression tests. If maintainers prefer
#5471, the tests and selection split here can be reused there.

## Validation

- `ruff==0.16.0` on both changed files
- `black --check` on both changed files
- Python bytecode compilation on both changed files
- `git diff --check`

The focused tests do not launch a GPU kernel. GPU execution was not available
locally; kernel dispatch and kernel arguments are unchanged.

AI assistance was used for investigation and implementation. Human review is
requested before merging.
