### PR TITLE
[FlyDSL] Fix PA edge cases and add tuned page-128 support

### DIFF
--- a/aiter/ops/flydsl/kernels/pa_decode_tile.py
+++ b/aiter/ops/flydsl/kernels/pa_decode_tile.py
@@ -10,7 +10,7 @@ score, value scale + 1/FP8_MAX into the epilogue); softmax max/sum stay f32.
 ``key_scale``/``value_scale`` are either a ``[1]`` per-tensor scalar or a
 ``[num_blocks, num_kv_heads, block_size]`` per-token tensor (chosen by rank).
 
-``block_size`` (16/64) and ``head_dim`` (multiple of 64) are compile-time
+``block_size`` (16/64/128) and ``head_dim`` (multiple of 64) are compile-time
 constants. Layouts are logical, not production's preshuffle.
 
 * ``query``        [num_seqs, num_q_heads, head_dim]  f16/bf16 (head_dim contiguous)
@@ -101,7 +101,8 @@ def compile_pa_decode_tile(
     assert block_size in (
         16,
         64,
-    ), f"pa_decode_tile only supports block_size in (16, 64), got {block_size}"
+        128,
+    ), f"pa_decode_tile only supports block_size in (16, 64, 128), got {block_size}"
     assert query_dtype in (
         "f16",
         "bf16",
@@ -121,9 +122,8 @@ def compile_pa_decode_tile(
     NWARP = 4  # 4 waves / CTA
     TOK_PER_WARP = 64  # tokens each warp owns per compute block (matches production KV_COMPUTE_BLOCK)
     TILE_TOK = NWARP * TOK_PER_WARP  # 256 tokens / compute block
-    PAGES_PER_CHUNK = (
-        TOK_PER_WARP // block_size
-    )  # pages spanned by one 64-token warp-chunk: 1 (bs=64) or 4 (bs=16)
+    # A warp owns 64 tokens: four page-16s, one page-64, or half a page-128.
+    PAGES_PER_CHUNK = cdiv(TOK_PER_WARP, block_size)
     assert (
         head_dim % (NWARP * MFMA_MNK) == 0
     ), "head_dim must split across the 4 warps for PV"
@@ -306,10 +306,12 @@ def compile_pa_decode_tile(
         bt_num_records_bytes = (
             fx.Index(gpu.grid_dim.x) * fx.Index(max_blocks_per_seq) * 4
         )  # int32 entries
+        # Wide loads must preserve row starts that are only int32-aligned.
         bt_buf = ptr_buf_tensor(
             block_tables_ptr,
             fx.Int32,
             unit_elems=PAGES_PER_CHUNK,
+            unit_stride=1,
             num_records_bytes=bt_num_records_bytes,
         )
         # Per-tensor: a single global scale, read once. Per-token: read
@@ -358,10 +360,10 @@ def compile_pa_decode_tile(
         NCHUNK = TILE_TOK // TOK_CHUNK  # 4
 
         if const_expr(per_token_kv):
-            scale_load_width = NCHUNK if block_size == 64 else 1
+            scale_load_width = NCHUNK if block_size >= 64 else 1
             scale_copy_op = (
                 fx.rocdl.BufferCopy128b()
-                if block_size == 64
+                if block_size >= 64
                 else fx.rocdl.BufferCopy32b()
             )
             scale_copy_atom = fx.make_copy_atom(scale_copy_op, fx.Float32)
@@ -405,7 +407,7 @@ def compile_pa_decode_tile(
             frag = fx.make_fragment_like(fx.slice(bt_buf, (0, None)))
             fx.copy(
                 bt_copy_atom,
-                fx.slice(bt_buf, (element_offset // fx.Int32(vec_width), None)),
+                fx.slice(bt_buf, (element_offset, None)),
                 frag,
             )
             loaded = fx.Vector(fx.memref_load_vec(frag))
@@ -422,7 +424,7 @@ def compile_pa_decode_tile(
             # its rgroup row and broadcasts via LDS (read back by _v_page_read_row).
             base_page = tt_i32 * TILE_TOK // block_size  # tile start is page-aligned
             fetched = _load_phys_scalar(
-                base_page + warp * PAGES_PER_CHUNK, PAGES_PER_CHUNK
+                base_page + (warp * TOK_PER_WARP) // block_size, PAGES_PER_CHUNK
             )
             if lane == 0:
                 fetched_vec = (
@@ -445,13 +447,14 @@ def compile_pa_decode_tile(
             return 0
 
         def _stage_kv_scale_to_lds(phys_vec, buf_off=0):
-            if const_expr(block_size == 64):
+            if const_expr(block_size >= 64):
                 phys = fx.Int32(phys_vec[0])
-                base_tok = lane16 * NCHUNK
-                scale_idx = phys * stride_ks_block + kv_h * stride_ks_head + base_tok
+                chunk_tok = lane16 * NCHUNK
+                page_tok = (warp * TOK_PER_WARP) % block_size + chunk_tok
+                scale_idx = phys * stride_ks_block + kv_h * stride_ks_head + page_tok
                 k_scale_vec = _k_scale_load(scale_idx)
                 v_scale_vec = _v_scale_load(scale_idx)
-                slot = (warp * TOK_PER_WARP + base_tok) * f32
+                slot = (warp * TOK_PER_WARP + chunk_tok) * f32
                 _lds_store(sKScale_off + buf_off + slot, fx.Float32, k_scale_vec)
                 _lds_store(sVScale_off + buf_off + slot, fx.Float32, v_scale_vec)
             else:
@@ -488,7 +491,7 @@ def compile_pa_decode_tile(
         # token = warp*TOK_CHUNK + a*c16 + lane16 (the softmax mask and P-pack
         # write position below must encode this same formula).
         def _k_ops(phys, a):
-            within_page_tok = (a * c16 + lane16) % block_size
+            within_page_tok = (warp * TOK_PER_WARP + a * c16 + lane16) % block_size
             ops = []
             for qkhe in range_constexpr(QKHE_LOOP):
                 he_idx = qkhe * RGROUP_QUARTERS + rgroup
@@ -508,7 +511,7 @@ def compile_pa_decode_tile(
         def _k_ops_flat(tt_i32):
             base_page = tt_i32 * TILE_TOK // block_size  # tile start is page-aligned
             fetched = _load_phys_scalar(
-                base_page + warp * PAGES_PER_CHUNK, PAGES_PER_CHUNK
+                base_page + (warp * TOK_PER_WARP) // block_size, PAGES_PER_CHUNK
             )
             phys_vec = (
                 fx.Vector.from_elements([fx.Int32(fetched)], dtype=fx.Int32)
@@ -524,15 +527,22 @@ def compile_pa_decode_tile(
 
             return fx.Vector.from_elements(flat, dtype=fx.Int64), phys_vec
 
-        # -- prologue: prefetch the first tile's K --
-        num_tiles_m1 = num_tiles - 1
-        start_safe = (part_start < num_tiles).select(part_start, num_tiles_m1)
-        k_pf0, phys_vec0 = _k_ops_flat(start_safe)
-        # V page-index prefetch, issued here too for the same overlap; the
-        # LDS write is visible after the barrier below.
-        _v_page_fetch_and_stage(start_safe)
-        if const_expr(per_token_kv):
-            _stage_kv_scale_to_lds(phys_vec0, _kv_buf_off(fx.Int32(start_safe)))
+        # Empty partitions retain neutral state and must not read K/V or the
+        # block table. In particular, an empty context has no valid first tile.
+        k_pf0 = fx.Vector.filled(NCHUNK * N_SUBCHUNKS, 0, fx.Int64)
+        if part_start < part_end:
+            k_pf0, phys_vec0 = _k_ops_flat(part_start)
+            # Issue the V page-index prefetch alongside K; the LDS write is
+            # visible after the barrier below.
+            _v_page_fetch_and_stage(part_start)
+            if const_expr(per_token_kv):
+                _stage_kv_scale_to_lds(phys_vec0, _kv_buf_off(fx.Int32(part_start)))
+        elif lane == 0:
+            _lds_store(
+                sVPage_off + warp * (PAGES_PER_CHUNK * 4),
+                fx.Int32,
+                fx.Vector.filled(PAGES_PER_CHUNK, 0, fx.Int32),
+            )
 
         # per_token_kv has no single global key_scale/value_scale: scale_qk
         # drops the key_scale factor (folded in per-token, see masked_chunks
@@ -700,25 +710,32 @@ def compile_pa_decode_tile(
         # changes the offset formula. `sub`/`step` walk pages/16-token sub-blocks.
         NVOPS = TILE_TOK // MFMA_K  # 8 PV k_steps (256 tokens / K=32)
         STEPS_PER_PAGE = block_size // 16
+        STEPS_PER_CHUNK = min(block_size, TOK_PER_WARP) // 16
 
         def _v_ops(phys_row, vh):
             head_group = ((vh * VHE_SIZE) // 16) + warp
             head_element = head_group * 16 + lane16
             ops = []
             for sub in range_constexpr(PAGES_PER_CHUNK):
-                for step in range_constexpr(STEPS_PER_PAGE):
+                for step in range_constexpr(STEPS_PER_CHUNK):
+                    # PV's token chunk is owned by rgroup after the LDS transpose.
+                    page_step = ((rgroup * TOK_PER_WARP) % block_size) // 16 + step
                     if const_expr(trans_v):
                         base = _kv_addr(
                             phys_row[sub],
                             n_kv * (STEPS_PER_PAGE * head_dim * 16),
-                            ((kv_h * STEPS_PER_PAGE + step) * head_dim + head_element)
+                            (
+                                (kv_h * STEPS_PER_PAGE + page_step) * head_dim
+                                + head_element
+                            )
                             * 16,
                         )
                     else:
                         base = _kv_addr(
                             phys_row[sub],
                             n_kv * (head_dim * block_size),
-                            (kv_h * head_dim + head_element) * block_size + step * 16,
+                            (kv_h * head_dim + head_element) * block_size
+                            + page_step * 16,
                         )
                     w = _v_load16(base)
                     if const_expr(block_size == 16):

--- a/aiter/ops/flydsl/kernels/pa_decode_tile.py
+++ b/aiter/ops/flydsl/kernels/pa_decode_tile.py
@@ -185,9 +185,10 @@ def compile_pa_decode_tile(
     SP_ROW_BYTES = TILE_TOK + 16
     sP_bytes = P_BUFFERS * MFMA_MNK * SP_ROW_BYTES  # fp8, padded rows
     sQscale_off = sP_off + sP_bytes
-    NWARP_PAD = (
-        NWARP + 1
-    )  # coprime with 32 banks -> no LDS bank conflict on the cross-warp scratch
+    # Keep reduction rows 16-byte aligned on the tuned gfx950 page-128 path
+    # so each cross-wave row can be read as one vector. Other paths retain
+    # the padding used to avoid LDS bank conflicts.
+    NWARP_PAD = NWARP if tune_page128 else NWARP + 1
     # Phase-split slices sLmax per M-tile so all pass-1 writes share one barrier.
     sLmax_off = sQscale_off + ROWS_PADDED * f32
     sLsum_off = sLmax_off + M_TILES * MFMA_MNK * NWARP_PAD * f32

--- a/aiter/ops/flydsl/kernels/pa_decode_tile.py
+++ b/aiter/ops/flydsl/kernels/pa_decode_tile.py
@@ -65,6 +65,7 @@ def compile_pa_decode_tile(
     query_length: int = 1,
     trans_v: bool = True,
     wide_kv_addressing: bool = False,
+    prefetch_v: bool = False,
 ):
     """Build the tile-programming PA-decode kernel + launch wrapper.
 
@@ -117,6 +118,17 @@ def compile_pa_decode_tile(
     TOTAL_ROWS = query_length * query_group_size
     M_TILES = cdiv(TOTAL_ROWS, MFMA_MNK)
     ROWS_PADDED = M_TILES * MFMA_MNK
+    # The page-128 gfx950 scalar-scale path benefits from earlier V loads
+    # for decode and alternating P/reduction buffers for three M-tiles.
+    tune_page128 = (
+        is_gfx950
+        and head_dim == 128
+        and block_size == 128
+        and trans_v
+        and not per_token_kv
+    )
+    EARLY_V = prefetch_v and tune_page128 and M_TILES == 1
+    P_BUFFERS = 2 if tune_page128 and M_TILES == 3 else 1
     # PV layout: V=A, P=B -> output [head-dim (row), query-row (col=lane16)],
     # generalized over head_dim via the VHE_CHUNKS loop.
     NWARP = 4  # 4 waves / CTA
@@ -171,7 +183,7 @@ def compile_pa_decode_tile(
     # +16B row padding breaks a 32-bank LDS conflict on the P-pack writes while
     # keeping the row 16B-aligned for PV's ds_read_b128.
     SP_ROW_BYTES = TILE_TOK + 16
-    sP_bytes = MFMA_MNK * SP_ROW_BYTES  # fp8, padded rows
+    sP_bytes = P_BUFFERS * MFMA_MNK * SP_ROW_BYTES  # fp8, padded rows
     sQscale_off = sP_off + sP_bytes
     NWARP_PAD = (
         NWARP + 1
@@ -180,7 +192,7 @@ def compile_pa_decode_tile(
     sLmax_off = sQscale_off + ROWS_PADDED * f32
     sLsum_off = sLmax_off + M_TILES * MFMA_MNK * NWARP_PAD * f32
     # V page-index broadcast (V's page depends on `rgroup`, shared across warps).
-    sVPage_off = sLsum_off + MFMA_MNK * NWARP_PAD * f32
+    sVPage_off = sLsum_off + P_BUFFERS * MFMA_MNK * NWARP_PAD * f32
     sVPage_bytes = NWARP * PAGES_PER_CHUNK * 4  # i32
     # Per-token KV-scale staging (per_token only), double-buffered so the tt+1
     # prefetch (into the other buffer) doesn't clobber the current tile's scales.
@@ -823,10 +835,10 @@ def compile_pa_decode_tile(
                 def _mask_v_scale(vec, a, thr=ctx_thr, zero=zero4_scale):
                     return (_ct[a] < thr).select(vec, zero)
 
-            # V data doesn't depend on `m`; hoist once for the phase-split
-            # instead of reloading per M-tile.
+            # V is independent of QK/softmax. Load it early for the tuned
+            # decode path and reuse it across M-tiles in the phase-split path.
             v_vh_shared = None
-            if const_expr(M_TILES > 1):
+            if const_expr(M_TILES > 1 or EARLY_V):
                 v_vh_shared = [
                     _v_ops(v_page_cur, vh) for vh in range_constexpr(VHE_CHUNKS)
                 ]
@@ -964,6 +976,8 @@ def compile_pa_decode_tile(
                     ]
 
                 for m in range_constexpr(M_TILES):
+                    p_base = sP_off + (m % P_BUFFERS) * MFMA_MNK * SP_ROW_BYTES
+                    lsum_base = sLsum_off + (m % P_BUFFERS) * MFMA_MNK * NWARP_PAD * f32
                     o_acc = [
                         ostate[_o_slot(m, vh)] for vh in range_constexpr(VHE_CHUNKS)
                     ]
@@ -1019,7 +1033,7 @@ def compile_pa_decode_tile(
                         words.append(_f32_to_fp8_words(p_scaled)[0])
 
                     p_off0 = (
-                        sP_off + lane16 * SP_ROW_BYTES + warp * TOK_CHUNK + rgroup * 4
+                        p_base + lane16 * SP_ROW_BYTES + warp * TOK_CHUNK + rgroup * 4
                     )
                     # The NCHUNK P words scatter across the row at stride c16//4
                     # i32 (the token->fp8-lane interleave the PV ds_read_b128
@@ -1037,13 +1051,13 @@ def compile_pa_decode_tile(
                     safe_prev = (m_prev > NEG_INF).select(m_prev, ZERO_F)
                     corr_reg = fx.Float32(exp2_amdgcn_scalar(safe_prev - safe_max))
                     if rgroup == 0:
-                        _st_lw(sLsum_off, lane16, warp, ls)
+                        _st_lw(lsum_base, lane16, warp, ls)
                     gpu.barrier()
-                    gsum = _ld_lw_row(sLsum_off, lane16).reduce(ReductionOp.ADD)
+                    gsum = _ld_lw_row(lsum_base, lane16).reduce(ReductionOp.ADD)
                     l_new = l_prev * corr_reg + gsum
 
                     p_ops = _lds_load(
-                        sP_off + lane16 * SP_ROW_BYTES + rgroup * 64, fx.Int64, NVOPS
+                        p_base + lane16 * SP_ROW_BYTES + rgroup * 64, fx.Int64, NVOPS
                     )
 
                     corr_b = fx.Vector.from_elements(
@@ -1065,11 +1079,15 @@ def compile_pa_decode_tile(
                             ).broadcast_to(OP_ELEMS)
                         o_acc[vh] = o_acc[vh] * corr_b + op
                     next_state.extend([*o_acc, m_new, l_new])
-                    # sP and sLsum are reused by the next M-tile. Synchronize
-                    # all waves after their LDS reads before any wave overwrites
-                    # those regions, then retire this tile's dependency chain.
+                    # A shared P/Lsum slot needs all reads to finish before
+                    # the next M-tile overwrites it. With alternating slots,
+                    # the next tile's write barrier retires those reads before
+                    # that slot is reused. The Phase A barrier protects reuse
+                    # across loop iterations. Keep the scheduler fence to
+                    # bound register liveness across M-tiles.
                     if const_expr(m < M_TILES - 1):
-                        gpu.barrier()
+                        if const_expr(P_BUFFERS == 1):
+                            gpu.barrier()
                         fx.rocdl.sched_barrier(0)
             else:
                 # M_TILES==1 single tile (m==0 for the _o_slot/_m_slot/_l_slot helpers).
@@ -1217,11 +1235,14 @@ def compile_pa_decode_tile(
                 corr_b = fx.Vector.from_elements(
                     [corr_reg], dtype=fx.Float32
                 ).broadcast_to(OP_ELEMS)
-                # Single tile: batch both vh's V loads upfront (no sibling chain
-                # to hide the latency behind).
-                v_vh_batch = [
-                    _v_ops(v_page_cur, vh) for vh in range_constexpr(VHE_CHUNKS)
-                ]
+                # Use the early V loads where enabled; other shapes retain
+                # the existing batched loads before PV.
+                if const_expr(EARLY_V):
+                    v_vh_batch = v_vh_shared
+                else:
+                    v_vh_batch = [
+                        _v_ops(v_page_cur, vh) for vh in range_constexpr(VHE_CHUNKS)
+                    ]
                 for vh in range_constexpr(VHE_CHUNKS):
                     v_vh = v_vh_batch[vh]
                     acc = fx.Vector.filled(MFMA_ACC_ELEMS, 0.0, fx.Float32)

--- a/aiter/ops/flydsl/pa_decode.py
+++ b/aiter/ops/flydsl/pa_decode.py
@@ -10,7 +10,7 @@ score, value scale + 1/FP8_MAX into the epilogue); softmax max/sum stay f32.
 ``key_scale``/``value_scale`` are either a ``[1]`` per-tensor scalar or a
 ``[num_blocks, num_kv_heads, block_size, 1]`` per-token tensor.
 
-``block_size`` (16/64) and ``head_dim`` (multiple of 64) are compile-time
+``block_size`` (16/64/128) and ``head_dim`` (multiple of 64) are compile-time
 constants. Layouts are logical, not production's preshuffle.
 
 * ``query``        [num_seqs, num_q_heads, head_dim]  f16/bf16 (head_dim contiguous)
@@ -166,7 +166,10 @@ def pa_decode(
 
     The call signature and intermediate-buffer layouts follow the shared
     aiter paged-attention decode API. This kernel currently supports FP8 K/V caches,
-    BF16/FP16 queries, a 256-token context partition, and block sizes 16/64.
+    BF16/FP16 queries, a 256-token compute tile, and block sizes 16/64/128.
+    Sparse attention uses caller-prepared block tables and selected context
+    lengths. Each independently selected MTP query must have its own table row
+    and use query_length=1; query_length>1 applies dense causal masking.
     ALiBi, attention sinks, sliding-window attention, and externally quantized
     FP8 queries are not supported.
     """
@@ -183,7 +186,7 @@ def pa_decode(
         raise NotImplementedError("pa_decode does not support ALiBi")
     if sinks is not None:
         raise NotImplementedError("pa_decode does not support attention sinks")
-    if sliding_window != 0:
+    if sliding_window not in (0, -1):
         raise NotImplementedError("pa_decode does not support sliding-window attention")
     if query_length < 1:
         raise ValueError(f"query_length must be positive, got {query_length}")
@@ -237,7 +240,8 @@ def pa_decode(
     assert block_size in (
         16,
         64,
-    ), f"pa_decode only supports block_size in (16, 64), got {block_size}"
+        128,
+    ), f"pa_decode only supports block_size in (16, 64, 128), got {block_size}"
 
     trans_v = value_cache.dim() == 5
     if trans_v:
@@ -295,10 +299,9 @@ def pa_decode(
         ("block_tables", block_tables),
         ("context_lengths", context_lengths),
     ):
-        assert tensor.device == dev, (
-            f"{name} must be on the same device as query ({dev}), "
-            f"got {tensor.device}"
-        )
+        assert (
+            tensor.device == dev
+        ), f"{name} must be on the same device as query ({dev}), got {tensor.device}"
     for name, tensor in (
         ("key_cache", key_cache),
         ("value_cache", value_cache),

--- a/aiter/ops/flydsl/pa_decode.py
+++ b/aiter/ops/flydsl/pa_decode.py
@@ -378,6 +378,22 @@ def pa_decode(
     # if either does.
     wide_kv_addressing = max(key_cache.numel(), value_cache.numel()) >= 2**31
 
+    # Early V loads help the measured one-to-two-workgroup-per-CU regime.
+    # Keep other grids on the existing schedule: early loads regress
+    # short-context decode at larger grid sizes.
+    prefetch_v = False
+    if (
+        arch == "gfx950"
+        and head_dim == 128
+        and block_size == 128
+        and trans_v
+        and not per_token_kv
+        and query_length * query_group_size <= 16
+    ):
+        num_cus = torch.cuda.get_device_properties(dev).multi_processor_count
+        workgroups = num_seqs * num_kv_heads * num_partitions
+        prefetch_v = num_cus < workgroups <= 2 * num_cus
+
     with torch.cuda.device(dev):
         compiled = compile_pa_decode_tile(
             head_dim=head_dim,
@@ -390,6 +406,7 @@ def pa_decode(
             query_length=query_length,
             trans_v=trans_v,
             wide_kv_addressing=wide_kv_addressing,
+            prefetch_v=prefetch_v,
         )
 
     if num_partitions == 1:

--- a/op_tests/test_flydsl_pa_decode.py
+++ b/op_tests/test_flydsl_pa_decode.py
@@ -667,6 +667,7 @@ def _constant_page_decode_case(
     block_table_width,
     poison_padding=False,
     per_token=False,
+    trans_v=False,
 ):
     """Each sequence's V pages are constant, so its attention output is known."""
     _require_gpu()
@@ -690,6 +691,12 @@ def _constant_page_decode_case(
         .contiguous()
         .to(quant_dtype)
     )
+    if trans_v:
+        value_cache = (
+            value_cache.view(num_pages, 1, head_dim, block_size // 16, 16)
+            .permute(0, 1, 3, 2, 4)
+            .contiguous()
+        )
     block_tables = torch.full(
         (batch_size, block_table_width),
         num_pages + 1024 if poison_padding else 0,
@@ -722,11 +729,14 @@ def _constant_page_decode_case(
         scale,
         scale,
     )
+    # The reference uses the values actually representable in the FP8 cache.
     expected = (
         torch.tensor(
             [float(seq + 1) if length else 0.0 for seq, length in enumerate(lengths)],
             dtype=dtypes.fp32,
         )
+        .to(quant_dtype)
+        .to(dtypes.fp32)
         .reshape(batch_size, 1, 1)
         .expand_as(output)
     )
@@ -936,6 +946,41 @@ def test_prepared_sparse_page_tables(block_size, per_token, packed):
         sliding_window=-1,
     )
     _assert_matches(output.float(), reference)
+
+
+@pytest.mark.parametrize("context_length", [3, 257, 2051])
+@pytest.mark.parametrize("num_partitions", [1, 4])
+@pytest.mark.parametrize("trans_v", [False, True])
+@pytest.mark.parametrize("zero_query", [False, True])
+def test_mtp3_page128_partition_boundaries(
+    context_length, num_partitions, trans_v, zero_query
+):
+    """MTP rows retain independent softmax state across partial/empty partitions."""
+    output, reference = _adversarial_case(
+        head_dim=128,
+        context_length=context_length,
+        block_size=128,
+        query_group_size=16,
+        query_length=3,
+        num_partitions=num_partitions,
+        trans_v=trans_v,
+        zero_query=zero_query,
+    )
+    _assert_matches(output, reference)
+
+
+@pytest.mark.parametrize("all_empty", [False, True])
+def test_page128_decode_prefetch_mixed_contexts(all_empty):
+    """A two-CTA-per-CU decode grid handles empty partitions and poisoned padding."""
+    lengths = [0] * 64 if all_empty else [0, 1, 63, 127, 128, 129, 257, 2051] * 8
+    _constant_page_decode_case(
+        lengths,
+        block_size=128,
+        num_partitions=8,
+        block_table_width=0 if all_empty else 17,
+        poison_padding=True,
+        trans_v=True,
+    )
 
 
 def main():

--- a/op_tests/test_flydsl_pa_decode.py
+++ b/op_tests/test_flydsl_pa_decode.py
@@ -37,7 +37,7 @@ KV_COMPUTE_BLOCK = 256
 # Pairwise coverage of the normal-accuracy axes in FlyDSL's PA regression test:
 # batches {3, 81, 128}, Q/KV heads {(4,1), (8,1), (16,1)}, head dims
 # {128, 256}, and contexts {1027, 8192}. Keep the original 257-token boundary
-# case as well. Both supported block sizes are crossed with every case in main().
+# case as well. All supported block sizes are crossed with every case in main().
 DEFAULT_BATCH_SIZES = [3, 81, 128]
 DEFAULT_SHAPES = [
     (8, 1, 128, 257),
@@ -430,7 +430,7 @@ def run_pa_decode_tile_case(
     return ret
 
 
-@pytest.mark.parametrize("block_size", [16, 64])
+@pytest.mark.parametrize("block_size", [16, 64, 128])
 def test_pa_decode_tile(block_size):
     if not torch.cuda.is_available():
         pytest.skip("ROCm is not available")
@@ -472,6 +472,8 @@ def _adversarial_case(
     poison_padding_blocks=False,
     tail_value_scale=None,
     seed=0,
+    trans_v=False,
+    num_partitions=1,
 ):
     """Build one case plus its torch reference over the same dequantised fp8 KV.
 
@@ -533,7 +535,14 @@ def _adversarial_case(
         .permute(0, 1, 3, 2, 4)
         .contiguous()
     )
-    value_cache = value.permute(0, 1, 3, 2).contiguous()
+    if trans_v:
+        value_cache = (
+            value.view(blocks, 1, block_size // 16, 16, head_dim)
+            .permute(0, 1, 2, 4, 3)
+            .contiguous()
+        )
+    else:
+        value_cache = value.permute(0, 1, 3, 2).contiguous()
     block_tables = torch.arange(blocks, dtype=dtypes.i32).reshape(1, blocks)
     context_lengths = torch.full((1,), context_length, dtype=dtypes.i32)
 
@@ -561,7 +570,7 @@ def _adversarial_case(
         block_tables,
         head_dim**-0.5,
         query_length,
-        1,
+        num_partitions,
         256,
         quant_dtype,
         None,
@@ -592,7 +601,7 @@ def test_zero_query_stays_finite(query_length, per_token):
     _assert_matches(output, reference)
 
 
-@pytest.mark.parametrize("block_size", [16, 64])
+@pytest.mark.parametrize("block_size", [16, 64, 128])
 @pytest.mark.parametrize("context_length", [1, 257, 1027])
 def test_block_table_padding_is_not_dereferenced(block_size, context_length):
     """Entries past the sequence's extent must resolve to block 0.
@@ -651,6 +660,284 @@ def test_unsupported_head_dim_is_rejected(head_dim):
         _adversarial_case(head_dim=head_dim, context_length=64)
 
 
+def _constant_page_decode_case(
+    lengths,
+    block_size,
+    num_partitions,
+    block_table_width,
+    poison_padding=False,
+    per_token=False,
+):
+    """Each sequence's V pages are constant, so its attention output is known."""
+    _require_gpu()
+    batch_size, query_heads, head_dim = len(lengths), 8, 128
+    pages_per_sequence = [(length + block_size - 1) // block_size for length in lengths]
+    page_values = [
+        float(seq + 1)
+        for seq, pages in enumerate(pages_per_sequence)
+        for _ in range(pages)
+    ]
+    num_pages = len(page_values)
+    quant_dtype = _quant_dtype()
+    query = torch.ones(batch_size, query_heads, head_dim, dtype=dtypes.bf16)
+    key_cache = torch.zeros(
+        num_pages, 1, head_dim // 16, block_size, 16, dtype=quant_dtype
+    )
+    value_cache = (
+        torch.tensor(page_values, dtype=dtypes.fp32)
+        .reshape(num_pages, 1, 1, 1)
+        .expand(num_pages, 1, head_dim, block_size)
+        .contiguous()
+        .to(quant_dtype)
+    )
+    block_tables = torch.full(
+        (batch_size, block_table_width),
+        num_pages + 1024 if poison_padding else 0,
+        dtype=dtypes.i32,
+    )
+    next_page = 0
+    for seq, pages in enumerate(pages_per_sequence):
+        block_tables[seq, :pages] = torch.arange(
+            next_page, next_page + pages, dtype=dtypes.i32
+        )
+        next_page += pages
+    context_lengths = torch.tensor(lengths, dtype=dtypes.i32)
+    scale = torch.ones(
+        (num_pages, 1, block_size, 1) if per_token else (1,), dtype=dtypes.fp32
+    )
+    output = torch.full_like(query, float("nan"))
+    torch.ops.aiter.pa_decode_flydsl(
+        output,
+        query,
+        key_cache,
+        value_cache,
+        context_lengths,
+        block_tables,
+        head_dim**-0.5,
+        1,
+        num_partitions,
+        256,
+        quant_dtype,
+        None,
+        scale,
+        scale,
+    )
+    expected = (
+        torch.tensor(
+            [float(seq + 1) if length else 0.0 for seq, length in enumerate(lengths)],
+            dtype=dtypes.fp32,
+        )
+        .reshape(batch_size, 1, 1)
+        .expand_as(output)
+    )
+    _assert_matches(output.float(), expected, tolerance=0.02)
+
+
+@pytest.mark.parametrize("num_partitions", [1, 4])
+@pytest.mark.parametrize("block_table_width", [1, 2, 3, 4, 5])
+def test_block_table_row_alignment(block_table_width, num_partitions):
+    """A contiguous block table need not have four-entry-aligned row starts."""
+    _constant_page_decode_case([16, 16, 16], 16, num_partitions, block_table_width)
+
+
+@pytest.mark.parametrize("num_partitions", [1, 4])
+@pytest.mark.parametrize("block_size", [16, 64, 128])
+@pytest.mark.parametrize(
+    "lengths,per_token",
+    [
+        pytest.param([64, 0], False, id="mixed"),
+        pytest.param([64, 0], True, id="mixed-per-token"),
+        pytest.param([0, 0], False, id="all-empty"),
+    ],
+)
+def test_empty_contexts_do_not_read_kv(lengths, per_token, block_size, num_partitions):
+    """Empty rows must not follow padding or read an empty KV allocation."""
+    width = 2 * KV_COMPUTE_BLOCK // block_size if any(lengths) else 0
+    _constant_page_decode_case(
+        lengths,
+        block_size,
+        num_partitions,
+        width,
+        poison_padding=True,
+        per_token=per_token,
+    )
+
+
+@pytest.mark.parametrize("context_length", [63, 64, 65, 127, 128, 129, 257])
+@pytest.mark.parametrize("trans_v", [False, True])
+@pytest.mark.parametrize("per_token", [False, True])
+def test_page128_chunk_boundaries(context_length, trans_v, per_token):
+    """Two waves share a page-128, but must load different K/V/scales halves."""
+    _require_gpu()
+    output, reference = _adversarial_case(
+        block_size=128,
+        context_length=context_length,
+        query_group_size=16,
+        trans_v=trans_v,
+        per_token=per_token,
+        num_partitions=4,
+    )
+    _assert_matches(output, reference)
+
+
+@pytest.mark.parametrize("context_length", [2048, 100000, 200000])
+@pytest.mark.parametrize("query_length", [1, 3])
+@pytest.mark.parametrize("per_token", [False, True])
+def test_tp4_page128_contexts(context_length, query_length, per_token):
+    """64 Q / 4 KV heads under TP4: Hq16, Hkv1, D128, including dense MTP."""
+    _require_gpu()
+    output, reference = _adversarial_case(
+        block_size=128,
+        query_group_size=16,
+        context_length=context_length,
+        query_length=query_length,
+        trans_v=True,
+        per_token=per_token,
+        num_partitions=8,
+    )
+    _assert_matches(output, reference)
+
+
+@pytest.mark.parametrize("trans_v", [False, True])
+def test_page128_cache_above_2gib(trans_v):
+    """Large batches at 200k context cross the signed-i32 cache offset limit."""
+    _require_gpu()
+    block_size, head_dim = 128, 128
+    boundary_page = 2**31 // (block_size * head_dim)
+    pages = boundary_page + 2
+    quant_dtype = _quant_dtype()
+    key_cache = torch.empty(pages, 1, 8, block_size, 16, dtype=quant_dtype)
+    value_shape = (
+        (pages, 1, 8, head_dim, 16) if trans_v else (pages, 1, head_dim, block_size)
+    )
+    value_cache = torch.empty(value_shape, dtype=quant_dtype)
+    key_cache[0].zero_()
+    value_cache[0].zero_()
+    page_ids = [boundary_page - 1, boundary_page, boundary_page + 1]
+    for index, page in enumerate(page_ids):
+        key_cache[page].zero_()
+        value_cache[page].fill_(index + 1)
+    query = torch.ones(1, 16, head_dim, dtype=dtypes.bf16)
+    output = torch.empty_like(query)
+    scale = torch.ones(1, dtype=dtypes.fp32)
+    torch.ops.aiter.pa_decode_flydsl(
+        output,
+        query,
+        key_cache,
+        value_cache,
+        torch.tensor([257], dtype=dtypes.i32),
+        torch.tensor([page_ids], dtype=dtypes.i32),
+        head_dim**-0.5,
+        1,
+        8,
+        256,
+        quant_dtype,
+        None,
+        scale,
+        scale,
+    )
+    expected = torch.full_like(output, (128 + 2 * 128 + 3) / 257, dtype=dtypes.fp32)
+    _assert_matches(output.float(), expected, tolerance=0.02)
+
+
+@pytest.mark.parametrize(
+    "block_size,per_token,packed",
+    [
+        (16, False, False),
+        (16, True, False),
+        (16, False, True),
+        (128, False, False),
+        (128, True, False),
+    ],
+)
+def test_prepared_sparse_page_tables(block_size, per_token, packed):
+    """PA consumes selected pages; each MTP query already has its own table.
+
+    Select 2048 tokens from a 200k-token cache. In the page-16 adapter each
+    selected logical page-128 expands to eight physical pages. Packed K/V
+    sides share a block and V has a different base pointer and cache extent.
+    """
+    _require_gpu()
+    torch.manual_seed(7)
+    rows, query_heads, head_dim = 6, 16, 128  # two requests with three MTP queries
+    logical_blocks = (200000 + 127) // 128
+    pages_per_logical = 128 // block_size
+    page_stride = pages_per_logical * (2 if packed else 1)
+    num_pages = logical_blocks * page_stride
+    quant_dtype = _quant_dtype()
+    key = (torch.rand(num_pages, 1, block_size, head_dim) - 0.5).to(quant_dtype)
+    value = (torch.rand_like(key, dtype=dtypes.fp32) - 0.5).to(quant_dtype)
+    key_cache = (
+        key.view(num_pages, 1, block_size, head_dim // 16, 16)
+        .permute(0, 1, 3, 2, 4)
+        .contiguous()
+    )
+    value_cache = (
+        value.view(num_pages, 1, block_size // 16, 16, head_dim)
+        .permute(0, 1, 2, 4, 3)
+        .contiguous()
+    )
+    if packed:
+        # Mirror the adapter's contiguous, overlapping views into interleaved
+        # K/V storage. Only K-side page ids are put into the block table.
+        value_cache = key_cache.flatten()[
+            pages_per_logical * block_size * head_dim :
+        ].view(num_pages - pages_per_logical, 1, block_size // 16, head_dim, 16)
+        value = value_cache.permute(0, 1, 2, 4, 3).reshape(
+            num_pages - pages_per_logical, 1, block_size, head_dim
+        )
+
+    query = (torch.rand(rows, query_heads, head_dim) - 0.5).to(dtypes.bf16)
+    lengths = [2046, 2047, 2048] * 2
+    # Spare entry deliberately leaves page-16 rows non-vector-aligned.
+    block_tables = torch.full(
+        (rows, 16 * pages_per_logical + 1), num_pages + 1024, dtype=dtypes.i32
+    )
+    if per_token:
+        key_scale = 0.5 + torch.rand(num_pages, 1, block_size, 1)
+        value_scale = 0.5 + torch.rand_like(key_scale)
+    else:
+        key_scale = torch.ones(1, dtype=dtypes.fp32)
+        value_scale = torch.ones(1, dtype=dtypes.fp32)
+    reference = torch.empty_like(query, dtype=dtypes.fp32)
+    for row, length in enumerate(lengths):
+        selected = torch.randperm(logical_blocks - 1)[:15]
+        # Partial current block comes last; earlier selections differ per query.
+        selected = torch.cat((selected, selected.new_tensor([logical_blocks - 1])))
+        pages = (
+            selected[:, None] * page_stride + torch.arange(pages_per_logical)[None, :]
+        ).flatten()
+        block_tables[row, : pages.numel()] = pages.to(dtypes.i32)
+        keys = key[pages].float()
+        values = value[pages].float()
+        if per_token:
+            keys = keys * key_scale[pages]
+            values = values * value_scale[pages]
+        keys = keys.reshape(-1, head_dim)[:length]
+        values = values.reshape(-1, head_dim)[:length]
+        scores = query[row].float() @ keys.T * head_dim**-0.5
+        reference[row] = torch.softmax(scores, dim=-1) @ values
+    output = torch.empty_like(query)
+    torch.ops.aiter.pa_decode_flydsl(
+        output,
+        query,
+        key_cache,
+        value_cache,
+        torch.tensor(lengths, dtype=dtypes.i32),
+        block_tables,
+        head_dim**-0.5,
+        1,
+        8,
+        256,
+        quant_dtype,
+        None,
+        key_scale,
+        value_scale,
+        sliding_window=-1,
+    )
+    _assert_matches(output.float(), reference)
+
+
 def main():
     torch.set_default_device("cuda")
     if not torch.cuda.is_available():
@@ -698,8 +985,8 @@ def main():
         "--block-size",
         type=int,
         nargs="*",
-        choices=[16, 64],
-        default=[16, 64],
+        choices=[16, 64, 128],
+        default=[16, 64, 128],
         help="""KV-cache block sizes.""",
     )
     args = parser.parse_args()

--- a/op_tests/test_flydsl_pa_decode.py
+++ b/op_tests/test_flydsl_pa_decode.py
@@ -983,6 +983,26 @@ def test_page128_decode_prefetch_mixed_contexts(all_empty):
     )
 
 
+@pytest.mark.parametrize(
+    "query_group_size,query_length", [(8, 3), (16, 2), (16, 4), (16, 5)]
+)
+@pytest.mark.parametrize("context_length", [129, 1027])
+def test_page128_reduction_rows_across_m_tiles(
+    query_group_size, query_length, context_length
+):
+    """Aligned scratch rows stay independent across padded M-tiles and partitions."""
+    output, reference = _adversarial_case(
+        head_dim=128,
+        context_length=context_length,
+        block_size=128,
+        query_group_size=query_group_size,
+        query_length=query_length,
+        num_partitions=4,
+        trans_v=True,
+    )
+    _assert_matches(output, reference)
+
+
 def main():
     torch.set_default_device("cuda")
     if not torch.cuda.is_available():


### PR DESCRIPTION
FlyDSL PA can read another sequence's pages when a page-16 block-table row is not four-entry aligned, and an empty context can trigger a GPU illegal access during prefetch. This change fixes both cases and adds native page-128 support for Hq16/Hkv1/D128 workloads with selected 2048-token sparse contexts and 100k/200k dense contexts. It also overlaps V loads and reduces LDS synchronization on selected gfx950 page-128 paths.

This PR is based on `flydsl-pa-decode-tile` from #4332 (`d8b00e0630ce6b1080d8b5d2e7a944537676ba8a`); its diff contains only the follow-up changes.

## Changes

- Preserve exact int32 element offsets for vector block-table loads and skip K/V prefetch for empty partitions.
- Address both 64-token halves of page 128 correctly for K, plain/transposed V, and per-token KV scales. Use wide offsets when either KV tensor reaches 2 GiB.
- Accept `sliding_window=-1` as the disabled-window sentinel used by the MiniMax-M3 sparse PA adapter.
- Validate caller-prepared sparse tables with nonconsecutive selected pages. Each independently selected MTP query uses its own table/context row and `query_length=1`; dense MTP uses the existing causal path. Cover native physical page 128 and the adapter's logical-page-128 to physical-page-16 mapping, including interleaved K/V views. Top-K selection and compaction remain upstream of PA.
- For gfx950/D128/page128 with transposed V and scalar KV scales, load V before QK/softmax for a single M-tile when `CU_count < workgroups <= 2 * CU_count`, where `workgroups = batch * KV_heads * partitions`. The public `pa_decode` interface is unchanged. The grid guard avoids the approximately 4% short-context Decode regression seen with unrestricted early loads at B128.
- For the same layout with three M-tiles, alternate two LDS P/sum buffers. The following tile's barrier protects slot reuse; the Phase A barrier protects the next loop iteration. Retain the scheduler fence to constrain register liveness.

- Compact four-float cross-wave max/sum rows to a 16-byte stride on the tuned gfx950 path, keeping the padded layout elsewhere. This reduces MTP shared-memory allocation and address arithmetic without changing the attention math or barriers.

## Validation

On gfx950 with PyTorch `2.10.0+rocm7.2.4.git3d3aa833` and FlyDSL `0.3.1`:

```bash
HIP_VISIBLE_DEVICES=0 PYTHONPATH="$PWD" python -m pytest op_tests/test_flydsl_pa_decode.py -q --tb=short
```

**135 passed, 1 skipped** in 15.83 s. The skip is the existing MTP case with a non-positive first causal bound; the existing PyTorch profiler warning remains. Coverage includes page/half-page boundaries, scalar/per-token scales, 2048/100000/200000 contexts, dense MTP=3, independent sparse rows, empty allocations, poisoned table padding, and K/V addressing across 2 GiB. MTP cases exercise partial/empty partitions with random and zero queries; eight additional cases cover 2/4/5 M-tiles, partial rows, and the compact scratch layout. The constant-page reference rounds expected values through FP8 to match the cache; its 2% tolerance is unchanged.

Both original page-table defects reproduced on the unchanged base: 66.667% relative output error for an unaligned row and `hipErrorIllegalAddress` for a mixed empty/nonempty batch. Black check, Ruff lint, and `git diff --check` pass. Files applied to this branch were verified byte-for-byte against the tested sources.

## Performance

Paired comparison against `65f8002dae0842aef52e986ac91b1a4dc6b46774`, which already contains page-128 support and the correctness fixes. GPU: gfx950 with 256 CUs. B64/Hq16/Hkv1/D128, physical page128, FP8 K/V, BF16 Q/output, transposed V, scalar scales, eight partitions. Sequences own distinct, randomly permuted physical pages; all variants share identical input tensors within a run.

Latency includes PA and partition reduction. Three independent processes use warmed CUDA graphs, 30 rounds of 50 calls each, rotating all variants through measurement order. All compared outputs are bitwise equal. The table reports the combined effect of the V-load, double-buffering, and scratch-layout changes.

| Context | Query length | Baseline (us) | Final (us) | Median paired latency reduction |
| ---: | ---: | ---: | ---: | ---: |
| 2048 | 1 | 9.015 | 8.477 | 5.97% |
| 2048 | 3 | 13.765 | 13.173 | 3.83% |
| 100000 | 1 | 277.326 | 274.425 | 1.03% |
| 100000 | 3 | 292.419 | 289.192 | 1.10% |
| 200000 | 1 | 543.825 | 541.435 | 0.48% |
| 200000 | 3 | 568.991 | 558.188 | 1.91% |

Latency columns are medians of the three per-process medians; reduction is the median of the three paired ratios, so it need not equal the ratio of the displayed columns. These combined gains were measured directly, not compounded from separate experiments.

The scratch-layout change alone was also compared against `873fdb0204e89ceb411daf45e0d46b6e5e3a38a3` in three alternating A/B processes (32 rounds of 50 calls). Its median incremental reductions are 3.70% for short Decode, 2.38% for short MTP, and about 1% for long MTP. Long Decode is essentially unchanged. Additional B1/B16/B128 checks found no material regression; B16/B128 short Decode was within 0.28% of baseline.

A separate partition sweep over 1/2/4/8/16/32 partitions kept eight as the best measured choice for long contexts. Each output was checked against a FP32 PyTorch attention reference using the existing 6% max-error/max-reference-magnitude criterion; observed errors were about 2.6%-3.4%. No partition heuristic or accuracy tolerance was changed.

Per-token scales were tested for correctness, not separately benchmarked. These timings exclude model inference, sparse selection/compaction, TP communication, and CPU launch overhead. This PR does not change vLLM backend selection.

Trace data shows the following resource changes from the original optimization baseline to the final kernel:

| Resource | Decode baseline -> final | MTP=3 baseline -> final |
| --- | ---: | ---: |
| VGPR count | 60 -> 64 | 104 -> 104 |
| LDS bytes / workgroup | 7168 -> 7168 | 12288 -> 16384 |
| Scratch bytes | 0 -> 0 | 0 -> 0 |
| Barriers / steady loop iteration | 2 -> 2 | 6 -> 4 |

MTP trades 4096 additional LDS bytes per workgroup for fewer barriers. Compact rows recover 512 bytes compared with the intermediate double-buffered layout. The ATT samples cover eight waves on SE0/CU1; they are not whole-GPU utilization figures. The row-layout change does not reduce LDS-read instruction counts. Separate PMC data shows slightly higher bank-conflict metrics and nearly flat or lower occupancy. These metrics do not explain the measured A/B speedup.
