### PR TITLE
[FlyDSL] gather_kv_b_proj: lift the 4 GiB cache limit, and let callers ask before committing

### DIFF
--- a/aiter/ops/flydsl/__init__.py
+++ b/aiter/ops/flydsl/__init__.py
@@ -78,6 +78,10 @@ _LAZY_IMPORTS = {
         ".gather_kv_b_proj",
         "gather_kv_b_proj_flydsl",
     ),
+    "gather_kv_b_proj_flydsl_supported": (
+        ".gather_kv_b_proj",
+        "gather_kv_b_proj_flydsl_supported",
+    ),
 }
 
 __all__ = [
@@ -99,6 +103,7 @@ __all__ = [
     "flydsl_preshuffle_gemm_a8",
     "flydsl_qk_norm_rope_quant",
     "gather_kv_b_proj_flydsl",
+    "gather_kv_b_proj_flydsl_supported",
 ]
 
 

--- a/aiter/ops/flydsl/gather_kv_b_proj.py
+++ b/aiter/ops/flydsl/gather_kv_b_proj.py
@@ -40,53 +40,176 @@ def lds_bytes(block_m: int, block_n: int) -> int:
     return _LDS_BYTES_PER_BLOCK_UNIT * (int(block_m) + int(block_n))
 
 
-def _validate(
+def _config_reason(
     *,
     n_heads: int,
     nope: int,
     v_dim: int,
     block_m: int,
     waves_per_eu: int,
-    num_blocks: int | None = None,
     m_rows: int | None = None,
-) -> None:
-    """Re-check every kernel precondition as ValueError."""
+) -> str | None:
+    """Why the kernel cannot serve this configuration, or None if it can.
+
+    Every precondition is written once here and reaches callers two ways: as an
+    exception via :func:`_validate`, as a bool via
+    :func:`gather_kv_b_proj_flydsl_supported`. A second copy for the predicate
+    would drift, and drift reads as "declines a shape it handles" or, worse,
+    "accepts one it does not".
+    """
     block_n = nope + v_dim  # BLOCK_N is one head
     if block_m < 128 or block_m % 128 != 0:
-        raise ValueError(
-            f"[FlyDSL gather_kv_b_proj] BLOCK_M must be >=128 and %128==0, got {block_m}"
-        )
+        return f"BLOCK_M must be >=128 and %128==0, got {block_m}"
     if nope != 128 or v_dim != 128:
-        raise ValueError(
-            f"[FlyDSL gather_kv_b_proj] this backend requires qk_nope_head_dim == "
-            f"v_head_dim == 128 (the k/v split is the MFMA accumulator-group "
-            f"boundary, not a runtime offset), got nope={nope} v_head_dim={v_dim}. "
-            f"Use the Triton op for other head dims."
+        return (
+            f"this backend requires qk_nope_head_dim == v_head_dim == 128 (the "
+            f"k/v split is the MFMA accumulator-group boundary, not a runtime "
+            f"offset), got nope={nope} v_head_dim={v_dim}"
         )
     if int(waves_per_eu) < 1:
-        raise ValueError(
-            f"[FlyDSL gather_kv_b_proj] waves_per_eu must be >=1 (the kernel always "
-            f"emits the rocdl.waves_per_eu attribute), got {waves_per_eu}"
+        return (
+            f"waves_per_eu must be >=1 (the kernel always emits the "
+            f"rocdl.waves_per_eu attribute), got {waves_per_eu}"
         )
     need = lds_bytes(block_m, block_n)
     have = get_lds_capacity_bytes(get_rocm_arch().split(":", 1)[0])
     if need > have:
-        raise ValueError(
-            f"[FlyDSL gather_kv_b_proj] BLOCK_M={block_m} needs {need} B of LDS, "
-            f"limit is {have} B"
-        )
+        return f"BLOCK_M={block_m} needs {need} B of LDS, limit is {have} B"
     # No num_blocks ceiling: past _BUFFER_SPAN_MAX the kernel addresses the
     # cache in 64 bits per lane instead (`wide_index`).
     if m_rows is not None:
         if m_rows < 0:
-            raise ValueError(
-                f"[FlyDSL gather_kv_b_proj] num_tokens must be >=0, got {m_rows}"
-            )
+            return f"num_tokens must be >=0, got {m_rows}"
         if m_rows * n_heads * (nope + KV_PE_DIM) >= _I32_MAX:
-            raise ValueError(
-                f"[FlyDSL gather_kv_b_proj] num_tokens={m_rows} x {n_heads} heads "
-                f"overflows 32-bit output indexing"
+            return (
+                f"num_tokens={m_rows} x {n_heads} heads overflows 32-bit output "
+                f"indexing"
             )
+    return None
+
+
+def _raise(reason: str) -> None:
+    raise ValueError(f"[FlyDSL gather_kv_b_proj] {reason}")
+
+
+def _validate(**kwargs) -> None:
+    """:func:`_config_reason` for the callers with nowhere to fall back."""
+    reason = _config_reason(**kwargs)
+    if reason is not None:
+        _raise(reason)
+
+
+def _is_per_row_scale(kv_proj_scale: Tensor) -> bool:
+    return kv_proj_scale.dim() == 1 or (
+        kv_proj_scale.dim() == 2 and kv_proj_scale.shape[1] == 1
+    )
+
+
+def _unsupported_reason(
+    k_buffer: Tensor,
+    kv_proj_weight: Tensor,
+    kv_proj_scale: Tensor | None,
+    k_prefix: Tensor,
+    v_prefix: Tensor,
+    *,
+    shuffled_kv_cache: bool = False,
+    block_m: int = 256,
+    waves_per_eu: int = 2,
+) -> str | None:
+    """Why this backend cannot serve these tensors, or None if it can.
+
+    Everything here is fixed once the weights are loaded and the cache is
+    allocated, so a caller that wants to route around this backend can ask once
+    and keep the answer. What is left inside the op is per-call.
+    """
+    if shuffled_kv_cache:
+        return (
+            "shuffled_kv_cache is not supported (the gather assumes each slot's "
+            f"{KV_ROW_ELEMS} latents are contiguous)"
+        )
+    if kv_proj_scale is None:
+        return (
+            "an unquantized weight (kv_proj_scale=None) is not supported; this "
+            "backend is fp8 x per-output-row scale only"
+        )
+    if k_buffer.dim() != 3 or k_buffer.shape[1] != 1:
+        return (
+            f"k_buffer must be [num_blocks, 1, {KV_ROW_ELEMS}] (page_size 1), got "
+            f"{tuple(k_buffer.shape)}"
+        )
+    if k_buffer.shape[2] != KV_ROW_ELEMS:
+        return f"k_buffer last dim must be {KV_ROW_ELEMS}, got {k_buffer.shape[2]}"
+
+    arch = _arch_of(k_buffer.device.index)
+    if arch != "gfx950":
+        return f"gfx950 only (OCP e4m3 + CDNA4 MFMA_Scale + 128 KB LDS), got {arch}"
+    for name, t in (("k_buffer", k_buffer), ("kv_proj_weight", kv_proj_weight)):
+        if t.dtype != torch.float8_e4m3fn:
+            return f"{name} must be torch.float8_e4m3fn (OCP e4m3), got {t.dtype}"
+    if k_prefix.dim() != 3 or v_prefix.dim() != 3:
+        return (
+            f"outputs must be 3-D, got {tuple(k_prefix.shape)}, "
+            f"{tuple(v_prefix.shape)}"
+        )
+    if k_prefix.dtype != torch.bfloat16 or v_prefix.dtype != torch.bfloat16:
+        return "outputs must be bf16"
+
+    total_kv, n_heads, kp_dim = k_prefix.shape
+    total_kv_v, n_heads_v, v_dim = v_prefix.shape
+    if (total_kv, n_heads) != (total_kv_v, n_heads_v):
+        return (
+            f"k_prefix / v_prefix disagree: {tuple(k_prefix.shape)} vs "
+            f"{tuple(v_prefix.shape)}"
+        )
+    nope = kp_dim - KV_PE_DIM
+    weight_n, weight_k = kv_proj_weight.shape
+    if weight_k != KV_C_DIM:
+        return f"weight K must be {KV_C_DIM}, got {weight_k}"
+    if weight_n != n_heads * (nope + v_dim):
+        return (
+            f"weight N={weight_n} != n_heads*(nope+v_dim)="
+            f"{n_heads}*({nope}+{v_dim})"
+        )
+
+    if _is_per_row_scale(kv_proj_scale):
+        if kv_proj_scale.numel() != weight_n:
+            return (
+                f"per-row kv_proj_scale must have {weight_n} elements, got "
+                f"{tuple(kv_proj_scale.shape)}"
+            )
+    elif kv_proj_scale.dim() != 2:
+        return (
+            f"kv_proj_scale must be 1-D (per-row) or 2-D (block), got "
+            f"{tuple(kv_proj_scale.shape)}"
+        )
+    elif (
+        kv_proj_scale.shape[0] * 128 != weight_n
+        or kv_proj_scale.shape[1] * 128 != KV_C_DIM
+    ):
+        return (
+            f"block kv_proj_scale must be [{weight_n // 128}, "
+            f"{KV_C_DIM // 128}] (128x128 granularity), got "
+            f"{tuple(kv_proj_scale.shape)}"
+        )
+
+    return _config_reason(
+        n_heads=n_heads,
+        nope=nope,
+        v_dim=v_dim,
+        block_m=block_m,
+        waves_per_eu=waves_per_eu,
+    )
+
+
+def gather_kv_b_proj_flydsl_supported(*args, **kwargs) -> bool:
+    """Would :func:`gather_kv_b_proj_flydsl` serve these tensors?
+
+    For callers holding a fallback -- the Triton op takes the same arguments and
+    covers bf16 caches, unquantized and MXFP4 weights, page_size > 1 and every
+    non-gfx950 arch. Ask once: the answer is fixed by the weights and the cache,
+    not by the call. Arguments are :func:`_unsupported_reason`'s.
+    """
+    return _unsupported_reason(*args, **kwargs) is None
 
 
 @functools.lru_cache(maxsize=64)
@@ -186,117 +309,52 @@ def gather_kv_b_proj_flydsl(
     distinct value.
     """
 
-    if shuffled_kv_cache:
-        raise ValueError(
-            "[FlyDSL gather_kv_b_proj] shuffled_kv_cache is not supported (the "
-            "gather assumes each slot's 576 latents are contiguous). "
-        )
-    if kv_proj_scale is None:
-        raise ValueError(
-            "[FlyDSL gather_kv_b_proj] an unquantized weight (kv_proj_scale=None) "
-            "is not supported; this backend is fp8 x per-output-row scale only. "
-        )
+    reason = _unsupported_reason(
+        k_buffer,
+        kv_proj_weight,
+        kv_proj_scale,
+        k_prefix,
+        v_prefix,
+        shuffled_kv_cache=shuffled_kv_cache,
+        block_m=block_m,
+        waves_per_eu=waves_per_eu,
+    )
+    if reason is not None:
+        _raise(reason)
 
-    if k_buffer.dim() != 3 or k_buffer.shape[1] != 1:
-        raise ValueError(
-            f"[FlyDSL gather_kv_b_proj] k_buffer must be [num_blocks, 1, {KV_ROW_ELEMS}] "
-            f"(page_size 1), got {tuple(k_buffer.shape)}. Use the Triton op for "
-            f"page_size > 1."
-        )
-    num_blocks, _, hidden = k_buffer.shape
-    if hidden != KV_ROW_ELEMS:
-        raise ValueError(
-            f"[FlyDSL gather_kv_b_proj] k_buffer last dim must be {KV_ROW_ELEMS}, got {hidden}"
-        )
-
-    arch = _arch_of(k_buffer.device.index)
-    if arch != "gfx950":
-        raise ValueError(
-            f"[FlyDSL gather_kv_b_proj] gfx950 only (OCP e4m3 + CDNA4 MFMA_Scale + "
-            f"128 KB LDS), got {arch}."
-        )
-    for name, t in (("k_buffer", k_buffer), ("kv_proj_weight", kv_proj_weight)):
-        if t.dtype != torch.float8_e4m3fn:
-            raise ValueError(
-                f"[FlyDSL gather_kv_b_proj] {name} must be torch.float8_e4m3fn "
-                f"(OCP e4m3), got {t.dtype}"
-            )
-    if k_prefix.dim() != 3 or v_prefix.dim() != 3:
-        raise ValueError(
-            f"[FlyDSL gather_kv_b_proj] outputs must be 3-D, got "
-            f"{tuple(k_prefix.shape)}, {tuple(v_prefix.shape)}"
-        )
-    if k_prefix.dtype != torch.bfloat16 or v_prefix.dtype != torch.bfloat16:
-        raise ValueError("[FlyDSL gather_kv_b_proj] outputs must be bf16")
-
+    num_blocks = k_buffer.shape[0]
     total_kv, n_heads, kp_dim = k_prefix.shape
-    total_kv_v, n_heads_v, v_dim = v_prefix.shape
-    if (total_kv, n_heads) != (total_kv_v, n_heads_v):
-        raise ValueError(
-            f"[FlyDSL gather_kv_b_proj] k_prefix / v_prefix disagree: "
-            f"{tuple(k_prefix.shape)} vs {tuple(v_prefix.shape)}"
-        )
     nope = kp_dim - KV_PE_DIM
-    weight_n, weight_k = kv_proj_weight.shape
-    if weight_k != KV_C_DIM:
-        raise ValueError(
-            f"[FlyDSL gather_kv_b_proj] weight K must be {KV_C_DIM}, got {weight_k}"
-        )
-    if weight_n != n_heads * (nope + v_dim):
-        raise ValueError(
-            f"[FlyDSL gather_kv_b_proj] weight N={weight_n} != n_heads*(nope+v_dim)="
-            f"{n_heads}*({nope}+{v_dim})"
-        )
+    v_dim = v_prefix.shape[2]
 
     m_rows = int(total_kv if num_tokens is None else num_tokens)
+    # Per-call, so not in `_unsupported_reason`: violating either is a caller
+    # bug, not a shape this backend declines, and raising is the right answer.
     if m_rows > total_kv:
-        raise ValueError(
-            f"[FlyDSL gather_kv_b_proj] num_tokens={m_rows} exceeds the allocated "
-            f"{total_kv} output rows"
-        )
+        _raise(f"num_tokens={m_rows} exceeds the allocated {total_kv} output rows")
     if m_rows == 0:
         return
     if kv_indices.numel() < m_rows:
-        raise ValueError(
-            f"[FlyDSL gather_kv_b_proj] kv_indices has {kv_indices.numel()} entries, "
-            f"need at least num_tokens={m_rows}"
+        _raise(
+            f"kv_indices has {kv_indices.numel()} entries, need at least "
+            f"num_tokens={m_rows}"
         )
 
-    per_row_scale = kv_proj_scale.dim() == 1 or (
-        kv_proj_scale.dim() == 2 and kv_proj_scale.shape[1] == 1
-    )
-    if per_row_scale:
-        if kv_proj_scale.numel() != weight_n:
-            raise ValueError(
-                f"[FlyDSL gather_kv_b_proj] per-row kv_proj_scale must have "
-                f"{weight_n} elements, got {tuple(kv_proj_scale.shape)}"
-            )
-    else:
-        if kv_proj_scale.dim() != 2:
-            raise ValueError(
-                f"[FlyDSL gather_kv_b_proj] kv_proj_scale must be 1-D (per-row) or "
-                f"2-D (block), got {tuple(kv_proj_scale.shape)}"
-            )
-        scale_n, scale_k = kv_proj_scale.shape
-        if scale_n * 128 != weight_n or scale_k * 128 != KV_C_DIM:
-            raise ValueError(
-                f"[FlyDSL gather_kv_b_proj] block kv_proj_scale must be "
-                f"[{weight_n // 128}, {KV_C_DIM // 128}] (128x128 granularity), "
-                f"got {tuple(kv_proj_scale.shape)}"
-            )
+    per_row_scale = _is_per_row_scale(kv_proj_scale)
     scale = kv_proj_scale.reshape(-1)
     if scale.dtype != torch.float32:
         scale = scale.to(torch.float32)
 
     xcd_swizzle = _default_xcd(m_rows) if xcd_swizzle is None else int(xcd_swizzle)
 
+    # The config half already ran in `_unsupported_reason`; this is here for
+    # `m_rows`, which only exists once `num_tokens` is resolved.
     _validate(
         n_heads=n_heads,
         nope=nope,
         v_dim=v_dim,
         block_m=block_m,
         waves_per_eu=waves_per_eu,
-        num_blocks=num_blocks,
         m_rows=m_rows,
     )
 

--- a/aiter/ops/flydsl/gather_kv_b_proj.py
+++ b/aiter/ops/flydsl/gather_kv_b_proj.py
@@ -6,6 +6,10 @@
 Supported: fp8 KV cache (OCP e4m3), fp8 weight in either row-major or
 ``shuffle_weight((16,16))`` layout, per-output-row *or* 128x128 block weight
 scale, per-tensor activation scale, page_size 1, bf16 outputs, gfx950.
+
+The cache has no size limit: up to 4 GiB it is reached through one buffer
+descriptor, beyond that through 64-bit per-lane addresses. Output width is
+bounded, though -- see ``m_rows`` in :func:`_validate`.
 """
 
 import functools
@@ -18,7 +22,7 @@ from torch import Tensor
 from aiter.jit.utils.chip_info import get_lds_capacity_bytes
 
 from .kernels.gather_gemm_8wave import compile_gather_kv_b_proj_8w
-from .kernels.tensor_shim import _run_compiled
+from .kernels.tensor_shim import _run_compiled, ptr_arg
 
 # The MLA latent layout, fixed by the model.
 KV_C_DIM = 512
@@ -28,6 +32,8 @@ KV_ROW_ELEMS = KV_C_DIM + KV_PE_DIM
 # LDS = 4 A buffers of (BM/2)x128 plus 4 B buffers of (BN/2)x128, 1 byte/elem.
 _LDS_BYTES_PER_BLOCK_UNIT = 256
 _I32_MAX = 2**31
+# num_records is a 32-bit BYTE count, so one descriptor spans at most this.
+_BUFFER_SPAN_MAX = 2**32
 
 
 def lds_bytes(block_m: int, block_n: int) -> int:
@@ -69,12 +75,8 @@ def _validate(
             f"[FlyDSL gather_kv_b_proj] BLOCK_M={block_m} needs {need} B of LDS, "
             f"limit is {have} B"
         )
-    # Every gathered address and every output index is computed in 32-bit.
-    if num_blocks is not None and num_blocks * KV_ROW_ELEMS >= _I32_MAX:
-        raise ValueError(
-            f"[FlyDSL gather_kv_b_proj] num_blocks={num_blocks} x {KV_ROW_ELEMS} "
-            f"overflows 32-bit buffer indexing"
-        )
+    # No num_blocks ceiling: past _BUFFER_SPAN_MAX the kernel addresses the
+    # cache in 64 bits per lane instead (`wide_index`).
     if m_rows is not None:
         if m_rows < 0:
             raise ValueError(
@@ -98,6 +100,7 @@ def compile_gather_kv_b_proj(
     xcd_swizzle: int,
     weight_preshuffle: bool,
     per_row_scale: bool,
+    wide_index: bool,
 ):
     """Compile (and memoize) a gather+proj launcher."""
     _validate(
@@ -116,6 +119,7 @@ def compile_gather_kv_b_proj(
         xcd_swizzle=int(xcd_swizzle),
         weight_preshuffle=bool(weight_preshuffle),
         per_row_scale=bool(per_row_scale),
+        wide_index=bool(wide_index),
     )
 
 
@@ -305,11 +309,19 @@ def gather_kv_b_proj_flydsl(
         xcd_swizzle=int(xcd_swizzle),
         weight_preshuffle=bool(weight_preshuffle),
         per_row_scale=bool(per_row_scale),
+        # This cache's own extent, as its own compile-time variant. The two
+        # measure the same, so the split is not for speed: the descriptor form
+        # keeps the hardware bounds check, which the wide form gives up.
+        wide_index=(num_blocks * KV_ROW_ELEMS >= _BUFFER_SPAN_MAX),
     )
 
+    # Local: `ptr_arg` keeps only the address, so a `.contiguous()` temporary
+    # has to outlive the launch.
+    kv_cache = k_buffer.contiguous()
     _run_compiled(
         exe,
-        _as_i8(k_buffer.contiguous()).view(-1),
+        ptr_arg(kv_cache),
+        num_blocks,
         kv_indices.contiguous().view(-1),
         _as_i8(kv_proj_weight.contiguous()).view(-1),
         scale.contiguous(),

--- a/aiter/ops/flydsl/kernels/gather_gemm_8wave.py
+++ b/aiter/ops/flydsl/kernels/gather_gemm_8wave.py
@@ -5,8 +5,10 @@
 
 import flydsl.compiler as flyc
 import flydsl.expr as fx
-from flydsl._mlir import ir as _ir
-from flydsl._mlir.dialects import llvm as _llvm_d
+
+# Raw dialect, and the only one here: `global_load_lds` has no fx wrapper (the
+# expr/rocdl surface stops at the buffer form). Pointers still go through
+# `fx.to_llvm_ptr`, so no address space is hardcoded.
 from flydsl._mlir.dialects import rocdl as _rocdl_d
 from flydsl.expr import T, const_expr, range_constexpr, rocdl
 from flydsl.expr.rocdl import cvt_pk_f32_fp8
@@ -33,17 +35,12 @@ N_WAVES = 8  # 512 threads
 BLOCK_K = 128  # fixed by MFMA_Scale(16, 16, 128)
 
 
-def _ir_ptr(space: int):
-    """``!llvm.ptr<space>`` -- the raw ROCDL ops take these, not ``!fly.ptr``."""
-    return _ir.Type.parse(f"!llvm.ptr<{space}>")
-
-
 def _raw(v):
     return v.ir_value() if hasattr(v, "ir_value") else v
 
 
 def _gather_a_offsets(
-    kvi_div, m_base, lane_id, wave_id, n_rounds, half_row_off, kv_base=None
+    kvi_div, m_base, lane_id, wave_id, n_rounds, half_row_off, wide=False
 ):
     """Per-lane A sources: gathered kv_cache row + the stock XOR-swizzled column.
 
@@ -58,10 +55,10 @@ def _gather_a_offsets(
     invariant across rounds and halves -- one VGPR for the whole tile rather
     than re-emitting ``swizzle_128``'s divide chain per step.
 
-    Element offsets by default; with ``kv_base``, the cache's address, absolute
-    64-bit byte addresses. Row and column widen together here because they are
-    added here: split across two functions the two widths could disagree, and
-    an i32 sum of a 64-bit address is not an error, just a wrong row.
+    Offsets are in fp8 elements; ``wide`` makes them 64-bit, for a cache the
+    32-bit form can no longer reach. Row and column widen together here because
+    they are added here: split across two functions the widths could disagree,
+    and an i32 sum against a 64-bit row is not an error, just a wrong row.
     """
     atom = fx.make_copy_atom(fx.rocdl.BufferCopy32b(), fx.Int32)
     regs = []
@@ -74,11 +71,9 @@ def _gather_a_offsets(
     mask = ((lane_id // 8 + (wave_id % 2) * 8) // 2) * 16
     col = ((lane_id % 8) * 16) ^ mask
     idxs = [Vec(fx.memref_load_vec(reg))[0] for reg in regs]
-    if kv_base is None:
+    if not wide:
         return [i * KV_ROW_ELEMS + col for i in idxs]
-    return [
-        kv_base + fx.Int64(i) * fx.Int64(KV_ROW_ELEMS) + fx.Int64(col) for i in idxs
-    ]
+    return [fx.Int64(i) * fx.Int64(KV_ROW_ELEMS) + fx.Int64(col) for i in idxs]
 
 
 class _WideG2SLoader:
@@ -96,10 +91,13 @@ class _WideG2SLoader:
     faults instead of returning zeros.
     """
 
-    LDS_BYTES_PER_WAVE_STEP = 1024  # 64 lanes x 16 B
+    # 64 lanes x 16 B. Both sides count fp8 elements, which are 1 B, so this is
+    # an element step too.
+    LDS_ELEMS_PER_WAVE_STEP = 1024
 
-    def __init__(self, gl_addrs, n_load_steps, wave_id, lane_id):
-        self.gl_addrs = gl_addrs
+    def __init__(self, kv_ptr, gl_offsets, n_load_steps, wave_id, lane_id):
+        self.kv_ptr = kv_ptr
+        self.gl_offsets = gl_offsets
         self.n_load_steps = n_load_steps
         self.wave_id = wave_id
         self.lane_id = lane_id
@@ -107,21 +105,13 @@ class _WideG2SLoader:
 
     def load(self, lds_dst, k_offset):
         for step in range_constexpr(self.n_load_steps):
-            step_off = self.wave_id * self.LDS_BYTES_PER_WAVE_STEP + step * (
-                self.n_waves * self.LDS_BYTES_PER_WAVE_STEP
+            step_off = self.wave_id * self.LDS_ELEMS_PER_WAVE_STEP + step * (
+                self.n_waves * self.LDS_ELEMS_PER_WAVE_STEP
             )
-            lds_off = (
-                fx.Int32(fx.ptrtoint(lds_dst.ptr))
-                + fx.Int32(step_off)
-                + self.lane_id * 16
-            )
+            src = fx.add_offset(self.kv_ptr, self.gl_offsets[step] + fx.Int64(k_offset))
+            dst = fx.add_offset(lds_dst.ptr, fx.Int32(step_off) + self.lane_id * 16)
             _rocdl_d.global_load_lds(
-                _llvm_d.inttoptr(
-                    _ir_ptr(1), _raw(self.gl_addrs[step] + fx.Int64(k_offset))
-                ),
-                _llvm_d.inttoptr(_ir_ptr(3), _raw(lds_off)),
-                16,
-                0,
+                _raw(fx.to_llvm_ptr(src)), _raw(fx.to_llvm_ptr(dst)), 16, 0
             )
 
 
@@ -359,17 +349,12 @@ class _RopeCopy:
         block_m,
         nope,
         n_heads,
-        kv_base=None,
+        kv_ptr=None,
     ):
-        # kv_base set: the cache outgrew a descriptor, so `a_div` is None and
-        # each rope row is reached by its own 64-bit address.
+        # kv_ptr set: the cache outgrew a descriptor, so `a_div` is None and each
+        # rope row is reached by a 64-bit offset off the cache pointer instead.
         self.a_div = a_div
-        self.kv_base = kv_base
-        self.f8_ptr_t = (
-            None
-            if kv_base is None
-            else fx.PointerType.get(fx.Float8E4M3FN.ir_type, fx.AddressSpace.Global, 16)
-        )
+        self.kv_ptr = kv_ptr
         self.kvi_div = kvi_div
         self.kp_div = kp_div
         self.m_base = m_base
@@ -381,7 +366,7 @@ class _RopeCopy:
         self.atom32 = fx.make_copy_atom(fx.rocdl.BufferCopy32b(), fx.Int32)
         # Wide form has no descriptor to load through, so a plain global load.
         self.ld = fx.make_copy_atom(
-            fx.rocdl.BufferCopy128b() if kv_base is None else fx.UniversalCopy128b(),
+            fx.rocdl.BufferCopy128b() if kv_ptr is None else fx.UniversalCopy128b(),
             fx.Float8E4M3FN,
         )
         self.st = fx.make_copy_atom(fx.rocdl.BufferCopy128b(), fx.BFloat16)
@@ -408,9 +393,8 @@ class _RopeCopy:
             idx = Vec(fx.memref_load_vec(self.iregs[_p]))[0]
             rope_src = (
                 idx * KV_ROW_ELEMS + KV_C_DIM + self.half * 32
-                if self.kv_base is None
-                else self.kv_base
-                + fx.Int64(idx) * fx.Int64(KV_ROW_ELEMS)
+                if self.kv_ptr is None
+                else fx.Int64(idx) * fx.Int64(KV_ROW_ELEMS)
                 + fx.Int64(KV_C_DIM + self.half * 32)
             )
             self.bases.append(
@@ -434,10 +418,10 @@ class _RopeCopy:
             ):  # 2 x 16 fp8 = the 32 elements this lane owns
                 src = (
                     fx.slice(self.a_div, (None, self.bases[_p][0] + sub * 16))
-                    if self.kv_base is None
+                    if self.kv_ptr is None
                     else fx.make_view(
-                        fx.inttoptr(
-                            self.f8_ptr_t, self.bases[_p][0] + fx.Int64(sub * 16)
+                        fx.add_offset(
+                            self.kv_ptr, self.bases[_p][0] + fx.Int64(sub * 16)
                         ),
                         fx.make_layout(16, 1),
                     )
@@ -588,24 +572,20 @@ def compile_gather_kv_b_proj_8w(
         # shapes as i32, and this one passes 2**31 elements (2 GiB of fp8) while
         # the descriptor still reaches 4 GiB. The extent comes alongside, as
         # `kv_num_blocks`, and only ever widens in 64-bit.
+        # fp8 view of it, so every A offset below counts elements whichever form
+        # runs.
+        kv_f8 = fx.recast_iter(
+            fx.PointerType.get(F8_IR_t, KV_cache.address_space), KV_cache
+        )
         # Python-level branch: only one of the two forms is traced.
-        kv_base = fx.Int64(fx.ptrtoint(KV_cache)) if wide_index else None
         a_div = (
             None
-            if wide_index
+            if const_expr(wide_index)
             else rocdl.make_buffer_tensor(
                 # Flat-index carrier, as in causal_conv1d's `_view`: 16 is the
                 # widest unit A copies, and the unit strides let a flat element
                 # index reach anywhere. num_records, not the layout, bounds it.
-                fx.Tensor(
-                    fx.make_view(
-                        fx.recast_iter(
-                            fx.PointerType.get(F8_IR_t, KV_cache.address_space),
-                            KV_cache,
-                        ),
-                        fx.make_layout((16, 1), (1, 1)),
-                    )
-                ),
+                fx.Tensor(fx.make_view(kv_f8, fx.make_layout((16, 1), (1, 1)))),
                 max_size=False,
                 num_records_bytes=fx.Int64(kv_num_blocks) * fx.Int64(KV_ROW_ELEMS),
             )
@@ -620,10 +600,10 @@ def compile_gather_kv_b_proj_8w(
 
         # Index loads must precede the first G2S load -- see wait_barrier.
         gl_off_a0 = _gather_a_offsets(
-            kvi_div, m_base, lane_id, wave_id, N_LDS_ROUNDS, 0, kv_base
+            kvi_div, m_base, lane_id, wave_id, N_LDS_ROUNDS, 0, wide_index
         )
         gl_off_a1 = _gather_a_offsets(
-            kvi_div, m_base, lane_id, wave_id, N_LDS_ROUNDS, LDS_BLOCK_M, kv_base
+            kvi_div, m_base, lane_id, wave_id, N_LDS_ROUNDS, LDS_BLOCK_M, wide_index
         )
         gl_off_b = compute_global_swizzle(
             lane_id, wave_id, K, N_LDS_ROUNDS, preshuffled=weight_preshuffle
@@ -636,12 +616,12 @@ def compile_gather_kv_b_proj_8w(
         # Two A loaders: the stock kernel separates the halves via soffset, but
         # with a gather the half offset lives in the row index instead.
         a0_g2s = (
-            _WideG2SLoader(gl_off_a0, N_LDS_STEPS_A, wave_id, lane_id)
+            _WideG2SLoader(kv_f8, gl_off_a0, N_LDS_STEPS_A, wave_id, lane_id)
             if const_expr(wide_index)
             else G2SLoader(a_div, gl_off_a0, N_LDS_STEPS_A, F8_IR_t, wave_id)
         )
         a1_g2s = (
-            _WideG2SLoader(gl_off_a1, N_LDS_STEPS_A, wave_id, lane_id)
+            _WideG2SLoader(kv_f8, gl_off_a1, N_LDS_STEPS_A, wave_id, lane_id)
             if const_expr(wide_index)
             else G2SLoader(a_div, gl_off_a1, N_LDS_STEPS_A, F8_IR_t, wave_id)
         )
@@ -775,7 +755,7 @@ def compile_gather_kv_b_proj_8w(
             BLOCK_M,
             nope,
             n_heads,
-            kv_base,
+            kv_f8 if const_expr(wide_index) else None,
         )
         rope.load_idx()
         store.prefetch_scales(head, wave_n * (N_TILES_B * 16))

--- a/aiter/ops/flydsl/kernels/gather_gemm_8wave.py
+++ b/aiter/ops/flydsl/kernels/gather_gemm_8wave.py
@@ -6,8 +6,13 @@
 import flydsl.compiler as flyc
 import flydsl.expr as fx
 
-# Raw dialect, and the only one here: `global_load_lds` has no fx wrapper (the
-# expr/rocdl surface stops at the buffer form). Pointers still go through
+# Raw dialect, and the only one here. There IS an fx atom for global -> LDS,
+# `cdna4.GlobalLoadAsyncLDS128b`, but only the async one: it completes through
+# asyncmark / wait_asyncmark, while this pipeline's `wait_barrier` is a
+# hand-counted `s_waitcnt vmcnt(N)` covering A and B together. Tracking A one
+# way and B the other is how the MFMAs come to read stale LDS -- see BlockScale
+# below. `rocdl.global.load.lds` is the synchronous form and counts in vmcnt,
+# so the existing barrier keeps covering it. Pointers still go through
 # `fx.to_llvm_ptr`, so no address space is hardcoded.
 from flydsl._mlir.dialects import rocdl as _rocdl_d
 from flydsl.expr import T, const_expr, range_constexpr, rocdl
@@ -84,11 +89,11 @@ class _WideG2SLoader:
     per-tile rebase of ROCm/aiter#4473 works only for a scan. ``global_load_lds``
     is the same DMA on a per-lane 64-bit pointer.
 
-    Two things the copy atom did implicitly and this does by hand: lane ``i``
-    lands at ``lds_base + i*16``, and the K offset rides in the address, there
-    being no ``soffset`` -- safe only because nothing range-checks an origin
-    here. Nothing bounds the read either: a kv_indices entry outside the cache
-    faults instead of returning zeros.
+    Three things the copy atom did implicitly and this does by hand: lane ``i``
+    lands at ``lds_base + i*16``; the K offset rides in the address, there being
+    no ``soffset`` -- safe only because nothing range-checks an origin here; and
+    nothing bounds the read, so a kv_indices entry outside the cache faults
+    instead of returning zeros.
     """
 
     # 64 lanes x 16 B. Both sides count fp8 elements, which are 1 B, so this is

--- a/aiter/ops/flydsl/kernels/gather_gemm_8wave.py
+++ b/aiter/ops/flydsl/kernels/gather_gemm_8wave.py
@@ -5,6 +5,9 @@
 
 import flydsl.compiler as flyc
 import flydsl.expr as fx
+from flydsl._mlir import ir as _ir
+from flydsl._mlir.dialects import llvm as _llvm_d
+from flydsl._mlir.dialects import rocdl as _rocdl_d
 from flydsl.expr import T, const_expr, range_constexpr, rocdl
 from flydsl.expr.rocdl import cvt_pk_f32_fp8
 from flydsl.expr.typing import Vector as Vec
@@ -30,15 +33,35 @@ N_WAVES = 8  # 512 threads
 BLOCK_K = 128  # fixed by MFMA_Scale(16, 16, 128)
 
 
-def _load_row_bases(kvi_div, m_base, lane_id, wave_id, n_rounds, half_row_off):
-    """Gathered kv_cache row bases (in fp8 elements) for the rows this lane DMAs.
+def _ir_ptr(space: int):
+    """``!llvm.ptr<space>`` -- the raw ROCDL ops take these, not ``!fly.ptr``."""
+    return _ir.Type.parse(f"!llvm.ptr<{space}>")
+
+
+def _raw(v):
+    return v.ir_value() if hasattr(v, "ir_value") else v
+
+
+def _gather_a_offsets(
+    kvi_div, m_base, lane_id, wave_id, n_rounds, half_row_off, kv_base=None
+):
+    """Per-lane A sources: gathered kv_cache row + the stock XOR-swizzled column.
 
     The row map is exactly ``compute_global_swizzle``'s non-preshuffled A map:
-    ``row = lane//8 + wave*8 + round*(N_WAVES*8) (+ LDS_BLOCK_M)``.
+    ``row = lane//8 + wave*8 + round*(N_WAVES*8) (+ LDS_BLOCK_M)``. Every index
+    load is issued before any is consumed so they coalesce into one
+    ``s_waitcnt`` instead of ``n_rounds`` serialized round trips; eight lanes
+    share a row, so their requests fold into one L1 access.
 
-    All loads are issued before any result is consumed so they coalesce into one
-    ``s_waitcnt`` instead of ``n_rounds`` serialized round trips.  Eight lanes
-    share each row, so the eight requests fold into one L1 access.
+    ``mask`` depends only on ``row % 16``, and both the round step (64) and the
+    half step (LDS_BLOCK_M, a multiple of 128) are multiples of 16, so it is
+    invariant across rounds and halves -- one VGPR for the whole tile rather
+    than re-emitting ``swizzle_128``'s divide chain per step.
+
+    Element offsets by default; with ``kv_base``, the cache's address, absolute
+    64-bit byte addresses. Row and column widen together here because they are
+    added here: split across two functions the two widths could disagree, and
+    an i32 sum of a 64-bit address is not an error, just a wrong row.
     """
     atom = fx.make_copy_atom(fx.rocdl.BufferCopy32b(), fx.Int32)
     regs = []
@@ -47,20 +70,59 @@ def _load_row_bases(kvi_div, m_base, lane_id, wave_id, n_rounds, half_row_off):
         reg = fx.make_rmem_tensor(fx.make_layout(1, 1), fx.Int32)
         fx.copy(atom, fx.slice(kvi_div, (None, m_base + row)), reg)
         regs.append(reg)
-    return [Vec(fx.memref_load_vec(reg))[0] * KV_ROW_ELEMS for reg in regs]
 
-
-def _gather_a_offsets(lane_id, wave_id, n_rounds, row_bases):
-    """Per-lane A offsets: gathered row base + the stock XOR-swizzled column.
-
-    ``mask`` depends only on ``row % 16``, and both the round step (64) and the
-    half step (LDS_BLOCK_M, a multiple of 128) are multiples of 16, so it is
-    invariant across rounds and halves -- one VGPR for the whole tile rather
-    than re-emitting ``swizzle_128``'s divide chain per step.
-    """
     mask = ((lane_id // 8 + (wave_id % 2) * 8) // 2) * 16
-    col_swz = ((lane_id % 8) * 16) ^ mask
-    return [row_bases[r] + col_swz for r in range_constexpr(n_rounds)]
+    col = ((lane_id % 8) * 16) ^ mask
+    idxs = [Vec(fx.memref_load_vec(reg))[0] for reg in regs]
+    if kv_base is None:
+        return [i * KV_ROW_ELEMS + col for i in idxs]
+    return [
+        kv_base + fx.Int64(i) * fx.Int64(KV_ROW_ELEMS) + fx.Int64(col) for i in idxs
+    ]
+
+
+class _WideG2SLoader:
+    """``G2SLoader``'s A path without the buffer descriptor.
+
+    ``buffer_load ... lds`` stops at 4 GiB: its SRsrc base must stay uniform
+    across the wave, so a gather's per-lane row can never ride in it -- the
+    per-tile rebase of ROCm/aiter#4473 works only for a scan. ``global_load_lds``
+    is the same DMA on a per-lane 64-bit pointer.
+
+    Two things the copy atom did implicitly and this does by hand: lane ``i``
+    lands at ``lds_base + i*16``, and the K offset rides in the address, there
+    being no ``soffset`` -- safe only because nothing range-checks an origin
+    here. Nothing bounds the read either: a kv_indices entry outside the cache
+    faults instead of returning zeros.
+    """
+
+    LDS_BYTES_PER_WAVE_STEP = 1024  # 64 lanes x 16 B
+
+    def __init__(self, gl_addrs, n_load_steps, wave_id, lane_id):
+        self.gl_addrs = gl_addrs
+        self.n_load_steps = n_load_steps
+        self.wave_id = wave_id
+        self.lane_id = lane_id
+        self.n_waves = fx.block_dim.x // 64
+
+    def load(self, lds_dst, k_offset):
+        for step in range_constexpr(self.n_load_steps):
+            step_off = self.wave_id * self.LDS_BYTES_PER_WAVE_STEP + step * (
+                self.n_waves * self.LDS_BYTES_PER_WAVE_STEP
+            )
+            lds_off = (
+                fx.Int32(fx.ptrtoint(lds_dst.ptr))
+                + fx.Int32(step_off)
+                + self.lane_id * 16
+            )
+            _rocdl_d.global_load_lds(
+                _llvm_d.inttoptr(
+                    _ir_ptr(1), _raw(self.gl_addrs[step] + fx.Int64(k_offset))
+                ),
+                _llvm_d.inttoptr(_ir_ptr(3), _raw(lds_off)),
+                16,
+                0,
+            )
 
 
 class BlockScale:
@@ -286,9 +348,28 @@ class _RopeCopy:
     ROWS_PER_PASS = 256  # 512 threads / 2 threads-per-row
 
     def __init__(
-        self, a_div, kvi_div, kp_div, m_base, head, tid, k_scale, block_m, nope, n_heads
+        self,
+        a_div,
+        kvi_div,
+        kp_div,
+        m_base,
+        head,
+        tid,
+        k_scale,
+        block_m,
+        nope,
+        n_heads,
+        kv_base=None,
     ):
+        # kv_base set: the cache outgrew a descriptor, so `a_div` is None and
+        # each rope row is reached by its own 64-bit address.
         self.a_div = a_div
+        self.kv_base = kv_base
+        self.f8_ptr_t = (
+            None
+            if kv_base is None
+            else fx.PointerType.get(fx.Float8E4M3FN.ir_type, fx.AddressSpace.Global, 16)
+        )
         self.kvi_div = kvi_div
         self.kp_div = kp_div
         self.m_base = m_base
@@ -298,7 +379,11 @@ class _RopeCopy:
         self.kp_row = n_heads * (nope + KV_PE_DIM)
         self.col_base = head * (nope + KV_PE_DIM) + nope
         self.atom32 = fx.make_copy_atom(fx.rocdl.BufferCopy32b(), fx.Int32)
-        self.ld = fx.make_copy_atom(fx.rocdl.BufferCopy128b(), fx.Float8E4M3FN)
+        # Wide form has no descriptor to load through, so a plain global load.
+        self.ld = fx.make_copy_atom(
+            fx.rocdl.BufferCopy128b() if kv_base is None else fx.UniversalCopy128b(),
+            fx.Float8E4M3FN,
+        )
         self.st = fx.make_copy_atom(fx.rocdl.BufferCopy128b(), fx.BFloat16)
         self.dst_reg = fx.make_rmem_tensor(fx.make_layout(8, 1), fx.BFloat16)
         self.ks4 = Vec.filled(4, k_scale, fx.Float32)
@@ -321,9 +406,16 @@ class _RopeCopy:
         for _p in range_constexpr(self.n_passes):
             row_local = self.tid // 2 + _p * self.ROWS_PER_PASS
             idx = Vec(fx.memref_load_vec(self.iregs[_p]))[0]
+            rope_src = (
+                idx * KV_ROW_ELEMS + KV_C_DIM + self.half * 32
+                if self.kv_base is None
+                else self.kv_base
+                + fx.Int64(idx) * fx.Int64(KV_ROW_ELEMS)
+                + fx.Int64(KV_C_DIM + self.half * 32)
+            )
             self.bases.append(
                 (
-                    idx * KV_ROW_ELEMS + KV_C_DIM + self.half * 32,
+                    rope_src,
                     (self.m_base + row_local) * self.kp_row
                     + self.col_base
                     + self.half * 32,
@@ -340,11 +432,17 @@ class _RopeCopy:
             for sub in range_constexpr(
                 2
             ):  # 2 x 16 fp8 = the 32 elements this lane owns
-                fx.copy(
-                    self.ld,
-                    fx.slice(self.a_div, (None, self.bases[_p][0] + sub * 16)),
-                    self.src_regs[_p][sub],
+                src = (
+                    fx.slice(self.a_div, (None, self.bases[_p][0] + sub * 16))
+                    if self.kv_base is None
+                    else fx.make_view(
+                        fx.inttoptr(
+                            self.f8_ptr_t, self.bases[_p][0] + fx.Int64(sub * 16)
+                        ),
+                        fx.make_layout(16, 1),
+                    )
                 )
+                fx.copy(self.ld, src, self.src_regs[_p][sub])
 
     def commit(self):
         v2f32 = T.vec(2, T.f32)
@@ -384,8 +482,14 @@ def compile_gather_kv_b_proj_8w(
     xcd_swizzle: int = 1,
     weight_preshuffle: bool = True,
     per_row_scale: bool = True,
+    wide_index: bool = False,
 ):
-    """Build the fused gather + kv_b_proj kernel for one fixed MLA configuration."""
+    """Build the fused gather + kv_b_proj kernel for one fixed MLA configuration.
+
+    ``wide_index`` swaps the KV cache's descriptor-addressed DMA for
+    ``global_load_lds`` over 64-bit per-lane addresses, which is what a cache
+    spanning more than 4 GiB needs. The host sets it from the cache extent.
+    """
     K = KV_C_DIM
     BLOCK_N = nope + v_dim
 
@@ -416,6 +520,7 @@ def compile_gather_kv_b_proj_8w(
         f"h{n_heads}_{waves_per_eu}x{xcd_swizzle}"
         f"{'_ps' if weight_preshuffle else '_rm'}"
         f"{'_row' if per_row_scale else '_blk'}"
+        f"{'_wide' if wide_index else ''}"
     )
 
     @fx.struct
@@ -431,7 +536,8 @@ def compile_gather_kv_b_proj_8w(
 
     @flyc.kernel(name=_kname, known_block_size=[512, 1, 1])
     def kernel_gather(
-        KV_cache: fx.Tensor,
+        KV_cache: fx.Pointer,
+        kv_num_blocks: fx.Int32,
         KV_indices: fx.Tensor,
         W: fx.Tensor,
         W_scale: fx.Tensor,
@@ -478,9 +584,33 @@ def compile_gather_kv_b_proj_8w(
         B0_gl_offset = (block_n * BLOCK_N) * K
         B1_gl_offset = (block_n * BLOCK_N + LDS_BLOCK_N) * K
 
-        gA = make_fp8_buffer_tensor(KV_cache, F8_IR_t)
+        # The cache arrives as a pointer, not a memref: FlyDSL packs memref
+        # shapes as i32, and this one passes 2**31 elements (2 GiB of fp8) while
+        # the descriptor still reaches 4 GiB. The extent comes alongside, as
+        # `kv_num_blocks`, and only ever widens in 64-bit.
+        # Python-level branch: only one of the two forms is traced.
+        kv_base = fx.Int64(fx.ptrtoint(KV_cache)) if wide_index else None
+        a_div = (
+            None
+            if wide_index
+            else rocdl.make_buffer_tensor(
+                # Flat-index carrier, as in causal_conv1d's `_view`: 16 is the
+                # widest unit A copies, and the unit strides let a flat element
+                # index reach anywhere. num_records, not the layout, bounds it.
+                fx.Tensor(
+                    fx.make_view(
+                        fx.recast_iter(
+                            fx.PointerType.get(F8_IR_t, KV_cache.address_space),
+                            KV_cache,
+                        ),
+                        fx.make_layout((16, 1), (1, 1)),
+                    )
+                ),
+                max_size=False,
+                num_records_bytes=fx.Int64(kv_num_blocks) * fx.Int64(KV_ROW_ELEMS),
+            )
+        )
         gB = make_fp8_buffer_tensor(W, F8_IR_t)
-        a_div = fx.logical_divide(gA, fx.make_layout(1, 1))
         b_div = fx.logical_divide(gB, fx.make_layout(1, 1))
 
         gKVI = fx.rocdl.make_buffer_tensor(
@@ -489,14 +619,12 @@ def compile_gather_kv_b_proj_8w(
         kvi_div = fx.logical_divide(gKVI, fx.make_layout(1, 1))
 
         # Index loads must precede the first G2S load -- see wait_barrier.
-        row_bases_0 = _load_row_bases(
-            kvi_div, m_base, lane_id, wave_id, N_LDS_ROUNDS, 0
+        gl_off_a0 = _gather_a_offsets(
+            kvi_div, m_base, lane_id, wave_id, N_LDS_ROUNDS, 0, kv_base
         )
-        row_bases_1 = _load_row_bases(
-            kvi_div, m_base, lane_id, wave_id, N_LDS_ROUNDS, LDS_BLOCK_M
+        gl_off_a1 = _gather_a_offsets(
+            kvi_div, m_base, lane_id, wave_id, N_LDS_ROUNDS, LDS_BLOCK_M, kv_base
         )
-        gl_off_a0 = _gather_a_offsets(lane_id, wave_id, N_LDS_ROUNDS, row_bases_0)
-        gl_off_a1 = _gather_a_offsets(lane_id, wave_id, N_LDS_ROUNDS, row_bases_1)
         gl_off_b = compute_global_swizzle(
             lane_id, wave_id, K, N_LDS_ROUNDS, preshuffled=weight_preshuffle
         )
@@ -507,8 +635,16 @@ def compile_gather_kv_b_proj_8w(
 
         # Two A loaders: the stock kernel separates the halves via soffset, but
         # with a gather the half offset lives in the row index instead.
-        a0_g2s = G2SLoader(a_div, gl_off_a0, N_LDS_STEPS_A, F8_IR_t, wave_id)
-        a1_g2s = G2SLoader(a_div, gl_off_a1, N_LDS_STEPS_A, F8_IR_t, wave_id)
+        a0_g2s = (
+            _WideG2SLoader(gl_off_a0, N_LDS_STEPS_A, wave_id, lane_id)
+            if const_expr(wide_index)
+            else G2SLoader(a_div, gl_off_a0, N_LDS_STEPS_A, F8_IR_t, wave_id)
+        )
+        a1_g2s = (
+            _WideG2SLoader(gl_off_a1, N_LDS_STEPS_A, wave_id, lane_id)
+            if const_expr(wide_index)
+            else G2SLoader(a_div, gl_off_a1, N_LDS_STEPS_A, F8_IR_t, wave_id)
+        )
         b_g2s = G2SLoader(b_div, gl_off_b, N_LDS_STEPS_B, F8_IR_t, wave_id)
         a_s2r = S2RLoader(wave_m, N_TILES_A)
         b_s2r = S2RLoader(wave_n, N_TILES_B)
@@ -639,6 +775,7 @@ def compile_gather_kv_b_proj_8w(
             BLOCK_M,
             nope,
             n_heads,
+            kv_base,
         )
         rope.load_idx()
         store.prefetch_scales(head, wave_n * (N_TILES_B * 16))
@@ -682,7 +819,8 @@ def compile_gather_kv_b_proj_8w(
 
     @flyc.jit
     def launch_gather_kv_b_proj(
-        KV_cache: fx.Tensor,
+        KV_cache: fx.Pointer,
+        kv_num_blocks: fx.Int32,
         KV_indices: fx.Tensor,
         W: fx.Tensor,
         W_scale: fx.Tensor,
@@ -695,6 +833,7 @@ def compile_gather_kv_b_proj_8w(
         grid_x = ceildiv(m_rows, BLOCK_M) * n_heads
         kernel_gather(
             KV_cache,
+            kv_num_blocks,
             KV_indices,
             W,
             W_scale,

--- a/op_tests/test_flydsl_gather_kv_b_proj.py
+++ b/op_tests/test_flydsl_gather_kv_b_proj.py
@@ -24,7 +24,10 @@ import torch
 import aiter
 from aiter import dtypes
 from aiter.jit.utils.chip_info import get_gfx
-from aiter.ops.flydsl.gather_kv_b_proj import gather_kv_b_proj_flydsl
+from aiter.ops.flydsl.gather_kv_b_proj import (
+    gather_kv_b_proj_flydsl,
+    gather_kv_b_proj_flydsl_supported,
+)
 from aiter.ops.shuffle import shuffle_weight
 from aiter.ops.triton.gather_kv_b_proj import (
     gather_kv_b_proj as triton_gather_kv_b_proj,
@@ -309,6 +312,60 @@ def test_gather_kv_b_proj_flydsl_rejects_unsupported(kwargs, needle):
     case = _make_case(256, 12)
     with pytest.raises(ValueError, match=needle):
         _run_flydsl(case, **kwargs)
+
+
+def _supported(case, **kw):
+    return gather_kv_b_proj_flydsl_supported(
+        case["k_buffer"],
+        shuffle_weight(case["weight"], layout=(16, 16)),
+        case["weight_scale"],
+        case["k_prefix"],
+        case["v_prefix"],
+        **kw,
+    )
+
+
+@_SKIP
+def test_gather_kv_b_proj_flydsl_supported_agrees_with_the_op():
+    """The predicate and the op must never disagree about a configuration.
+
+    Both read one ``_unsupported_reason``; this pins that they keep doing so,
+    because the failure mode of a second copy is a caller routing a shape here
+    that the kernel then refuses mid-forward.
+    """
+    ok = _make_case(256, 12)
+    assert _supported(ok)
+    _run_flydsl(ok)  # and it really runs
+
+    for kw, needle in (
+        ({"shuffled_kv_cache": True}, "shuffled_kv_cache"),
+        ({"block_m": 192}, "BLOCK_M"),
+    ):
+        assert not _supported(ok, **kw)
+        with pytest.raises(ValueError, match=needle):
+            _run_flydsl(ok, **kw)
+
+
+@_SKIP
+@pytest.mark.parametrize("break_it", ["bf16_cache", "no_scale", "mxfp4_weight"])
+def test_gather_kv_b_proj_flydsl_declines_what_triton_covers(break_it):
+    """The three shapes ATOM hands this op that only the Triton one can serve.
+
+    Two of them took down a CI accuracy job apiece: the FlyDSL op raised, and
+    ATOM had gated on "did the import succeed" rather than on this predicate,
+    so the engine died instead of using the fallback sitting next to it.
+    """
+    case = _make_case(256, 12)
+    if break_it == "bf16_cache":
+        case["k_buffer"] = case["k_buffer"].to(torch.bfloat16)  # GLM-5.2
+    elif break_it == "no_scale":
+        case["weight_scale"] = None  # Kimi-K3 DSpark
+    else:
+        case["weight"] = case["weight"].view(torch.uint8)  # MXFP4 kv_b_proj
+
+    assert not _supported(case)
+    with pytest.raises(ValueError):
+        _run_flydsl(case)
 
 
 def _sparse_case(num_blocks, m, n_heads, lo):

--- a/op_tests/test_flydsl_gather_kv_b_proj.py
+++ b/op_tests/test_flydsl_gather_kv_b_proj.py
@@ -311,6 +311,93 @@ def test_gather_kv_b_proj_flydsl_rejects_unsupported(kwargs, needle):
         _run_flydsl(case, **kwargs)
 
 
+def _sparse_case(num_blocks, m, n_heads, lo):
+    """A case whose cache is zero except the ``m`` rows it gathers, all at or
+    above row ``lo``.
+
+    ``_make_case`` tiles its content every 4096 rows, so a misaddressed load
+    there can return data that still looks plausible. Zero everywhere else means
+    a wrong address can only come back as zeros, which the reference never is.
+    """
+    torch.manual_seed(0)
+    row = KV_C_DIM + KV_PE_DIM
+    k_buffer = torch.zeros((num_blocks, 1, row), device="cuda", dtype=torch.uint8)
+    kv_indices = (torch.randperm(num_blocks - lo, device="cuda")[:m] + lo).to(
+        torch.int32
+    )
+    # 0x01..0x76 is positive-finite e4m3 -- no NaN to poison the reference.
+    k_buffer[kv_indices.long()] = torch.randint(
+        1, 0x77, (m, 1, row), device="cuda", dtype=torch.uint8
+    )
+    case = _make_case(m, n_heads, num_blocks=4096)
+    case["k_buffer"] = k_buffer.view(dtypes.fp8)
+    case["kv_indices"] = kv_indices
+    return case
+
+
+def _check_sparse_case(case):
+    """Assert on cosine, not on checkAllclose, which only warns.
+
+    These cases feed the full positive-finite e4m3 range through a 512-deep dot
+    product, so the bf16 result carries a real absolute error at the top of the
+    range; cosine is the scale-free statement, and a gather that reads the wrong
+    row lands nowhere near 1 because everything off the gathered rows is zero.
+    """
+    k_ref, v_ref = _torch_ref(case)
+    _run_flydsl(case)
+    checkAllclose(k_ref, case["k_prefix"].float(), rtol=2e-2, atol=2e-2, msg="k_prefix")
+    checkAllclose(v_ref, case["v_prefix"].float(), rtol=2e-2, atol=2e-2, msg="v_prefix")
+    for name, got, ref in (
+        ("k_prefix", case["k_prefix"], k_ref),
+        ("v_prefix", case["v_prefix"], v_ref),
+    ):
+        cos = torch.nn.functional.cosine_similarity(
+            got.float().flatten(), ref.flatten(), dim=0
+        )
+        assert cos > 0.999, f"{name} cosine {cos:.6f} -- gathered the wrong rows"
+    assert (case["k_prefix"] != 0).any(), "every gathered row read back as zero"
+    torch.cuda.empty_cache()
+
+
+@_SKIP
+def test_gather_kv_b_proj_flydsl_spans_past_2gib():
+    """A cache past 2**31 bytes, gathered only above that boundary.
+
+    The DeepSeek-R1-0528 tp4 shape, and two distinct 32-bit edges: FlyDSL packs
+    memref shapes as i32, so the cache goes in as a pointer plus ``num_blocks``
+    rather than a flattened memref; and the descriptor form's ``idx * 576`` is
+    an i32 whose wrap is harmless only because voffset is read unsigned.
+    """
+    row = KV_C_DIM + KV_PE_DIM
+    num_blocks = 4_458_592
+    assert 2**31 < num_blocks * row < 2**32, "must land in the descriptor's range"
+    _check_sparse_case(_sparse_case(num_blocks, 256, 12, 2**31 // row + 1))
+
+
+@_SKIP
+@pytest.mark.parametrize(
+    "num_blocks, wide",
+    [
+        # Brackets the switch: the widest cache one descriptor still spans, then
+        # the narrowest it does not. Both gather only from the top of the cache.
+        ((2**32 - 1) // (KV_C_DIM + KV_PE_DIM), False),
+        (2**32 // (KV_C_DIM + KV_PE_DIM) + 1, True),
+        (9_000_000, True),  # 4.83 GiB -- well past, not just over
+    ],
+)
+def test_gather_kv_b_proj_flydsl_brackets_the_descriptor_span(num_blocks, wide):
+    """Either side of 4 GiB must agree with the reference.
+
+    Past it the kernel drops the buffer descriptor for ``global_load_lds`` over
+    64-bit per-lane addresses: a gather's row is per-lane, so it can never be
+    folded into an SRsrc base the way a tile scan's can.
+    """
+    row = KV_C_DIM + KV_PE_DIM
+    assert (num_blocks * row >= 2**32) == wide
+    lo = 2**31 // row + 1
+    _check_sparse_case(_sparse_case(num_blocks, 256, 12, lo))
+
+
 @_SKIP
 @pytest.mark.parametrize("num_tokens, block_m", [(16384, 256), (8192, 128)])
 def test_gather_kv_b_proj_flydsl_determinism_large_m(num_tokens, block_m):


### PR DESCRIPTION
Two things about `aiter/ops/flydsl/gather_kv_b_proj` and its contract with the caller. They are separate commits and could be split if you prefer; the second touches the guards the first moved, so it is stacked rather than parallel.

## 1. The cache no longer has a 4 GiB limit

### Motivation

The op refused a KV cache whose byte span reached `2**31`. DeepSeek-R1-0528 tp4 reaches it at 4,458,592 pages, so every MLA prefill that hit the guard took down the model runner:

```
ValueError: [FlyDSL gather_kv_b_proj] num_blocks=4458592 x 576 overflows 32-bit buffer indexing
[atom] AsyncIOProcManager(ModelRunner): [ModelRunner3/4] proc died unexpectedly (exitcode=1)
```

Three distinct 32-bit edges sat behind that one message, and only the third is real:

1. **Host ABI.** FlyDSL packs memref *shapes* as i32 (`jit_argument.py`), and the op handed the cache over flattened, so `shape[0] = num_blocks * 576` broke the C-ABI marshalling before any kernel ran — `struct.error: 'i' format requires ...`. The cache now goes in as a pointer plus `num_blocks`, and the extent only ever widens in 64 bits.
2. **The `idx * 576` gather offset.** Measured on gfx950: the raw-buffer voffset is read unsigned, so the i32 wrap addresses correctly all the way to 4 GiB. The `2**31` guard was one bit conservative and the arithmetic needed no change at all.
3. **`num_records`, a 32-bit byte count.** This one is real, and a gather cannot escape it the way #4473's tile scan does: an SRsrc base has to stay uniform across the wave, and a gathered row is per-lane.

### Technical details

Past 4 GiB the A path drops the descriptor for `rocdl.global.load.lds` — the same direct-to-LDS DMA, driven by a per-lane 64-bit pointer instead of an SRsrc. It is selected as a compile-time `wide_index` variant from the cache's own extent, so a cache that fits a descriptor keeps the descriptor.

Two things the copy atom did implicitly and the wide form does by hand: lane `i` lands at `lds_base + i*16`, and the K offset rides in the address, there being no `soffset` operand. That last point is the inverse of #4473's warning — with no descriptor there is no second origin to mismatch, so folding it in is unconditionally right. The narrow path still passes `soffset`, and now says so in a comment, because a future rebase there would have to move it into the base or read zeros silently.

Both forms are kept. They measure the same, so the split is not for speed: the descriptor form keeps the hardware bounds check, which the wide form gives up (an out-of-range `kv_indices` entry faults instead of returning zeros).

### Test plan

`op_tests/test_flydsl_gather_kv_b_proj.py` stopped at `num_blocks=3_000_000`, just under the 3,728,270 boundary, which is why this was never caught. Added cases brackets the switch at one row either side of 4 GiB, plus one well past it and the R1 shape:

| num_blocks | span | path | |
|---|---|---|---|
| 4,458,592 | 2.39 GiB | descriptor | PASS — the shape CI died on |
| 7,456,540 | 4.00 GiB, the widest a descriptor spans | descriptor | PASS |
| 7,456,541 | 4.00 GiB, the narrowest it does not | `global_load_lds` | PASS |
| 9,000,000 | 4.83 GiB | `global_load_lds` | PASS |

Each zero-fills the cache outside the gathered rows, so a misaddressed load can only come back as zeros — `_make_case` tiles its content every 4096 rows, which would let a wrong address return something plausible. `checkAllclose` only warns, so these assert on cosine.

### Test result

```
                 M = 2048   8192   16384
narrow (us)         16.06  33.65   58.90     base 16.07 / 33.69 / 58.54
wide / narrow       1.007x 1.001x  0.995x
```

The wide path costs nothing measurable, and the descriptor path is unchanged.

## 2. Callers can ask whether a shape is servable

### Motivation

The op refuses a good deal more than it accepts — non-gfx950, `page_size > 1`, bf16 caches, unquantized and MXFP4 weights, head dims other than 128 — and it refuses by raising. A caller holding a fallback has no way to find out before committing.

ATOM therefore gated on "did the import succeed", and in one CI run three accuracy jobs died mid-forward on shapes `aiter.ops.triton.gather_kv_b_proj` — same arguments, positional drop-in — serves without complaint:

```
ValueError: [FlyDSL gather_kv_b_proj] an unquantized weight (kv_proj_scale=None) is not supported
ValueError: [FlyDSL gather_kv_b_proj] k_buffer must be torch.float8_e4m3fn (OCP e4m3), got torch.bfloat16
```

### Technical details

Adds `gather_kv_b_proj_flydsl_supported`. The guards move into `_unsupported_reason` / `_config_reason`, which return the reason as a string; the op raises it and the predicate compares it against None. One copy, two outlets — a second copy written for the predicate would drift, and drift reads as "declines a shape it handles" or, worse, "accepts one it does not".

Everything the predicate looks at is fixed once the weights are loaded and the cache is allocated, so a caller asks once and keeps the answer. What stays inside the op is per-call — `num_tokens` against the workspace, `kv_indices` length — and is a caller bug rather than a shape this backend declines, so it still raises.

### Test plan

`33 passed` (was 25). Beyond the size cases above:

- the predicate and the op never disagree, on an accepted config and on two rejected ones;
- the three shapes ATOM actually hands this op that only the Triton one covers — bf16 cache, `kv_proj_scale=None`, MXFP4 weight — are each declined by the predicate *and* raised by the op.

The ATOM-side change that consumes this is separate. Without it nothing behaves differently; with an older aiter, ATOM's import falls into its existing `except` and the FlyDSL gather simply stays off.

---

Reviewed against gfx950 hardware for every number quoted. `ruff` and `black` clean.
