### PR TITLE
[HIP] [Kernel] Fix group quant dispatch for hidden sizes in (4096, 6144]

### DIFF
--- a/csrc/kernels/rmsnorm_quant_kernels.cu
+++ b/csrc/kernels/rmsnorm_quant_kernels.cu
@@ -371,7 +371,13 @@ __global__ void add_rmsnorm_quant_kernel(
     } else if (n <= 4096){ \
         ADD_RMSNORM_QUANT_KERNEL_IMPL(DTYPE_O, 256, 16, ADD_RESIDUAL, FUSE_QUANT); \
     } else if (n <= 6144){ \
-        ADD_RMSNORM_QUANT_KERNEL_IMPL(DTYPE_O, 256, 24, ADD_RESIDUAL, FUSE_QUANT); \
+        if (group_size == 0 || group_size % 24 == 0) { \
+            ADD_RMSNORM_QUANT_KERNEL_IMPL(DTYPE_O, 256, 24, ADD_RESIDUAL, FUSE_QUANT); \
+        } else if (cu_num < 160) { \
+            ADD_RMSNORM_QUANT_KERNEL_IMPL(DTYPE_O, 512, 16, ADD_RESIDUAL, FUSE_QUANT); \
+        } else { \
+            ADD_RMSNORM_QUANT_KERNEL_IMPL(DTYPE_O, 1024, 8, ADD_RESIDUAL, FUSE_QUANT); \
+        } \
     } else if (n <= 8192){ \
         if (group_size == 0) { \
             ADD_RMSNORM_QUANT_KERNEL_IMPL(DTYPE_O, 256, 32, ADD_RESIDUAL, FUSE_QUANT); \
@@ -463,7 +469,13 @@ __global__ void add_rmsnorm_quant_kernel(
     } else if (n <= 4096){ \
         ADD_RMSNORM_QUANT_KERNEL_IMPL(DTYPE_O, 256, 16, ADD_RESIDUAL, FUSE_QUANT); \
     } else if (n <= 6144){ \
-        ADD_RMSNORM_QUANT_KERNEL_IMPL(DTYPE_O, 256, 24, ADD_RESIDUAL, FUSE_QUANT); \
+        if (group_size == 0 || group_size % 24 == 0) { \
+            ADD_RMSNORM_QUANT_KERNEL_IMPL(DTYPE_O, 256, 24, ADD_RESIDUAL, FUSE_QUANT); \
+        } else if (cu_num < 160) { \
+            ADD_RMSNORM_QUANT_KERNEL_IMPL(DTYPE_O, 512, 16, ADD_RESIDUAL, FUSE_QUANT); \
+        } else { \
+            ADD_RMSNORM_QUANT_KERNEL_IMPL(DTYPE_O, 1024, 8, ADD_RESIDUAL, FUSE_QUANT); \
+        } \
     } else if (n <= 8192){ \
         ADD_RMSNORM_QUANT_KERNEL_IMPL(DTYPE_O, 256, 32, ADD_RESIDUAL, FUSE_QUANT); \
     } else { \

--- a/op_tests/test_rmsnorm2dFusedAddQuant.py
+++ b/op_tests/test_rmsnorm2dFusedAddQuant.py
@@ -333,7 +333,10 @@ if __name__ == "__main__":
     parser.add_argument(
         "-n",
         type=int,
-        default=[1024, 2048, 3584, 4096, 8192],
+        # 5120 and 6144 cover the n in (4096, 6144] band, which dispatches to
+        # thread_data_size=24; without them no shape here exercises a group quant
+        # whose group_size is not a multiple of the per-thread chunk.
+        default=[1024, 2048, 3584, 4096, 5120, 6144, 8192],
         nargs="*",
         help="""N of mnk.
     e.g.: -n 1024""",


### PR DESCRIPTION
## Problem

`rmsnorm_quant` and `add_rmsnorm_quant` abort for any group quant whose `group_size` is not a multiple of 24 when `4096 < n <= 6144`.

The dispatch selects `thread_data_size` from `n`, then `ADD_RMSNORM_QUANT_KERNEL_IMPL_` asserts `group_size % thread_data_size == 0`. That band uses `thread_data_size = 24`, so `group_size = 32` -- `QuantType.per_1x32`, i.e. both MXFP4 and MXFP8 -- fails:

```
[AITER] csrc/kernels/rmsnorm_quant_kernels.cu:447 operator() group_size not support: 32
```

This is not a feature request: the existing `per_1x32` test path hits it on `main`.

```
python op_tests/test_rmsnorm2dFusedAddQuant.py --mode 8 -n 5120 -m 8 --quant_dtype fp4x2
```

It went unnoticed because the default `-n` sweep is `[1024, 2048, 3584, 4096, 8192]`, which skips the band entirely.

## Fix

The `n <= 8192` branch already solves this problem: when `group_size != 0` it deliberately avoids `thread_data_size = 32` and selects `(512, 16)` or `(1024, 8)` by CU count. This applies the same rule to the `(4096, 6144]` band, reusing those same instantiations -- both cover `n`, and 32 is a multiple of 16 and of 8.

Strictly additive: `group_size == 0` and any multiple of 24 keep the existing `(256, 24)` config, so no currently-working call changes kernel.

## Validation

gfx950 / MI355X. Before the fix both shapes abort; after, the existing mode-8 numerical check against the torch reference passes (test tolerance is `1e-2`):

|   m |    n | quant_dtype | hip err | hip bw(GB/s) |
|----:|-----:|:------------|--------:|-------------:|
|   8 | 5120 | fp4x2       | 0.00486 |         22.4 |
| 256 | 5120 | fp4x2       | 0.00668 |        600.9 |
|   8 | 6144 | fp4x2       | 0.00566 |         25.9 |
| 256 | 6144 | fp4x2       | 0.00636 |        448.8 |

MXFP8 was checked separately: at hidden 5120, `add_rmsnorm_quant` with `group_size=32` and a 1-byte E8M0 scale now produces FP8 E4M3 values plus per-32 E8M0 scales that agree with a reference MX quantizer on 99.7% of block scales, with dequantized values within one E4M3 ULP and the residual output bit-exact. `group_size = 0` was re-checked as unchanged.

## Motivation

DeepSeek-V4.1-Flash has `hidden_size = 5120`, so today none of its dense MXFP8 activations can use the fused norm+quant path. Measured on MI355X, folding the MX quant into the norm is 1.49x at M=8 and 1.77x at M=256 versus `add_rmsnorm` followed by a separate MX quant launch (2.2us and 4.1us saved per call, graph-replay latency with the replay floor amortized over 64 copies), and removes one kernel launch per occurrence.
